### PR TITLE
Add nonce to script tags

### DIFF
--- a/src/site/includes/how-do-you-rate.drupal.liquid
+++ b/src/site/includes/how-do-you-rate.drupal.liquid
@@ -43,7 +43,7 @@
     <p aria-hidden="true" id="thank-you-message" class="vads-u-display--none vads-u-margin--0">Thank you for your feedback.</p>
   </form>
 
-  <script>
+  <script nonce="**CSP_NONCE**" type="text/javascript">
     function onRatingChange(event) {
       // Derive the elements on the page.
       var ratingOptionsElement = document.getElementById("rating-options");

--- a/src/site/paragraphs/lists_of_links.drupal.liquid
+++ b/src/site/paragraphs/lists_of_links.drupal.liquid
@@ -70,7 +70,7 @@
 </div>
 
 {% if formattedVaParagraphs.length > 6 %}
-  <script>
+  <script nonce="**CSP_NONCE**" type="text/javascript">
     function onShowAllTopics() {
       // Derive the extra paragraphs element.
       var extraParagraphsElements = document.querySelectorAll('[data-hidden-lists_of_links-entity-id="{{ entity.entityId }}"]');


### PR DESCRIPTION
# Description

**Slack:** https://dsva.slack.com/archives/C52CL1PKQ/p1623254243056500

This PR adds missing `nonce` attributes to script tags in liquid templates.
