### PR TITLE
Vamc events page preview-able

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -771,30 +771,18 @@ module.exports = function registerFilters() {
     });
   };
 
-  //* Sorts event dates (fieldDatetimeRangeTimezone) from oldest to newest, removing expired items.
-  liquid.filters.eventDateSorter = (
-    dates = [],
-    reverse = false,
-    stale = true,
-  ) => {
+  //* Sorts event dates (fieldDatetimeRangeTimezone) from newest to oldest.
+  liquid.filters.eventDateSorter = dates => {
     if (!dates) return null;
-    let sorted = dates.sort((a, b) => {
+    return dates.sort((a, b) => {
       const start1 = a.fieldDatetimeRangeTimezone.value;
       const start2 = b.fieldDatetimeRangeTimezone.value;
-      return reverse ? start2 - start1 : start1 - start2;
+      return start1 - start2;
     });
-
-    const currentDateUTC = new Date().getTime() / 1000;
-
-    if (stale) {
-      sorted = sorted.filter(
-        item => item.fieldDatetimeRangeTimezone.value > currentDateUTC,
-      );
-    }
-
-    return sorted.reverse();
+    // return sorted
   };
 
+  //* paginatePages has limitations, it is not yet fully operational.
   liquid.filters.paginatePages = (page, items, aria) => {
     const perPage = 10;
 

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -792,7 +792,7 @@ module.exports = function registerFilters() {
       );
     }
 
-    return sorted;
+    return sorted.reverse();
   };
 
   liquid.filters.paginatePages = (page, items, aria) => {

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -4,6 +4,7 @@ const converter = require('number-to-words');
 const he = require('he');
 const liquid = require('tinyliquid');
 const moment = require('moment-timezone');
+const set = require('lodash/fp/set');
 // Relative imports.
 const phoneNumberArrayToObject = require('./phoneNumberArrayToObject');
 
@@ -754,5 +755,126 @@ module.exports = function registerFilters() {
       featureContentObj.entity.fieldCta = buttonFeatured;
     }
     return [featureContentObj, ...featureContentArray];
+  };
+
+  liquid.filters.filterPastEvents = data => {
+    if (!data) return null;
+    return data.filter(event => {
+      return moment(event.fieldDatetimeRangeTimezone.value * 1000).isBefore();
+    });
+  };
+
+  liquid.filters.filterUpcomingEvents = data => {
+    if (!data) return null;
+    return data.filter(event => {
+      return moment(event.fieldDatetimeRangeTimezone.value * 1000).isAfter();
+    });
+  };
+
+  //* Sorts event dates (fieldDatetimeRangeTimezone) from oldest to newest, removing expired items.
+  liquid.filters.eventDateSorter = (
+    dates = [],
+    reverse = false,
+    stale = true,
+  ) => {
+    if (!dates) return null;
+    let sorted = dates.sort((a, b) => {
+      const start1 = a.fieldDatetimeRangeTimezone.value;
+      const start2 = b.fieldDatetimeRangeTimezone.value;
+      return reverse ? start2 - start1 : start1 - start2;
+    });
+
+    const currentDateUTC = new Date().getTime() / 1000;
+
+    if (stale) {
+      sorted = sorted.filter(
+        item => item.fieldDatetimeRangeTimezone.value > currentDateUTC,
+      );
+    }
+
+    return sorted;
+  };
+
+  liquid.filters.paginatePages = (page, items, aria) => {
+    const perPage = 10;
+
+    const ariaLabel = aria ? ` of ${aria}` : '';
+
+    const paginationPath = pageNum => {
+      return pageNum === 0 ? '' : `/page-${pageNum + 1}`;
+    };
+
+    const pageReturn = [];
+
+    if (items.length > 0) {
+      const pagedEntities = _.chunk(items, perPage);
+
+      for (let pageNum = 0; pageNum < pagedEntities.length; pageNum++) {
+        let pagedPage = Object.assign({}, page);
+        if (pageNum > 0) {
+          pagedPage = set(
+            'entityUrl.path',
+            `${page.entityUrl.path}${paginationPath(pageNum)}`,
+            page,
+          );
+        }
+
+        pagedPage.pagedItems = pagedEntities[pageNum];
+        const innerPages = [];
+
+        if (pagedEntities.length > 0) {
+          // add page numbers
+          const numPageLinks = 3;
+          let start;
+          let length;
+          if (pagedEntities.length <= numPageLinks) {
+            start = 0;
+            length = pagedEntities.length;
+          } else {
+            length = numPageLinks;
+
+            if (pageNum + numPageLinks > pagedEntities.length) {
+              start = pagedEntities.length - numPageLinks;
+            } else {
+              start = pageNum;
+            }
+          }
+
+          for (let num = start; num < start + length; num++) {
+            innerPages.push({
+              href:
+                num === pageNum
+                  ? null
+                  : `${page.entityUrl.path}${paginationPath(num)}`,
+              label: num + 1,
+              class: num === pageNum ? 'va-pagination-active' : '',
+            });
+          }
+
+          pagedPage.paginator = {
+            ariaLabel,
+            prev:
+              pageNum > 0
+                ? `${page.entityUrl.path}${paginationPath(pageNum - 1)}`
+                : null,
+            inner: innerPages,
+            next:
+              pageNum < pagedEntities.length - 1
+                ? `${page.entityUrl.path}${paginationPath(pageNum + 1)}`
+                : null,
+          };
+          pageReturn.push(pagedPage);
+        }
+      }
+    }
+
+    if (!pageReturn[0]) {
+      return {};
+    }
+
+    return {
+      pagedItems: pageReturn[0].pagedItems,
+      paginator: pageReturn[0].paginator,
+    };
   };
 };

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -779,7 +779,6 @@ module.exports = function registerFilters() {
       const start2 = b.fieldDatetimeRangeTimezone.value;
       return start1 - start2;
     });
