### PR TITLE
Local builds do not re-download cached assets 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ src/site/tests/html/
 # Files to ignore
 ._*
 .cache
+.drupalAssets
 .config
 .DS_Store
 .env

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -133,6 +133,7 @@ function applyDefaultOptions(options) {
       `${teasers}/**/*.{md,html,liquid}`,
     ],
     cacheDirectory: path.join(projectRoot, '.cache', options.buildtype),
+    assetDirectory: path.join(projectRoot, '.drupalAssets', options.buildtype),
     paramsDirectory: path.join(utilities, 'query-params'),
   });
 }

--- a/src/site/stages/build/plugins/download-drupal-assets.js
+++ b/src/site/stages/build/plugins/download-drupal-assets.js
@@ -19,30 +19,33 @@ async function downloadFile(
   if (!asset) {
     return;
   }
-  const fileOutputPath = path.join(
-    options.cacheDirectory,
-    'drupal/downloads',
-    asset.dest,
-  );
+  const fileOutputPath = path.join(options.assetDirectory, asset.dest);
 
-  let response;
-  let retries = 3;
-  while (retries--) {
-    try {
-      // eslint-disable-next-line no-await-in-loop
-      response = await client.proxyFetch(asset.src);
-      break;
-    } catch (e) {
-      if (retries > 0) {
-        // eslint-disable-next-line no-console
-        console.error(
-          `Error while fetching ${asset.src}. ${e} Retries remaining: ${retries}`,
-        );
-        // Pause to give the proxy connection a break.
-        // eslint-disable-next-line no-await-in-loop,no-loop-func
-        await new Promise(resolve => setTimeout(resolve, 2000 - retries * 500));
-      } else {
-        throw e;
+  let response = {};
+
+  if (fs.existsSync(fileOutputPath)) {
+    response.cached = true;
+  } else {
+    let retries = 3;
+    while (retries--) {
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        response = await client.proxyFetch(asset.src);
+        break;
+      } catch (e) {
+        if (retries > 0) {
+          // eslint-disable-next-line no-console
+          console.error(
+            `Error while fetching ${asset.src}. ${e} Retries remaining: ${retries}`,
+          );
+          // Pause to give the proxy connection a break.
+          // eslint-disable-next-line no-await-in-loop,no-loop-func
+          await new Promise(resolve =>
+            setTimeout(resolve, 2000 - retries * 500),
+          );
+        } else {
+          throw e;
+        }
       }
     }
   }
@@ -64,6 +67,9 @@ async function downloadFile(
       process.stdout.write('.');
       if (!assetsToDownload.length) process.stdout.write('\n');
     }
+  } else if (response.cached) {
+    log(`${fileOutputPath} already downloaded; skipping`);
+    downloadResults.downloadCount++;
   } else {
     // For now, not going to fail the build for a missing asset
     // Should get caught by the broken link checker, though


### PR DESCRIPTION
## Description

Keep Drupal assets in `.drupalAssets`. Do not delete cache between builds. Do not re-download assets if already in cache. If desired, we can add a yarm command to clear the asset cache.

## Acceptance criteria
- [x] Local builds do not re-download cached assets 

## Testing done
Ran `yarn build --pull-drupal` twice.

Assets downloads went from ~20 minutes to 102ms for the 2nd run.
