### PR TITLE
updated omitdebug template based on vets-website feedback

### DIFF
--- a/src/site/includes/debug.drupal.liquid
+++ b/src/site/includes/debug.drupal.liquid
@@ -1,5 +1,7 @@
-{% if isPreview or buildtype != 'vagovprod' and omitdebug = false %}
-  {% assign showDebug = true %}
+{% if isPreview or buildtype != 'vagovprod' %}
+  {% if omitdebug == false %}
+    {% assign showDebug = true %}
+  {% endif %}
 {% endif %}
 
 {% if showDebug %}


### PR DESCRIPTION
This is the conditional in place for when we need to omit debug information from a template because it causes issues in the diff when validating content.

This will be removed when we don't need to validate content anymore.