### PR TITLE
Fix for links must have discernible text on TOC in build

### DIFF
--- a/src/site/stages/build/plugins/modify-dom/add-id-to-subheadings.js
+++ b/src/site/stages/build/plugins/modify-dom/add-id-to-subheadings.js
@@ -82,6 +82,7 @@ module.exports = {
         if (
           el.tagName.toLowerCase() === 'h2' &&
           tableOfContents &&
+          heading.attr('id') &&
           heading.text().toLowerCase() !== 'on this page' &&
           !isInAccordionButton &&
           !isInAccordion

--- a/src/site/stages/build/plugins/modify-dom/add-id-to-subheadings.js
+++ b/src/site/stages/build/plugins/modify-dom/add-id-to-subheadings.js
@@ -94,7 +94,7 @@ module.exports = {
               'id',
             )}' });"
               class="vads-u-display--flex vads-u-text-decoration--none">
-              <i class="fas fa-arrow-down va-c-font-size--xs vads-u-margin-top--1 vads-u-margin-right--1" aria-hidden=true>
+              <i class="fas fa-arrow-down va-c-font-size--xs vads-u-margin-top--1 vads-u-margin-right--1" aria-hidden="true">
               </i>${heading.text()}</a></li>`,
           );
           idAdded = true;


### PR DESCRIPTION
## Description
[Nightwatch sitemap a11y scan ](http://jenkins.vfs.va.gov/blue/organizations/jenkins/testing%2Fcontent-build/detail/feature%2Fnightwatch-content-a11y-tests/9/pipeline/)is picking up an error for `Links must have discernible text` on https://www.va.gov/albany-health-care/policies/

I tracked this down to a rogue H2 coming from the CMS, so I added a check in the TOC generator to test for the presence of and ID before creating the link.

## Screenshots
### Before
<img width="365" alt="before" src="https://user-images.githubusercontent.com/459581/118842091-e4503900-b896-11eb-8a33-4f18d1a0f286.png">

### After
<img width="358" alt="after" src="https://user-images.githubusercontent.com/459581/118842104-e6b29300-b896-11eb-9175-121f1363369f.png">