### PR TITLE
Lambda Function to cache non-node content

### DIFF
--- a/.github/workflows/non-node-content.yml
+++ b/.github/workflows/non-node-content.yml
@@ -52,17 +52,17 @@ jobs:
 
       - name: Generate and upload content cache function
         run: |
-          yarn webpack --config config/webpack.non-node-content.js
+          yarn webpack --config config/webpack.non-node-content-cache.js
           mkdir -p ./tmp
-          zip -j ./tmp/function.zip build/non-node-content/index.js
-          aws s3 cp ./tmp/function.zip s3://vetsgov-website-builds-s3-upload/non-node-content/master/function.zip --acl public-read
+          zip -j ./tmp/function.zip build/non-node-content-cache/index.js
+          aws s3 cp ./tmp/function.zip s3://vetsgov-website-builds-s3-upload/non-node-content-cache/master/function.zip --acl public-read
 
       - name: Update content cache function
         run: >
           aws lambda update-function-code
           --function-name cacheNonNodeContent
           --s3-bucket vetsgov-website-builds-s3-upload
-          --s3-key non-node-content/master/function.zip
+          --s3-key non-node-content-cache/master/function.zip
 
       - name: Invoke content cache function
         run: aws lambda invoke --function-name cacheNonNodeContent outfile.txt

--- a/.github/workflows/non-node-content.yml
+++ b/.github/workflows/non-node-content.yml
@@ -1,0 +1,68 @@
+name: Non-Node Content Lambda Deploy
+
+on: [push]
+
+jobs:
+  non-node-content-cache:
+    name: Non-Node Content Cache
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v2
+
+      - name: Configure AWS Credentials (1)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Get bot token from Parameter Store
+        uses: marvinpinto/action-inject-ssm-secrets@latest
+        with:
+          ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
+          env_variable_name: AWS_FRONTEND_NONPROD_ROLE
+
+      - name: Configure AWS Credentials (2)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+          role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
+          role-duration-seconds: 1200
+          role-session-name: vsp-frontendteam-githubaction
+
+      - name: Cache dependencies
+        id: cache-dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/yarn
+            node_modules
+          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --prefer-offline
+        env:
+          YARN_CACHE_FOLDER: ~/.cache/yarn
+
+      - name: Generate and upload content cache function
+        run: |
+          yarn webpack --config config/webpack.non-node-content.js
+          mkdir -p ./tmp
+          zip -j ./tmp/function.zip build/non-node-content/index.js
+          aws s3 cp ./tmp/function.zip s3://vetsgov-website-builds-s3-upload/non-node-content/master/function.zip --acl public-read
+
+      - name: Update content cache function
+        run: >
+          aws lambda update-function-code
+          --function-name cacheNonNodeContent
+          --s3-bucket vetsgov-website-builds-s3-upload
+          --s3-key non-node-content/master/function.zip
+
+      - name: Invoke content cache function
+        run: aws lambda invoke --function-name cacheNonNodeContent outfile.txt

