### PR TITLE
Revert bucket url to old url

### DIFF
--- a/src/site/constants/buckets.js
+++ b/src/site/constants/buckets.js
@@ -7,8 +7,8 @@ const {
 
 const prodBucket = 'https://prod-va-gov-assets.s3-us-gov-west-1.amazonaws.com';
 const stagingBucket =
-  'https://s3-us-gov-west-1.amazonaws.com/apps.staging.va.gov';
-const devBucket = 'https://s3-us-gov-west-1.amazonaws.com/apps.dev.va.gov';
+  'https://staging-va-gov-assets.s3-us-gov-west-1.amazonaws.com';
+const devBucket = 'https://dev-va-gov-assets.s3-us-gov-west-1.amazonaws.com';
 
 module.exports = {
   [VAGOVDEV]: devBucket,


### PR DESCRIPTION
## Description
Update bucket URL to use old URL.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
