### PR TITLE
Added Liquid filter to check for and updated duplicate ID values in the WYSIWYG editor

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -763,11 +763,12 @@ module.exports = function registerFilters() {
     let searchedIdValue;
     let idList;
 
-    try {
+    // If there's no content, don't run this because Cheerio will throw and error
+    if (replaced !== null) {
       // Load the DOM fragement into Cheerio so we can parse it.
       const $ = cheerio.load(replaced);
 
-      // Loop through all the IDs.
+      // Loop through all the IDs in the WYSIWYG output.
       $('[id]').each(function() {
         searchedIdValue = $(this).attr('id');
         idList = $(`[id="${searchedIdValue}"]`);
@@ -783,10 +784,8 @@ module.exports = function registerFilters() {
           replaced = $.html();
         }
       });
-    } catch (e) {
-      // eslint-disable-next-line no-console
-      console.error(e);
-    }
+    } // if()
+
     return replaced;
   };
 

--- a/src/site/paragraphs/wysiwyg.drupal.liquid
+++ b/src/site/paragraphs/wysiwyg.drupal.liquid
@@ -11,7 +11,7 @@
 
 <div data-template="paragraphs/wysiwyg" data-entity-id="{{ entity.entityId }}" class="processed-content">
   <div itemprop="text">
-    {{ entity.fieldWysiwyg.processed | drupalToVaPath | outputLinks }}
+    {{ entity.fieldWysiwyg.processed | drupalToVaPath | outputLinks | checkForDuplicateIdValues }}
   </div>
 </div>
 

--- a/src/site/paragraphs/wysiwyg.drupal.liquid
+++ b/src/site/paragraphs/wysiwyg.drupal.liquid
@@ -9,9 +9,11 @@
   }
 {% endcomment %}
 
+{% if entity.fieldWysiwyg.processed }
 <div data-template="paragraphs/wysiwyg" data-entity-id="{{ entity.entityId }}" class="processed-content">
   <div itemprop="text">
     {{ entity.fieldWysiwyg.processed | drupalToVaPath | outputLinks | checkForDuplicateIdValues }}
   </div>
 </div>
+{% endif %}
 

--- a/src/site/paragraphs/wysiwyg.drupal.liquid
+++ b/src/site/paragraphs/wysiwyg.drupal.liquid
@@ -9,11 +9,9 @@
   }
 {% endcomment %}
 
-{% if entity.fieldWysiwyg.processed }
 <div data-template="paragraphs/wysiwyg" data-entity-id="{{ entity.entityId }}" class="processed-content">
   <div itemprop="text">
     {{ entity.fieldWysiwyg.processed | drupalToVaPath | outputLinks | checkForDuplicateIdValues }}
   </div>
 </div>
-{% endif %}
 

--- a/src/site/stages/build/plugins/modify-dom/add-id-to-subheadings.js
+++ b/src/site/stages/build/plugins/modify-dom/add-id-to-subheadings.js
@@ -27,7 +27,7 @@ function createUniqueId(headingEl, headingOptions) {
     .substring(0, length);
 
   if (headingOptions.previousHeadings.includes(anchor)) {
-    anchor += `${headingOptions.getHeadingId()}`;
+    anchor += `-${headingOptions.getHeadingId()}`;
   }
 
   headingOptions.previousHeadings.push(anchor);

--- a/src/site/stages/build/plugins/modify-dom/add-id-to-subheadings.js
+++ b/src/site/stages/build/plugins/modify-dom/add-id-to-subheadings.js
@@ -27,7 +27,7 @@ function createUniqueId(headingEl, headingOptions) {
     .substring(0, length);
 
   if (headingOptions.previousHeadings.includes(anchor)) {
-    anchor += `WHAT-${headingOptions.getHeadingId()}`;
+    anchor += `${headingOptions.getHeadingId()}`;
   }
 
   headingOptions.previousHeadings.push(anchor);

--- a/src/site/stages/build/plugins/modify-dom/add-id-to-subheadings.js
+++ b/src/site/stages/build/plugins/modify-dom/add-id-to-subheadings.js
@@ -27,7 +27,7 @@ function createUniqueId(headingEl, headingOptions) {
     .substring(0, length);
 
   if (headingOptions.previousHeadings.includes(anchor)) {
-    anchor += `-${headingOptions.getHeadingId()}`;
+    anchor += `WHAT-${headingOptions.getHeadingId()}`;
   }
 
   headingOptions.previousHeadings.push(anchor);


### PR DESCRIPTION
## Description

We have a reported section 508 scan issue of a duplicate ID value the in WYSIWYG content output on https://va.gov/health-care/health-needs-conditions/military-sexual-trauma/ - this PR adds a liquid filter to check for duplicate IDs in the WYSIWYG content and makes them unique.

## Testing Done

Successful pipeline build and spot checking content pages.
