### PR TITLE
#23667: Increase tinyliquid timeout to 20 minutes

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -7,6 +7,10 @@ const moment = require('moment-timezone');
 // Relative imports.
 const phoneNumberArrayToObject = require('./phoneNumberArrayToObject');
 
+// The default 2-minute timeout is insufficient with high node counts, likely
+// because metalsmith runs many tinyliquid engines in parallel.
+const TINYLIQUID_TIMEOUT_MINUTES = 20;
+
 function getPath(obj) {
   return obj.path;
 }
@@ -14,9 +18,14 @@ function getPath(obj) {
 module.exports = function registerFilters() {
   const { cmsFeatureFlags } = global;
 
-  // Set timeout option to something higher (20mins)
-  // eslint-disable-next-line no-new
-  new liquid.Context({ timeout: 1200000 });
+  // Set the tinyliquid timeout. This requires access to the liquid context
+  // which is why we're replacing the run() method here.
+  const originalRun = liquid.run;
+  liquid.run = (astList, context, callback) => {
+    // eslint-disable-next-line no-param-reassign
+    context.options.timeout = TINYLIQUID_TIMEOUT_MINUTES * 60 * 1000;
+    originalRun(astList, context, callback);
+  };
 
   // Custom liquid filter(s)
   liquid.filters.humanizeDate = dt =>

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -717,3 +717,18 @@ describe('appendCentralizedFeaturedContent', () => {
     ).to.equal(2);
   });
 });
+
+describe('run', () => {
+  it('sets timeout to 20 minutes', () => {
+    // Save the context so we can check the timeout value
+    let savedContext = {};
+    const originalRun = liquid.run;
+    liquid.run = (astList, context, callback) => {
+      savedContext = context;
+      originalRun(astList, context, callback);
+    };
+
+    liquid.run([], { options: {} }, () => {});
+    expect(savedContext.options.timeout).to.eq(1200000);
+  });
+});


### PR DESCRIPTION
## Description
We use tinyliquid to render templates into HTML. Tinyliquid's default 2-minute timeout is insufficient with high node counts, likely because metalsmith runs many tinyliquid engines in parallel. At 48k nodes the following error would cause the build to fail both locally and on CI:

```
Step 21 of 54 start: Apply layouts C
/Users/chris/Documents/code/content-build/src/site/stages/build/index.js:243
    if (err) throw err;
             ^
Error: Timeout.
    at Timeout.<anonymous> (/Users/chris/Documents/code/content-build/node_modules/tinyliquid/lib/index.js:79:16)
```

Increasing the timeout to 20 minutes resolves the error.

## Testing done
- Successful 48k node content build (no timeout observed)
- Instrument tinyliquid to output timeout value, ensuring it is set correctly
- No regressions in existing build

## Acceptance criteria
- [x] Current and 48k node content builds are successful (no timeouts)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
