### PR TITLE
Update h4 to h3

### DIFF
--- a/src/site/layouts/home.drupal.liquid
+++ b/src/site/layouts/home.drupal.liquid
@@ -98,7 +98,6 @@
 
       </div>
     </section>
-
     <!-- end triple column -->
 
   </div> <!-- end #content -->
@@ -106,7 +105,6 @@
   <section class="usa-grid usa-grid-full">
     <div class="va-h-ruled--stars"></div>
   </section>
-
 
   <section id="homepage-news">
     <div class="usa-grid usa-grid-full">
@@ -116,8 +114,15 @@
         <div class="homepage-image-wrapper">
           <img class="lazy" width="552" data-src="{{ promo.entity.fieldImage.entity.image.url }}" alt="{{ promo.entity.fieldImage.entity.image.alt }}"/>
         </div>
-        <h4 class="homepage-news-story-title"><a class="no-external-icon" href="{{ promo.entity.fieldPromoLink.entity.fieldLink.uri }}"
-          onClick="recordEvent({ event: 'nav-footer-news-story' });"/>{{ promo.entity.fieldPromoLink.entity.fieldLink.title }}</a></h4>
+        <h3 class="homepage-news-story-title vads-u-font-size--h4">
+          <a
+            class="no-external-icon"
+            href="{{ promo.entity.fieldPromoLink.entity.fieldLink.uri }}"
+            onClick="recordEvent({ event: 'nav-footer-news-story' });"
+          >
+            {{ promo.entity.fieldPromoLink.entity.fieldLink.title }}
+          </a>
+        </h3>
         <p class="homepage-news-story-desc">{{ promo.entity.fieldPromoLink.entity.fieldLinkSummary }}</p>
       </div>
       {% if hub.end_row == true and forloop.last != true %}
@@ -127,7 +132,6 @@
     {% endfor %}
     </div>
   </section>
-
 </main>
 
 {% include "src/site/includes/footer.html" %}


### PR DESCRIPTION
# Description

**Slack:** https://dsva.slack.com/archives/CE4304QPK/p1623951602172600

This PR updates the `h4` tags on the homepage to `h3` tags so that headers increment correctly.

## Screenshots

![image](https://user-images.githubusercontent.com/12773166/122453167-4a4be100-cf67-11eb-98db-5e827d9d0238.png)

## Acceptance Criteria

- [x] Resolve homepage a11y errors
