### PR TITLE
Update FSR link as well as breadcrumbs

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -892,8 +892,8 @@
   },
   {
     "appName": "Financial Status Report",
-    "entryName": "request-debt-help-5655",
-    "rootUrl": "/manage-va-debt/request-debt-help-5655",
+    "entryName": "request-debt-help-form-5655",
+    "rootUrl": "/manage-va-debt/request-debt-help-form-5655",
     "template": {
       "title:": "Request help with VA debt with VA Form 5655",
       "vagovprod": true,
@@ -904,11 +904,11 @@
       "breadcrumbs_override": [
         {
           "path": "manage-va-debt",
-          "name": "Manage your VA debt"
+          "name": " Manage VA debt"
         },
         {
           "path": "manage-va-debt/request-debt-help-5655",
-          "name": "Request help with VA debt with VA Form 5655"
+          "name": "Request help with VA debt"
         }
       ]
     }


### PR DESCRIPTION
This PR was opened for this [ticket](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/department-of-veterans-affairs/va.gov-team/23341) in conjunction with this [PR](https://github.com/department-of-veterans-affairs/vets-website/pull/17540)

## Description
FSR URL should be updated to www.va.gov/manage-va-debt/request-debt-help-form-5655/ and the breadcrumbs should be: Home > Manage VA debt > Request help with VA debt

[Ticket](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/department-of-veterans-affairs/va.gov-team/23341)

## Testing done
- Manual and visual testing

## Screenshots


## Acceptance criteria
- [x] URL is updated to www.va.gov/manage-va-debt/request-debt-help-form-5655/
- [x] Bread crumbs read as  Home > Manage VA debt > Request help with VA debt

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
