### PR TITLE
Update how do you rate component with a11y improvements

### DIFF
--- a/src/site/includes/how-do-you-rate.drupal.liquid
+++ b/src/site/includes/how-do-you-rate.drupal.liquid
@@ -35,7 +35,7 @@
 
     <div>
       <button class="usa-button vads-u-width--full medium-screen:vads-u-width--auto vads-u-margin--0 vads-u-margin-top--2p5" id="rating-submit" type="submit">
-        Submit Rating
+        Submit rating
       </button>
     </div>
 

--- a/src/site/includes/how-do-you-rate.drupal.liquid
+++ b/src/site/includes/how-do-you-rate.drupal.liquid
@@ -5,24 +5,29 @@
     class="vads-u-padding-top--3 vads-u-padding-bottom--1 vads-u-display--flex vads-u-flex-direction--column vads-u-padding-x--1 large-screen:vads-u-padding-x--0"
     data-template="includes/how-do-you-rate"
     onsubmit="onRatingSubmit(event)"
-  >
-    <!-- Section title -->
-    <h2 class="vads-u-margin-top--0 vads-u-font-size--h3">{{ ratingOptionsQuestion }}</h2>
-
+    >
     <!-- Rating options -->
     <fieldset id="rating-options" class="fieldset-input vads-u-margin-top--1">
+      <!-- Section title -->
+      <legend>
+        <h2 class="vads-u-margin--0 vads-u-margin-bottom--1p5 vads-u-font-size--h3">{{ ratingOptionsQuestion }}</h2>
+      </legend>
+
+      <!-- Error message -->
       <span class="vads-u-display--none usa-input-error-message" role="alert" id="rating-error-message">
         <span class="sr-only">Error</span> Please select an answer
       </span>
-      <div class="form-radio-buttons">
+
+      <div id="rating-buttons" class="form-radio-buttons">
+        <!-- Good rating -->
         <div class="radio-button">
-          <input id="good" onclick="onRatingChange(event)" name="rating" type="radio" value="Good" tabindex="0" />
+          <input id="good" onclick="onRatingChange(event)" name="rating" type="radio" value="Good" />
           <label class="vads-u-margin--0 vads-u-margin-right--2" for="good">Good</label>
         </div>
-      </div>
-      <div class="form-radio-buttons">
+
+        <!-- Bad rating -->
         <div class="radio-button">
-          <input id="bad" onclick="onRatingChange(event)" name="rating" type="radio" value="Bad" tabindex="0" />
+          <input id="bad" onclick="onRatingChange(event)" name="rating" type="radio" value="Bad" />
           <label class="vads-u-margin--0" for="bad">Bad</label>
         </div>
       </div>
@@ -30,7 +35,7 @@
 
     <div>
       <button class="usa-button vads-u-width--full medium-screen:vads-u-width--auto vads-u-margin--0 vads-u-margin-top--2p5" id="rating-submit" type="submit">
-        Submit
+        Submit Rating
       </button>
     </div>
 
@@ -55,6 +60,7 @@
       event.preventDefault()
 
       // Derive the elements on the page.
+      var ratingButtonsElement = document.getElementById("rating-buttons");
       var ratingOptionsElement = document.getElementById("rating-options");
       var ratingErrorMessageElement = document.getElementById('rating-error-message');
       var submitButton = document.getElementById("rating-submit");
@@ -94,15 +100,17 @@
       }
 
       // We don't need the rating options anymore, so hide it.
-      if (ratingOptionsElement) {
-        ratingOptionsElement.setAttribute('aria-hidden', 'true');
-        ratingOptionsElement.className = ratingOptionsElement.className + ' vads-u-display--none';
+      if (ratingButtonsElement) {
+        ratingButtonsElement.setAttribute('aria-hidden', 'true');
+        ratingButtonsElement.className = ratingButtonsElement.className + ' vads-u-display--none';
       }
 
       // We need to show the thank you message, so show it.
       if (thankYouMessageElement) {
         thankYouMessageElement.setAttribute('aria-hidden', 'false');
+        thankYouMessageElement.setAttribute('aria-live', 'assertive');
         thankYouMessageElement.className = thankYouMessageElement.className.replace('vads-u-display--none', 'vads-u-display--block');
+        thankYouMessageElement.focus();
       }
     }
   </script>


### PR DESCRIPTION
## Description
**Issue:** 

This PR implements some tweaks to a11y for the how do your rate component.

## Testing done
Locally

## Screenshots
<img width="505" alt="Screen Shot 2021-06-08 at 10 06 25 AM" src="https://user-images.githubusercontent.com/12773166/121219757-44f0e700-c841-11eb-860c-cbd8ba7fb493.png">
<img width="499" alt="Screen Shot 2021-06-08 at 10 06 31 AM" src="https://user-images.githubusercontent.com/12773166/121219760-44f0e700-c841-11eb-96ae-14b0f947d992.png">
<img width="525" alt="Screen Shot 2021-06-08 at 10 06 38 AM" src="https://user-images.githubusercontent.com/12773166/121219763-45897d80-c841-11eb-9a76-367d3c08a9e4.png">
<img width="496" alt="Screen Shot 2021-06-08 at 10 06 44 AM" src="https://user-images.githubusercontent.com/12773166/121219764-45897d80-c841-11eb-9b39-d0914d74962c.png">
<img width="500" alt="Screen Shot 2021-06-08 at 10 06 49 AM" src="https://user-images.githubusercontent.com/12773166/121219766-45897d80-c841-11eb-935b-68dff2703c23.png">


## Acceptance criteria
- [x] Place h2 tag in legend tag as first child of fieldset
- [x] Focus thank you message and add aria-live="assertive"
- [x] Remove unneeded `tabindex="0"`s
- [x] Change `Submit` to `Submit rating`

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
