### PR TITLE
Remove extra wrapping div for extra categories

### DIFF
--- a/src/site/paragraphs/lists_of_links.drupal.liquid
+++ b/src/site/paragraphs/lists_of_links.drupal.liquid
@@ -35,47 +35,51 @@
   {% endfor %}
 
   <!-- Extra Categories -->
-  <div aria-hidden="true" class="vads-u-display--none vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row medium-screen:vads-u-flex-wrap--wrap" data-hidden-lists_of_links-entity-id="{{ entity.entityId }}">
-    {% for vaParagraph in formattedVaParagraphs %}
-      {% if forloop.index > 6 %}
-        <div class="vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-l-col--3 medium-screen:vads-u-margin-right--8">
-          <!-- Section header -->
-          <h3>{{ vaParagraph.entity.fieldSectionHeader }}</h3>
+  {% for vaParagraph in formattedVaParagraphs %}
+    {% if forloop.index > 6 %}
+      <div
+        aria-hidden="true"
+        class="vads-u-display--none vads-u-flex-direction--column medium-screen:vads-l-col--3 medium-screen:vads-u-margin-right--8"
+        data-hidden-lists_of_links-entity-id="{{ entity.entityId }}"
+      >
+        <!-- Section header -->
+        <h3>{{ vaParagraph.entity.fieldSectionHeader }}</h3>
 
-          <ul class="usa-unstyled-list">
-            <!-- Links -->
-            {% for fieldLink in vaParagraph.entity.fieldLinks %}
-              <li class="vads-u-padding-y--1">
-                <a href="{{ fieldLink.url.path }}" rel="noreferrer noopener">
-                  {{ fieldLink.title }}
-                </a>
-              </li>
-            {% endfor %}
+        <ul class="usa-unstyled-list">
+          <!-- Links -->
+          {% for fieldLink in vaParagraph.entity.fieldLinks %}
+            <li class="vads-u-padding-y--1">
+              <a href="{{ fieldLink.url.path }}" rel="noreferrer noopener">
+                {{ fieldLink.title }}
+              </a>
+            </li>
+          {% endfor %}
 
-            <!-- See more articles link -->
-            {% if vaParagraph.entity.fieldLink.url.path %}
-              <li class="vads-u-padding-y--1">
-                <a class="vads-u-text-decoration--none" href="{{ vaParagraph.entity.fieldLink.url.path }}" rel="noreferrer noopener">
-                  {{ vaParagraph.entity.fieldLink.title }} <i class="fa fa-chevron-right vads-u-padding-left--0p5 vads-u-font-size--sm" aria-hidden="true" role="presentation"></i>
-                </a>
-              </li>
-            {% endif %}
-          </ul>
-        </div>
-      {% endif %}
-    {% endfor %}
-  </div>
+          <!-- See more articles link -->
+          {% if vaParagraph.entity.fieldLink.url.path %}
+            <li class="vads-u-padding-y--1">
+              <a class="vads-u-text-decoration--none" href="{{ vaParagraph.entity.fieldLink.url.path }}" rel="noreferrer noopener">
+                {{ vaParagraph.entity.fieldLink.title }} <i class="fa fa-chevron-right vads-u-padding-left--0p5 vads-u-font-size--sm" aria-hidden="true" role="presentation"></i>
+              </a>
+            </li>
+          {% endif %}
+        </ul>
+      </div>
+    {% endif %}
+  {% endfor %}
 </div>
 
 {% if formattedVaParagraphs.length > 6 %}
   <script>
     function onShowAllTopics() {
       // Derive the extra paragraphs element.
-      var extraParagraphsElement = document.querySelector('[data-hidden-lists_of_links-entity-id="{{ entity.entityId }}"]');
+      var extraParagraphsElements = document.querySelectorAll('[data-hidden-lists_of_links-entity-id="{{ entity.entityId }}"]');
 
       // Show the remaining categories.
-      extraParagraphsElement.setAttribute('aria-hidden', 'false');
-      extraParagraphsElement.className = extraParagraphsElement.className.replace(/vads-u-display--none/, 'vads-u-display--flex');
+      extraParagraphsElements.forEach(function(extraParagraphsElement) {
+        extraParagraphsElement.setAttribute('aria-hidden', 'false');
+        extraParagraphsElement.className = extraParagraphsElement.className.replace(/vads-u-display--none/, 'vads-u-display--flex');
+      })
 
       // Derive the show all topics button element.
       var showAllTopicsElement = document.querySelector('[data-show-all-topics-button-lists_of_links-entity-id="{{ entity.entityId }}"]');


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/24667

This PR fixes the styling of extra category columns on `/resources`.

## Testing done
Locally tested at http://localhost:3002/preview?nodeId=8296 when running `yarn build --pull-drupal && yarn preview`

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/118146946-5541ad80-b3cc-11eb-9cb6-15230f5f54f4.png)

![image](https://user-images.githubusercontent.com/12773166/118146979-5d015200-b3cc-11eb-9682-3a1e4cc0d5d0.png)

## Acceptance criteria
- [x] Remove extra wrapping div

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
