### PR TITLE
disallow health care questionnaire

### DIFF
--- a/src/site/assets/robots.txt
+++ b/src/site/assets/robots.txt
@@ -96,6 +96,7 @@ Disallow: /cgi-bin/
 Disallow: /drupal
 Disallow: /performance-dashboard
 Disallow: /covid19screen
+Disallow: /health-care/health-questionnaires/questionnaires/
 
 # disallow WIP VAMCs
 Disallow: /alaska-health-care


### PR DESCRIPTION
## Description
Adding new health care questionnaires to not be indexed by search engines. We want to prevent users from stumbling on our app as much as possible

## Testing done
- none
