### PR TITLE
Ensure pagination does not show when only 1 page

### DIFF
--- a/src/site/includes/pagination.drupal.liquid
+++ b/src/site/includes/pagination.drupal.liquid
@@ -11,17 +11,16 @@
   }
 {% endcomment %}
 
-
-{% assign paginatorCount = paginator.inner | size %}
-{% assign totalItems = paginatorCount %}
+{% assign totalPages = paginator.inner | size %}
+{% assign totalItems = totalPages %}
 
 {% if numItems %}
-{% assign totalItems = numItems | times: .1 %}
+  {% assign totalItems = numItems | times: .1 %}
 {% endif%}
 
-{% if paginator != empty and totalItems <= paginatorCount %}
-
+{% if paginator != empty and totalItems <= totalPages and 1 < totalPages %}
   <div class="va-pagination" data-template="includes/pagination">
+    <!-- Previous button -->
     {% if paginator.prev != empty %}
       <span class="va-pagination-prev">
         <a href="{{ paginator.prev }}" aria-label="Load previous page{{ paginator.ariaLabel }}">
@@ -29,6 +28,8 @@
         </a>
       </span>
     {% endif %}
+
+    <!-- Pages 1, 2, 3, ... -->
     <div class="va-pagination-inner">
       {% for page in paginator.inner %}
         <a
@@ -45,6 +46,8 @@
         {% assign totalItems = totalItems | minus: 1 %}
       {% endfor %}
     </div>
+
+    <!-- Next button -->
     {% if paginator.next != empty %}
       <span class="va-pagination-next">
         <a href="{{ paginator.next }}" aria-label="Load next page{{ paginator.ariaLabel }}">

--- a/src/site/includes/pagination.drupal.liquid
+++ b/src/site/includes/pagination.drupal.liquid
@@ -12,13 +12,17 @@
 {% endcomment %}
 
 {% assign totalPages = paginator.inner | size %}
-{% assign totalItems = totalPages %}
 
+<!-- This logic is for src/site/layouts/event_listing.drupal.liquid:56 -->
+<!-- =============== -->
+{% assign totalItems = totalPages %}
 {% if numItems %}
   {% assign totalItems = numItems | times: .1 %}
 {% endif%}
+{% assign showOnEventListingPage = totalItems <= totalPages %}
+<!-- =============== -->
 
-{% if paginator != empty and totalItems <= totalPages and 1 < totalPages %}
+{% if paginator != empty and 1 < totalPages and showOnEventListingPage %}
   <div class="va-pagination" data-template="includes/pagination">
     <!-- Previous button -->
     {% if paginator.prev != empty %}
@@ -43,6 +47,8 @@
         >
           {{ page.label }}
         </a>
+
+        <!-- This logic is for src/site/layouts/event_listing.drupal.liquid:56 -->
         {% assign totalItems = totalItems | minus: 1 %}
       {% endfor %}
     </div>

--- a/src/site/layouts/support_resources_article_listing.drupal.liquid
+++ b/src/site/layouts/support_resources_article_listing.drupal.liquid
@@ -4,11 +4,12 @@
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" %}
 
-<div id="content" class="interior">
+<div id="content" class="interior" data-template="layouts/support_resources_article_listing">
   <main class="va-l-detail-page">
     <div class="usa-grid usa-grid-full">
-      <div class="usa-width-three-fourths">
+      <div class="usa-width-three-fourths vads-u-padding-bottom--2">
         <div class="usa-content">
+          <!-- Title -->
           <div class="vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
             <h1>{{ title }}</h1>
           </div>
@@ -16,39 +17,45 @@
           <!-- Search bar -->
           {% include "src/site/includes/support_resources_search_bar.drupal.liquid" %}
 
+          <!-- Pagination title -->
           <p class="vads-u-padding-x--1 large-screen:vads-u-padding-x--0">{{ paginationTitle }}</p>
 
+          <!-- Articles -->
           <ul class="usa-unstyled-list vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
-          {% for article in articles %}
-            <li>
-              <div class="vads-u-padding-y--3 vads-u-border-top--1px vads-u-border-color--gray-lighter">
-                <div>
-                  <dfn class="vads-u-visibility--screen-reader">Article type: </dfn>
-                  {{ articleTypesByEntityBundle | get: article.entityBundle }}
+            {% for article in articles %}
+              <li>
+                <div class="vads-u-padding-y--3 vads-u-border-top--1px vads-u-border-color--gray-lighter">
+                  <div>
+                    <dfn class="vads-u-visibility--screen-reader">Article type: </dfn>
+                    {{ articleTypesByEntityBundle | get: article.entityBundle }}
+                  </div>
+                  <h2 class="vads-u-font-size--h3 vads-u-margin-top--0">
+                    <a href="{{ article.entityUrl.path }}">{{ article.title }}</a>
+                  </h2>
+                  {% assign snippet = article.fieldIntroTextLimitedHtml %}
+
+                  {% if article.entityBundle == 'q_a' %}
+                    {% assign snippet = article.fieldAnswer.entity.fieldWysiwyg %}
+                  {% endif %}
+
+                  {% if snippet %}
+                    {% assign sanitized = snippet.processed | strip_html %}
+                    {% assign truncated = sanitized | truncate: 200 %}
+                    <p class="vads-u-margin-bottom--0">{{ truncated }}{% if truncated != sanitized %}...{% endif %}</p>
+                  {% endif %}
                 </div>
-                <h2 class="vads-u-font-size--h3 vads-u-margin-top--0">
-                  <a href="{{ article.entityUrl.path }}">{{ article.title }}</a>
-                </h2>
-                {% assign snippet = article.fieldIntroTextLimitedHtml %}
-
-                {% if article.entityBundle == 'q_a' %}
-                  {% assign snippet = article.fieldAnswer.entity.fieldWysiwyg %}
-                {% endif %}
-
-                {% if snippet %}
-                  {% assign sanitized = snippet.processed | strip_html %}
-                  {% assign truncated = sanitized | truncate: 200 %}
-                  <p class="vads-u-margin-bottom--0">{{ truncated }}{% if truncated != sanitized %}...{% endif %}</p>
-                {% endif %}
-              </div>
-            </li>
-          {% endfor %}
+              </li>
+            {% endfor %}
           </ul>
         </div>
+
+        <!-- Pagination -->
         {% include "src/site/includes/pagination.drupal.liquid" %}
       </div>
     </div>
   </main>
+
+  <!-- Back to top -->
   {% include "src/site/components/up_to_top_button.html" %}
 </div>
 


### PR DESCRIPTION
# Description

**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/18571

This PR tweaks the pagination template to **not show when there is only 1 page.**

## Screenshots

**Before:** https://www.va.gov/resources/tag/claims-and-appeals-status/

![www va gov_resources_tag_claims-and-appeals-status_](https://user-images.githubusercontent.com/12773166/119528835-c6735000-bd3e-11eb-83ef-12675bceec19.png)

**After:**

![www va gov_resources_tag_claims-and-appeals-status_ (1)](https://user-images.githubusercontent.com/12773166/119529166-15b98080-bd3f-11eb-9459-e317d9d9ec9c.png)

## Acceptance Criteria

- [x] Do not show the pagination template when it only has 1 page
