### PR TITLE
Small cleanup of handling assets

### DIFF
--- a/src/site/stages/build/plugins/download-assets.js
+++ b/src/site/stages/build/plugins/download-assets.js
@@ -54,7 +54,7 @@ async function downloadFromLiveBucket(files, buildOptions) {
 
   const downloads = entryNames.map(async entryName => {
     let bundleFileName = fileManifest[entryName];
-    const bundleUrl = bundleFileName.includes('https')
+    const bundleUrl = bundleFileName.includes(bucket)
       ? `${bundleFileName}`
       : `${bucket}${bundleFileName}`;
     const bundleResponse = await fetch(bundleUrl);

--- a/src/site/stages/build/plugins/modify-dom/process-entry-names.js
+++ b/src/site/stages/build/plugins/modify-dom/process-entry-names.js
@@ -116,7 +116,7 @@ module.exports = {
           : fileSearch;
 
       // Ensure we have valid options and that the entry exists.
-      const entryExists = files[fileSearch];
+      const entryExists = files[fileSearch] || files[s3Search];
 
       if (
         buildOptions.buildtype !== environments.LOCALHOST &&

--- a/src/site/stages/build/plugins/modify-dom/process-entry-names.js
+++ b/src/site/stages/build/plugins/modify-dom/process-entry-names.js
@@ -79,13 +79,15 @@ module.exports = {
     const { dom } = file;
     if (!dom) return;
 
+    const bucket = buckets[buildOptions.buildtype];
+
     // Set font preload URLs to point to apps bucket
     dom('link[rel="preload"]').each((index, el) => {
       const $el = dom(el);
       const hrefVal = $el.attr('href');
       const filePath =
         buildOptions.buildtype !== environments.LOCALHOST
-          ? `${buckets[buildOptions.buildtype]}${hrefVal}`
+          ? `${bucket}${hrefVal}`
           : hrefVal;
 
       $el.attr('href', filePath);
@@ -109,12 +111,12 @@ module.exports = {
       const fileSearch = `generated/${hashedEntryName.split('/generated/')[1]}`;
       const s3Search =
         buildOptions.buildtype !== environments.LOCALHOST &&
-        !fileSearch.includes('https')
-          ? `${buckets[buildOptions.buildtype]}/${fileSearch}`
+        !fileSearch.includes(bucket)
+          ? `${bucket}/${fileSearch}`
           : fileSearch;
 
       // Ensure we have valid options and that the entry exists.
-      const entryExists = files[fileSearch] || files[s3Search];
+      const entryExists = files[fileSearch];
 
       if (
         buildOptions.buildtype !== environments.LOCALHOST &&


### PR DESCRIPTION
## Description
This PR makes some minor changes to the `download-assets.js` and `process-entry-names.js` plugins. Rather than checking if the path of an asset contains `https`, check if it contains the bucket URL. This way we know the URL of the assets being downloaded are consistent with the bucket constants.

## Testing done
Tested locally and in CI.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
