### PR TITLE
Stories page is preview-able

### DIFF
--- a/.liquidrc
+++ b/.liquidrc
@@ -1,0 +1,54 @@
+{
+  "ignore": [
+    {
+      "type": "liquid",
+      "begin": "comment",
+      "end": "endcomment"
+    },
+    {
+      "type": "html",
+      "begin": "script",
+      "end": "script"
+    },
+    {
+      "type": "html",
+      "begin": "style",
+      "end": "style"
+    }
+  ],
+  "html": {
+    "correct": false,
+    "force_attribute": false,
+    "braces": false,
+    "preserve": 2,
+    "unformatted": false
+  },
+  "js": {
+    "preserve": 1,
+    "method_chain": 0,
+    "quote_convert": "none",
+    "format_array": "indent",
+    "format_object": "indent",
+    "braces": false,
+    "no_semicolon": false,
+    "brace_block": true
+  },
+  "scss": {
+    "css_insert_lines": true,
+    "preserve": 2,
+    "braces": false,
+    "brace_block": true
+  },
+  "css": {
+    "css_insert_lines": true,
+    "preserve": 2,
+    "braces": false,
+    "brace_block": true
+  },
+  "json": {
+    "preserve": 0,
+    "braces": false,
+    "brace_block": true,
+    "no_semicolon": true
+  }
+}

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -869,4 +869,8 @@ module.exports = function registerFilters() {
       paginator: pageReturn[0].paginator,
     };
   };
+
+  liquid.filters.isFirstPage = paginator => {
+    return !paginator || paginator.prev === null;
+  };
 };

--- a/src/site/layouts/story_listing.drupal.liquid
+++ b/src/site/layouts/story_listing.drupal.liquid
@@ -18,33 +18,24 @@
                 </p>
                 {% endif %}
               </div>
-
-            {% assign stories = reverseFieldListingNode.entities %}
-              {% if paginator.prev == null %}
-                {% for storyFeature in stories %}
-                  {% if storyFeature.fieldFeatured == true %}
-                {% include "src/site/teasers/news_story_page_feature.drupal.liquid" with node = storyFeature %}
-              {% endif %}
-            {% endfor %}
-          {% endif %}
-
+          {% assign stories = reverseFieldListingNode.entities %}
           {% if isPreview %}
             {% assign pagingResult = debug | paginatePages: stories, 'story' %}
             {% assign pagedItems = pagingResult.pagedItems%}
             {% assign paginator = pagingResult.paginator%}
-            {% for story in pagedItems %}
-              {% if story.fieldFeatured == false %}
-                {% include "src/site/teasers/news_story_page.drupal.liquid" with node = story %}
-              {% endif %}
-            {% endfor %}
-          {% else %}
-            {% for story in pagedItems %}
-              {% if story.fieldFeatured == false %}
-                {% include "src/site/teasers/news_story_page.drupal.liquid" with node = story %}
+          {% endif %}
+          {% if paginator.prev == null %}
+            {% for storyFeature in stories %}
+              {% if storyFeature.fieldFeatured == true %}
+                {% include "src/site/teasers/news_story_page_feature.drupal.liquid" with node = storyFeature %}
               {% endif %}
             {% endfor %}
           {% endif %}
-
+          {% for story in pagedItems %}
+            {% if story.fieldFeatured == false %}
+              {% include "src/site/teasers/news_story_page.drupal.liquid" with node = story %}
+            {% endif %}
+          {% endfor %}
           {% if stories.length == 0 %}
             <div class="clearfix-text">No stories at this time.</div>
           {% endif %}

--- a/src/site/layouts/story_listing.drupal.liquid
+++ b/src/site/layouts/story_listing.drupal.liquid
@@ -18,21 +18,35 @@
                 </p>
                 {% endif %}
               </div>
-          {% if paginator.prev == null %}
-          {% for storyFeature in allNewsStoryTeasers.entities %}
-            {% if storyFeature.fieldFeatured == true %}
-              {% include "src/site/teasers/news_story_page_feature.drupal.liquid" with node = storyFeature %}
-            {% endif %}
-          {% endfor %}
-          {% endif %}
-          {% for story in pagedItems %}
-            {% if story.fieldFeatured == false %}
-              {% include "src/site/teasers/news_story_page.drupal.liquid" with node = story %}
-            {% endif %}
-          {% endfor %}
 