-    // return sorted
   };
 
   //* paginatePages has limitations, it is not yet fully operational.

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -190,13 +190,29 @@ describe('paginatePages', () => {
     const result = liquid.filters.paginatePages(
       eventListingMockData,
       eventListingMockData.reverseFieldListingNode.entities,
+      'event',
     );
 
+    const expected = {
+      ariaLabel: ' of event',
+      prev: null,
+      inner: [
+        {
+          href: null,
+          label: 1,
+          class: 'va-pagination-active',
+        },
+        {
+          href: '/pittsburgh-health-care/events/page-2',
+          label: 2,
+          class: '',
+        },
+      ],
+      next: '/pittsburgh-health-care/events/page-2',
+    };
+
     expect(result.pagedItems.length).to.be.below(11);
-    expect(result.paginator.next).to.not.equal(null);
-    expect(result.paginator.next).to.eq(
-      '/pittsburgh-health-care/events/page-2',
-    );
+    expect(result.paginator).to.deep.equal(expected);
   });
 });
 

--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -62,7 +62,15 @@
                 {% assign pagingResult = debug | paginatePages: sortedUpcomingEvents, 'event' %}
                 {% assign pagedItems = pagingResult.pagedItems %}
                 {% assign paginator = pagingResult.paginator %}
-                {% else %}
+
+                {% for event in pagedItems %}
+                  {% if featuredEventUrl != event.entityUrl.path %}
+                    <div class="clearfix-text">
+                      {% include "src/site/teasers/event.drupal.liquid" with node = event %}
+                    </div>
+                  {% endif %}
+                {% endfor %}
+              {% else %}
 
                 {% for event in pagedItems %}
                   {% if featuredEventUrl != event.entityUrl.path %}

--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -24,24 +24,27 @@
                 {% endif %}
               </div>
 
-              {% if pastEvents.entities.length > 0 %}
+              {% assign pastEvents = reverseFieldListingNode.entities | filterPastEvents %}
+
+              {% if pastEvents.length > 0 %}
                 {% include "src/site/facilities/facilities_events_toggle.drupal.liquid" with url = entityUrl.path %}
               {% endif %}
 
-              {% assign featuredUrl = null %}
+              {% assign featuredEventUrl = null %}
               {% assign featuredItemSet = false %}
+              {% assign allEventTeasers = reverseFieldListingNode %}
 
               {% for featuredEvent in allEventTeasers.entities %}
                 {% if featuredEvent.fieldFeatured == true %}
                   {% unless entityUrl.path contains 'past-events' %}
                     {% if featuredItemSet == false %}
