### PR TITLE
Run validate-content-build script from content-build repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 jobs:
   validate-content-build:
     docker:
-      - image: circleci/node:10.15.3
+      - image: circleci/node:14.15.0
     steps:
       - add_ssh_keys
       - checkout


### PR DESCRIPTION
## Description

This PR does the following:

1. Updates the node version of the CircleCI docker image from `10.15.3` to `14.15.0`
1. Runs the `validate-content-build` npm script from the `project` folder (`content-build`) instead of `vets-website`

## Related Links

- https://circleci.com/docs/2.0/configuration-reference/#job_name
   - `working_directory`: Default: `~/project`