### PR TITLE
Tweak how do you rate component styling

### DIFF
--- a/src/site/includes/how-do-you-rate.drupal.liquid
+++ b/src/site/includes/how-do-you-rate.drupal.liquid
@@ -18,7 +18,7 @@
         <span class="sr-only">Error</span> Please select an answer
       </span>
 
-      <div id="rating-buttons" class="form-radio-buttons">
+      <div id="rating-buttons" class="form-radio-buttons vads-u-display--flex vads-u-align-items--center">
         <!-- Good rating -->
         <div class="radio-button">
           <input id="good" name="rating" type="radio" value="Good" />
@@ -34,8 +34,8 @@
     </fieldset>
 
     <div>
-      <button class="usa-button vads-u-width--full medium-screen:vads-u-width--auto vads-u-margin--0 vads-u-margin-top--2p5" id="rating-submit" type="submit">
-        Submit rating
+      <button class="usa-button usa-button-secondary vads-u-width--full medium-screen:vads-u-width--auto vads-u-margin--0 vads-u-margin-top--2p5" id="rating-submit" type="submit">
+        Submit feedback
       </button>
     </div>
 
@@ -102,7 +102,7 @@
       // We don't need the rating options anymore, so hide it.
       if (ratingButtonsElement) {
         ratingButtonsElement.setAttribute('aria-hidden', 'true');
-        ratingButtonsElement.className = ratingButtonsElement.className + ' vads-u-display--none';
+        ratingButtonsElement.className = ratingButtonsElement.className.replace('vads-u-display--flex', '') + ' vads-u-display--none';
       }
 
       // We need to show the thank you message, so show it.


### PR DESCRIPTION
# Description

This PR is in response to [this comment](https://github.com/department-of-veterans-affairs/va.gov-team/issues/14302#issuecomment-860959106). This PR does the following:

> 1/ the Good/Bad radio buttons should be side by side on the same line, per mock here
> 2/ the Submit button should use a secondary button styling per comment above - design system: https://design.va.gov/components/buttons#secondary-button
> 3/ The text of the button - let's use Submit feedback since our thank you message says, "Thank you for your feedback."

# Screenshots

<img width="728" alt="Screen Shot 2021-06-14 at 2 22 00 PM" src="https://user-images.githubusercontent.com/12773166/121954494-0a44ee00-cd1c-11eb-8973-d17d2f925c7c.png">
<img width="761" alt="Screen Shot 2021-06-14 at 2 22 07 PM" src="https://user-images.githubusercontent.com/12773166/121954496-0b761b00-cd1c-11eb-8c75-a015751b4e0a.png">
<img width="735" alt="Screen Shot 2021-06-14 at 2 22 14 PM" src="https://user-images.githubusercontent.com/12773166/121954501-0b761b00-cd1c-11eb-9033-7da20073fedb.png">
<img width="736" alt="Screen Shot 2021-06-14 at 2 22 20 PM" src="https://user-images.githubusercontent.com/12773166/121954503-0c0eb180-cd1c-11eb-8a4c-b5e11da0b90e.png">
<img width="393" alt="Screen Shot 2021-06-14 at 2 22 38 PM" src="https://user-images.githubusercontent.com/12773166/121954505-0c0eb180-cd1c-11eb-8dc3-af8093ea3599.png">
<img width="385" alt="Screen Shot 2021-06-14 at 2 22 46 PM" src="https://user-images.githubusercontent.com/12773166/121954507-0c0eb180-cd1c-11eb-8beb-750cd8997b05.png">
<img width="389" alt="Screen Shot 2021-06-14 at 2 22 51 PM" src="https://user-images.githubusercontent.com/12773166/121954508-0ca74800-cd1c-11eb-9d9b-ed869af91f0d.png">
