### PR TITLE
NOD: build in prod

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1071,7 +1071,7 @@
       "description": "Apply online to request a Board Appeal.",
       "includeBreadcrumbs": true,
       "keywords": "notice of disagreement, board appeal, NOD",
-      "vagovprod": false,
+      "vagovprod": true,
       "breadcrumbs_override": [
         {
           "name": "Decision reviews and appeals",


### PR DESCRIPTION
## Description

Set Notice of Disagreement flag to have it build in production. This is in preparation for UAT testing. The form is behind a feature flag, so this change will only show a work-in-progress banner to those without the flag set.

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [x] NOD built in production

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
