### PR TITLE
Update GHA manual checks to run on PR and Push

### DIFF
--- a/.github/workflows/manual-review.yml
+++ b/.github/workflows/manual-review.yml
@@ -1,6 +1,9 @@
 name: Manual Review
 
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - master
 
 env:
   BOT_NAME: va-vfs-bot

--- a/.github/workflows/manual-review.yml
+++ b/.github/workflows/manual-review.yml
@@ -1,6 +1,6 @@
 name: Manual Review
 
-on: [push, pull_request]
+on: [push]
 
 env:
   BOT_NAME: va-vfs-bot

--- a/.github/workflows/manual-review.yml
+++ b/.github/workflows/manual-review.yml
@@ -1,6 +1,6 @@
 name: Manual Review
 
-on: [pull_request]
+on: [push, pull_request]
 
 env:
   BOT_NAME: va-vfs-bot

--- a/script/build-content.js
+++ b/script/build-content.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 const chokidar = require('chokidar');
 const chalk = require('chalk');
 const debounce = require('lodash/debounce');

--- a/script/build-content.js
+++ b/script/build-content.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 const chokidar = require('chokidar');
 const chalk = require('chalk');
 const debounce = require('lodash/debounce');

--- a/script/build-content.js
+++ b/script/build-content.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 const chokidar = require('chokidar');
 const chalk = require('chalk');
 const debounce = require('lodash/debounce');
@@ -7,7 +8,7 @@ const getOptions = require('../src/site/stages/build/options');
 const build = require('../src/site/stages/build');
 
 // If help, echo the options
-if (process.argv[2] === 'helps') {
+if (process.argv[2] === 'help') {
   printBuildHelp();
   process.exit(0);
 }

--- a/script/build-content.js
+++ b/script/build-content.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 const chokidar = require('chokidar');
 const chalk = require('chalk');
 const debounce = require('lodash/debounce');
@@ -8,7 +7,7 @@ const getOptions = require('../src/site/stages/build/options');
 const build = require('../src/site/stages/build');
 
 // If help, echo the options
-if (process.argv[2] === 'help') {
+if (process.argv[2] === 'helps') {
   printBuildHelp();
   process.exit(0);
 }


### PR DESCRIPTION
GHA manual checks were only running on PR so you can push into an open PR and skip the scans