### PR TITLE
Fix VAMC sidebars rendering on preview (#17057)

### DIFF
--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -318,7 +318,7 @@ def integrationTests(dockerContainer, ref) {
             )
           }
         } catch (error) {
-          slackIntegrationNotify()
+          // slackIntegrationNotify()
           throw error
         } finally {
           sh "docker-compose -p nightwatch-${env.EXECUTOR_NUMBER} down --remove-orphans"

--- a/src/site/navigation/facility_sidebar_nav.drupal.liquid
+++ b/src/site/navigation/facility_sidebar_nav.drupal.liquid
@@ -11,7 +11,10 @@
 {% assign deepLinks = deepLinksObj.link.links %}
 
 <script nonce="**CSP_NONCE**" type="text/javascript">
-    window.sideNav = {{ sidebarData | json }};
+    window.sideNav = {
+      rootPath: "{{ entityUrl.path }}/",
+      data: {{ sidebarData | json }},
+    };
 </script>
 
 {% comment %} React Widget located in `src/platform/site-wide/side-nav` {% endcomment %}


### PR DESCRIPTION
## Description
This PR adds support for the SideNav React component in the preview server, meaning previews of VAMC pages now have sidebars.

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/5236
https://github.com/department-of-veterans-affairs/va.gov-team/issues/21133
https://github.com/department-of-veterans-affairs/va.gov-team/issues/15710
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/5080

## Testing done
- Confirmed sidebar renders on http://localhost:3001/preview?nodeId=318
- Confirmed sidebar renders on http://localhost:3001/preview?nodeId=775

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/117015182-79600900-acbf-11eb-91f1-d56ea6c8e9bf.png)


## Acceptance criteria
- [ ] Previews of VAMC pages now have sidebars

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs


Signed-off-by: Tim Wright <timwright12@gmail.com>