### PR TITLE
Don't display pagination on pages with only one page

### DIFF
--- a/src/site/includes/pagination.drupal.liquid
+++ b/src/site/includes/pagination.drupal.liquid
@@ -14,11 +14,7 @@
 {% assign paginatorCount = paginator.inner | size %}
 {% assign totalItems = paginatorCount %}
 
-{% if numItems %}
-  {% assign totalItems = numItems | times: .1 %}
-{% endif%}
-
-{% if paginator != empty and totalItems <= paginatorCount and 1 < totalItems %}
+{% if paginator != empty and totalItems <= paginatorCount and totalItems > 1 %}
 
   <div class="va-pagination" data-template="includes/pagination">
     {% if paginator.prev != empty %}


### PR DESCRIPTION
Another attempt at Issue department-of-veterans-affairs/va.gov-team#18571

TODO: Add a Cypress test to confirm the outreach-and-events page is working

My theory: the following code was unnecessary, and causing the type of `totalItems` to be changed such that` 1 < totalItems` evaluates false.

```liquid
assign totalItems = numItems | times: .1 
```