### PR TITLE
Update paths used for searching entires & bundle url

### DIFF
--- a/src/site/layouts/tests/vamc/phone-number.unit.spec.js
+++ b/src/site/layouts/tests/vamc/phone-number.unit.spec.js
@@ -55,9 +55,7 @@ describe('phone-number', () => {
       const container = await renderHTML(layoutPath, data.numberWithExtension);
 
       expect(container.querySelector('a').innerHTML.trim()).to.equal(
-        `${data.numberWithExtension.number.fieldPhoneNumber}x ${
-          data.numberWithExtension.number.fieldPhoneExtension
-        }`,
+        `${data.numberWithExtension.number.fieldPhoneNumber}x ${data.numberWithExtension.number.fieldPhoneExtension}`,
       );
 
       expect(container.querySelector('a').getAttribute('aria-label')).to.equal(

--- a/src/site/stages/build/plugins/download-assets.js
+++ b/src/site/stages/build/plugins/download-assets.js
@@ -53,7 +53,7 @@ async function downloadFromLiveBucket(files, buildOptions) {
 
   const downloads = entryNames.map(async entryName => {
     let bundleFileName = fileManifest[entryName];
-    const bundleUrl = `${bundleFileName}`;
+    const bundleUrl = `${bucket}${bundleFileName}`;
     const bundleResponse = await fetch(bundleUrl);
 
     if (!bundleResponse.ok) {

--- a/src/site/stages/build/plugins/modify-dom/process-entry-names.js
+++ b/src/site/stages/build/plugins/modify-dom/process-entry-names.js
@@ -101,7 +101,7 @@ module.exports = {
           : fileSearch;
 
       // Ensure we have valid options and that the entry exists.
-      const entryExists = files[s3Search];
+      const entryExists = files[fileSearch];
 
       if (
         buildOptions.buildtype !== environments.LOCALHOST &&


### PR DESCRIPTION
### Description
This PR updates the path used for searching entries in the `process-entry-names.js` step of the Metalsmith pipeline. This needs to be changed because now the path values for files generated in the `file-manifest.json` do not contain the absolute URL. See https://s3-us-gov-west-1.amazonaws.com/apps.dev.va.gov/generated/file-manifest.json for reference.

The bundle URL in the `download-assets` step of the Metalsmith pipeline needs to be updated to use the s3 URL so that the fetch request for getting the assets is successful.