### PR TITLE
Add derivative sizing to clp story images

### DIFF
--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -245,10 +245,10 @@
                     {% if storyTeaser.entity.fieldMedia.entity.thumbnail.url %}
                       <img
                         alt="{{ storyTeaser.entity.fieldMedia.entity.thumbnail.alt }}"
-                        class="vads-l-col--12 medium-screen:vads-l-col--4 medium-screen:vads-u-margin-right--2"
-                        height="{{ storyTeaser.entity.fieldImage.entity.thumbnail.derivative.height }}"
+                        class="story-image vads-u-height--full medium-screen:vads-u-margin-right--2"
+                        height="{{ storyTeaser.entity.fieldMedia.entity.thumbnail.derivative.height }}"
                         src="{{ storyTeaser.entity.fieldMedia.entity.thumbnail.derivative.url }}"
-                        width="{{ storyTeaser.entity.fieldImage.entity.thumbnail.derivative.width }}"
+                        width="{{ storyTeaser.entity.fieldMedia.entity.thumbnail.derivative.width }}"
                       />
                     {% endif %}
                     <div class="vads-u-margin-top--2 medium-screen:vads-u-margin-top--0">
@@ -658,6 +658,15 @@
     {% include "src/site/components/up_to_top_button.html" with isCampaignLandingPage = true %}
   </main>
 </div>
+
+<style>
+  /* 768px = $medium-screen */
+  @media (min-width: 768px) {
+    .story-image {
+      max-width: 40%;
+    }
+  }
+</style>
 
 {% include "src/site/includes/footer.html" %}
 {% include "src/site/includes/debug.drupal.liquid" %}

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -246,7 +246,9 @@
                       <img
                         alt="{{ storyTeaser.entity.fieldMedia.entity.thumbnail.alt }}"
                         class="vads-l-col--12 medium-screen:vads-l-col--4 medium-screen:vads-u-margin-right--2"
-                        src="{{ storyTeaser.entity.fieldMedia.entity.thumbnail.url }}"
+                        height="{{ storyTeaser.entity.fieldImage.entity.thumbnail.derivative.height }}"
+                        src="{{ storyTeaser.entity.fieldMedia.entity.thumbnail.derivative.url }}"
+                        width="{{ storyTeaser.entity.fieldImage.entity.thumbnail.derivative.width }}"
                       />
                     {% endif %}
                     <div class="vads-u-margin-top--2 medium-screen:vads-u-margin-top--0">

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -106,7 +106,12 @@
         {% for promo in fieldClpWhatYouCanDoPromos %}
           <div class="vads-l-col--12 medium-screen:vads-l-col--4 vads-u-align-content--stretch vads-u-margin-y--1 ">
             <div class="vads-u-background-color--gray-light-alt vads-u-height--full medium-screen:vads-u-margin-x--1 medium-screen:vads-u-margin-y--0">
-              <img alt="{{ promo.entity.fieldImage.entity.thumbnail.alt }}" height="{{ promo.entity.fieldImage.entity.thumbnail.derivative.height }}" width="{{ promo.entity.fieldImage.entity.thumbnail.derivative.width }}" src="{{ promo.entity.fieldImage.entity.thumbnail.derivative.url }}" />
+              <img
+                alt="{{ promo.entity.fieldImage.entity.thumbnail.alt }}"
+                height="{{ promo.entity.fieldImage.entity.thumbnail.derivative.height }}"
+                src="{{ promo.entity.fieldImage.entity.thumbnail.derivative.url }}"
+                width="{{ promo.entity.fieldImage.entity.thumbnail.derivative.width }}"
+              />
               <h3 class="vads-u-padding-x--2 vads-u-margin-top--1">
                 <a
                   href="{{ promo.entity.fieldPromoLink.entity.fieldLink.uri }}"

--- a/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
@@ -390,6 +390,11 @@ const nodeCampaignLandingPage = `
               ... on Media {
                 name
                 thumbnail {
+                  derivative(style: _32MEDIUMTHUMBNAIL) {
+                    url
+                    width
+                    height
+                  }
                   height
                   width
                   url

--- a/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
@@ -395,9 +395,6 @@ const nodeCampaignLandingPage = `
                     width
                     height
                   }
-                  height
-                  width
-                  url
                   targetId
                   alt
                   title
@@ -436,9 +433,6 @@ const nodeCampaignLandingPage = `
                     width
                     height
                   }
-                  height
-                  width
-                  url
                   targetId
                   alt
                   title


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/25520

This PR implements a 3x2 derivative image for CLP stories.

## Testing done
Locally

## Screenshots
<img width="797" alt="Screen Shot 2021-06-09 at 9 28 02 AM" src="https://user-images.githubusercontent.com/12773166/121383955-176d7180-c905-11eb-9567-500b96e91bd6.png">
<img width="556" alt="Screen Shot 2021-06-09 at 9 28 17 AM" src="https://user-images.githubusercontent.com/12773166/121383964-189e9e80-c905-11eb-93de-d830d5fa4690.png">


## Acceptance criteria
- [x] Use 3x2 derivative image for CLP stories

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
