### PR TITLE
Default to a dev instead of prod build

### DIFF
--- a/src/site/constants/buckets.js
+++ b/src/site/constants/buckets.js
@@ -13,14 +13,15 @@ const hostnames = require('./hostnames');
 const bucket = 'https://s3-us-gov-west-1.amazonaws.com';
 
 const prodBucket = 'https://prod-va-gov-assets.s3-us-gov-west-1.amazonaws.com';
+const devBucket = 'https://dev-va-gov-assets.s3-us-gov-west-1.amazonaws.com';
 
 module.exports = {
   [DEVELOPMENT]: `${bucket}/${hostnames[DEVELOPMENT]}`,
   [PRODUCTION]: `${bucket}/${hostnames[PRODUCTION]}`,
   [STAGING]: `${bucket}/${hostnames[STAGING]}`,
-  [VAGOVDEV]: 'https://dev-va-gov-assets.s3-us-gov-west-1.amazonaws.com',
+  [VAGOVDEV]: devBucket,
   [VAGOVSTAGING]:
     'https://staging-va-gov-assets.s3-us-gov-west-1.amazonaws.com',
   [VAGOVPROD]: prodBucket,
-  [LOCALHOST]: prodBucket,
+  [LOCALHOST]: devBucket,
 };

--- a/src/site/stages/build/plugins/process-entry-names.js
+++ b/src/site/stages/build/plugins/process-entry-names.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-continue, no-param-reassign */
 
+const path = require('path');
 const environments = require('../../../constants/environments');
 
 const FILE_MANIFEST_FILENAME = 'generated/file-manifest.json';
@@ -41,6 +42,22 @@ function copyAssetsToTeamSitePaths(buildOptions, files, entryNamesDictionary) {
 }
 
 function getEntryNamesDictionary(buildOptions, files) {
+  const isDevBuild = [environments.LOCALHOST, environments.VAGOVDEV].includes(
+    buildOptions.buildtype,
+  );
+
+  if (isDevBuild) {
+    return {
+      get(entryName) {
+        const isJs = path.extname(entryName) === '.js';
+        const fileName = isJs
+          ? `${path.parse(entryName).name}.entry.js`
+          : entryName;
+        return `/generated/${fileName}`;
+      },
+    };
+  }
+
   const fileManifest = files[FILE_MANIFEST_FILENAME];
 
   if (!fileManifest) {


### PR DESCRIPTION
This makes it easier to compare this build output with a content build
in vets-website since we don't have to deal with hashed filenames

Also, this undoes some of the changes made in #1 