### PR TITLE
Add applications directory name option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ on VA.gov, you'll need to build these static pages using the following commands:
 `yarn build` (`—-pull-drupal` runs by default when cache is empty)
 
 - needs active socks proxy connection
-- creates symlink to `../vets-website/build/localhost/generated` allowing access to app bundles
+- creates symlink to `../vets-website/build/localhost/generated` by default, allowing access to app bundles (use `--apps-directory-name` to change the default apps directory name; e.g. `--apps-directory-name application`)
 - run once to pull and cache the latest Drupal content and build the static HTML files
 - need to run this again when adding new templates based on new Drupal entities (use `--pull-drupal` to fetch fresh content)
 

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -32,6 +32,7 @@ const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   { name: 'public', type: String, defaultValue: null },
   { name: 'destination', type: String, defaultValue: null },
   { name: 'asset-source', type: String, defaultValue: assetSources.LOCAL },
+  { name: 'apps-directory-name', type: String, defaultValue: 'vets-website' },
   { name: 'content-directory', type: String, defaultValue: defaultContentDir },
   { name: 'pull-drupal', type: Boolean, defaultValue: false },
   { name: 'use-cms-export', type: Boolean, defaultValue: false },

--- a/src/site/stages/build/plugins/create-symlink.js
+++ b/src/site/stages/build/plugins/create-symlink.js
@@ -4,8 +4,9 @@ const fs = require('fs-extra');
 const { createSymlink } = require('../../../../../script/utils');
 
 function createMetalSmithSymlink(options) {
+  const appsDirectoryName = options['apps-directory-name'];
   const basePath = `build/${options.buildtype}/generated`;
-  const vetsWebsiteGenPath = path.resolve('../vets-website/', basePath);
+  const vetsWebsiteGenPath = path.resolve(`../${appsDirectoryName}/`, basePath);
   const vetsWebsiteGenPathExists = fs.existsSync(vetsWebsiteGenPath);
   const destinationPath = path.join(__dirname, '../../../../../', basePath);
   const destinationPathExists = fs.existsSync(destinationPath);
@@ -16,10 +17,12 @@ function createMetalSmithSymlink(options) {
   } else {
     console.log(' ');
     console.log('/**');
-    console.error(' * ATTN: Cannot create symlink with vets-website.');
+    console.error(
+      ` * ATTN: Cannot create symlink with "${appsDirectoryName}".`,
+    );
     console.error(` * Path: ${vetsWebsiteGenPath} does not exist.`);
     console.error(
-      ' * Please run "yarn build" in vets-wesbite to create this directory.',
+      ` * Please run "yarn build" in "${appsDirectoryName}" to create this directory.`,
     );
     console.log(' */');
     console.log(' ');


### PR DESCRIPTION
Currently, the [create-symlink](https://github.com/department-of-veterans-affairs/content-build/blob/master/src/site/stages/build/plugins/create-symlink.js) plugin assumes the local directory name for applications is `vets-website`. This may not be the case for all instances.

This PR adds the build option `apps-directory-name`, which gives the option to specify the application's directory name. The default value is set to `vets-website`.

Other changes include:
- Update the `create-symlink` plugin to reference new build option
- Update documentation to include usage of new option

Testing done:
- Tested locally with and without the build option