### PR TITLE
#25074: Add manual garbage collection at regular interval

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Content build for vets.gov website static assets.",
   "scripts": {
-    "build": "node --max-old-space-size=8192 script/build-content.js",
+    "build": "node --max-old-space-size=5000 --expose-gc script/build-content.js",
     "build:compare": "node script/content-build-compare.js",
     "build:validate": "node ./script/validate-content-builds.js",
     "cms:compare": "./script/cms/compare.sh",

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
     "test:integration:nightwatch": "nightwatch -c config/nightwatch.js --tag integration",
     "test:integration:nightwatch:docker": "docker-compose -p e2e up -d && docker-compose -p e2e run --user=node --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod -e WEB_HOST=staging.va.gov -e WEB_PORT=80 content-build --no-color run nightwatch:docker -- --tag integration && docker-compose -p e2e stop",
     "update:schema": "./script/update-json-schema.sh",
-    "watch": "concurrently \"node --max-old-space-size=8192 script/build-content.js --watch\" \"http-server build/localhost -s -c-1 -p 3002\"",
-    "watch:css-sourcemaps": "node --max-old-space-size=8192 script/build-content.js --watch --local-css-sourcemaps",
+    "watch": "concurrently \"node --max-old-space-size=5000 --expose-gc script/build-content.js --watch\" \"http-server build/localhost -s -c-1 -p 3002\"",
+    "watch:css-sourcemaps": "node --max-old-space-size=5000 --expose-gc script/build-content.js --watch --local-css-sourcemaps",
     "watch:review": "node ./script/run-review-instance-api.js",
     "watch:static": "concurrently -n metalsmith,webpack \"npm:watch:content\" \"npm run watch -- --env.entry=static-pages --progress=false\""
   },

--- a/src/site/stages/build/index.js
+++ b/src/site/stages/build/index.js
@@ -271,10 +271,10 @@ function build(BUILD_OPTIONS) {
       // If this isn't a watch, just output the normal "end of build" information
       if (global.verbose) {
         smith.printSummary();
+        smith.printPeakMemory();
       }
 
       smith.endGarbageCollection();
-      smith.printPeakMemory();
 
       console.log('The Metalsmith build has completed.');
 

--- a/src/site/stages/build/index.js
+++ b/src/site/stages/build/index.js
@@ -75,6 +75,10 @@ function build(BUILD_OPTIONS) {
 
   registerLiquidFilters();
 
+  // Start manual garbage collection to limit large spikes in memory use.
+  // This prevents running out of memory on CI.
+  smith.startGarbageCollection();
+
   // Set up Metalsmith. BE CAREFUL if you change the order of the plugins. Read the comments and
   // add comments about any implicit dependencies you are introducing!!!
   //
@@ -240,7 +244,10 @@ function build(BUILD_OPTIONS) {
   );
 
   smith.build(err => {
-    if (err) throw err;
+    if (err) {
+      smith.endGarbageCollection();
+      throw err;
+    }
 
     // If we're running a watch, let the engineer know important information
     if (BUILD_OPTIONS.watch) {
@@ -265,6 +272,10 @@ function build(BUILD_OPTIONS) {
       if (global.verbose) {
         smith.printSummary();
       }
+
+      smith.endGarbageCollection();
+      smith.printPeakMemory();
+
       console.log('The Metalsmith build has completed.');
 
       if (usingCMSExport) {

--- a/src/site/stages/build/silversmith.js
+++ b/src/site/stages/build/silversmith.js
@@ -132,7 +132,7 @@ module.exports = () => {
         const memBefore = process.memoryUsage();
         global.gc();
         const memAfter = process.memoryUsage();
-        printGarbageCollectionStats(memBefore, memAfter);
+        if (global.verbose) printGarbageCollectionStats(memBefore, memAfter);
       }, GARBAGE_COLLECTION_FREQUENCY_SECONDS * 1000);
     } else {
       throw new Error(


### PR DESCRIPTION
## Description
Parts of the content build rapidly allocate and deallocate large amounts of data. V8's automatic garbage collection handles this well in most cases, but it can fall behind. This causes spikes in heap and non-heap (buffer) allocation, resulting in very large peak memory use at high node counts.

To address the problem, this PR:
- triggers manual garbage collection at a 10-second interval to keep memory use in check, particularly during the Apply Layouts steps
- adds 1ms pauses to allow garbage collection during two especially memory-intensive steps
- adds logging for total memory use (RSS) to the log, helping track changes  over time

See [#25074](https://app.zenhub.com/workspaces/vsp---frontend-tools-5fc9325744944e0015ed1861/issues/department-of-veterans-affairs/va.gov-team/25074) and [#24022](https://github.com/department-of-veterans-affairs/va.gov-team/issues/24022) for more information and benchmarks.

## Testing done
- Benchmark memory use locally and on CI with a variety of GC intervals
- Manual checks to ensure no regressions

## Screenshots
- See above tickets for graphs, memory use logs, and other benchmarks

## Acceptance criteria
- [x] Manual garbage collection is performed at a regular interval
- [x] Total memory use (RSS) is logged to allow monitoring over time

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
