### PR TITLE
Added tests for toTitleCase

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -94,7 +94,7 @@ module.exports = function registerFilters() {
       .toString()
       .toLowerCase()
       .split(' ')
-      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+      .map(word => _.upperFirst(word))
       .join(' ');
   };
 

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -88,12 +88,15 @@ module.exports = function registerFilters() {
     }
   };
 
-  liquid.filters.toTitleCase = phrase =>
-    phrase
+  liquid.filters.toTitleCase = phrase => {
+    if (phrase === null) return null;
+    return phrase
+      .toString()
       .toLowerCase()
       .split(' ')
       .map(word => word.charAt(0).toUpperCase() + word.slice(1))
       .join(' ');
+  };
 
   liquid.filters.formatDate = (dt, format) => prettyTimeFormatted(dt, format);
 

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -92,9 +92,8 @@ module.exports = function registerFilters() {
     if (phrase === null) return null;
     return phrase
       .toString()
-      .toLowerCase()
       .split(' ')
-      .map(word => _.upperFirst(word))
+      .map(_.capitalize)
       .join(' ');
   };
 

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -10,24 +10,24 @@ registerFilters();
 describe('toTitleCase', () => {
   it('returns null when null is passed', () => {
     expect(liquid.filters.toTitleCase(null)).to.eq(null);
-  })
+  });
 
   it('returns an empty string when an empty string is passed', () => {
     expect(liquid.filters.toTitleCase('')).to.eq('');
-  })
+  });
 
   it('returns an empty string when an empty array is passed', () => {
     expect(liquid.filters.toTitleCase([])).to.eq('');
-  })
+  });
 
   it('returns a string with only the first letter of word capitalized', () => {
     expect(liquid.filters.toTitleCase('tEST')).to.eq('Test');
-  })
+  });
 
   it('returns all words in string with the first letter capitalized', () => {
     expect(liquid.filters.toTitleCase('t3sT String')).to.eq('T3st String');
-  })
-})
+  });
+});
 
 describe('isLaterThan', () => {
   it('returns true when the left arg is a timestamp later than the right arg', () => {

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -7,6 +7,28 @@ import featuredContentData from '../layouts/tests/vet_center/fixtures/featuredCo
 
 registerFilters();
 
+describe('toTitleCase', () => {
+  it('returns null when null is passed', () => {
+    expect(liquid.filters.toTitleCase(null)).to.eq(null);
+  })
+
+  it('returns an empty string when an empty string is passed', () => {
+    expect(liquid.filters.toTitleCase('')).to.eq('');
+  })
+
+  it('returns an empty string when an empty array is passed', () => {
+    expect(liquid.filters.toTitleCase([])).to.eq('');
+  })
+
+  it('returns a string with only the first letter of word capitalized', () => {
+    expect(liquid.filters.toTitleCase('tEST')).to.eq('Test');
+  })
+
+  it('returns all words in string with the first letter capitalized', () => {
+    expect(liquid.filters.toTitleCase('t3sT String')).to.eq('T3st String');
+  })
+})
+
 describe('isLaterThan', () => {
   it('returns true when the left arg is a timestamp later than the right arg', () => {
     expect(liquid.filters.isLaterThan('2020-01-11', '2016-07-10')).to.be.true;


### PR DESCRIPTION
## Description
Added the following tests to `toTitleCase`:

- null => null
- "" => ""
- [] => ""
- "tEST" => "Test"
- "t3sT String" => "T3st String"

Also, refactored the function to include lodash - upperFirst.

## Testing done
Yes

## Screenshots
N/A

## Acceptance criteria
- [ ] All tests must pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