-                      {% assign featuredUrl = featuredEvent.entityUrl.path %}
+                      {% assign featuredEventUrl = featuredEvent.entityUrl.path %}
                       <div class="usa-width-two-thirds">
                         <div class="usa-grid usa-grid-full vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4 vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-border-left--7px vads-u-border-color--primary-alt-lightest" id="featured-content">
                           <div class="usa-width-full vads-u-padding-left--2">
                             <div class="vads-u-margin-bottom--2">
                               <strong>In the spotlight at
-                                {{ fieldOffice.entity.title }}</strong>
+                                {{ fieldOffice.entity.entityLabel }}</strong>
                             </div>
                             {% include "src/site/teasers/event_featured.drupal.liquid" with node = featuredEvent %}
                           </div>
@@ -53,23 +56,33 @@
                 {% endif %}
               {% endfor %}
 
+              {% if isPreview %}
+                {% assign upcomingEvents = reverseFieldListingNode.entities | filterUpcomingEvents  %}
+                {% assign sortedUpcomingEvents = upcomingEvents | eventDateSorter %}
+                {% assign pagingResult = debug | paginatePages: sortedUpcomingEvents, 'event' %}
+                {% assign pagedItems = pagingResult.pagedItems %}
+                {% assign paginator = pagingResult.paginator %}
+                {% else %}
+
+                {% for event in pagedItems %}
+                  {% if featuredEventUrl != event.entityUrl.path %}
+                    <div class="clearfix-text">
+                      {% include "src/site/teasers/event.drupal.liquid" with node = event %}
+                    </div>
+                  {% endif %}
+                {% endfor %}
+              {% endif %}
+
               {% assign numItems = pagedItems | size %}
               {% if numItems < 1 %}
                 <div class="clearfix-text">No events at this time.</div>
               {% endif %}
-              {% for event in pagedItems %}
-                {% if featuredUrl != event.entityUrl.path %}
-                  <div class="clearfix-text">
-                    {% include "src/site/teasers/event.drupal.liquid" with node = event %}
-                  </div>
-                {% endif %}
-              {% endfor %}
+
               {% include "src/site/includes/pagination.drupal.liquid" %}
 
             </div>
           </div>
         </article>
-
       </div>
     </div>
   </main>

