### PR TITLE
Move debug info to end of build process

### DIFF
--- a/src/site/stages/build/add-debug-info.js
+++ b/src/site/stages/build/add-debug-info.js
@@ -1,0 +1,78 @@
+/* eslint-disable no-console */
+const fs = require('fs-extra');
+const path = require('path');
+
+function addDebugInfo(files, buildtype) {
+  try {
+    console.log('\nAdding debug info to Drupal pages...\n');
+
+    const keysToIgnore = [
+      'breadcrumb_path',
+      'collection',
+      'contents',
+      'filename',
+      'isDrupalPage',
+      'layout',
+      'modified',
+      'nav_children',
+      'nav_path',
+      'path',
+      'private',
+    ];
+
+    Object.keys(files)
+      .filter(fileName => files[fileName].isDrupalPage)
+      .forEach(fileName => {
+        const filePath = `build/${buildtype}/${fileName}`;
+        const tmpFilepath = `tmp/${filePath}`;
+        const tmpFileDir = path.dirname(tmpFilepath);
+
+        if (!fs.existsSync(tmpFileDir)) {
+          fs.mkdirSync(tmpFileDir, { recursive: true });
+        }
+
+        const readStream = fs.createReadStream(filePath, {
+          encoding: 'utf8',
+          autoClose: true,
+        });
+
+        const outputStream = fs.createWriteStream(tmpFilepath, {
+          encoding: 'utf8',
+          autoClose: true,
+        });
+
+        const debugInfo = Object.fromEntries(
+          Object.entries(files[fileName]).filter(
+            key => !keysToIgnore.includes(key[0]),
+          ),
+        );
+
+        // `window.contentData = null` is added to Drupal pages from the debug.drupal.liquid template
+        // when the `debug` key doesn't exist in the Metalsmith file entry.
+        // We want to replace all instances of that with the debug object.
+        readStream.on('data', data => {
+          outputStream.write(
+            data
+              .toString()
+              .replace(
+                'window.contentData = null;',
+                `window.contentData = ${JSON.stringify(debugInfo)};`,
+              ),
+          );
+        });
+
+        readStream.on('end', () => {
+          outputStream.end();
+        });
+
+        outputStream.on('finish', () => {
+          // Overwrite original file with new file
+          fs.moveSync(tmpFilepath, filePath, { overwrite: true });
+        });
+      });
+  } catch (error) {
+    console.error('\nError adding debug info to files.\n', error);
+  }
+}
+
+module.exports = addDebugInfo;

--- a/src/site/stages/build/drupal/page.js
+++ b/src/site/stages/build/drupal/page.js
@@ -19,7 +19,7 @@ function createFileObj(page, layout) {
     isDrupalPage: true,
     layout,
     contents: Buffer.from('<!-- Drupal-provided data -->'),
-    debug: page,
+    debug: global.isPreviewServer ? page : null,
     private: privStatus,
   };
 }

--- a/src/site/stages/build/index.js
+++ b/src/site/stages/build/index.js
@@ -1,7 +1,5 @@
 // Builds the site using Metalsmith as the top-level build runner.
 /* eslint-disable no-console */
-const fs = require('fs-extra');
-const path = require('path');
 const chalk = require('chalk');
 const assets = require('metalsmith-assets');
 const collections = require('metalsmith-collections');
@@ -14,6 +12,7 @@ const navigation = require('metalsmith-navigation');
 const permalinks = require('metalsmith-permalinks');
 
 const silverSmith = require('./silversmith');
+const addDebugInfo = require('./add-debug-info');
 
 // const assetSources = require('../../constants/assetSources');
 
@@ -39,79 +38,6 @@ const modifyDom = require('./plugins/modify-dom');
 const rewriteDrupalPages = require('./plugins/rewrite-drupal-pages');
 const rewriteVaDomains = require('./plugins/rewrite-va-domains');
 const updateRobots = require('./plugins/update-robots');
-
-function addDebugInfo(files, buildtype) {
-  try {
-    console.log('\nAdding debug info to Drupal pages...\n');
-
-    const keysToIgnore = [
-      'breadcrumb_path',
-      'collection',
-      'contents',
-      'filename',
-      'isDrupalPage',
-      'layout',
-      'modified',
-      'nav_children',
-      'nav_path',
-      'path',
-      'private',
-    ];
-
-    Object.keys(files)
-      .filter(fileName => files[fileName].isDrupalPage)
-      .forEach(fileName => {
-        const filePath = `build/${buildtype}/${fileName}`;
-        const tmpFilepath = `tmp/${filePath}`;
-        const tmpFileDir = path.dirname(tmpFilepath);
-
-        if (!fs.existsSync(tmpFileDir)) {
-          fs.mkdirSync(tmpFileDir, { recursive: true });
-        }
-
-        const readStream = fs.createReadStream(filePath, {
-          encoding: 'utf8',
-          autoClose: true,
-        });
-
-        const outputStream = fs.createWriteStream(tmpFilepath, {
-          encoding: 'utf8',
-          autoClose: true,
-        });
-
-        const debugInfo = Object.fromEntries(
-          Object.entries(files[fileName]).filter(
-            key => !keysToIgnore.includes(key[0]),
-          ),
-        );
-
-        // `window.contentData = null` is added to Drupal pages from the debug.drupal.liquid template
-        // when the `debug` key doesn't exist in the Metalsmith file entry.
-        // We want to replace all instances of that with the debug object.
-        readStream.on('data', data => {
-          outputStream.write(
-            data
-              .toString()
-              .replace(
-                'window.contentData = null;',
-                `window.contentData = ${JSON.stringify(debugInfo)};`,
-              ),
-          );
-        });
-
-        readStream.on('end', () => {
-          outputStream.end();
-        });
-
-        outputStream.on('finish', () => {
-          // Overwrite original file with new file
-          fs.moveSync(tmpFilepath, filePath, { overwrite: true });
-        });
-      });
-  } catch (error) {
-    console.error('\nError adding debug info to files.\n', error);
-  }
-}
 
 function build(BUILD_OPTIONS) {
   const smith = silverSmith();

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -239,6 +239,7 @@ async function getOptions(commandLineOptions) {
   // Setting verbosity for the whole content build process as global so we don't
   // have to pass the buildOptions around for just that.
   global.verbose = options.verbose;
+  global.isPreviewServer = options.isPreviewServer;
 
   return options;
 }


### PR DESCRIPTION
## Description
Currently, debug info for Drupal pages in stored in the `files` object during the Metalsmith build. This is using more memory during the build than needed since we aren't performing and modifications on that information. Removing the debug info from the `files` object during the build, and adding it directly to HTML pages on disk, can free up memory. 

Overall, this reduced the build time on our current node count by over 2 minutes, and reduced peak memory usage by `500mB`. When tested on 48k nodes, the build didn't run out of memory with these changes.

## Testing done
- Compared build files from the changes in this branch to `master`.
- Tested on CI on our current node count
- Tested on 48k nodes in CI
- Tested debug info in preview server

More info about testing can be seen in the [ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/25100).
## Screenshots


## Acceptance criteria
- [ ] Debug information is not stored in the `files` object in the build
- [ ] Debug information is present on non prod builds as before

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
