### PR TITLE
Preview route should return a non-200 status code.

### DIFF
--- a/script/preview-routes/single-page-diff.js
+++ b/script/preview-routes/single-page-diff.js
@@ -61,7 +61,9 @@ function singlePageDiff(
         res
           .set('Retry-After', 30)
           .status(503)
-          .send(`Please hold while the preview server is starting - ${percent}%`);
+          .send(
+            `Please hold while the preview server is starting - ${percent}%`,
+          );
         return;
       }
 

--- a/script/preview-routes/single-page-diff.js
+++ b/script/preview-routes/single-page-diff.js
@@ -58,9 +58,12 @@ function singlePageDiff(
     try {
       if (!nonNodeContent.content) {
         const percent = Number(nonNodeContent.refreshProgress * 100).toFixed(2);
-        res.send(
-          `Please hold while the preview server is starting - ${percent}%`,
-        );
+        res
+          .set('Retry-After', 30)
+          .status(503)
+          .send(
+            `Please hold while the preview server is starting - ${percent}%`,
+          );
         return;
       }
 

--- a/script/preview-routes/single-page-diff.js
+++ b/script/preview-routes/single-page-diff.js
@@ -61,9 +61,7 @@ function singlePageDiff(
         res
           .set('Retry-After', 30)
           .status(503)
-          .send(
-            `Please hold while the preview server is starting - ${percent}%`,
-          );
+          .send(`Please hold while the preview server is starting - ${percent}%`);
         return;
       }
 

--- a/script/preview.js
+++ b/script/preview.js
@@ -235,9 +235,12 @@ app.get('/preview', async (req, res, next) => {
   try {
     if (!nonNodeContent.content) {
       const percent = Number(nonNodeContent.refreshProgress * 100).toFixed(2);
-      res.send(
-        `Please hold while the preview server is starting - ${percent}%`,
-      );
+      res
+        .set('Retry-After', 30)
+        .status(503)
+        .send(
+          `Please hold while the preview server is starting - ${percent}%`,
+        );
       return;
     }
 

--- a/script/preview.js
+++ b/script/preview.js
@@ -238,9 +238,7 @@ app.get('/preview', async (req, res, next) => {
       res
         .set('Retry-After', 30)
         .status(503)
-        .send(
-          `Please hold while the preview server is starting - ${percent}%`,
-        );
+        .send(`Please hold while the preview server is starting - ${percent}%`);
       return;
     }
 


### PR DESCRIPTION
## Description
Currently, the preview server returns HTTP 200 while starting up.  This causes a problem for some uses, e.g. [this one](https://github.com/department-of-veterans-affairs/content-build/pull/177) where we're using the output of the preview build to replace individual pages from the monolithic build.

After some thought, I think an HTTP 503 along with a 'Retry-After' header is a more appropriate response.  I'm a foole, though, and agreeable to modifications or other suggestions.  I thought 30 seconds was a reasonable retry-after time, but maybe that should be less.

## Testing done
Started up preview server, curled it in another tab, saw appropriate status code and headers.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
