### PR TITLE
Remove the linkAssetsToBucketCSS function

### DIFF
--- a/src/site/stages/prearchive/link-assets-to-bucket.js
+++ b/src/site/stages/prearchive/link-assets-to-bucket.js
@@ -33,21 +33,6 @@ function linkAssetsToBucketHTML(options, fileNames, bucketPath) {
   });
 }
 
-function linkAssetsToBucketCSS(fileNames, bucketPath) {
-  const cssFileNames = fileNames.filter(file => path.extname(file) === '.css');
-  const cssUrlRegex = new RegExp(/url\(\/(?!(va_files))/, 'g');
-  const cssUrlBucket = `url(${bucketPath}/`;
-
-  for (const cssFileName of cssFileNames) {
-    const cssFile = fs.readFileSync(cssFileName);
-    const css = cssFile.toString();
-
-    const newCss = css.replace(cssUrlRegex, cssUrlBucket);
-
-    fs.writeFileSync(cssFileName, newCss);
-  }
-}
-
 function linkAssetsToBucketProxyRewrite(fileNames, bucketPath) {
   // The proxy-rewrite is a special case.
   const proxyRewriteFileName = fileNames.find(file =>
@@ -68,7 +53,6 @@ function linkAssetsToBucket(options, fileNames) {
   if (!bucketPath) return;
 
   linkAssetsToBucketHTML(options, fileNames, bucketPath);
-  linkAssetsToBucketCSS(fileNames, bucketPath);
   linkAssetsToBucketProxyRewrite(fileNames, bucketPath);
 }
 


### PR DESCRIPTION
## Description
Since we are now [setting the public path for CSS assets](https://github.com/department-of-veterans-affairs/vets-website/pull/17200) in vets-website, we no longer need the `linkAssetsToBucketCSS`function in the Prearchive script.

## Testing done
Tested in CI.

## Screenshots


## Acceptance criteria
- [ ] The Prearchive stage of the pipeline should not set the public path for CSS assets.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
