### PR TITLE
Add expand image button to show more items

### DIFF
--- a/src/site/layouts/media_list_images.drupal.liquid
+++ b/src/site/layouts/media_list_images.drupal.liquid
@@ -113,7 +113,7 @@
                               <{{image_title_tag}} class="{{image_title_classes }} medium-screen:vads-u-margin-top--0">{{ remainingImage.entity.entityLabel }}</{{image_title_tag}}>
                             </dt>
 
-                            <dd>
+                            <dd class="va-c-position--relative">
                               <picture>
                                 {% if remainingImage.entity.image.url == empty %}
                                   <img
@@ -123,6 +123,14 @@
                                     width="{{ remainingImage.entity.image.width }}"
                                   />
                                 {% else %}
+                                  <a
+                                    aria-label="Open image in new tab"
+                                    class="vads-u-margin-right--1p5 vads-u-margin-top--1p5 vads-u-text-decoration--none vads-u-display--flex vads-u-align-items--center expand-image-button va-c-position--absolute va-c-position-top-right-corner vads-u-justify-content--center"
+                                    href="{{ remainingImage.entity.image.url }}"
+                                    target="_blank"
+                                  >
+                                    <i aria-hidden="true" class="fas fa-expand-arrows-alt" role="img"></i>
+                                  </a>
                                   <img
                                     alt="{{ alt }}"
                                     class="vads-u-border--1px vads-u-border-color--gray-light"


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/24293

This PR adds the expand image button to items that are hidden by `show more` on http://localhost:3002/preview?nodeId=6954.

## Testing done
Locally

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/120331389-f4aadf80-c2aa-11eb-9518-042d7629d9ee.png)


## Acceptance criteria
- [x] Add expand image button to show more items

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
