### PR TITLE
Handle paths with bucket url

### DIFF
--- a/src/site/constants/buckets.js
+++ b/src/site/constants/buckets.js
@@ -7,8 +7,8 @@ const {
 
 const prodBucket = 'https://prod-va-gov-assets.s3-us-gov-west-1.amazonaws.com';
 const stagingBucket =
-  'https://staging-va-gov-assets.s3-us-gov-west-1.amazonaws.com';
-const devBucket = 'https://dev-va-gov-assets.s3-us-gov-west-1.amazonaws.com';
+  'https://s3-us-gov-west-1.amazonaws.com/apps.staging.va.gov';
+const devBucket = 'https://s3-us-gov-west-1.amazonaws.com/apps.dev.va.gov';
 
 module.exports = {
   [VAGOVDEV]: devBucket,

--- a/src/site/constants/buckets.js
+++ b/src/site/constants/buckets.js
@@ -7,7 +7,7 @@ const {
 
 const prodBucket = 'https://prod-va-gov-assets.s3-us-gov-west-1.amazonaws.com';
 const stagingBucket =
-  'https://s3-us-gov-west-1.amazonaws.com/apps.staging.va.gov';
+  'https://staging-va-gov-assets.s3-us-gov-west-1.amazonaws.com';
 const devBucket = 'https://s3-us-gov-west-1.amazonaws.com/apps.dev.va.gov';
 
 module.exports = {

--- a/src/site/stages/build/plugins/download-assets.js
+++ b/src/site/stages/build/plugins/download-assets.js
@@ -54,7 +54,9 @@ async function downloadFromLiveBucket(files, buildOptions) {
 
   const downloads = entryNames.map(async entryName => {
     let bundleFileName = fileManifest[entryName];
-    const bundleUrl = `${bucket}${bundleFileName}`;
+    const bundleUrl = bundleFileName.includes(`${bucket}`)
+      ? `${bundleFileName}`
+      : `${bucket}${bundleFileName}`;
     const bundleResponse = await fetch(bundleUrl);
 
     if (bundleFileName.includes('generated/../')) {

--- a/src/site/stages/build/plugins/download-assets.js
+++ b/src/site/stages/build/plugins/download-assets.js
@@ -54,7 +54,7 @@ async function downloadFromLiveBucket(files, buildOptions) {
 
   const downloads = entryNames.map(async entryName => {
     let bundleFileName = fileManifest[entryName];
-    const bundleUrl = bundleFileName.includes(`${bucket}`)
+    const bundleUrl = bundleFileName.includes('https')
       ? `${bundleFileName}`
       : `${bucket}${bundleFileName}`;
     const bundleResponse = await fetch(bundleUrl);

--- a/src/site/stages/build/plugins/modify-dom/process-entry-names.js
+++ b/src/site/stages/build/plugins/modify-dom/process-entry-names.js
@@ -108,7 +108,8 @@ module.exports = {
       // Assemble the filename so we can match it in the generated files array.
       const fileSearch = `generated/${hashedEntryName.split('/generated/')[1]}`;
       const s3Search =
-        buildOptions.buildtype !== environments.LOCALHOST
+        buildOptions.buildtype !== environments.LOCALHOST &&
+        !fileSearch.includes('https')
           ? `${buckets[buildOptions.buildtype]}/${fileSearch}`
           : fileSearch;
 

--- a/src/site/stages/build/plugins/modify-dom/process-entry-names.js
+++ b/src/site/stages/build/plugins/modify-dom/process-entry-names.js
@@ -114,7 +114,7 @@ module.exports = {
           : fileSearch;
 
       // Ensure we have valid options and that the entry exists.
-      const entryExists = files[fileSearch];
+      const entryExists = files[fileSearch] || files[s3Search];
 
       if (
         buildOptions.buildtype !== environments.LOCALHOST &&


### PR DESCRIPTION
## Description
We want the content build to be able to download assets with or without the S3 paths in the name.
Slack thread: https://dsva.slack.com/archives/C01S39QMSSV/p1620936974267300
## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
