### PR TITLE
disabled slack alert for broken links

### DIFF
--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -161,7 +161,7 @@ def checkForBrokenLinks(String buildLogPath, String envName, Boolean contentOnly
   // Output a csv file with the broken links
   sh "cd /application && jenkins/glean-broken-links.sh ${buildLogPath} ${csvFileName}"
   if (fileExists(csvFile)) {
-    echo "Found broken links (add slack alert back in after content-build release)."
+    echo "Found broken links."
 
     // Only break the build if broken links are found in master
     if (IS_PROD_BRANCH || contentOnlyBuild) {
@@ -174,17 +174,16 @@ def checkForBrokenLinks(String buildLogPath, String envName, Boolean contentOnly
       def brokenLinksCount = sh(returnStdout: true, script: "wc -l /application/${csvFileName} | cut -d ' ' -f1") as Integer
       def brokenLinksMessage = "${brokenLinksCount} broken links found in the `${envName}` build on `${env.BRANCH_NAME}`\n@cmshelpdesk\n${env.RUN_DISPLAY_URL}\n${brokenLinks}".stripMargin()
 
-      // @TODO: Add this feature back in post-release
-      // slackSend(
-      //   message: brokenLinksMessage,
-      //   color: 'danger',
-      //   failOnError: true,
-      //   channel: 'cms-helpdesk-bot'
-      //   // attachments: brokenLinks
-      //   // TODO: errors out with ERROR: Slack notification failed with exception: net.sf.json.JSONException: Invalid JSON String
-      //   // needs to be formatted into JSON
-      //   // see also: https://stackoverflow.com/a/51556653/2043808
-      // )
+      slackSend(
+        message: brokenLinksMessage,
+        color: 'danger',
+        failOnError: true,
+        channel: 'cms-helpdesk-bot'
+        // attachments: brokenLinks
+        // TODO: errors out with ERROR: Slack notification failed with exception: net.sf.json.JSONException: Invalid JSON String
+        // needs to be formatted into JSON
+        // see also: https://stackoverflow.com/a/51556653/2043808
+      )
 
       // TODO: Move this slackUploadFile to cacheDrupalContent and update the echo statement above
       // TODO: determine correct file path relative to agent's workspace
@@ -225,7 +224,8 @@ def build(String ref, dockerContainer, String assetSource, String envName, Boole
 
       if (envName == 'vagovprod') {
         // Find any broken links in the log
-	      checkForBrokenLinks(buildLogPath, envName, contentOnlyBuild)
+        // @TODO: Add this feature back in post-release
+	      // checkForBrokenLinks(buildLogPath, envName, contentOnlyBuild)
         findMissingQueryFlags(buildLogPath, envName)
       }
 

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -174,6 +174,7 @@ def checkForBrokenLinks(String buildLogPath, String envName, Boolean contentOnly
       def brokenLinksCount = sh(returnStdout: true, script: "wc -l /application/${csvFileName} | cut -d ' ' -f1") as Integer
       def brokenLinksMessage = "${brokenLinksCount} broken links found in the `${envName}` build on `${env.BRANCH_NAME}`\n@cmshelpdesk\n${env.RUN_DISPLAY_URL}\n${brokenLinks}".stripMargin()
 
+      // @TODO: Add this feature back in post-release
       // slackSend(
       //   message: brokenLinksMessage,
       //   color: 'danger',

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -161,7 +161,7 @@ def checkForBrokenLinks(String buildLogPath, String envName, Boolean contentOnly
   // Output a csv file with the broken links
   sh "cd /application && jenkins/glean-broken-links.sh ${buildLogPath} ${csvFileName}"
   if (fileExists(csvFile)) {
-    echo "Found broken links."
+    echo "Found broken links (add slack alert back in after content-build release)."
 
     // Only break the build if broken links are found in master
     if (IS_PROD_BRANCH || contentOnlyBuild) {
@@ -174,16 +174,16 @@ def checkForBrokenLinks(String buildLogPath, String envName, Boolean contentOnly
       def brokenLinksCount = sh(returnStdout: true, script: "wc -l /application/${csvFileName} | cut -d ' ' -f1") as Integer
       def brokenLinksMessage = "${brokenLinksCount} broken links found in the `${envName}` build on `${env.BRANCH_NAME}`\n@cmshelpdesk\n${env.RUN_DISPLAY_URL}\n${brokenLinks}".stripMargin()
 
-      slackSend(
-        message: brokenLinksMessage,
-        color: 'danger',
-        failOnError: true,
-        channel: 'cms-helpdesk-bot'
-        // attachments: brokenLinks
-        // TODO: errors out with ERROR: Slack notification failed with exception: net.sf.json.JSONException: Invalid JSON String
-        // needs to be formatted into JSON
-        // see also: https://stackoverflow.com/a/51556653/2043808
-      )
+      // slackSend(
+      //   message: brokenLinksMessage,
+      //   color: 'danger',
+      //   failOnError: true,
+      //   channel: 'cms-helpdesk-bot'
+      //   // attachments: brokenLinks
+      //   // TODO: errors out with ERROR: Slack notification failed with exception: net.sf.json.JSONException: Invalid JSON String
+      //   // needs to be formatted into JSON
+      //   // see also: https://stackoverflow.com/a/51556653/2043808
+      // )
 
       // TODO: Move this slackUploadFile to cacheDrupalContent and update the echo statement above
       // TODO: determine correct file path relative to agent's workspace


### PR DESCRIPTION
CMS team is getting reports of broken link notifications from this repo. This is the only reference I could find to something that might cause that, so we're disabling is and seeing if that helps.

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/4636