### PR TITLE
Add expand image button to each image in media list images

### DIFF
--- a/src/site/layouts/media_list_images.drupal.liquid
+++ b/src/site/layouts/media_list_images.drupal.liquid
@@ -78,7 +78,7 @@
                               href="{{ mediaImage.entity.image.url }}"
                               target="_blank"
                             >
-                              <i class="fas fa-expand-arrows-alt"></i>
+                              <i aria-hidden="true" class="fas fa-expand-arrows-alt" role="img"></i>
                             </a>
                             <img
                               alt="{{ alt }}"

--- a/src/site/layouts/media_list_images.drupal.liquid
+++ b/src/site/layouts/media_list_images.drupal.liquid
@@ -62,7 +62,7 @@
                         </{{ image_title_tag }}>
                       </dt>
 
-                      <dd>
+                      <dd class="va-c-position--relative">
                         <picture>
                           {% if mediaImage.entity.image.url == empty %}
                             <img
@@ -72,6 +72,14 @@
                               width="{{ mediaImage.entity.image.width }}"
                             />
                           {% else %}
+                            <a
+                              aria-label="Open image in new tab"
+                              class="vads-u-margin-right--1p5 vads-u-margin-top--1p5 vads-u-text-decoration--none vads-u-display--flex vads-u-align-items--center expand-image-button va-c-position--absolute va-c-position-top-right-corner vads-u-justify-content--center"
+                              href="{{ mediaImage.entity.image.url }}"
+                              target="_blank"
+                            >
+                              <i class="fas fa-expand-arrows-alt"></i>
+                            </a>
                             <img
                               alt="{{ alt }}"
                               class="vads-u-border--1px vads-u-border-color--gray-light"

--- a/src/site/paragraphs/media.drupal.liquid
+++ b/src/site/paragraphs/media.drupal.liquid
@@ -1,34 +1,35 @@
 {% comment %}
-    Example data:
-    {
-        "entity": {
-        "entityType": "paragraph",
-        "entityBundle": "media",
-        "fieldAllowClicksOnThisImage": true,
-        "fieldMedia": {
-            "entity": {
-                "entityBundle": "image",
-                "image": {
-                    "url": "https://dev.cms.va.gov/sites/default/files/2019-08/UD-sitemap.gif",
-                    "alt": "university drive site map",
-                    "title": ""
-                }
-            }
-        }
-    }
+  Example data:
+  {
+      "entity": {
+      "entityType": "paragraph",
+      "entityBundle": "media",
+      "fieldAllowClicksOnThisImage": true,
+      "fieldMedia": {
+          "entity": {
+              "entityBundle": "image",
+              "image": {
+                  "url": "https://dev.cms.va.gov/sites/default/files/2019-08/UD-sitemap.gif",
+                  "alt": "university drive site map",
+                  "title": ""
+              }
+          }
+      }
+  }
 }
 {% endcomment %}
 <div data-template="paragraphs/media" data-entity-id="{{ entity.entityId }}" class="vads-u-display--block">
-    <div class="va-c-position--relative vads-u-display--inline-block vads-u-margin-y--1p5">
-        {% if entity.fieldAllowClicksOnThisImage %}
-            <a
-                aria-label="Open image in new tab"
-                class="vads-u-margin-right--1p5 vads-u-margin-top--1p5 vads-u-text-decoration--none vads-u-display--flex vads-u-align-items--center expand-image-button va-c-position--absolute va-c-position-top-right-corner vads-u-justify-content--center"
-                href="{{ entity.fieldMedia.entity.image.url }}"
-                target="_blank">
-                <i class="fas fa-expand-arrows-alt"></i>
-            </a>
-        {% endif %}
-        <img src="{{ entity.fieldMedia.entity.image.url }}" alt="{{ entity.fieldMedia.entity.image.alt }}"/>
-    </div>
+  <div class="va-c-position--relative vads-u-display--inline-block vads-u-margin-y--1p5">
+    {% if entity.fieldAllowClicksOnThisImage %}
+      <a
+        aria-label="Open image in new tab"
+        class="vads-u-margin-right--1p5 vads-u-margin-top--1p5 vads-u-text-decoration--none vads-u-display--flex vads-u-align-items--center expand-image-button va-c-position--absolute va-c-position-top-right-corner vads-u-justify-content--center"
+        href="{{ entity.fieldMedia.entity.image.url }}"
+        target="_blank"
+      >
+        <i class="fas fa-expand-arrows-alt"></i>
+      </a>
+    {% endif %}
+    <img src="{{ entity.fieldMedia.entity.image.url }}" alt="{{ entity.fieldMedia.entity.image.alt }}"/>
+  </div>
 </div>

--- a/src/site/stages/build/drupal/graphql/nodeMediaListImages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeMediaListImages.graphql.js
@@ -49,7 +49,6 @@ fragment nodeMediaListImages on NodeMediaListImages {
       ... linkTeaser
     }
   }
-
   fieldMediaListImages {
     entity {
       ... on ParagraphMediaListImages {


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/24293

This PR adds expand image buttons to each image in `media_list_images` pages.

## Testing done
Locally

## Screenshots
![localhost_3002_preview_nodeId=6954 (1)](https://user-images.githubusercontent.com/12773166/119505182-f2380b00-bd29-11eb-9c0d-71c025096ce7.png)

## Acceptance criteria
- [x] Add expand image button to each image in media list images

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
