### PR TITLE
Uncomment vagovstaging, and comment out vagovprod

### DIFF
--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -18,8 +18,8 @@ DRUPAL_CREDENTIALS = [
 
 ALL_VAGOV_BUILDTYPES = [
   // 'vagovdev',
-  // 'vagovstaging',
-  'vagovprod'
+  'vagovstaging'
+  // 'vagovprod'
 ]
 
 BUILD_TYPE_OVERRIDE = DRUPAL_MAPPING.get(params.cmsEnvBuildOverride, null)


### PR DESCRIPTION
## Description

CI was failing on `master` because of the broken link checking. 
  - http://jenkins.vfs.va.gov/blue/organizations/jenkins/testing%2Fcontent-build/detail/master/9/pipeline

This PR changes the environment used by the `content-build` from `vagovprod` to `vagovstaging`. 