-          {% if pagedItems == false %}
-          <div class="clearfix-text">No stories at this time.</div>
+            {% assign stories = reverseFieldListingNode.entities %}
+              {% if paginator.prev == null %}
+                {% for storyFeature in stories %}
+                  {% if storyFeature.fieldFeatured == true %}
+                {% include "src/site/teasers/news_story_page_feature.drupal.liquid" with node = storyFeature %}
+              {% endif %}
+            {% endfor %}
+          {% endif %}
+
+          {% if isPreview %}
+            {% assign pagingResult = debug | paginatePages: stories, 'story' %}
+            {% assign pagedItems = pagingResult.pagedItems%}
+            {% assign paginator = pagingResult.paginator%}
+            {% for story in pagedItems %}
+              {% if story.fieldFeatured == false %}
+                {% include "src/site/teasers/news_story_page.drupal.liquid" with node = story %}
+              {% endif %}
+            {% endfor %}
+          {% else %}
+            {% for story in pagedItems %}
+              {% if story.fieldFeatured == false %}
+                {% include "src/site/teasers/news_story_page.drupal.liquid" with node = story %}
+              {% endif %}
+            {% endfor %}
+          {% endif %}
+
+          {% if stories.length == 0 %}
+            <div class="clearfix-text">No stories at this time.</div>
           {% endif %}
 
           {% include "src/site/includes/pagination.drupal.liquid" %}

--- a/src/site/layouts/story_listing.drupal.liquid
+++ b/src/site/layouts/story_listing.drupal.liquid
@@ -19,12 +19,13 @@
                 {% endif %}
               </div>
           {% assign stories = reverseFieldListingNode.entities %}
+          {% assign isFirstPage = isPreview or paginator | isFirstPage %}
           {% if isPreview %}
             {% assign pagingResult = debug | paginatePages: stories, 'story' %}
             {% assign pagedItems = pagingResult.pagedItems%}
             {% assign paginator = pagingResult.paginator%}
           {% endif %}
-          {% if paginator.prev == null %}
+          {% if isFirstPage %}
             {% for storyFeature in stories %}
               {% if storyFeature.fieldFeatured == true %}
                 {% include "src/site/teasers/news_story_page_feature.drupal.liquid" with node = storyFeature %}

--- a/src/site/stages/build/drupal/graphql/GetLatestPageById.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetLatestPageById.graphql.js
@@ -10,6 +10,7 @@ const faqMultipleQa = require('./faqMultipleQa.graphql');
 const healthCareLocalFacilityPage = require('./healthCareLocalFacilityPage.graphql');
 const healthCareRegionDetailPage = require('./healthCareRegionDetailPage.graphql');
 const healthServicesListingPage = require('./healthServicesListingPage.graphql');
+const storyListingPage = require('./storyListingPage.graphql');
 const newsStoryPage = require('./newStoryPage.graphql');
 const nodeBasicLandingPage = require('./nodeBasicLandingPage.graphql');
 const nodeCampaignLandingPage = require('./nodeCampaignLandingPage.graphql');
@@ -49,6 +50,7 @@ module.exports = `
   ${healthServicesListingPage.fragment}
   ${pressReleasePage.fragment}
   ${vamcOperatingStatusAndAlerts.fragment}
+  ${storyListingPage.fragment}
   ${newsStoryPage.fragment}
   ${eventPage.fragment}
   ${eventListingPage.fragment}
@@ -81,6 +83,7 @@ module.exports = `
         ... healthCareLocalFacilityPage
         ... healthCareRegionDetailPage
         ... healthServicesListingPage
+        ... storyListingPage
         ... newsStoryPage
         ... pressReleasePage
         ... vamcOperatingStatusAndAlerts


### PR DESCRIPTION
## Description
Issue linked below

## Acceptance criteria
- [ ] Stories page can be view on preview
- [ ] When running a full build, there should be no changes in behavior for stories page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
