### PR TITLE
Fix broken links logfile location

### DIFF
--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -197,7 +197,7 @@ def accessibilityTests() {
 }
 
 def checkForBrokenLinks(String buildLogPath, String envName, Boolean contentOnlyBuild) {
-  def brokenLinksFile = "${WORKSPACE}/vets-website/logs/${envName}-broken-links.json"
+  def brokenLinksFile = "${WORKSPACE}/content-build/logs/${envName}-broken-links.json"
 
   if (fileExists(brokenLinksFile)) {
     def rawJsonFile = readFile(brokenLinksFile);


### PR DESCRIPTION
## Description

The broken link slack notification is not working, I believe because the logfile path is incorrect.

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
