### PR TITLE
Set frontend-review-group as default CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+#  @department-of-veterans-affairs/frontend-review-group will be requested for
+# review when someone opens a pull request.
+#
+# Review the CODEOWNERS guide before editing:
+# https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/codeowners.md
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,5 @@
 # Review the CODEOWNERS guide before editing:
 # https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/codeowners.md
 
+# VSP
+*       @department-of-veterans-affairs/frontend-review-group


### PR DESCRIPTION
## Description

This PR sets the `frontend-review-group` as the default code owners for the `content-build` repo. 

## Links

- https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners
- [`CODEOWNERS` file from `vets-website`](https://github.com/department-of-veterans-affairs/vets-website/blob/master/.github/CODEOWNERS)