### PR TITLE
Reducing the number of Nightwatch retries

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint:js:changed": "LIST=`git diff-index --diff-filter=d --name-only --cached HEAD | grep \"\\.js[x]\\{0,1\\}$\"`; if [ \"$LIST\" ]; then eslint --quiet --config changed.eslintrc.js $LIST; fi",
     "lint:js:changed:fix": "LIST=`git diff-index --name-only HEAD | grep \"\\.js[x]\\{0,1\\}$\"`; if [ \"$LIST\" ]; then eslint --fix --quiet $LIST; fi",
     "new:cms-content-model": "yo ./src/site/stages/build/process-cms-exports/generator/index.js && npm run lint:js:untracked:fix",
-    "nightwatch:docker": "nightwatch -c config/nightwatch.docker-compose.js --suiteRetries 3",
+    "nightwatch:docker": "nightwatch -c config/nightwatch.docker-compose.js --suiteRetries 1",
     "nightwatch": "nightwatch -c config/nightwatch.js",
     "nightwatch-sauce": "nightwatch -c config/nightwatch-sauce.js",
     "nightwatch-visual": "node src/platform/testing/visual-regression/index.js",


### PR DESCRIPTION
## Description
* The Nightwatch accessibility checks retry 1000+ page scans when a test fails
* This will help reduce the time the daily a11y check runs
* One retry should catch lagging tests like (possibly) the MegaMenu e2e test

## Testing done
* Tests run in CI, no failures
* Nightwatch keyboard testing fails on `localhost` for reasons unknown. The test passes consistently on Jenkins. Verified there are only two Nightwatch e2e tests on content-build:
  * Home page test
  * Accessible modal dialog (mocks keyboard navigation)

## Acceptance criteria
- [x] All tests pass in CI

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