--- a/src/site/layouts/tests/vamc/fixtures/eventListingMockData.json
+++ b/src/site/layouts/tests/vamc/fixtures/eventListingMockData.json
@@ -1,0 +1,262 @@
+{
+  "entityBundle": "event_listing",
+  "entityId": "2807",
+  "entityPublished": true,
+  "title": "Events",
+  "vid": 16487,
+  "entityUrl": {
+    "breadcrumb": [ { "url": { "path": "/", "routed": true }, "text": "Home" },
+      {
+        "url": { "path": "/pittsburgh-health-care", "routed": true },
+        "text": "VA Pittsburgh health care"
+      },
+      { "url": { "path": "", "routed": true }, "text": "News and events" },
+      { "url": { "path": "", "routed": true }, "text": "Events" } ],
+    "path": "/pittsburgh-health-care/events"
+  },
+  "entityMetatags": [
+    {
+      "__typename": "MetaValue",
+      "key": "description",
+      "value": "Learn more about events in our VA Pittsburgh health care community, including classes on health and wellness."
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:description",
+      "value": "Learn more about events in our VA Pittsburgh health care community, including classes on health and wellness."
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:site_name",
+      "value": "Veterans Affairs"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:title",
+      "value": "Events | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "title",
+      "value": "VA Pittsburgh Health Care | Events | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:card",
+      "value": "summary_large_image"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:description",
+      "value": "Learn more about events in our VA Pittsburgh health care community, including classes on health and wellness."
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:site",
+      "value": "@DeptVetAffairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:title",
+      "value": "Events | Veterans Affairs"
+    }
+  ],
+  "changed": 1583958997,
+  "fieldIntroText": "Learn more about events in our VA Pittsburgh health care community, including classes on health and wellness.",
+  "pastEvents": { "entities": [] },
+  "reverseFieldListingNode": {
+    "entities": [
+      {
+        "title": "Virtual Veterans Town Hall",
+        "entityUrl": {
+          "path": "/pittsburgh-health-care/events/virtual-veterans-town-hall"
+        },
+        "fieldFeatured": true,
+        "fieldDatetimeRangeTimezone": {
+          "value": 1624284000,
+          "endValue": 1624287600,
+          "timezone": "America/New_York"
+        },
+        "fieldDescription": null,
+        "fieldLocationHumanreadable": null,
+        "fieldFacilityLocation": null
+      },
+      {
+        "title": "Mindful Mondays",
+        "entityUrl": { "path": "/pittsburgh-health-care/events/mindful-mondays-2" },
+        "fieldFeatured": false,
+        "fieldDatetimeRangeTimezone": {
+          "value": 1581343200,
+          "endValue": 1581346800,
+          "timezone": "America/New_York"
+        },
+        "fieldDescription": "VA Pittsburgh’s whole health facilitators invite you to join them once weekly for a moment of mindfulness.",
+        "fieldLocationHumanreadable": null,
+        "fieldFacilityLocation": null
+      },
+      {
+        "title": "Mindful Mondays",
+        "entityUrl": { "path": "/pittsburgh-health-care/events/mindful-mondays-3" },
+        "fieldFeatured": false,
+        "fieldDatetimeRangeTimezone": {
+          "value": 1577109600,
+          "endValue": 1577113200,
+          "timezone": "America/New_York"
+        },
+        "fieldDescription": "VA Pittsburgh’s whole health facilitators invite you to join them once weekly for a moment of mindfulness.",
+        "fieldLocationHumanreadable": null,
+        "fieldFacilityLocation": null
+      },
+      {
+        "title": "Caregiver Support Annual Resource Fair",
+        "entityUrl": {
+          "path": "/pittsburgh-health-care/events/caregiver-support-annual-resource-fair"
+        },
+        "fieldFeatured": false,
+        "fieldDatetimeRangeTimezone": {
+          "value": 1620925200,
+          "endValue": 1620932400,
+          "timezone": "America/New_York"
+        },
+        "fieldDescription": null,
+        "fieldLocationHumanreadable": null,
+        "fieldFacilityLocation": null
+      },
+      {
+        "title": "The Bridge Screening and Discussion",
+        "entityUrl": {
+          "path": "/pittsburgh-health-care/events/the-bridge-screening-and-discussion"
+        },
+        "fieldFeatured": false,
+        "fieldDatetimeRangeTimezone": {
+          "value": 1568988000,
+          "endValue": 1569002400,
+          "timezone": "America/New_York"
+        },
+        "fieldDescription": "Watch the documentary and join our panel to talk about moral injury, suicide and mental health.",
+        "fieldLocationHumanreadable": "Learning Exchange",
+        "fieldFacilityLocation": null
+      },
+      {
+        "title": "Teal Tuesdays",
+        "entityUrl": { "path": "/pittsburgh-health-care/events/teal-tuesdays-2" },
+        "fieldFeatured": false,
+        "fieldDatetimeRangeTimezone": {
+          "value": 1619496000,
+          "endValue": 1619582400,
+          "timezone": "America/New_York"
+        },
+        "fieldDescription": null,
+        "fieldLocationHumanreadable": null,
+        "fieldFacilityLocation": null
+      },
+      {
+        "title": "Teal Tuesdays",
+        "entityUrl": { "path": "/pittsburgh-health-care/events/teal-tuesdays-1" },
+        "fieldFeatured": false,
+        "fieldDatetimeRangeTimezone": {
+          "value": 1618891200,
+          "endValue": 1619063940,
+          "timezone": "America/New_York"
+        },
+        "fieldDescription": null,
+        "fieldLocationHumanreadable": null,
+        "fieldFacilityLocation": null
+      },
+      {
+        "title": "Teal Tuesdays",
+        "entityUrl": { "path": "/pittsburgh-health-care/events/teal-tuesdays-" },
+        "fieldFeatured": false,
+        "fieldDatetimeRangeTimezone": {
+          "value": 1618286400,
+          "endValue": 1618372800,
+          "timezone": "America/New_York"
+        },
+        "fieldDescription": null,
+        "fieldLocationHumanreadable": null,
+        "fieldFacilityLocation": null
+      },
+      {
+        "title": "Teal Tuesdays",
+        "entityUrl": { "path": "/pittsburgh-health-care/events/teal-tuesdays" },
+        "fieldFeatured": false,
+        "fieldDatetimeRangeTimezone": {
+          "value": 1617681600,
+          "endValue": 1617854340,
+          "timezone": "America/New_York"
+        },
+        "fieldDescription": null,
+        "fieldLocationHumanreadable": null,
+        "fieldFacilityLocation": null
+      },
+      {
+        "title": "Veterans Breakfast Club Scuttlebutt ",
+        "entityUrl": {
+          "path": "/pittsburgh-health-care/events/veterans-breakfast-club-scuttlebutt-0"
+        },
+        "fieldFeatured": false,
+        "fieldDatetimeRangeTimezone": {
+          "value": 1619442000,
+          "endValue": 1619445600,
+          "timezone": "America/New_York"
+        },
+        "fieldDescription": null,
+        "fieldLocationHumanreadable": null,
+        "fieldFacilityLocation": null
+      },
+      {
+        "title": "Veterans Breakfast Club Scuttlebutt ",
+        "entityUrl": {
+          "path": "/pittsburgh-health-care/events/veterans-breakfast-club-scuttlebutt"
+        },
+        "fieldFeatured": false,
+        "fieldDatetimeRangeTimezone": {
+          "value": 1618837200,
+          "endValue": 1618840800,
+          "timezone": "America/New_York"
+        },
+        "fieldDescription": null,
+        "fieldLocationHumanreadable": null,
+        "fieldFacilityLocation": null
+      },
+      {
+        "title": "Double Edged Sword of Military Culture: Helping and Hurting the Warrior",
+        "entityUrl": {
+          "path": "/pittsburgh-health-care/events/double-edged-sword-of-military-culture-helping-and-hurting-the-warrior"
+        },
+        "fieldFeatured": false,
+        "fieldDatetimeRangeTimezone": {
+          "value": 1618527600,
+          "endValue": 1618533000,
+          "timezone": "America/New_York"
+        },
+        "fieldDescription": null,
+        "fieldLocationHumanreadable": null,
+        "fieldFacilityLocation": null
+      }
+    ]
+  },
+  "fieldOffice": { 
+    "entity": { 
+      "entityLabel": "VA Pittsburgh health care" 
+    } 
+  },
+  "facilitySidebar": {
+    "name": "VA Pittsburgh health care",
+    "description": "VISN 4 | va.gov/pittsburgh-health-care",
+    "links": [  {
+      "label": "VA Pittsburgh health care",
+      "expanded": true,
+      "description": null,
+      "url": { "path": "/pittsburgh-health-care" },
+      "links": ["test"] } ]
+  },
+  "outreachSidebar": { "name": "Outreach and events", "description": " ", "links": [] },
+  "alert": {
+    "entities": []
+  },
+  "bannerAlert": {
+    "entities": []
+  },
+  "pid": 2807
+}

