### PR TITLE
Experiment: add Chai assertion for aXe check #17110

### DIFF
--- a/src/platform/testing/unit/axe-plugin.js
+++ b/src/platform/testing/unit/axe-plugin.js
@@ -1,0 +1,49 @@
+module.exports = function(chai, utils) {
+  const axe = require('axe-core');
+  const Assertion = chai.Assertion;
+
+  utils.addMethod(chai.Assertion.prototype, 'accessible', function(
+    rules = {},
+    rulesets = ['section508', 'wcag2a', 'wcag2aa', 'best-practice'],
+  ) {
+    const el = this._obj;
+    const config = {
+      runOnly: {
+        type: 'tag',
+        values: rulesets,
+      },
+      rules: {
+        region: { enabled: false },
+        ...rules,
+      },
+    };
+    return new Promise((resolve, reject) => {
+      axe.run(el, config, (err, result) => {
+        if (err) {
+          reject(err);
+        }
+
+        const violations = result.violations?.map(violation => {
+          const nodeInfo = violation.nodes.reduce((str, node) => {
+            const { html, target } = node;
+            return [str, html, ...target].join('\n');
+          }, '');
+
+          return `[${violation.impact}] ${violation.help}
+See ${violation.helpUrl}
+${nodeInfo}`;
+        });
+
+        try {
+          new Assertion('axe').assert(
+            !violations?.length,
+            violations.join('\n\n'),
+          );
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+  });
+};

--- a/src/platform/testing/unit/mocha-setup.js
+++ b/src/platform/testing/unit/mocha-setup.js
@@ -12,6 +12,7 @@ import { JSDOM } from 'jsdom';
 import '../../site-wide/moment-setup';
 import ENVIRONMENTS from 'site/constants/environments';
 import * as Sentry from '@sentry/browser';
+import chaiAxe from './axe-plugin';
 
 import { sentryTransport } from './sentry';
 
@@ -155,6 +156,10 @@ function setupJSDom() {
 } // end setupJSDom()
 
 setupJSDom();
+
+// This needs to be after JSDom has been setup, otherwise
+// axe has strange issues with globals not being set up
+chai.use(chaiAxe);
 
 export const mochaHooks = {
   beforeEach() {


### PR DESCRIPTION
## Description
It's hard to test all variations of a page in Cypress, so this makes it easier to use the axe check in a unit test, against elements rendered in JSDom.

## Testing done
Ran unit tests

## Screenshots
![Screen Shot 2021-05-06 at 11 42 19 AM](https://user-images.githubusercontent.com/634932/117327466-a0097580-ae60-11eb-8c16-a61a324771f7.png)


## Acceptance criteria
- [ ] VSP is happy with the change

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
