### PR TITLE
News release page now preview-able

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -778,7 +778,11 @@ module.exports = function registerFilters() {
 
   //* Sorts event dates (fieldDatetimeRangeTimezone) starting with the most upcoming event.
   //* Also sorts press releases (fieldReleaseDate) from newest to oldest.
-  liquid.filters.eventOrPressReleasesDateSorter = (dates, dateKey, reverse) => {
+  liquid.filters.sortByDateKey = (
+    dates,
+    dateKey = 'fieldDatetimeRangeTimezone',
+    reverse = false,
+  ) => {
     if (!dates) return null;
     return dates.sort((a, b) => {
       const start1 = moment(a[dateKey].value);

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -776,13 +776,15 @@ module.exports = function registerFilters() {
     });
   };
 
-  //* Sorts event dates (fieldDatetimeRangeTimezone) from newest to oldest.
-  liquid.filters.eventDateSorter = dates => {
+  //* Sorts event dates (fieldDatetimeRangeTimezone) starting with the most upcoming event.
+  //* Also sorts press releases (fieldReleaseDate) from newest to oldest.
+  liquid.filters.eventOrPressReleasesDateSorter = (dates, dateKey, reverse) => {
     if (!dates) return null;
     return dates.sort((a, b) => {
-      const start1 = a.fieldDatetimeRangeTimezone.value;
-      const start2 = b.fieldDatetimeRangeTimezone.value;
-      return start1 - start2;
+      const start1 = moment(a[dateKey].value);
+      const start2 = moment(b[dateKey].value);
+
+      return reverse ? start2 - start1 : start1 - start2;
     });
   };
 

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -5,6 +5,7 @@ import registerFilters from './liquid';
 import vetCenterData from '../layouts/tests/vet_center/fixtures/vet_center_escanaba_data';
 import featuredContentData from '../layouts/tests/vet_center/fixtures/featuredContentData.json';
 import eventListingMockData from '../layouts/tests/vamc/fixtures/eventListingMockData.json';
+import pressReleasesMockData from '../layouts/tests/vamc/fixtures/pressReleasesMockData.json';
 
 const _ = require('lodash');
 
@@ -53,48 +54,48 @@ const eventsMockData = [
   },
 ];
 
-const pressReleasesMockData = [
-  {
-    entityId: '19797',
-    entityUrl: {
-      path:
-        '/pittsburgh-health-care/news-releases/va-secretary…ttsburgh-nurse-for-dedication-service-to-veterans',
-    },
-    fieldIntroText:
-      'A VA Pittsburgh Healthcare System nurse recently won the Secretary’s Award for Excellence in Nursing and Advancement of Nursing Programs for helping to improve health care services for veterans.',
-    fieldReleaseDate: {
-      value: '2021-05-14T15:11:11',
-    },
-    title: 'VA secretary recognizes VA Pittsburgh nurse for',
-  },
-  {
-    entityId: '841',
-    entityUrl: {
-      path:
-        '/pittsburgh-health-care/news-releases/women-veterans-resource-fair-spotlights-va-and-community-care',
-    },
-    fieldIntroText:
-      'Veterans Affairs (VA) Pittsburgh Healthcare System is connecting women Veterans with VA and non-VA services during a resource fair on Friday, Aug. 16, from 10 a.m. to 1 p.m. ',
-    fieldReleaseDate: {
-      value: '2019-08-12T19:12:40',
-    },
-    title: 'Women Veterans resource fair spotlights VA and community care',
-  },
-  {
-    entityId: '7640',
-    entityUrl: {
-      path:
-        '/pittsburgh-health-care/news-releases/va-pittsburgh-named-lgbtq-healthcare-equality-leader-for-8th',
-    },
-    fieldIntroText:
-      'VA Pittsburgh Healthcare System was named a 2020 “LGBTQ Healthcare Equality Leader” by the Human Rights Campaign Foundation (HRC). The designation is the eighth time in as many years and is listed in the 13th edition of the Healthcare Equality Index (HEI). ',
-    fieldReleaseDate: {
-      value: '2020-09-14T11:40:46',
-    },
-    title:
-      'VA Pittsburgh named ‘LGBTQ Healthcare Equality Leader’ for 8th year',
-  },
-];
+// const pressReleasesMockData = [
+//   {
+//     entityId: '19797',
+//     entityUrl: {
+//       path:
+//         '/pittsburgh-health-care/news-releases/va-secretary…ttsburgh-nurse-for-dedication-service-to-veterans',
+//     },
+//     fieldIntroText:
+//       'A VA Pittsburgh Healthcare System nurse recently won the Secretary’s Award for Excellence in Nursing and Advancement of Nursing Programs for helping to improve health care services for veterans.',
+//     fieldReleaseDate: {
+//       value: '2021-05-14T15:11:11',
+//     },
+//     title: 'VA secretary recognizes VA Pittsburgh nurse for',
+//   },
+//   {
+//     entityId: '841',
+//     entityUrl: {
+//       path:
+//         '/pittsburgh-health-care/news-releases/women-veterans-resource-fair-spotlights-va-and-community-care',
+//     },
+//     fieldIntroText:
+//       'Veterans Affairs (VA) Pittsburgh Healthcare System is connecting women Veterans with VA and non-VA services during a resource fair on Friday, Aug. 16, from 10 a.m. to 1 p.m. ',
+//     fieldReleaseDate: {
+//       value: '2019-08-12T19:12:40',
+//     },
+//     title: 'Women Veterans resource fair spotlights VA and community care',
+//   },
+//   {
+//     entityId: '7640',
+//     entityUrl: {
+//       path:
+//         '/pittsburgh-health-care/news-releases/va-pittsburgh-named-lgbtq-healthcare-equality-leader-for-8th',
+//     },
+//     fieldIntroText:
+//       'VA Pittsburgh Healthcare System was named a 2020 “LGBTQ Healthcare Equality Leader” by the Human Rights Campaign Foundation (HRC). The designation is the eighth time in as many years and is listed in the 13th edition of the Healthcare Equality Index (HEI). ',
+//     fieldReleaseDate: {
+//       value: '2020-09-14T11:40:46',
+//     },
+//     title:
+//       'VA Pittsburgh named ‘LGBTQ Healthcare Equality Leader’ for 8th year',
+//   },
+// ];
 
 describe('filterPastEvents', () => {
   it('returns null when null is passed', () => {
@@ -178,21 +179,21 @@ describe('filterUpcomingEvents', () => {
   });
 });
 
-describe('eventOrPressReleasesDateSorter', () => {
+describe('sortByDateKey', () => {
   it('returns null when null is passed', () => {
-    expect(liquid.filters.eventOrPressReleasesDateSorter(null)).to.eq(null);
+    expect(liquid.filters.sortByDateKey(null)).to.eq(null);
   });
 
   it('returns null when empty string is passed', () => {
-    expect(liquid.filters.eventOrPressReleasesDateSorter('')).to.eq(null);
+    expect(liquid.filters.sortByDateKey('')).to.eq(null);
   });
 
-  it('returns an array of upcoming events in date order starting with most recent to least recent', () => {
+  it('returns an array of upcoming events in date/time order starting with most recent to least recent', () => {
     expect(
-      liquid.filters.eventOrPressReleasesDateSorter(
+      liquid.filters.sortByDateKey(
         eventsMockData,
         'fieldDatetimeRangeTimezone',
-        true,
+        false,
       ),
     ).to.deep.include.members([
       {
@@ -216,12 +217,12 @@ describe('eventOrPressReleasesDateSorter', () => {
 
   it('returns an array of press releases in date order from newest to oldest', () => {
     expect(
-      liquid.filters.eventOrPressReleasesDateSorter(
-        pressReleasesMockData,
+      liquid.filters.sortByDateKey(
+        pressReleasesMockData.entities,
         'fieldReleaseDate',
-        false,
+        true,
       ),
-    ).to.have.deep.members([
+    ).to.deep.equal([
       {
         entityId: '19797',
         entityUrl: {
@@ -261,6 +262,29 @@ describe('eventOrPressReleasesDateSorter', () => {
           value: '2019-08-12T19:12:40',
         },
         title: 'Women Veterans resource fair spotlights VA and community care',
+      },
+    ]);
+  });
+
+  it('returns an array of upcoming events in date/time order when no dateKey is passed', () => {
+    expect(
+      liquid.filters.sortByDateKey(eventsMockData),
+    ).to.deep.include.members([
+      {
+        title: 'Clean-up Block Event',
+        fieldDatetimeRangeTimezone: {
+          endValue: 1628355741,
+          timezone: 'America/New_York',
+          value: 1628348541,
+        },
+      },
+      {
+        title: 'Holiday Office Dinner',
+        fieldDatetimeRangeTimezone: {
+          endValue: 1639670421,
+          timezone: 'America/New_York',
+          value: 1639659621,
+        },
       },
     ]);
   });

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -54,49 +54,6 @@ const eventsMockData = [
   },
 ];
 
-// const pressReleasesMockData = [
-//   {
-//     entityId: '19797',
-//     entityUrl: {
-//       path:
-//         '/pittsburgh-health-care/news-releases/va-secretary…ttsburgh-nurse-for-dedication-service-to-veterans',
-//     },
-//     fieldIntroText:
-//       'A VA Pittsburgh Healthcare System nurse recently won the Secretary’s Award for Excellence in Nursing and Advancement of Nursing Programs for helping to improve health care services for veterans.',
-//     fieldReleaseDate: {
-//       value: '2021-05-14T15:11:11',
-//     },
-//     title: 'VA secretary recognizes VA Pittsburgh nurse for',
-//   },
-//   {
-//     entityId: '841',
-//     entityUrl: {
-//       path:
-//         '/pittsburgh-health-care/news-releases/women-veterans-resource-fair-spotlights-va-and-community-care',
-//     },
-//     fieldIntroText:
-//       'Veterans Affairs (VA) Pittsburgh Healthcare System is connecting women Veterans with VA and non-VA services during a resource fair on Friday, Aug. 16, from 10 a.m. to 1 p.m. ',
-//     fieldReleaseDate: {
-//       value: '2019-08-12T19:12:40',
-//     },
-//     title: 'Women Veterans resource fair spotlights VA and community care',
-//   },
-//   {
-//     entityId: '7640',
-//     entityUrl: {
-//       path:
-//         '/pittsburgh-health-care/news-releases/va-pittsburgh-named-lgbtq-healthcare-equality-leader-for-8th',
-//     },
-//     fieldIntroText:
-//       'VA Pittsburgh Healthcare System was named a 2020 “LGBTQ Healthcare Equality Leader” by the Human Rights Campaign Foundation (HRC). The designation is the eighth time in as many years and is listed in the 13th edition of the Healthcare Equality Index (HEI). ',
-//     fieldReleaseDate: {
-//       value: '2020-09-14T11:40:46',
-//     },
-//     title:
-//       'VA Pittsburgh named ‘LGBTQ Healthcare Equality Leader’ for 8th year',
-//   },
-// ];
-
 describe('filterPastEvents', () => {
   it('returns null when null is passed', () => {
     expect(liquid.filters.filterPastEvents(null)).to.eq(null);

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -53,6 +53,49 @@ const eventsMockData = [
   },
 ];
 
+const pressReleasesMockData = [
+  {
+    entityId: '19797',
+    entityUrl: {
+      path:
+        '/pittsburgh-health-care/news-releases/va-secretary…ttsburgh-nurse-for-dedication-service-to-veterans',
+    },
+    fieldIntroText:
+      'A VA Pittsburgh Healthcare System nurse recently won the Secretary’s Award for Excellence in Nursing and Advancement of Nursing Programs for helping to improve health care services for veterans.',
+    fieldReleaseDate: {
+      value: '2021-05-14T15:11:11',
+    },
+    title: 'VA secretary recognizes VA Pittsburgh nurse for',
+  },
+  {
+    entityId: '841',
+    entityUrl: {
+      path:
+        '/pittsburgh-health-care/news-releases/women-veterans-resource-fair-spotlights-va-and-community-care',
+    },
+    fieldIntroText:
+      'Veterans Affairs (VA) Pittsburgh Healthcare System is connecting women Veterans with VA and non-VA services during a resource fair on Friday, Aug. 16, from 10 a.m. to 1 p.m. ',
+    fieldReleaseDate: {
+      value: '2019-08-12T19:12:40',
+    },
+    title: 'Women Veterans resource fair spotlights VA and community care',
+  },
+  {
+    entityId: '7640',
+    entityUrl: {
+      path:
+        '/pittsburgh-health-care/news-releases/va-pittsburgh-named-lgbtq-healthcare-equality-leader-for-8th',
+    },
+    fieldIntroText:
+      'VA Pittsburgh Healthcare System was named a 2020 “LGBTQ Healthcare Equality Leader” by the Human Rights Campaign Foundation (HRC). The designation is the eighth time in as many years and is listed in the 13th edition of the Healthcare Equality Index (HEI). ',
+    fieldReleaseDate: {
+      value: '2020-09-14T11:40:46',
+    },
+    title:
+      'VA Pittsburgh named ‘LGBTQ Healthcare Equality Leader’ for 8th year',
+  },
+];
+
 describe('filterPastEvents', () => {
   it('returns null when null is passed', () => {
     expect(liquid.filters.filterPastEvents(null)).to.eq(null);
@@ -135,18 +178,22 @@ describe('filterUpcomingEvents', () => {
   });
 });
 
-describe('eventDateSorter', () => {
+describe('eventOrPressReleasesDateSorter', () => {
   it('returns null when null is passed', () => {
-    expect(liquid.filters.eventDateSorter(null)).to.eq(null);
+    expect(liquid.filters.eventOrPressReleasesDateSorter(null)).to.eq(null);
   });
 
   it('returns null when empty string is passed', () => {
-    expect(liquid.filters.eventDateSorter('')).to.eq(null);
+    expect(liquid.filters.eventOrPressReleasesDateSorter('')).to.eq(null);
   });
 
-  it('returns an array of upcoming events in date and time order starting with most recent to least recent', () => {
+  it('returns an array of upcoming events in date order starting with most recent to least recent', () => {
     expect(
-      liquid.filters.eventDateSorter(eventsMockData),
+      liquid.filters.eventOrPressReleasesDateSorter(
+        eventsMockData,
+        'fieldDatetimeRangeTimezone',
+        true,
+      ),
     ).to.deep.include.members([
       {
         title: 'Clean-up Block Event',
@@ -163,6 +210,57 @@ describe('eventDateSorter', () => {
           timezone: 'America/New_York',
           value: 1639659621,
         },
+      },
+    ]);
+  });
+
+  it('returns an array of press releases in date order from newest to oldest', () => {
+    expect(
+      liquid.filters.eventOrPressReleasesDateSorter(
+        pressReleasesMockData,
+        'fieldReleaseDate',
+        false,
+      ),
+    ).to.have.deep.members([
+      {
+        entityId: '19797',
+        entityUrl: {
+          path:
+            '/pittsburgh-health-care/news-releases/va-secretary…ttsburgh-nurse-for-dedication-service-to-veterans',
+        },
+        fieldIntroText:
+          'A VA Pittsburgh Healthcare System nurse recently won the Secretary’s Award for Excellence in Nursing and Advancement of Nursing Programs for helping to improve health care services for veterans.',
+        fieldReleaseDate: {
+          value: '2021-05-14T15:11:11',
+        },
+        title: 'VA secretary recognizes VA Pittsburgh nurse for',
+      },
+      {
+        entityId: '7640',
+        entityUrl: {
+          path:
+            '/pittsburgh-health-care/news-releases/va-pittsburgh-named-lgbtq-healthcare-equality-leader-for-8th',
+        },
+        fieldIntroText:
+          'VA Pittsburgh Healthcare System was named a 2020 “LGBTQ Healthcare Equality Leader” by the Human Rights Campaign Foundation (HRC). The designation is the eighth time in as many years and is listed in the 13th edition of the Healthcare Equality Index (HEI). ',
+        fieldReleaseDate: {
+          value: '2020-09-14T11:40:46',
+        },
+        title:
+          'VA Pittsburgh named ‘LGBTQ Healthcare Equality Leader’ for 8th year',
+      },
+      {
+        entityId: '841',
+        entityUrl: {
+          path:
+            '/pittsburgh-health-care/news-releases/women-veterans-resource-fair-spotlights-va-and-community-care',
+        },
+        fieldIntroText:
+          'Veterans Affairs (VA) Pittsburgh Healthcare System is connecting women Veterans with VA and non-VA services during a resource fair on Friday, Aug. 16, from 10 a.m. to 1 p.m. ',
+        fieldReleaseDate: {
+          value: '2019-08-12T19:12:40',
+        },
+        title: 'Women Veterans resource fair spotlights VA and community care',
       },
     ]);
   });

--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -58,7 +58,7 @@
 
               {% if isPreview %}
                 {% assign upcomingEvents = reverseFieldListingNode.entities | filterUpcomingEvents  %}
-                {% assign sortedUpcomingEvents = upcomingEvents | eventDateSorter %}
+                {% assign sortedUpcomingEvents = upcomingEvents | eventOrPressReleasesDateSorter: 'fieldDatetimeRangeTimezone', false %}
                 {% assign pagingResult = debug | paginatePages: sortedUpcomingEvents, 'event' %}
                 {% assign pagedItems = pagingResult.pagedItems %}
                 {% assign paginator = pagingResult.paginator %}

--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -58,7 +58,7 @@
 
               {% if isPreview %}
                 {% assign upcomingEvents = reverseFieldListingNode.entities | filterUpcomingEvents  %}
-                {% assign sortedUpcomingEvents = upcomingEvents | eventOrPressReleasesDateSorter: 'fieldDatetimeRangeTimezone', false %}
+                {% assign sortedUpcomingEvents = upcomingEvents | sortByDateKey: 'fieldDatetimeRangeTimezone', false %}
                 {% assign pagingResult = debug | paginatePages: sortedUpcomingEvents, 'event' %}
                 {% assign pagedItems = pagingResult.pagedItems %}
                 {% assign paginator = pagingResult.paginator %}

--- a/src/site/layouts/press_releases_listing.drupal.liquid
+++ b/src/site/layouts/press_releases_listing.drupal.liquid
@@ -68,19 +68,28 @@ larger space in the Fayette Plaza at 627 Pittsburgh Road, Suite 2, Uniontown,
               </p>
               {% endif %}
             </div>
+            
+            {% if isPreview %}
+              {% assign pressReleases = reverseFieldListingNode.entities %}
+              {% assign sortedReleases = pressReleases | eventOrPressReleasesDateSorter: 'fieldReleaseDate', true %}
+              {% assign pagingResult = debug | paginatePages: sortedReleases, 'press_release' %}
+              {% assign pagedItems = pagingResult.pagedItems %}
+              {% assign paginator = pagingResult.paginator %}
+            {% endif %}
+
             {% for pr in pagedItems %}
-            <section class="vads-u-margin-bottom--4">
-              <h2
-                class="vads-u-margin-bottom--1p5 vads-u-font-size--md medium-screen:vads-u-font-size--lg">
-                <a href="{{ pr.entityUrl.path }}">{{ pr.title }}</a></h2>
-              <strong>{{ pr.fieldReleaseDate.value | formatDate: "MMMM DD, YYYY" }}</strong>
-              <p class="vads-u-margin-top--0">
-                {{ pr.fieldIntroText | truncatewords: 60, "..." }}</p>
-            </section>
+              <section class="vads-u-margin-bottom--4">
+                <h2
+                  class="vads-u-margin-bottom--1p5 vads-u-font-size--md medium-screen:vads-u-font-size--lg">
+                  <a href="{{ pr.entityUrl.path }}">{{ pr.title }}</a></h2>
+                <strong>{{ pr.fieldReleaseDate.value | formatDate: "MMMM DD, YYYY" }}</strong>
+                <p class="vads-u-margin-top--0">
+                  {{ pr.fieldIntroText | truncatewords: 60, "..." }}</p>
+              </section>
             {% endfor %}
 
-            {% if pagedItems == false %}
-            <div class="clearfix-text">No news releases at this time.</div>
+            {% if pagedItems.length < 1 %}
+              <div class="clearfix-text">No news releases at this time.</div>
             {% endif %}
 
             {% include "src/site/includes/pagination.drupal.liquid" %}

--- a/src/site/layouts/press_releases_listing.drupal.liquid
+++ b/src/site/layouts/press_releases_listing.drupal.liquid
@@ -71,7 +71,7 @@ larger space in the Fayette Plaza at 627 Pittsburgh Road, Suite 2, Uniontown,
             
             {% if isPreview %}
               {% assign pressReleases = reverseFieldListingNode.entities %}
-              {% assign sortedReleases = pressReleases | eventOrPressReleasesDateSorter: 'fieldReleaseDate', true %}
+              {% assign sortedReleases = pressReleases | sortByDateKey: 'fieldReleaseDate', true %}
               {% assign pagingResult = debug | paginatePages: sortedReleases, 'press_release' %}
               {% assign pagedItems = pagingResult.pagedItems %}
               {% assign paginator = pagingResult.paginator %}

--- a/src/site/layouts/tests/vamc/fixtures/pressReleasesMockData.json
+++ b/src/site/layouts/tests/vamc/fixtures/pressReleasesMockData.json
@@ -1,0 +1,44 @@
+{
+  "entities": [
+    {
+      "entityId": "19797",
+      "entityUrl": {
+        "path":
+          "/pittsburgh-health-care/news-releases/va-secretary…ttsburgh-nurse-for-dedication-service-to-veterans"
+      },
+      "fieldIntroText":
+        "A VA Pittsburgh Healthcare System nurse recently won the Secretary’s Award for Excellence in Nursing and Advancement of Nursing Programs for helping to improve health care services for veterans.",
+      "fieldReleaseDate": {
+        "value": "2021-05-14T15:11:11"
+      },
+      "title": "VA secretary recognizes VA Pittsburgh nurse for"
+    },
+    {
+      "entityId": "841",
+      "entityUrl": {
+        "path":
+          "/pittsburgh-health-care/news-releases/women-veterans-resource-fair-spotlights-va-and-community-care"
+      },
+      "fieldIntroText":
+        "Veterans Affairs (VA) Pittsburgh Healthcare System is connecting women Veterans with VA and non-VA services during a resource fair on Friday, Aug. 16, from 10 a.m. to 1 p.m. ",
+      "fieldReleaseDate": {
+        "value": "2019-08-12T19:12:40"
+      },
+      "title": "Women Veterans resource fair spotlights VA and community care"
+    },
+    {
+      "entityId": "7640",
+      "entityUrl": {
+        "path":
+          "/pittsburgh-health-care/news-releases/va-pittsburgh-named-lgbtq-healthcare-equality-leader-for-8th"
+      },
+      "fieldIntroText":
+        "VA Pittsburgh Healthcare System was named a 2020 “LGBTQ Healthcare Equality Leader” by the Human Rights Campaign Foundation (HRC). The designation is the eighth time in as many years and is listed in the 13th edition of the Healthcare Equality Index (HEI). ",
+      "fieldReleaseDate": {
+        "value": "2020-09-14T11:40:46"
+      },
+      "title":
+        "VA Pittsburgh named ‘LGBTQ Healthcare Equality Leader’ for 8th year"
+    }
+  ]
+}

--- a/src/site/stages/build/drupal/graphql/GetLatestPageById.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetLatestPageById.graphql.js
@@ -21,6 +21,7 @@ const nodeQa = require('./nodeQa.graphql');
 const nodeStepByStep = require('./nodeStepByStep.graphql');
 const nodeSupportResourcesDetailPage = require('./nodeSupportResourcesDetailPage.graphql');
 const pressReleasePage = require('./pressReleasePage.graphql');
+const pressReleasesListingPage = require('./pressReleasesListingPage.graphql');
 const vaFormPage = require('./vaFormPage.graphql');
 const vamcOperatingStatusAndAlerts = require('./vamcOperatingStatusAndAlerts.graphql');
 const vetCenters = require('./vetCenter.graphql');
@@ -49,6 +50,7 @@ module.exports = `
   ${healthCareRegionDetailPage.fragment}
   ${healthServicesListingPage.fragment}
   ${pressReleasePage.fragment}
+  ${pressReleasesListingPage.fragment}
   ${vamcOperatingStatusAndAlerts.fragment}
   ${storyListingPage.fragment}
   ${newsStoryPage.fragment}
@@ -86,6 +88,7 @@ module.exports = `
         ... storyListingPage
         ... newsStoryPage
         ... pressReleasePage
+        ... pressReleasesListingPage
         ... vamcOperatingStatusAndAlerts
         ... eventPage
         ... eventListingPage


### PR DESCRIPTION
## Description
Issue is linked below
To preview use - http://localhost:3002/preview?nodeId=2805

## Acceptance criteria
- [ ] All tests pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