--- a/src/site/stages/build/drupal/graphql/GetLatestPageById.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetLatestPageById.graphql.js
@@ -5,6 +5,7 @@ const healthCareRegionPage = require('./healthCareRegionPage.graphql');
 
 const bioPage = require('./bioPage.graphql');
 const eventPage = require('./eventPage.graphql');
+const eventListingPage = require('./eventListingPage.graphql');
 const faqMultipleQa = require('./faqMultipleQa.graphql');
 const healthCareLocalFacilityPage = require('./healthCareLocalFacilityPage.graphql');
 const healthCareRegionDetailPage = require('./healthCareRegionDetailPage.graphql');
@@ -50,6 +51,7 @@ module.exports = `
   ${vamcOperatingStatusAndAlerts.fragment}
   ${newsStoryPage.fragment}
   ${eventPage.fragment}
+  ${eventListingPage.fragment}
   ${bioPage.fragment}
   ${vaFormPage.fragment}
   ${nodeQa.fragment}
@@ -83,6 +85,7 @@ module.exports = `
         ... pressReleasePage
         ... vamcOperatingStatusAndAlerts
         ... eventPage
+        ... eventListingPage
         ... bioPage
         ... vaFormPage
         ... nodeQa


### PR DESCRIPTION
## Description
Events page can now be viewed in preview server
Note: There are limitations related to paginating pages but this does NOT affect build.
In addition, if an event is featured, the title is now fixed to say `In the spotlight at <name of location>`

## Testing done
Units tests were added to liquid filters added

## Screenshots


## Acceptance criteria
- [ ] All tests pass
- [ ] Can view events page on preview

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
