### PR TITLE
Added breadcrumbs (#17096)

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1094,7 +1094,22 @@
     "rootUrl": "/housing-assistance/home-loans/apply-lgy-form-1880",
     "template": {
       "vagovprod": false,
-      "layout": "page-react.html"
+      "layout": "page-react.html",
+      "includeBreadcrumbs": true,
+      "breadcrumbs_override": [
+        {
+          "name": "Housing assistance",
+          "path": "/housing-assistance"
+        },
+        {
+          "name": "VA-backed home loans",
+          "path": "/housing-assistance/home-loans"
+        },
+        {
+          "name": "Apply for Certificate of Eligibility Form 26-1880",
+          "path": "/housing-assistance/home-loans/apply-lgy-form-1880"
+        }
+      ]
     }
   }
 ]


### PR DESCRIPTION
REPO SYNC FROM https://github.com/department-of-veterans-affairs/vets-website/pull/17096

## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/24262)

When we initially scaffolded the COE application we skipped adding breadcrumbs as the URLs for these were not available yet. This PR adds those breadcrumbs since we now know the URLs.

## Screenshots

<img width="820" alt="Screen Shot 2021-05-05 at 4 09 54 PM" src="https://user-images.githubusercontent.com/1899695/117220601-64b56b00-adbc-11eb-8961-ce8ec56a2cab.png">

## Acceptance criteria
- [x] The COE feature has breadcrumbs
