### PR TITLE
Enable broken link checker

### DIFF
--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -271,7 +271,7 @@ def build(String ref, dockerContainer, String assetSource, String envName, Boole
       sh "cd ${buildPath} && jenkins/build.sh --envName ${envName} --assetSource ${assetSource} --drupalAddress ${drupalAddress} --drupalMaxParallelRequests ${drupalMaxParallelRequests} ${drupalMode} ${noDrupalProxy} --buildLog ${buildLogPath} --verbose ${localhostBuild}"
 
       if (envName == 'vagovprod') {
-	checkForBrokenLinks(buildLogPath, envName, contentOnlyBuild)
+        checkForBrokenLinks(buildLogPath, envName, contentOnlyBuild)
         findMissingQueryFlags(buildLogPath, envName)
       }
 

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -271,9 +271,7 @@ def build(String ref, dockerContainer, String assetSource, String envName, Boole
       sh "cd ${buildPath} && jenkins/build.sh --envName ${envName} --assetSource ${assetSource} --drupalAddress ${drupalAddress} --drupalMaxParallelRequests ${drupalMaxParallelRequests} ${drupalMode} ${noDrupalProxy} --buildLog ${buildLogPath} --verbose ${localhostBuild}"
 
       if (envName == 'vagovprod') {
-        // Find any broken links in the log
-        // @TODO: Add this feature back in post-release
-	      // checkForBrokenLinks(buildLogPath, envName, contentOnlyBuild)
+	checkForBrokenLinks(buildLogPath, envName, contentOnlyBuild)
         findMissingQueryFlags(buildLogPath, envName)
       }
 


### PR DESCRIPTION
## Description
Broken link checker should be turned back on now, I think. We're missing broken link reports.

See thread, https://dsva.slack.com/archives/C0MQ281DJ/p1620841640457600

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
