### PR TITLE
Add heading and click text to zone one links

### DIFF
--- a/src/site/layouts/home.drupal.liquid
+++ b/src/site/layouts/home.drupal.liquid
@@ -14,12 +14,15 @@
         <div class="hub-links-container" data-e2e="bucket">
           <h2 class="heading-level-3 hub-links-title"><i class="icon-large-baseline icon-heading hub-icon-{{ card.label | downcase | replace: ' ', '-' }} hub-color-{{ card.label | downcase | replace: ' ', '-' }}"></i>{{ card.label }}</h2>
           <ul class="hub-links-list">
+            {% assign card_label = card.label %}
             {% for link in card.links %}
               <li>
                 <a href="{{ link.url.path }}"
                   onclick="recordEvent({
                     event: 'nav-zone-one',
                     'nav-path': '->{% if link.url.path != empty %}{{ link.url.path }}{% else %}{{ link.label }}{% endif %}',
+                    'click-text': '{{ link.label | strip }}',
+                    heading: '{{ card_label | strip }}',
                   });"
                   >
                   {{ link.label }}


### PR DESCRIPTION
## Description

(Originally in https://github.com/department-of-veterans-affairs/vets-website/pull/17033)

For:  https://github.com/department-of-veterans-affairs/va.gov-team/issues/24078

> The "Zone One" links on the home page only record the click URL.
> `Navigation - Zone One - ->/claim-or-appeal-status`
> Because we have several links that share URLs (and Click Text even), we need to add Click Text and Heading to differentiate.

## Testing done


## Screenshots

![image](https://user-images.githubusercontent.com/62304138/116767569-0163bb80-a9ff-11eb-8ac4-0718de7c77df.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
