### PR TITLE
Conditionally render cta link

### DIFF
--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -192,12 +192,14 @@
             <h2 class="vads-u-margin-top--0">{{ fieldClpSpotlightHeader }}</h2>
             <p class="va-introtext vads-u-margin-top--1 vads-u-margin-bottom--4">
               {{ fieldClpSpotlightIntroText }}
-              <a
-                href="{{ fieldClpSpotlightCta.entity.fieldButtonLink.url.path }}"
-                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Spotlight', 'clp-section-title': '{{ fieldClpSpotlightHeader | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpSpotlightCta.entity.fieldButtonLabel | encode }}' });"
-              >
-                {{ fieldClpSpotlightCta.entity.fieldButtonLabel }}
-              </a>
+              {% if fieldClpSpotlightCta.entity.fieldButtonLink.url.path %}
+                <a
+                  href="{{ fieldClpSpotlightCta.entity.fieldButtonLink.url.path }}"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Spotlight', 'clp-section-title': '{{ fieldClpSpotlightHeader | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpSpotlightCta.entity.fieldButtonLabel | encode }}' });"
+                >
+                  {{ fieldClpSpotlightCta.entity.fieldButtonLabel }}
+                </a>
+              {% endif %}
             </p>
           </div>
         </div>

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -192,7 +192,7 @@
             <h2 class="vads-u-margin-top--0">{{ fieldClpSpotlightHeader }}</h2>
             <p class="va-introtext vads-u-margin-top--1 vads-u-margin-bottom--4">
               {{ fieldClpSpotlightIntroText }}
-              {% if fieldClpSpotlightCta.entity.fieldButtonLink.url.path %}
+              {% if fieldClpSpotlightCta.entity.fieldButtonLink.url.path and fieldClpSpotlightCta.entity.fieldButtonLabel %}
                 <a
                   href="{{ fieldClpSpotlightCta.entity.fieldButtonLink.url.path }}"
                   onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Spotlight', 'clp-section-title': '{{ fieldClpSpotlightHeader | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpSpotlightCta.entity.fieldButtonLabel | encode }}' });"
@@ -314,7 +314,7 @@
           {% endfor %}
         </div>
 
-        {% if fieldClpResourcesCta.entity.fieldButtonLink %}
+        {% if fieldClpResourcesCta.entity.fieldButtonLink and fieldClpResourcesCta.entity.fieldButtonLabel %}
           <div class="vads-l-row">
             <div class="vads-u-col--12">
               <a
@@ -351,7 +351,7 @@
               <div class="medium-screen:vads-u-margin-x--6">
                 <!-- Title -->
                 <h3 class="vads-u-margin-top--0">
-                  {% if eventReference.entity.entityUrl.path %}
+                  {% if eventReference.entity.entityUrl.path and eventReference.entity.title %}
                     <a
                       href="{{ eventReference.entity.entityUrl.path }}"
                       onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Events', 'clp-section-title': '{{ fieldClpEventsHeader | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ eventReference.entity.title | encode }}' });"
@@ -389,7 +389,7 @@
                     <!-- Event link -->
                     <div class="vads-u-display--flex vads-u-flex-direction--column">
                       <!-- Facility link -->
-                      {% if eventReference.entity.fieldFacilityLocation.entity.entityUrl.path %}
+                      {% if eventReference.entity.fieldFacilityLocation.entity.entityUrl.path and eventReference.entity.fieldFacilityLocation.entity.title %}
                         <a
                           href="{{ eventReference.entity.fieldFacilityLocation.entity.entityUrl.path }}"
                           onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Events', 'clp-section-title': '{{ fieldClpEventsHeader | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ eventReference.entity.fieldFacilityLocation.entity.title | encode }}' });"
@@ -401,7 +401,7 @@
                       {% endif %}
 
                       <!-- Event link -->
-                      {% if eventReference.entity.fieldLink.uri %}
+                      {% if eventReference.entity.fieldLink.uri and eventReference.entity.fieldEventCta %}
                         <a
                           href="{{ eventReference.entity.fieldLink.uri }}"
                           onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Events', 'clp-section-title': '{{ fieldClpEventsHeader | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ eventReference.entity.fieldEventCta | encode }}' });"
@@ -468,7 +468,7 @@
           </div>
         </div>
 
-        {% if fieldClpFaqCta %}
+        {% if fieldClpFaqCta.entity.fieldButtonLink.url.path and fieldClpFaqCta.entity.fieldButtonLabel %}
           <div class="vads-l-row">
             <div class="vads-u-col--12">
               <a
@@ -499,7 +499,7 @@
         </div>
 
         <div class="vads-l-row medium-screen:vads-u-margin-x--neg1">
-          {% if fieldClpConnectWithUs.entity.fieldEmailUpdatesUrl %}
+          {% if fieldClpConnectWithUs.entity.fieldEmailUpdatesUrl and fieldClpConnectWithUs.entity.fieldEmailUpdatesLinkText %}
             <div class="vads-l-col--12 medium-screen:vads-l-col--4">
               <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
                 <a


### PR DESCRIPTION
# Description

**Issue:** N/A

**Slack thread:** https://dsva.slack.com/archives/C0MQ281DJ/p1621873230052900?thread_ts=1621872540.049800&cid=C0MQ281DJ

This PR fixes an empty a tag that was rendered even when the CMS said it shouldn't. 🙂 

## Images

![image](https://user-images.githubusercontent.com/12773166/119380256-b7789900-bc7d-11eb-9f56-ff0037469986.png)

![localhost_3002_preview_nodeId=19578](https://user-images.githubusercontent.com/12773166/119380366-de36cf80-bc7d-11eb-8f24-c155509bb3c7.png)
