### PR TITLE
#13455: Fail build if internal-dsva-vagov* links are detected

### DIFF
--- a/src/site/stages/build/plugins/check-cms-urls.js
+++ b/src/site/stages/build/plugins/check-cms-urls.js
@@ -11,9 +11,8 @@ function checkForCMSUrls(BUILD_OPTIONS) {
       if (file.isDrupalPage && !ignoredPages.has(fileName)) {
         const contents = file.contents.toString();
         if (
-          contents.includes('cms.va.gov') ||
-          contents.includes('-vagovcms-3000') ||
-          contents.includes('va.agile6.com')
+          contents.includes('internal-dsva-vagov') ||
+          contents.includes('cms.va.gov')
         ) {
           filesWithBadUrls.push(fileName);
         }
@@ -22,12 +21,12 @@ function checkForCMSUrls(BUILD_OPTIONS) {
 
     if (filesWithBadUrls.length) {
       console.log(
-        'The following pages have an internal AWS, cms.va.gov, or va.agile6.com url referenced:',
+        "The following pages have an 'internal-dsva-vagov-*' or '*.cms.va.gov' URL referenced:",
       );
       console.log(filesWithBadUrls.join('\n'));
 
       if (BUILD_OPTIONS.buildtype === ENVIRONMENTS.VAGOVPROD) {
-        throw new Error('Pages found that reference internal CMS urls');
+        throw new Error('Pages found that reference internal CMS URLs');
       }
     }
 


### PR DESCRIPTION
## Description
See https://github.com/department-of-veterans-affairs/va.gov-team/issues/13455

Moved from https://github.com/department-of-veterans-affairs/vets-website/pull/13216


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
