### PR TITLE
Added tests for 4 liquid.filter functions

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -266,12 +266,12 @@ module.exports = function registerFilters() {
   };
 
   liquid.filters.hashReference = str => {
-    if (str === null) return null;
+    if (!str) return null;
     return str
       .toString()
       .toLowerCase()
-      .split(' ')
-      .join('-');
+      .trim()
+      .replace(/\s+/g, '-');
   };
 
   // We might not need this filter, refactor

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -22,8 +22,6 @@ module.exports = function registerFilters() {
   liquid.filters.humanizeDate = dt =>
     moment(dt, 'YYYY-MM-DD').format('MMMM D, YYYY');
 
-  liquid.filters.humanizeTime = dt => moment(dt).format('LT');
-
   liquid.filters.humanizeTimestamp = dt =>
     moment.unix(dt).format('MMMM D, YYYY');
 
@@ -154,8 +152,6 @@ module.exports = function registerFilters() {
       .replace(/PM/g, 'p.m.');
   };
 
-  liquid.filters.unixFromDate = data => new Date(data).getTime();
-
   liquid.filters.currentTimeInSeconds = () => {
     const time = new Date();
     return Math.floor(time.getTime() / 1000);
@@ -164,8 +160,6 @@ module.exports = function registerFilters() {
   liquid.filters.numToWord = numConvert => converter.toWords(numConvert);
 
   liquid.filters.jsonToObj = jsonString => JSON.parse(jsonString);
-
-  liquid.filters.modulo = item => item % 2;
 
   liquid.filters.genericModulo = (i, n) => i % n;
 
@@ -222,20 +216,6 @@ module.exports = function registerFilters() {
     return `${hyphenatedDesc}-${id}`;
   };
 
-  liquid.filters.breakTerms = data => {
-    let output = '';
-    if (data != null) {
-      const count = data.length;
-      data.forEach((element, index) => {
-        if (index < count - 1) {
-          output += `${element}, `;
-        } else {
-          output += `${element}`;
-        }
-      });
-    }
-    return output;
-  };
   liquid.filters.benefitTerms = data => {
     if (data === null) return null;
     let output = 'General benefits information';
@@ -294,25 +274,6 @@ module.exports = function registerFilters() {
       .join('-');
   };
 
-  liquid.filters.facilityIds = facilities =>
-    facilities.map(facility => facility.fieldFacilityLocatorApiId).join(',');
-
-  // Used for the react widget "Facilities List" - includes the facility locator api id and the image object from drupal
-  liquid.filters.widgetFacilitiesList = facilities => {
-    const facilityList = {};
-    facilities.forEach(f => {
-      // Facility Locator ids - the ids NEED to match what is returned from the facility locator api
-      const facilityLocatorApiId = f.fieldFacilityLocatorApiId
-        .split('_')[1]
-        .toUpperCase();
-      const id = `vha_`.concat(facilityLocatorApiId);
-
-      facilityList[id] = f.fieldMedia ? f.fieldMedia.entity.image : {};
-      facilityList[id].entityUrl = f.entityUrl;
-    });
-    return JSON.stringify(facilityList);
-  };
-
   // We might not need this filter, refactor
   liquid.filters.widgetFacilityDetail = facility => {
     const facilityLocatorApiId = facility.split('_')[1].toUpperCase();
@@ -322,14 +283,6 @@ module.exports = function registerFilters() {
 
   liquid.filters.sortMainFacility = item =>
     item ? item.sort((a, b) => a.entityId - b.entityId) : undefined;
-
-  liquid.filters.eventSorter = item =>
-    item &&
-    item.sort((a, b) => {
-      const start1 = moment(a.fieldDatetimeRangeTimezone.startTime);
-      const start2 = moment(b.fieldDatetimeRangeTimezone.startTime);
-      return start1.isAfter(start2);
-    });
 
   // Find the current path in an array of nested link arrays and then return it's depth + it's parent and children
   liquid.filters.findCurrentPathDepth = (linksArray, currentPath) => {
@@ -475,8 +428,6 @@ module.exports = function registerFilters() {
       : null;
   };
 
-  liquid.filters.getPagerPage = page => parseInt(page.split('page-')[1], 10);
-
   liquid.filters.featureSingleValueFieldLink = fieldLink => {
     if (fieldLink && cmsFeatureFlags.FEATURE_SINGLE_VALUE_FIELD_LINK) {
       return fieldLink[0];
@@ -565,14 +516,6 @@ module.exports = function registerFilters() {
     return inMenu !== -1;
   };
 
-  // check if this is a pittsburgh page
-  liquid.filters.isPitt = path => {
-    if (path.includes('pittsburgh-health-care')) {
-      return true;
-    }
-    return false;
-  };
-
   liquid.filters.detectLang = url => {
     if (url?.endsWith('-esp')) return 'es';
     if (url?.endsWith('-tag')) return 'tl';
@@ -605,9 +548,6 @@ module.exports = function registerFilters() {
     !!childPageEntityUrl.breadcrumb.find(
       b => b.text.toLowerCase() === parentPage.toLowerCase(),
     );
-
-  // find out if date is in the past
-  liquid.filters.isPastDate = contentDate => moment().diff(contentDate, 'days');
 
   liquid.filters.isLaterThan = (timestamp1, timestamp2) =>
     moment(timestamp1, 'YYYY-MM-DD').isAfter(moment(timestamp2, 'YYYY-MM-DD'));

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -174,11 +174,14 @@ module.exports = function registerFilters() {
 
   liquid.filters.fileSize = data => `${(data / 1000000).toFixed(2)}MB`;
 
-  liquid.filters.fileExt = data =>
-    data
+  liquid.filters.fileExt = data => {
+    if (data === null) return null;
+    return data
+      .toString()
       .split('.')
       .slice(-1)
       .pop();
+  };
 
   liquid.filters.breakIntoSingles = data => {
     let output = '';
@@ -234,6 +237,7 @@ module.exports = function registerFilters() {
     return output;
   };
   liquid.filters.benefitTerms = data => {
+    if (data === null) return null
     let output = 'General benefits information';
     if (data != null) {
       switch (data) {
@@ -281,11 +285,14 @@ module.exports = function registerFilters() {
     return output;
   };
 
-  liquid.filters.hashReference = str =>
-    str
+  liquid.filters.hashReference = str => {
+    if (str === null) return null
+    return str
+      .toString()
       .toLowerCase()
       .split(' ')
       .join('-');
+  };
 
   liquid.filters.facilityIds = facilities =>
     facilities.map(facility => facility.fieldFacilityLocatorApiId).join(',');

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -175,7 +175,7 @@ module.exports = function registerFilters() {
   liquid.filters.fileSize = data => `${(data / 1000000).toFixed(2)}MB`;
 
   liquid.filters.fileExt = data => {
-    if (data === null) return null;
+    if (!data) return null;
     return data
       .toString()
       .split('.')

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -237,7 +237,7 @@ module.exports = function registerFilters() {
     return output;
   };
   liquid.filters.benefitTerms = data => {
-    if (data === null) return null
+    if (data === null) return null;
     let output = 'General benefits information';
     if (data != null) {
       switch (data) {
@@ -286,7 +286,7 @@ module.exports = function registerFilters() {
   };
 
   liquid.filters.hashReference = str => {
-    if (str === null) return null
+    if (str === null) return null;
     return str
       .toString()
       .toLowerCase()

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -11,69 +11,142 @@ describe('benefitTerms', () => {
   it('returns null when null is passed', () => {
     expect(liquid.filters.benefitTerms(null)).to.eq(null);
   });
-  it('returns Life insurance', () => {
-    expect(liquid.filters.benefitTerms('')).to.eq('General benefits information')
-  })
   it('returns General benefits information', () => {
-    expect(liquid.filters.benefitTerms('general')).to.eq('General benefits information')
-  })
+    expect(liquid.filters.benefitTerms('')).to.eq(
+      'General benefits information',
+    );
+  });
+  it('returns General benefits information', () => {
+    expect(liquid.filters.benefitTerms('general')).to.eq(
+      'General benefits information',
+    );
+  });
   it('returns Burials and memorials', () => {
-    expect(liquid.filters.benefitTerms('burial')).to.eq('Burials and memorials')
-  })
+    expect(liquid.filters.benefitTerms('burial')).to.eq(
+      'Burials and memorials',
+    );
+  });
   it('returns Careers and employment', () => {
-    expect(liquid.filters.benefitTerms('careers')).to.eq('Careers and employment')
-  })
+    expect(liquid.filters.benefitTerms('careers')).to.eq(
+      'Careers and employment',
+    );
+  });
   it('returns Disability', () => {
-    expect(liquid.filters.benefitTerms('disability')).to.eq('Disability')
-  })
+    expect(liquid.filters.benefitTerms('disability')).to.eq('Disability');
+  });
   it('returns Education and training', () => {
-    expect(liquid.filters.benefitTerms('education')).to.eq('Education and training')
-  })
+    expect(liquid.filters.benefitTerms('education')).to.eq(
+      'Education and training',
+    );
+  });
   it('returns Family member benefits', () => {
-    expect(liquid.filters.benefitTerms('family')).to.eq('Family member benefits')
-  })
+    expect(liquid.filters.benefitTerms('family')).to.eq(
+      'Family member benefits',
+    );
+  });
   it('returns Health care', () => {
-    expect(liquid.filters.benefitTerms('healthcare')).to.eq('Health care')
-  })
+    expect(liquid.filters.benefitTerms('healthcare')).to.eq('Health care');
+  });
   it('returns Housing assistance', () => {
-    expect(liquid.filters.benefitTerms('housing')).to.eq('Housing assistance')
-  })
+    expect(liquid.filters.benefitTerms('housing')).to.eq('Housing assistance');
+  });
   it('returns Life insurance', () => {
-    expect(liquid.filters.benefitTerms('insurance')).to.eq('Life insurance')
-  })
+    expect(liquid.filters.benefitTerms('insurance')).to.eq('Life insurance');
+  });
   it('returns Pension', () => {
-    expect(liquid.filters.benefitTerms('pension')).to.eq('Pension')
-  })
-  it('returns Life insurance', () => {
-    expect(liquid.filters.benefitTerms('service')).to.eq('Service member benefits')
-  })
-  it('returns Life insurance', () => {
-    expect(liquid.filters.benefitTerms('records')).to.eq('Records')
-  })
+    expect(liquid.filters.benefitTerms('pension')).to.eq('Pension');
+  });
+  it('returns Service memeber benefits', () => {
+    expect(liquid.filters.benefitTerms('service')).to.eq(
+      'Service member benefits',
+    );
+  });
+  it('returns Records', () => {
+    expect(liquid.filters.benefitTerms('records')).to.eq('Records');
+  });
 });
 
 describe('findCurrentPathDepth', () => {
   it('returns {"depth":1}', () => {
-    let linksArr = [{url: {path: '/home'}, }]
-    assert.equal(liquid.filters.findCurrentPathDepth(linksArr, '/home'),'{"depth":1}')
-  })
+    const linksArr = [{ url: { path: '/home' } }];
+    assert.equal(
+      liquid.filters.findCurrentPathDepth(linksArr, '/home'),
+      '{"depth":1}',
+    );
+  });
   it('returns  {"depth":2}', () => {
-    let linksArr = [{url: {path: '/home'}, links:[{url:{path:'/page'}}]}]
-    assert.equal(liquid.filters.findCurrentPathDepth(linksArr, '/page'),'{"depth":2}')
-  })
+    const linksArr = [
+      { url: { path: '/home' }, links: [{ url: { path: '/page' } }] },
+    ];
+    assert.equal(
+      liquid.filters.findCurrentPathDepth(linksArr, '/page'),
+      '{"depth":2}',
+    );
+  });
   it('returns  {"depth":3}', () => {
-    let linksArr = [{url: {path: '/home'}, links:[{url:{path:'/page'}, links:[{url:{path:'/testing3'}}]}]}]
-    assert.equal(liquid.filters.findCurrentPathDepth(linksArr, '/testing3'),'{"depth":3,"links":{"url":{"path":"/page"},"links":[{"url":{"path":"/testing3"}}]}}')
-  })
+    const linksArr = [
+      {
+        url: { path: '/home' },
+        links: [
+          { url: { path: '/page' }, links: [{ url: { path: '/testing3' } }] },
+        ],
+      },
+    ];
+    assert.equal(
+      liquid.filters.findCurrentPathDepth(linksArr, '/testing3'),
+      '{"depth":3,"links":{"url":{"path":"/page"},"links":[{"url":{"path":"/testing3"}}]}}',
+    );
+  });
   it('returns  {"depth":4}', () => {
-    let linksArr = [{url: {path: '/home'}, links:[{url:{path:'/page'}, links:[{url:{path:'/testing3'}, links:[{url:{path:'/testing4'}}]}]}]}]
-    assert.equal(liquid.filters.findCurrentPathDepth(linksArr, '/testing4'),'{"depth":4,"links":{"url":{"path":"/testing3"},"links":[{"url":{"path":"/testing4"}}]}}')
-  })
+    const linksArr = [
+      {
+        url: { path: '/home' },
+        links: [
+          {
+            url: { path: '/page' },
+            links: [
+              {
+                url: { path: '/testing3' },
+                links: [{ url: { path: '/testing4' } }],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    assert.equal(
+      liquid.filters.findCurrentPathDepth(linksArr, '/testing4'),
+      '{"depth":4,"links":{"url":{"path":"/testing3"},"links":[{"url":{"path":"/testing4"}}]}}',
+    );
+  });
   it('returns  {"depth":5}', () => {
-    let linksArr = [{url: {path: '/home'}, links:[{url:{path:'/page'}, links:[{url:{path:'/testing3'}, links:[{url:{path:'/testing4'}, links:[{url:{path:'/testing5'}}]}]}]}]}]
-    assert.equal(liquid.filters.findCurrentPathDepth(linksArr, '/testing5'),'{"depth":5,"links":{"url":{"path":"/testing4"},"links":[{"url":{"path":"/testing5"}}]}}')
-  })
-})
+    const linksArr = [
+      {
+        url: { path: '/home' },
+        links: [
+          {
+            url: { path: '/page' },
+            links: [
+              {
+                url: { path: '/testing3' },
+                links: [
+                  {
+                    url: { path: '/testing4' },
+                    links: [{ url: { path: '/testing5' } }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    assert.equal(
+      liquid.filters.findCurrentPathDepth(linksArr, '/testing5'),
+      '{"depth":5,"links":{"url":{"path":"/testing4"},"links":[{"url":{"path":"/testing5"}}]}}',
+    );
+  });
+});
 
 describe('hashReference', () => {
   it('returns null when null is passed', () => {
@@ -81,9 +154,20 @@ describe('hashReference', () => {
   });
   it('returns an empty string when an empty array is passed', () => {
     expect(liquid.filters.hashReference([])).to.eq('');
-  })
+  });
   it('returns string with spaces replaced by "-" ', () => {
-    expect(liquid.filters.hashReference('testing one two three')).to.eq('testing-one-two-three');
+    expect(liquid.filters.hashReference('testing one two three')).to.eq(
+      'testing-one-two-three',
+    );
+  });
+});
+
+describe('fileExt', () => {
+  it('returns null when null is passed', () => {
+    expect(liquid.filters.fileExt(null)).to.eq(null);
+  });
+  it('returns an empty string when an empty array is passed', () => {
+    expect(liquid.filters.fileExt([])).to.eq('');
   })
 });
 

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -183,23 +183,23 @@ describe('hashReference', () => {
 
 describe('fileExt', () => {
   it('returns the following string - testing', () => {
-    expect(liquid.filters.fileExt('testing')).to.eq('testing')
+    expect(liquid.filters.fileExt('testing')).to.eq('testing');
   });
 
   it('returns the following string - bar', () => {
-    expect(liquid.filters.fileExt('foo.bar')).to.eq('bar')
+    expect(liquid.filters.fileExt('foo.bar')).to.eq('bar');
   });
 
   it('returns the following string - test', () => {
-    expect(liquid.filters.fileExt('foo.bar.test')).to.eq('test')
+    expect(liquid.filters.fileExt('foo.bar.test')).to.eq('test');
   });
 
   it('returns empty string', () => {
-    expect(liquid.filters.fileExt('foo.bar.test.')).to.eq('')
+    expect(liquid.filters.fileExt('foo.bar.test.')).to.eq('');
   });
 
   it('returns the following string - test', () => {
-    expect(liquid.filters.fileExt(['foo.bar.test'])).to.eq('test')
+    expect(liquid.filters.fileExt(['foo.bar.test'])).to.eq('test');
   });
 
   it('returns null when null is passed', () => {

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -168,7 +168,7 @@ describe('fileExt', () => {
   });
   it('returns an empty string when an empty array is passed', () => {
     expect(liquid.filters.fileExt([])).to.eq('');
-  })
+  });
 });
 
 describe('toTitleCase', () => {

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -67,7 +67,7 @@ describe('benefitTerms', () => {
   it('returns Pension', () => {
     expect(liquid.filters.benefitTerms('pension')).to.eq('Pension');
   });
-  
+
   it('returns Service memeber benefits', () => {
     expect(liquid.filters.benefitTerms('service')).to.eq(
       'Service member benefits',
@@ -193,7 +193,7 @@ describe('fileExt', () => {
   it('returns null when empty string is passed', () => {
     expect(liquid.filters.fileExt('')).to.eq(null);
   });
-  
+
   it('returns an empty string when an empty array is passed', () => {
     expect(liquid.filters.fileExt([])).to.eq('');
   });

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -170,12 +170,32 @@ describe('hashReference', () => {
     expect(liquid.filters.hashReference(null)).to.eq(null);
   });
 
+  it('returns null when undefined is passed', () => {
+    expect(liquid.filters.hashReference(undefined)).to.eq(null);
+  });
+
+  it('returns null when empty string is passed', () => {
+    expect(liquid.filters.hashReference('')).to.eq(null);
+  });
+
   it('returns an empty string when an empty array is passed', () => {
     expect(liquid.filters.hashReference([])).to.eq('');
   });
 
-  it('returns string with spaces replaced by "-" ', () => {
-    expect(liquid.filters.hashReference('testing one two three')).to.eq(
+  it('returns a hyphenated string', () => {
+    expect(liquid.filters.hashReference('Testing One two three')).to.eq(
+      'testing-one-two-three',
+    );
+  });
+
+  it('returns hyphenated string and removes multiple spaces', () => {
+    expect(liquid.filters.hashReference('testing  one two  three')).to.eq(
+      'testing-one-two-three',
+    );
+  });
+
+  it('returns hyphenated string with spaces removed from both sides of string', () => {
+    expect(liquid.filters.hashReference('  Testing one two three   ')).to.eq(
       'testing-one-two-three',
     );
   });

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -166,6 +166,12 @@ describe('fileExt', () => {
   it('returns null when null is passed', () => {
     expect(liquid.filters.fileExt(null)).to.eq(null);
   });
+  it('returns null when undefined is passed', () => {
+    expect(liquid.filters.fileExt(undefined)).to.eq(null);
+  });
+  it('returns null when empty string is passed', () => {
+    expect(liquid.filters.fileExt('')).to.eq(null);
+  });
   it('returns an empty string when an empty array is passed', () => {
     expect(liquid.filters.fileExt([])).to.eq('');
   });

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -11,56 +11,69 @@ describe('benefitTerms', () => {
   it('returns null when null is passed', () => {
     expect(liquid.filters.benefitTerms(null)).to.eq(null);
   });
+
   it('returns General benefits information', () => {
     expect(liquid.filters.benefitTerms('')).to.eq(
       'General benefits information',
     );
   });
+
   it('returns General benefits information', () => {
     expect(liquid.filters.benefitTerms('general')).to.eq(
       'General benefits information',
     );
   });
+
   it('returns Burials and memorials', () => {
     expect(liquid.filters.benefitTerms('burial')).to.eq(
       'Burials and memorials',
     );
   });
+
   it('returns Careers and employment', () => {
     expect(liquid.filters.benefitTerms('careers')).to.eq(
       'Careers and employment',
     );
   });
+
   it('returns Disability', () => {
     expect(liquid.filters.benefitTerms('disability')).to.eq('Disability');
   });
+
   it('returns Education and training', () => {
     expect(liquid.filters.benefitTerms('education')).to.eq(
       'Education and training',
     );
   });
+
   it('returns Family member benefits', () => {
     expect(liquid.filters.benefitTerms('family')).to.eq(
       'Family member benefits',
     );
   });
+
   it('returns Health care', () => {
     expect(liquid.filters.benefitTerms('healthcare')).to.eq('Health care');
   });
+
   it('returns Housing assistance', () => {
     expect(liquid.filters.benefitTerms('housing')).to.eq('Housing assistance');
   });
+
   it('returns Life insurance', () => {
     expect(liquid.filters.benefitTerms('insurance')).to.eq('Life insurance');
   });
+
   it('returns Pension', () => {
     expect(liquid.filters.benefitTerms('pension')).to.eq('Pension');
   });
+  
   it('returns Service memeber benefits', () => {
     expect(liquid.filters.benefitTerms('service')).to.eq(
       'Service member benefits',
     );
   });
+
   it('returns Records', () => {
     expect(liquid.filters.benefitTerms('records')).to.eq('Records');
   });
@@ -74,6 +87,7 @@ describe('findCurrentPathDepth', () => {
       '{"depth":1}',
     );
   });
+
   it('returns  {"depth":2}', () => {
     const linksArr = [
       { url: { path: '/home' }, links: [{ url: { path: '/page' } }] },
@@ -83,6 +97,7 @@ describe('findCurrentPathDepth', () => {
       '{"depth":2}',
     );
   });
+
   it('returns  {"depth":3}', () => {
     const linksArr = [
       {
@@ -97,6 +112,7 @@ describe('findCurrentPathDepth', () => {
       '{"depth":3,"links":{"url":{"path":"/page"},"links":[{"url":{"path":"/testing3"}}]}}',
     );
   });
+
   it('returns  {"depth":4}', () => {
     const linksArr = [
       {
@@ -119,6 +135,7 @@ describe('findCurrentPathDepth', () => {
       '{"depth":4,"links":{"url":{"path":"/testing3"},"links":[{"url":{"path":"/testing4"}}]}}',
     );
   });
+
   it('returns  {"depth":5}', () => {
     const linksArr = [
       {
@@ -152,9 +169,11 @@ describe('hashReference', () => {
   it('returns null when null is passed', () => {
     expect(liquid.filters.hashReference(null)).to.eq(null);
   });
+
   it('returns an empty string when an empty array is passed', () => {
     expect(liquid.filters.hashReference([])).to.eq('');
   });
+
   it('returns string with spaces replaced by "-" ', () => {
     expect(liquid.filters.hashReference('testing one two three')).to.eq(
       'testing-one-two-three',
@@ -166,12 +185,15 @@ describe('fileExt', () => {
   it('returns null when null is passed', () => {
     expect(liquid.filters.fileExt(null)).to.eq(null);
   });
+
   it('returns null when undefined is passed', () => {
     expect(liquid.filters.fileExt(undefined)).to.eq(null);
   });
+
   it('returns null when empty string is passed', () => {
     expect(liquid.filters.fileExt('')).to.eq(null);
   });
+  
   it('returns an empty string when an empty array is passed', () => {
     expect(liquid.filters.fileExt([])).to.eq('');
   });

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -7,6 +7,86 @@ import featuredContentData from '../layouts/tests/vet_center/fixtures/featuredCo
 
 registerFilters();
 
+describe('benefitTerms', () => {
+  it('returns null when null is passed', () => {
+    expect(liquid.filters.benefitTerms(null)).to.eq(null);
+  });
+  it('returns Life insurance', () => {
+    expect(liquid.filters.benefitTerms('')).to.eq('General benefits information')
+  })
+  it('returns General benefits information', () => {
+    expect(liquid.filters.benefitTerms('general')).to.eq('General benefits information')
+  })
+  it('returns Burials and memorials', () => {
+    expect(liquid.filters.benefitTerms('burial')).to.eq('Burials and memorials')
+  })
+  it('returns Careers and employment', () => {
+    expect(liquid.filters.benefitTerms('careers')).to.eq('Careers and employment')
+  })
+  it('returns Disability', () => {
+    expect(liquid.filters.benefitTerms('disability')).to.eq('Disability')
+  })
+  it('returns Education and training', () => {
+    expect(liquid.filters.benefitTerms('education')).to.eq('Education and training')
+  })
+  it('returns Family member benefits', () => {
+    expect(liquid.filters.benefitTerms('family')).to.eq('Family member benefits')
+  })
+  it('returns Health care', () => {
+    expect(liquid.filters.benefitTerms('healthcare')).to.eq('Health care')
+  })
+  it('returns Housing assistance', () => {
+    expect(liquid.filters.benefitTerms('housing')).to.eq('Housing assistance')
+  })
+  it('returns Life insurance', () => {
+    expect(liquid.filters.benefitTerms('insurance')).to.eq('Life insurance')
+  })
+  it('returns Pension', () => {
+    expect(liquid.filters.benefitTerms('pension')).to.eq('Pension')
+  })
+  it('returns Life insurance', () => {
+    expect(liquid.filters.benefitTerms('service')).to.eq('Service member benefits')
+  })
+  it('returns Life insurance', () => {
+    expect(liquid.filters.benefitTerms('records')).to.eq('Records')
+  })
+});
+
+describe('findCurrentPathDepth', () => {
+  it('returns {"depth":1}', () => {
+    let linksArr = [{url: {path: '/home'}, }]
+    assert.equal(liquid.filters.findCurrentPathDepth(linksArr, '/home'),'{"depth":1}')
+  })
+  it('returns  {"depth":2}', () => {
+    let linksArr = [{url: {path: '/home'}, links:[{url:{path:'/page'}}]}]
+    assert.equal(liquid.filters.findCurrentPathDepth(linksArr, '/page'),'{"depth":2}')
+  })
+  it('returns  {"depth":3}', () => {
+    let linksArr = [{url: {path: '/home'}, links:[{url:{path:'/page'}, links:[{url:{path:'/testing3'}}]}]}]
+    assert.equal(liquid.filters.findCurrentPathDepth(linksArr, '/testing3'),'{"depth":3,"links":{"url":{"path":"/page"},"links":[{"url":{"path":"/testing3"}}]}}')
+  })
+  it('returns  {"depth":4}', () => {
+    let linksArr = [{url: {path: '/home'}, links:[{url:{path:'/page'}, links:[{url:{path:'/testing3'}, links:[{url:{path:'/testing4'}}]}]}]}]
+    assert.equal(liquid.filters.findCurrentPathDepth(linksArr, '/testing4'),'{"depth":4,"links":{"url":{"path":"/testing3"},"links":[{"url":{"path":"/testing4"}}]}}')
+  })
+  it('returns  {"depth":5}', () => {
+    let linksArr = [{url: {path: '/home'}, links:[{url:{path:'/page'}, links:[{url:{path:'/testing3'}, links:[{url:{path:'/testing4'}, links:[{url:{path:'/testing5'}}]}]}]}]}]
+    assert.equal(liquid.filters.findCurrentPathDepth(linksArr, '/testing5'),'{"depth":5,"links":{"url":{"path":"/testing4"},"links":[{"url":{"path":"/testing5"}}]}}')
+  })
+})
+
+describe('hashReference', () => {
+  it('returns null when null is passed', () => {
+    expect(liquid.filters.hashReference(null)).to.eq(null);
+  });
+  it('returns an empty string when an empty array is passed', () => {
+    expect(liquid.filters.hashReference([])).to.eq('');
+  })
+  it('returns string with spaces replaced by "-" ', () => {
+    expect(liquid.filters.hashReference('testing one two three')).to.eq('testing-one-two-three');
+  })
+});
+
 describe('toTitleCase', () => {
   it('returns null when null is passed', () => {
     expect(liquid.filters.toTitleCase(null)).to.eq(null);

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -182,6 +182,26 @@ describe('hashReference', () => {
 });
 
 describe('fileExt', () => {
+  it('returns the following string - testing', () => {
+    expect(liquid.filters.fileExt('testing')).to.eq('testing')
+  });
+
+  it('returns the following string - bar', () => {
+    expect(liquid.filters.fileExt('foo.bar')).to.eq('bar')
+  });
+
+  it('returns the following string - test', () => {
+    expect(liquid.filters.fileExt('foo.bar.test')).to.eq('test')
+  });
+
+  it('returns empty string', () => {
+    expect(liquid.filters.fileExt('foo.bar.test.')).to.eq('')
+  });
+
+  it('returns the following string - test', () => {
+    expect(liquid.filters.fileExt(['foo.bar.test'])).to.eq('test')
+  });
+
   it('returns null when null is passed', () => {
     expect(liquid.filters.fileExt(null)).to.eq(null);
   });


### PR DESCRIPTION
## Description
Created tests for the following functions:

1. `benefitTerms()`
2. `findCurrentPathDepth()`
3. `hashReference()`
4. `fileExt()`


Additionally, I combed through `liquid.js` and found that the following tests are not currently being utilized and have removed them:

- `humanizeTime()`
- `unixFromDate()`
- `modulo()`
- `breakTerms()`
- `facilityIds()`
- `widgetFacilitiesList()`
- `eventSorter()`
- `getPagerPage()`
- `isPitt()`
- `isPastDate()`

## Acceptance criteria
- [ ] All tests must pass
- [ ] Please verify that the functions I listed above and removed, are indeed not in use.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
