### PR TITLE
Fix breadcrumb path

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1075,15 +1075,15 @@
       "breadcrumbs_override": [
         {
           "name": "Decision reviews and appeals",
-          "path": "/decision-reviews"
+          "path": "decision-reviews"
         },
         {
           "name": "Board Appeals",
-          "path": "/decision-reviews/board-appeal"
+          "path": "decision-reviews/board-appeal"
         },
         {
           "name": "Request a Board Appeal",
-          "path": "/decision-reviews/board-appeal/request-board-appeal-form-10182"
+          "path": "decision-reviews/board-appeal/request-board-appeal-form-10182"
         }
       ]
     }
@@ -1099,15 +1099,15 @@
       "breadcrumbs_override": [
         {
           "name": "Housing assistance",
-          "path": "/housing-assistance"
+          "path": "housing-assistance"
         },
         {
           "name": "VA-backed home loans",
-          "path": "/housing-assistance/home-loans"
+          "path": "housing-assistance/home-loans"
         },
         {
           "name": "Apply for Certificate of Eligibility Form 26-1880",
-          "path": "/housing-assistance/home-loans/apply-for-coe-form-26-1880"
+          "path": "housing-assistance/home-loans/apply-for-coe-form-26-1880"
         }
       ]
     }


### PR DESCRIPTION
## Description

During an IA review, Mikki discovered that the breadcrumb paths for form 10182 (Notice of Disagreement) were including appropriate links. It appears that the `path` in the `registry.json` file should not include a leading `/`. It has been removed for 2 forms in this PR:
- Form 10182 (Notice of Disagreement)
- Form 26-1880 (Certificate of Eligibility)

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/25216

## Testing done

N/A

## Screenshots

![Screen Shot 2021-05-25 at 3 08 36 PM](https://user-images.githubusercontent.com/136959/119561713-2384fb00-bd6b-11eb-9f82-ff3bd543253b.png)

## Acceptance criteria
- [x] Fix breadcrumb paths for Form 10182 & 26-1880

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
