### PR TITLE
pass down sharableText to sharableLink as a prop, for accessibility

### DIFF
--- a/src/site/paragraphs/collapsible_panel.drupal.liquid
+++ b/src/site/paragraphs/collapsible_panel.drupal.liquid
@@ -52,7 +52,7 @@
                         {% include {{ bundleComponent }} with entity = paragraph.entity %}
                     {%  endfor %}
 
-                    <div data-widget-type="sharable-link" parentId="{{id}}"></div>                
+                    <div data-widget-type="sharable-link" parentId="{{id}}" sharableText="{{item.fieldTitle}}"></div>                
                 </div>
             </li>
         {% endfor %}

--- a/src/site/paragraphs/q_a.collapsible_panel.drupal.liquid
+++ b/src/site/paragraphs/q_a.collapsible_panel.drupal.liquid
@@ -25,7 +25,7 @@
                 {% endfor %}
               </div>
 
-              <div data-widget-type="sharable-link" parentId="{{id}}" ></div>
+              <div data-widget-type="sharable-link" parentId="{{id}}" sharableText="{{item.fieldQuestion}}" ></div>
             </div>
           </div>
 

--- a/src/site/paragraphs/q_a.drupal.liquid
+++ b/src/site/paragraphs/q_a.drupal.liquid
@@ -28,7 +28,7 @@
     <div class="vads-u-display--flex">
       <{{ headingTag }} itemprop="name">
         {{ entity.fieldQuestion }}
-        <span data-widget-type="sharable-link" parentId="{{id}}">
+        <span data-widget-type="sharable-link" parentId="{{id}}" sharableText="{{entity.fieldQuestion}}">
         </span>
       </{{ headingTag }}>
 


### PR DESCRIPTION
resolves:
department-of-veterans-affairs/va.gov-team#23963
although the issue is closed, the fix introduced a bug. the assumption was that all associated content would be an h3, but that's not the case with accordion content, so we are passing down the content as a prop instead (as sharableText) instead of worrying about the structure of the content

associated vets-website PR: https://github.com/department-of-veterans-affairs/vets-website/pull/17227