### PR TITLE
Fix pagination styling on outreach mats

### DIFF
--- a/src/site/layouts/publication_listing.drupal.liquid
+++ b/src/site/layouts/publication_listing.drupal.liquid
@@ -260,45 +260,40 @@
 
             </div>
 
+            <!-- Pagination -->
             <div class="va-pagination library-show" id="va-pager-div">
-              <span class="vads-u-display--none
-              medium-screen::vads-u-display--block
-              small-desktop-screen:vads-u-display--block
-              large-screen:vads-u-display--block max-control">
-                <a href="#first-click" aria-label="First page"
-                  class="va-button-link pager-focus-item" id="first-click">First</a>
-              </span>
               <span class="va-pagination-prev">
-                <a href="#pager-previous-click" class="va-button-link pager-focus-item"
-                  id="pager-previous-click" aria-label="Load previous page"
-                  tabindex="0">Prev</a>
+                <a
+                  href="#pager-previous-click"
+                  id="pager-previous-click"
+                  aria-label="Load previous page"
+                >
+                  Prev
+                </a>
               </span>
-              <div id="pager-nums-insert" class="va-pagination-inner">
-              </div>
+              <div id="pager-nums-insert" class="va-pagination-inner"></div>
               <span class="va-pagination-next">
-                <a href="#pager-next-click" class="va-button-link pager-focus-item"
-                  id="pager-next-click" aria-label="Load next page"
-                  tabindex="0">Next</a>
-              </span>
-              <span class="vads-u-display--none
-              medium-screen::vads-u-display--block
-              small-desktop-screen:vads-u-display--block
-              large-screen:vads-u-display--block max-control">
-                <a aria-label="Last page" href="#search-entry"
-                  class="va-button-link pager-focus-item" id="last-click">Last</a>
+                <a
+                  href="#pager-next-click"
+                  id="pager-next-click"
+                  aria-label="Load next page"
+                >
+                  Next
+                </a>
               </span>
             </div>
+
             <div class="library-show" id="no-results">
               <div>
                 <p><b>Select a different topic or file type</b></p>
               </div>
             </div>
-
         </article>
 
       </div>
     </div>
   </main>
 </div>
+
 {% include "src/site/includes/footer.html" %}
 {% include "src/site/includes/debug.drupal.liquid" %}


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/21528

This PR fixes the styling of the custom pagination on outreach-materials.

## Testing done
http://localhost:3002/outreach-and-events/outreach-materials/

## Screenshots
![localhost_3002_outreach-and-events_outreach-materials_ (1)](https://user-images.githubusercontent.com/12773166/120525777-bdfdc380-c395-11eb-9568-d72ab3c6209a.png)

## Acceptance criteria
- [x] fixes the styling of the custom pagination on outreach-materials.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
