### PR TITLE
Remove random-lang-support-link from prod builds

### DIFF
--- a/src/site/stages/build/plugins/create-environment-filter.js
+++ b/src/site/stages/build/plugins/create-environment-filter.js
@@ -8,11 +8,13 @@ function createEnvironmentFilter(options) {
     for (const fileName of Object.keys(files)) {
       const file = files[fileName];
 
-      // Do not include random-lang-support-link on production (except for the preview server).
+      // Do not include the following pages on production (except for the preview server):
+      // va.gov/asistencia-y-recursos-en-espanol
+      // va.gov/tagalog-wika-mapagkukunan-at-tulong
       if (
         !options.isPreviewServer &&
         environmentName === ENVIRONMENTS.VAGOVPROD &&
-        file.entityBundle === 'random-lang-support-link'
+        (file.entityId === '20078' || file.entityId === '20092')
       ) {
         delete files[fileName];
       }

--- a/src/site/stages/build/plugins/create-environment-filter.js
+++ b/src/site/stages/build/plugins/create-environment-filter.js
@@ -8,6 +8,15 @@ function createEnvironmentFilter(options) {
     for (const fileName of Object.keys(files)) {
       const file = files[fileName];
 
+      // Do not include random-lang-support-link on production (except for the preview server).
+      if (
+        !options.isPreviewServer &&
+        environmentName === ENVIRONMENTS.VAGOVPROD &&
+        file.entityBundle === 'random-lang-support-link'
+      ) {
+        delete files[fileName];
+      }
+
       if (
         environmentName !== ENVIRONMENTS.LOCALHOST &&
         file.status === 'draft'


### PR DESCRIPTION
# Description

**Slack:** https://dsva.slack.com/archives/C52CL1PKQ/p1622058438250800?thread_ts=1622058073.248800&cid=C52CL1PKQ

This PR removes random-lang-support-link templates from production builds.

## Acceptance Criteria

- [ ] Remove random-lang-support-link templates from production builds.
