### PR TITLE
Fix broken link checker for filenames with commas

### DIFF
--- a/src/site/stages/build/plugins/modify-dom/check-broken-links/helpers/isBrokenLink.js
+++ b/src/site/stages/build/plugins/modify-dom/check-broken-links/helpers/isBrokenLink.js
@@ -22,7 +22,7 @@ function isBrokenLink(link, pagePath, allPaths) {
     return false;
   }
 
-  let filePath = decodeURI(parsed.pathname);
+  let filePath = decodeURIComponent(parsed.pathname);
 
   if (path.isAbsolute(filePath)) {
     filePath = path.join('.', filePath);


### PR DESCRIPTION
## Description

The image at https://www.va.gov/img/styles/2_3_medium_thumbnail/public/2021-05/Gann%2C%20Dottie.JPG is present on disk, but generating broken link errors in pages that reference it, because `%2C` is not decoded to `,` by the broken link checker. This PR switches from using `decodeURI` to `decodeURIComponent` as we are in fact decoding a URI component, and correctly (I believe) decodes `%2C` to `,`.

More background is available in [this slack thread](https://dsva.slack.com/archives/C0MQ281DJ/p1620841640457600).

## Testing done

Manual testing on tugboat CI.

## Acceptance criteria
- [ ] Images with `,` characters in their filenames do not cause spurious broken link errors

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
