### PR TITLE
Ignore everything in applications folder except registry.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ coverage
 yalc.lock
 /test-results.xml
 package-lock.json
-src/applications/proxy-rewrite/tests/__image_snapshots__/__diff_output__/
 src/applications/
 !src/applications/registry.json
 temp


### PR DESCRIPTION
## Description

There's [currently only one file in the `applications` folder of the `content-build` repo](https://github.com/department-of-veterans-affairs/content-build/tree/update-gitignore-to-ignore-app-folders/src/applications), and that is [`registry.json`](https://github.com/department-of-veterans-affairs/content-build/blob/update-gitignore-to-ignore-app-folders/src/applications/registry.json). 

This PR updates `.gitignore` to ignore everything in the applications folder except `registry.json`. 

Ignoring everything else in the `applications` folder should make it easier to keep the `content-build` repo in sync with the part of `vets-website` that is related to the content build. 