--- a/config/webpack.non-node-content-cache.js
+++ b/config/webpack.non-node-content-cache.js
@@ -1,0 +1,27 @@
+const path = require('path');
+const webpack = require('webpack');
+
+const root = path.resolve(__dirname, '..');
+
+module.exports = {
+  entry: path.join(root, 'src', 'platform', 'lambdas', 'non-node-content-cache.js'),
+  output: {
+    path: path.join(root, 'build', 'non-node-content-cache'),
+    filename: 'index.js',
+    libraryTarget: 'commonjs',
+  },
+  target: 'node',
+  node: { __dirname: true },
+  plugins: [
+    new webpack.IgnorePlugin(/process-cms-exports$/),
+    new webpack.DefinePlugin({ 'process.env.CONTENT_CACHE_FUNCTION': true }),
+  ],
+  optimization: {
+    // Disabling minimization to avoid errors from parsing optional chaining,
+    // which our current versions of Terser + Webpack don't support.
+    minimize: false,
+  },
+  externals: {
+    'aws-sdk/clients/s3': 'commonjs2 aws-sdk/clients/s3',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -196,6 +196,7 @@
     "sinon": "^3.2.1",
     "socks-proxy-agent": "^5.0.0",
     "webpack": "^4.43.0",
+    "webpack-cli": "^4.7.0",
     "webpack-dev-server": "^3.11.0",
     "yeoman-generator": "^4.2.0"
   },

--- a/src/platform/lambdas/non-node-content-cache.js
+++ b/src/platform/lambdas/non-node-content-cache.js
@@ -1,0 +1,65 @@
+/* eslint-disable no-console */
+
+const S3 = require('aws-sdk/clients/s3'); // eslint-disable-line import/no-unresolved
+
+const getOptions = require('../../site/stages/build/options');
+const getDrupalClient = require('../../site/stages/build/drupal/api');
+
+const nonNodeContent = require('../../site/stages/build/drupal/non-node-content');
+
+const DRUPAL_ADDRESS =
+  'http://internal-dsva-vagov-prod-cms-2000800896.us-gov-west-1.elb.amazonaws.com';
+
+/* eslint-enable no-await-in-loop */
+
+exports.handler = async function(event, context) {
+  console.log(`Event: ${JSON.stringify(event, null, 2)}`);
+  console.log(`Context: ${JSON.stringify(context, null, 2)}`);
+
+  const options = await getOptions({
+    'drupal-address': DRUPAL_ADDRESS,
+    'no-drupal-proxy': true,
+    'pull-drupal': true,
+  });
+
+  let content = { data: {} };
+
+  try {
+    console.log('Initializing Drupal client...');
+    const contentApi = getDrupalClient(options);
+    console.log('Fetching Non-Node Drupal content...');
+    content = await nonNodeContent.getNonNodeContent(contentApi);
+    console.log('Successfully fetched Non-Node Drupal content!');
+  } catch (error) {
+    console.error('Failed to fetch Drupal content.');
+    throw new Error(error);
+  }
+
+  if (content.errors && content.errors.length) {
+    console.log(JSON.stringify(content.errors, null, 2));
+    throw new Error('Drupal query returned with errors');
+  }
+
+  console.log('Stringifying the data...');
+  const pagesString = JSON.stringify(content, null, 2);
+
+  console.log('Uploading the cache...');
+  const s3 = new S3();
+  const request = s3.upload({
+    Body: pagesString,
+    Bucket: nonNodeContent.S3_BUCKET,
+    Key: nonNodeContent.S3_KEY,
+  });
+
+  let response = null;
+
+  try {
+    response = await request.promise();
+    console.log('Successfully uploaded the cache!');
+  } catch (error) {
+    console.error('Failed to upload the cache.');
+    throw new Error(error);
+  }
+
+  return response;
+};

--- a/src/site/stages/build/drupal/api.js
+++ b/src/site/stages/build/drupal/api.js
@@ -2,7 +2,7 @@ const path = require('path');
 const fs = require('fs-extra');
 const tar = require('tar-fs');
 const moment = require('moment');
-const fetch = require('node-fetch');
+const fetch = require('node-fetch').default;
 const chalk = require('chalk');
 const SocksProxyAgent = require('socks-proxy-agent');
 
@@ -14,11 +14,18 @@ const {
   CountEntityTypes,
 } = require('./individual-queries');
 
-const {
-  readAllNodeNames,
-  readEntity,
-} = require('../process-cms-exports/helpers');
-const entityTreeFactory = require('../process-cms-exports');
+// Using a global variable from the Webpack config, skip unnecessary requires
+// for CMS transformers code when building the content cache function.
+// eslint-disable-next-line no-undef
+const CONTENT_CACHE_FUNCTION = process.env.CONTENT_CACHE_FUNCTION;
+
+const { readAllNodeNames, readEntity } = CONTENT_CACHE_FUNCTION
+  ? {}
+  : require('../process-cms-exports/helpers');
+
+const entityTreeFactory = CONTENT_CACHE_FUNCTION
+  ? () => {}
+  : require('../process-cms-exports');
 
 function encodeCredentials({ user, password }) {
   const credentials = `${user}:${password}`;

--- a/src/site/stages/build/drupal/non-node-content.js
+++ b/src/site/stages/build/drupal/non-node-content.js
@@ -1,0 +1,39 @@
+/* eslint-disable no-console */
+
+const {
+  nonNodeQueries,
+} = require('individual-queries');
+
+const S3_BUCKET = 'vetsgov-website-builds-s3-upload';
+const S3_KEY = 'non-node-content-cache/master/non-node-content.json';
+
+/**
+ * Pulls all of the non-node content from Drupal.
+ *
+ * @returns {Promise<{data: {}}>}
+ */
+async function getNonNodeContent(drupalClient, refreshProgress = 0) {
+  const freshNonNodeContent = { data: {} };
+  const queries = Object.entries(nonNodeQueries());
+
+  console.time('Node-node queries');
+  for (const [queryName, query] of queries) {
+    console.time(queryName);
+
+    // eslint-disable-next-line no-await-in-loop
+    const json = await drupalClient.query({ query });
+    Object.assign(freshNonNodeContent.data, json.data);
+    console.timeEnd(queryName);
+
+    refreshProgress += 1 / queries.length;
+  }
+
+  console.timeEnd('Node-node queries');
+  return freshNonNodeContent;
+}
+
+module.exports = {
+  getNonNodeContent,
+  S3_KEY,
+  S3_BUCKET
+};

--- a/src/site/stages/build/drupal/queries.js
+++ b/src/site/stages/build/drupal/queries.js
@@ -1,15 +1,15 @@
 const queries = {
-  GET_ALL_PAGES: './graphql/GetAllPages.graphql',
-  GET_LATEST_PAGE_BY_ID: './graphql/GetLatestPageById.graphql',
+  GET_ALL_PAGES: 'GetAllPages.graphql',
+  GET_LATEST_PAGE_BY_ID: 'GetLatestPageById.graphql',
 };
 
 function getQuery(query, { useTomeSync } = {}) {
   if (query === queries.GET_ALL_PAGES) {
     // eslint-disable-next-line import/no-dynamic-require
-    return require(query)({ useTomeSync });
+    return require(`./graphql/${query}`)({ useTomeSync });
   }
   // eslint-disable-next-line import/no-dynamic-require
-  return require(query);
+  return require(`./graphql/${query}`)({ useTomeSync });
 }
 
 module.exports = {

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -78,7 +78,9 @@ const COMMAND_LINE_OPTIONS_DEFINITIONS = [
 ];
 
 function gatherFromCommandLine() {
-  const options = commandLineArgs(COMMAND_LINE_OPTIONS_DEFINITIONS);
+  const projectRoot = process.env.CONTENT_CACHE_FUNCTION
+    ? '/tmp' // The Lambda environment can only write to /tmp.
+    : path.resolve(__dirname, '../../../../');
 
   // Set defaults which require the value of other options
   options['cms-export-dir'] =
@@ -238,7 +240,10 @@ async function setUpFeatureFlags(options) {
 }
 
 async function getOptions(commandLineOptions) {
-  const options = commandLineOptions || gatherFromCommandLine();
+  const options = {
+    ...gatherFromCommandLine(),
+    ...commandLineOptions,
+  };
 
   applyDefaultOptions(options);
   applyEnvironmentOverrides(options);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1000,6 +1000,11 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
+"@discoveryjs/json-ext@^0.5.0":
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.3.tgz#90420f9f9c6d3987f176a19a7d8e764271a2f55d"
+  integrity sha512-Fxt+AfXgjMoin2maPIYzFZnQjAXjAL0PHscM5pRTtatFqB+vZxAM9tLp2Optnuw3QOQC40jTNeGYFOMvyf7v9g==
+
 "@eslint/eslintrc@^0.2.2":
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.2.2.tgz#d01fc791e2fc33e88a29d6f3dc7e93d0cd784b76"
@@ -1644,6 +1649,23 @@
     "@webassemblyjs/ast" "1.9.0"
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
+
+"@webpack-cli/configtest@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/configtest/-/configtest-1.0.3.tgz#204bcff87cda3ea4810881f7ea96e5f5321b87b9"
+  integrity sha512-WQs0ep98FXX2XBAfQpRbY0Ma6ADw8JR6xoIkaIiJIzClGOMqVRvPCWqndTxf28DgFopWan0EKtHtg/5W1h0Zkw==
+
+"@webpack-cli/info@^1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/info/-/info-1.2.4.tgz#7381fd41c9577b2d8f6c2594fad397ef49ad5573"
+  integrity sha512-ogE2T4+pLhTTPS/8MM3IjHn0IYplKM4HbVNMCWA9N4NrdPzunwenpCsqKEXyejMfRu6K8mhauIPYf8ZxWG5O6g==
+  dependencies:
+    envinfo "^7.7.3"
+
+"@webpack-cli/serve@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.4.0.tgz#f84fd07bcacefe56ce762925798871092f0f228e"
+  integrity sha512-xgT/HqJ+uLWGX+Mzufusl3cgjAcnqYYskaB7o0vRcwOEfuu6hMzSILQpnIzFMGsTaeaX4Nnekl+6fadLbl1/Vg==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -3437,6 +3459,11 @@ commander@^5.1.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
 
+commander@^7.0.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
+  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
+
 common-tags@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.0.tgz#8e3153e542d4a39e9b10554434afaaf98956a937"
@@ -3695,7 +3722,7 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.2:
+cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -4540,6 +4567,11 @@ entities@^2.0.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.1.0.tgz#992d3129cf7df6870b96c57858c249a120f8b8b5"
   integrity sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==
 
+envinfo@^7.7.3:
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.8.1.tgz#06377e3e5f4d379fea7ac592d5ad8927e0c4d475"
+  integrity sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==
+
 enzyme-adapter-react-16@^1.15.2:
   version "1.15.5"
   resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.15.5.tgz#7a6f0093d3edd2f7025b36e7fbf290695473ee04"
@@ -5247,6 +5279,21 @@ execa@^4.0.0, execa@^4.0.2:
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
+execa@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-5.0.0.tgz#4029b0007998a841fbd1032e5f4de86a3c1e3376"
+  integrity sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==
+  dependencies:
+    cross-spawn "^7.0.3"
+    get-stream "^6.0.0"
+    human-signals "^2.1.0"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.1"
+    onetime "^5.1.2"
+    signal-exit "^3.0.3"
+    strip-final-newline "^2.0.0"
+
 executable@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/executable/-/executable-4.1.1.tgz#41532bff361d3e57af4d763b70582db18f5d133c"
@@ -5477,6 +5524,11 @@ fast-xml-parser@^3.19.0:
   version "3.19.0"
   resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz#cb637ec3f3999f51406dd8ff0e6fc4d83e520d01"
   integrity sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==
+
+fastest-levenshtein@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz#9990f7d3a88cc5a9ffd1f1745745251700d497e2"
+  integrity sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==
 
 fastq@^1.6.0:
   version "1.9.0"
@@ -6058,6 +6110,11 @@ get-stream@^5.0.0, get-stream@^5.1.0:
   integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
   dependencies:
     pump "^3.0.0"
+
+get-stream@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
+  integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
 get-uri@2:
   version "2.0.4"
@@ -6649,6 +6706,11 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
+human-signals@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
+  integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -6710,6 +6772,14 @@ import-local@^2.0.0:
   dependencies:
     pkg-dir "^3.0.0"
     resolve-cwd "^2.0.0"
+
+import-local@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/import-local/-/import-local-3.0.2.tgz#a8cfd0431d1de4a2199703d003e3e62364fa6db6"
+  integrity sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==
+  dependencies:
+    pkg-dir "^4.2.0"
+    resolve-cwd "^3.0.0"
 
 import-modules@^2.0.0:
   version "2.0.0"
@@ -6840,6 +6910,11 @@ interpret@^1.0.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
+interpret@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
+  integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
+
 invariant@^2.2.2:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
@@ -6950,6 +7025,13 @@ is-core-module@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.2.0.tgz#97037ef3d52224d85163f5597b2b63d9afed981a"
   integrity sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==
+  dependencies:
+    has "^1.0.3"
+
+is-core-module@^2.2.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.4.0.tgz#8e9fc8e15027b011418026e98f0e6f4d86305cc1"
+  integrity sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==
   dependencies:
     has "^1.0.3"
 
@@ -9290,7 +9372,7 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-npm-run-path@^4.0.0:
+npm-run-path@^4.0.0, npm-run-path@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
@@ -9504,7 +9586,7 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-onetime@^5.1.0:
+onetime@^5.1.0, onetime@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
@@ -9995,7 +10077,7 @@ pkg-dir@^3.0.0:
   dependencies:
     find-up "^3.0.0"
 
-pkg-dir@^4.1.0:
+pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
@@ -10580,6 +10662,13 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
+rechoir@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.7.0.tgz#32650fd52c21ab252aa5d65b19310441c7e03aca"
+  integrity sha512-ADsDEH2bvbjltXEP+hTIAmeFekTFK0V2BTxMkok6qILyAJEXV0AFfoWcAq4yfll5VdIMd/RVXq0lR+wQi5ZU3Q==
+  dependencies:
+    resolve "^1.9.0"
+
 recursive-readdir@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/recursive-readdir/-/recursive-readdir-1.3.0.tgz#c6e66c9ae473f4928f8e6c67a05d80e7a56528ef"
@@ -10828,6 +10917,13 @@ resolve-cwd@^2.0.0:
   dependencies:
     resolve-from "^3.0.0"
 
+resolve-cwd@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
+  integrity sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==
+  dependencies:
+    resolve-from "^5.0.0"
+
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
@@ -10859,6 +10955,14 @@ resolve@^1.1.6, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.17
   integrity sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==
   dependencies:
     is-core-module "^2.1.0"
+    path-parse "^1.0.6"
+
+resolve@^1.9.0:
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
+  integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
+  dependencies:
+    is-core-module "^2.2.0"
     path-parse "^1.0.6"
 
 restore-cursor@^1.0.1:
@@ -11309,7 +11413,7 @@ sigmund@~1.0.0:
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
   integrity sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=
 
-signal-exit@^3.0.0, signal-exit@^3.0.2:
+signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
@@ -12642,6 +12746,11 @@ v8-compile-cache@^2.0.3:
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz#9471efa3ef9128d2f7c6a7ca39c4dd6b5055b132"
   integrity sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==
 
+v8-compile-cache@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
+  integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
+
 validate-npm-package-license@^3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
@@ -12752,6 +12861,25 @@ webidl-conversions@^4.0.2:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
+webpack-cli@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-4.7.0.tgz#3195a777f1f802ecda732f6c95d24c0004bc5a35"
+  integrity sha512-7bKr9182/sGfjFm+xdZSwgQuFjgEcy0iCTIBxRUeteJ2Kr8/Wz0qNJX+jw60LU36jApt4nmMkep6+W5AKhok6g==
+  dependencies:
+    "@discoveryjs/json-ext" "^0.5.0"
+    "@webpack-cli/configtest" "^1.0.3"
+    "@webpack-cli/info" "^1.2.4"
+    "@webpack-cli/serve" "^1.4.0"
+    colorette "^1.2.1"
+    commander "^7.0.0"
+    execa "^5.0.0"
+    fastest-levenshtein "^1.0.12"
+    import-local "^3.0.2"
+    interpret "^2.2.0"
+    rechoir "^0.7.0"
+    v8-compile-cache "^2.2.0"
+    webpack-merge "^5.7.3"
+
 webpack-dev-middleware@^3.7.2:
   version "3.7.3"
   resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-3.7.3.tgz#0639372b143262e2b84ab95d3b91a7597061c2c5"
@@ -12809,6 +12937,14 @@ webpack-log@^2.0.0:
   dependencies:
     ansi-colors "^3.0.0"
     uuid "^3.3.2"
+
+webpack-merge@^5.7.3:
+  version "5.7.3"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-5.7.3.tgz#2a0754e1877a25a8bbab3d2475ca70a052708213"
+  integrity sha512-6/JUQv0ELQ1igjGDzHkXbVDRxkfA57Zw7PfiupdLFJYrgFqY5ZP8xxbpp2lU3EPwYx89ht5Z/aDkD40hFCm5AA==
+  dependencies:
+    clone-deep "^4.0.1"
+    wildcard "^2.0.0"
 
 webpack-sources@^1.4.0, webpack-sources@^1.4.1:
   version "1.4.3"
@@ -12919,6 +13055,11 @@ wide-align@1.1.3, wide-align@^1.1.0:
   integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
   dependencies:
     string-width "^1.0.2 || 2"
+
+wildcard@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/wildcard/-/wildcard-2.0.0.tgz#a77d20e5200c6faaac979e4b3aadc7b3dd7f8fec"
+  integrity sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==
 
 win-fork@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
## Description

Add a lambda function that will pull the non-node drupal content every 5 minutes from Drupal and put it into s3.  This will also move some of the logic in the preview server to the lambda functions and set some foundation work for the incremental build lambda function.

Lots of this is based on https://github.com/department-of-veterans-affairs/vets-website/pull/16336.  

Linked issue: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/5080.

This is POC work

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
