### PR TITLE
Changes made to operating status page

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -879,4 +879,10 @@ module.exports = function registerFilters() {
   liquid.filters.isFirstPage = paginator => {
     return !paginator || paginator.prev === null;
   };
+
+  liquid.filters.isFieldSituationUpdates = fieldBannerAlert => {
+    return _.find(fieldBannerAlert, e => {
+      return e.entity.fieldSituationUpdates.length > 0;
+    });
+  };
 };

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -880,8 +880,8 @@ module.exports = function registerFilters() {
     return !paginator || paginator.prev === null;
   };
 
-  liquid.filters.isFieldSituationUpdates = fieldBannerAlert => {
-    return _.find(fieldBannerAlert, e => {
+  liquid.filters.hasFieldSituationUpdates = fieldBannerAlert => {
+    return _.some(fieldBannerAlert, e => {
       return e.entity.fieldSituationUpdates.length > 0;
     });
   };

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -882,8 +882,8 @@ module.exports = function registerFilters() {
 
   liquid.filters.hasContentAtPath = (rootArray, path) => {
     for (let i = 0; i < rootArray.length; i++) {
-      const hasLength = _.get(rootArray[i], path)?.length > 0;
-      if (hasLength) return hasLength;
+      const hasContent = _.get(rootArray[i], path)?.length > 0;
+      if (hasContent) return hasContent;
     }
     return false;
   };

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -880,9 +880,11 @@ module.exports = function registerFilters() {
     return !paginator || paginator.prev === null;
   };
 
-  liquid.filters.hasFieldSituationUpdates = fieldBannerAlert => {
-    return _.some(fieldBannerAlert, e => {
-      return e.entity.fieldSituationUpdates.length > 0;
-    });
+  liquid.filters.hasContentAtPath = (rootArray, path) => {
+    for (let i = 0; i < rootArray.length; i++) {
+      const hasLength = _.get(rootArray[i], path)?.length > 0;
+      if (hasLength) return hasLength;
+    }
+    return false;
   };
 };

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -881,10 +881,7 @@ module.exports = function registerFilters() {
   };
 
   liquid.filters.hasContentAtPath = (rootArray, path) => {
-    for (let i = 0; i < rootArray.length; i++) {
-      const hasContent = _.get(rootArray[i], path)?.length > 0;
-      if (hasContent) return hasContent;
-    }
-    return false;
+    const hasContent = e => _.get(e, path)?.length > 0;
+    return rootArray.some(hasContent);
   };
 };

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -54,6 +54,37 @@ const eventsMockData = [
   },
 ];
 
+describe('hasFieldSituationUpdates', () => {
+  let fieldBannerAlert;
+
+  beforeEach(() => {
+    fieldBannerAlert = [
+      {
+        entity: {
+          title: 'some time',
+          fieldSituationUpdates: [],
+          status: true,
+        },
+      },
+    ];
+  });
+
+  it('returns false if there are no field situation updates', () => {
+    expect(liquid.filters.hasFieldSituationUpdates(fieldBannerAlert)).to.be
+      .false;
+  });
+
+  it('returns true if there are field situation updates', () => {
+    fieldBannerAlert[0].entity.fieldSituationUpdates = [
+      'field situation update 1',
+      'field situation update 2',
+    ];
+
+    expect(liquid.filters.hasFieldSituationUpdates(fieldBannerAlert)).to.be
+      .true;
+  });
+});
+
 describe('filterPastEvents', () => {
   it('returns null when null is passed', () => {
     expect(liquid.filters.filterPastEvents(null)).to.eq(null);

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -54,11 +54,11 @@ const eventsMockData = [
   },
 ];
 
-describe('hasFieldSituationUpdates', () => {
-  let fieldBannerAlert;
+describe('hasContentAtPath', () => {
+  let testArray;
 
   beforeEach(() => {
-    fieldBannerAlert = [
+    testArray = [
       {
         entity: {
           title: 'some time',
@@ -69,19 +69,27 @@ describe('hasFieldSituationUpdates', () => {
     ];
   });
 
-  it('returns false if there are no field situation updates', () => {
-    expect(liquid.filters.hasFieldSituationUpdates(fieldBannerAlert)).to.be
-      .false;
+  it('returns false if there is no content at the given path', () => {
+    expect(
+      liquid.filters.hasContentAtPath(
+        testArray,
+        'entity.fieldSituationUpdates',
+      ),
+    ).to.be.false;
   });
 
-  it('returns true if there are field situation updates', () => {
-    fieldBannerAlert[0].entity.fieldSituationUpdates = [
+  it('returns true if there is content at the given path', () => {
+    testArray[0].entity.fieldSituationUpdates = [
       'field situation update 1',
       'field situation update 2',
     ];
 
-    expect(liquid.filters.hasFieldSituationUpdates(fieldBannerAlert)).to.be
-      .true;
+    expect(
+      liquid.filters.hasContentAtPath(
+        testArray,
+        'entity.fieldSituationUpdates',
+      ),
+    ).to.be.true;
   });
 });
 

--- a/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
+++ b/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
@@ -63,7 +63,7 @@
             </ul>
           </section>
 
-          {% assign situationUpdates = fieldBannerAlert | hasFieldSituationUpdates %}
+          {% assign situationUpdates = fieldBannerAlert | hasContentAtPath: 'entity.fieldSituationUpdates' %}
           {% if fieldBannerAlert and situationUpdates %}
             {% include "src/site/components/situation_updates.drupal.liquid" with fieldBannerAlert %}
           {% endif %}

--- a/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
+++ b/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
@@ -7,151 +7,135 @@
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
-<div id="content" class="interior">
-    <main class="va-l-detail-page va-facility-page">
-        <div class="usa-grid usa-grid-full">
-            {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
-            <div class="usa-width-three-fourths">
-                <article class="usa-content">
-                    <h1 class="vads-u-margin-bottom--2">Operating status</h1>
-                    <div class="va-introtext vads-u-margin-bottom--0">
-                        {{facilitySidebar.name}} facility operating statuses and emergency information.
-                    </div>
-                    {% if fieldOffice.entity.fieldLinkFacilityEmergList.url.path %}
-                    <div class="usa-grid usa-grid-full vads-u-margin-y--1p5">
-                        <div class="vads-l-row">
-                            <div class="vads-u-margin-right--2p5">
-                                <a class="vads-u-padding-x--5 usa-button vads-u-margin-top--1 vads-u-margin--0 vads-u-width--full vads-u-font-size--md"
-                                    href="{{fieldOffice.entity.fieldLinkFacilityEmergList.url.path}}">Subscribe
-                                    to emergency notifications</a>
-                            </div>
-                        </div>
-                    </div>
-                    {% endif %}
-                    <section class="table-of-contents"
-                        class="vads-u-margin-bottom--5" aria-labelledby="on-this-page">
-                        <h2 class="vads-u-margin-bottom--2 vads-u-font-size--lg"
-                            id="on-this-page">On this
-                            page</h2>
-                        <ul class="usa-unstyled-list">
-                            {% if fieldBannerAlert.0.entity.status != false and fieldBannerAlert.0.entity.fieldSituationUpdates.0.entity %}
-                            <li class="vads-u-margin-bottom--2">
-                                <a href="#situation-updates"
-                                    onclick="recordEvent({ event: 'nav-jumplink-click' });"
-                                    class="vads-u-display--flex vads-u-text-decoration--none">
-                                    <i
-                                        class="fas fa-arrow-down va-c-font-size--xs vads-u-margin-top--1 vads-u-margin-right--1"></i>
-                                    Situation updates and information
-                                </a>
-                            </li>
-                            {% endif %}
-                            <li class="vads-u-margin-bottom--2">
-                                <a href="#operating-statuses"
-                                    onclick="recordEvent({ event: 'nav-jumplink-click' });"
-                                    class="vads-u-display--flex vads-u-text-decoration--none">
-                                    <i
-                                        class="fas fa-arrow-down va-c-font-size--xs vads-u-margin-top--1 vads-u-margin-right--1"></i>
-                                    Facility operating statuses
-                                </a>
-                            </li>
-                            {% if fieldLink.0.uri or fieldOperatingStatusEmergInf.value %}
-                            <li class="vads-u-margin-bottom--2">
-                                <a href="#emergency-resources"
-                                    onclick="recordEvent({ event: 'nav-jumplink-click' });"
-                                    class="vads-u-display--flex vads-u-text-decoration--none">
-                                    <i
-                                        class="fas fa-arrow-down va-c-font-size--xs vads-u-margin-top--1 vads-u-margin-right--1"></i>
-                                    Emergency resources
-                                </a>
-                            </li>
-                            {% endif %}
-                        </ul>
-                    </section>
-
-                    {% if fieldBannerAlert %}
-                    {% include "src/site/components/situation_updates.drupal.liquid" with fieldBannerAlert %}
-                    {% endif %}
-
-                    {% if fieldFacilityOperatingStatus.0.entity %}
-                    <section id="operating-statuses"
-                        class="operating-statuses clearfix">
-                        <h2>Facility operating statuses</h2>
-                        <dl
-                            class="vads-l-grid-container vads-u-padding-x--0 vads-l-row vads-u-border-bottom--1px vads-u-border-color--gray-light">
-                            {% for status in fieldFacilityOperatingStatus %}
-                            <div
-                                class="vads-l-row vads-u-border-top--1px vads-u-border-color--gray-light">
-                                <dt
-                                    class="vads-l-col--6 vads-u-margin-y--3 vads-u-display--flex operating-status-title">
-                                    <a class="facility-title-width vads-u-font-weight--bold"
-                                        onclick="recordEvent({
-                                        'event':'nav-health-care-facility-status-click'});"
-                                        href="{{status.entity.entityUrl.path}}">{{ status.entity.title }}</a>
-                                </dt>
-                                <dd class="vads-l-col--6">
-                                    <div class="operating-status-info vads-u-padding-y--1p5 vads-u-padding-x--0">
-                                        {% if status.entity.fieldOperatingStatusFacility == 'notice' %}
-                                        <span
-                                            class="operating-status usa-alert usa-alert-info background-color-only vads-u-margin-top--0 vads-u-padding--1p5">
-                                            <i class="fa fa-info-circle"
-                                                aria-hidden="true"></i> Facility
-                                            notice
-                                        </span>
-                                        {% elsif status.entity.fieldOperatingStatusFacility == 'normal' %}
-                                        <span
-                                            class="operating-status normal-hours vads-u-margin-top--1p5 vads-u-display--block">
-                                            Normal services and hours
-                                        </span>
-                                        {% elsif status.entity.fieldOperatingStatusFacility == 'limited' %}
-                                        <span
-                                            class="operating-status usa-alert usa-alert-warning background-color-only vads-u-margin-top--0 vads-u-padding--1p5">
-                                            <i class="fa fa-exclamation-triangle"
-                                                aria-hidden="true"></i> Limited
-                                            services and hours
-                                        </span>
-                                        {% elsif status.entity.fieldOperatingStatusFacility == 'closed' %}
-                                        <span
-                                            class="operating-status usa-alert usa-alert-error background-color-only vads-u-margin-top--0 vads-u-padding--1p5">
-                                            <i class="fa fa-exclamation-circle"
-                                                aria-hidden="true"></i> Facility
-                                            Closed
-                                        </span>
-                                        {% endif %}
-
-                                        {% if status.entity.fieldOperatingStatusMoreInfo %}
-                                        <div class="vads-u-margin-top--1p5">
-                                            {{ status.entity.fieldOperatingStatusMoreInfo }}
-                                        </div>
-                                        {% endif %}
-                                    </div>
-                                </dd>
-                            </div>
-                            {% endfor %}
-                        </dl>
-                    </section>
-                    {% endif %}
-
-                    {% if fieldLink.0.uri or fieldOperatingStatusEmergInf.value %}
-                    <section id="emergency-resources"
-                        class="emergency-resources clearfix">
-                        <h2>Emergency information</h2>
-
-                        {% if fieldOperatingStatusEmergInf.value %}
-                        <div>{{ fieldOperatingStatusEmergInf.value }}</div>
-                        {% endif %}
-                        {% if fieldLinks.0.uri %}
-                        <h3 class="vads-u-margin-top--3 vads-u-margin-bottom--2 ">Local emergency resources</h3>
-                        {% for link in fieldLinks %}
-                        <p><a href="{{ link.uri }}">{{ link.title }}</a></p>
-                        {% endfor %}
-                        {% endif %}
-                    </section>
-                    {% endif %}
-
-                </article>
+<div class="interior" id="content">
+  <main class="va-l-detail-page va-facility-page">
+    <div class="usa-grid usa-grid-full">
+      {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
+      <div class="usa-width-three-fourths">
+        <article class="usa-content">
+          <h1 class="vads-u-margin-bottom--2">Operating status</h1>
+          <div class="va-introtext vads-u-margin-bottom--0">
+            {{facilitySidebar.name}}
+            facility operating statuses and emergency information.
+          </div>
+          {% if fieldOffice.entity.fieldLinkFacilityEmergList.url.path %}
+            <div class="usa-grid usa-grid-full vads-u-margin-y--1p5">
+              <div class="vads-l-row">
+                <div class="vads-u-margin-right--2p5">
+                  <a class="vads-u-padding-x--5 usa-button vads-u-margin-top--1 vads-u-margin--0 vads-u-width--full vads-u-font-size--md" href="{{fieldOffice.entity.fieldLinkFacilityEmergList.url.path}}">
+                      Subscriben to emergency notifications</a>
+                </div>
+              </div>
             </div>
-        </div>
-    </main>
+          {% endif %}
+          <section aria-labelledby="on-this-page" class="table-of-contents" class="vads-u-margin-bottom--5">
+            <h2 class="vads-u-margin-bottom--2 vads-u-font-size--lg" id="on-this-page">
+                On this page
+            </h2>
+            <ul class="usa-unstyled-list">
+
+              {% if fieldBannerAlert.0.entity.status != false and fieldBannerAlert.0.entity.fieldSituationUpdates.0.entity %}
+                <li class="vads-u-margin-bottom--2">
+                  <a class="vads-u-display--flex vads-u-text-decoration--none" href="#situation-updates" onclick="recordEvent({ event: 'nav-jumplink-click' });">
+                    <i class="fas fa-arrow-down va-c-font-size--xs vads-u-margin-top--1 vads-u-margin-right--1"></i>
+                    Situation updates and information
+                  </a>
+                </li>
+              {% endif %}
+
+              {% if fieldFacilityOperatingStatus.length > 0%}
+                <li class="vads-u-margin-bottom--2">
+                  <a class="vads-u-display--flex vads-u-text-decoration--none" href="#operating-statuses" onclick="recordEvent({ event: 'nav-jumplink-click' });">
+                    <i class="fas fa-arrow-down va-c-font-size--xs vads-u-margin-top--1 vads-u-margin-right--1"></i>
+                    Facility operating statuses
+                  </a>
+                </li>
+              {% endif %}
+
+              {% if fieldLink.0.uri or fieldOperatingStatusEmergInf.value %}
+                <li class="vads-u-margin-bottom--2">
+                  <a class="vads-u-display--flex vads-u-text-decoration--none" href="#emergency-resources" onclick="recordEvent({ event: 'nav-jumplink-click' });">
+                    <i class="fas fa-arrow-down va-c-font-size--xs vads-u-margin-top--1 vads-u-margin-right--1"></i>
+                    Emergency resources
+                  </a>
+                </li>
+              {% endif %}
+            </ul>
+          </section>
+
+          {% assign situationUpdates = fieldBannerAlert | isFieldSituationUpdates %}
+          {% if fieldBannerAlert and situationUpdates %}
+            {% include "src/site/components/situation_updates.drupal.liquid" with fieldBannerAlert %}
+          {% endif %}
+
+          {% if fieldFacilityOperatingStatus.0.entity %}
+            <section class="operating-statuses clearfix" id="operating-statuses">
+              <h2>Facility operating statuses</h2>
+              <dl class="vads-l-grid-container vads-u-padding-x--0 vads-l-row vads-u-border-bottom--1px vads-u-border-color--gray-light">
+                {% for status in fieldFacilityOperatingStatus %}
+                  <div class="vads-l-row vads-u-border-top--1px vads-u-border-color--gray-light">
+                    <dt class="vads-l-col--6 vads-u-margin-y--3 vads-u-display--flex operating-status-title">
+                      <a class="facility-title-width vads-u-font-weight--bold" onclick="recordEvent({
+                                                                'event':'nav-health-care-facility-status-click'});" href="{{status.entity.entityUrl.path}}">{{ status.entity.title }}</a>
+                    </dt>
+                    <dd class="vads-l-col--6">
+                      <div class="operating-status-info vads-u-padding-y--1p5 vads-u-padding-x--0">
+                        {% if status.entity.fieldOperatingStatusFacility == 'notice' %}
+                          <span class="operating-status usa-alert usa-alert-info background-color-only vads-u-margin-top--0 vads-u-padding--1p5">
+                            <i aria-hidden="true" class="fa fa-info-circle"></i>
+                            Facility notice
+                          </span>
+                        {% elsif status.entity.fieldOperatingStatusFacility == 'normal' %}
+                          <span class="operating-status normal-hours vads-u-margin-top--1p5 vads-u-display--block">
+                            Normal services and hours
+                          </span>
+                        {% elsif status.entity.fieldOperatingStatusFacility == 'limited' %}
+                          <span class="operating-status usa-alert usa-alert-warning background-color-only vads-u-margin-top--0 vads-u-padding--1p5">
+                            <i aria-hidden="true" class="fa fa-exclamation-triangle"></i>
+                            Limited services and hours
+                          </span>
+                        {% elsif status.entity.fieldOperatingStatusFacility == 'closed' %}
+                          <span class="operating-status usa-alert usa-alert-error background-color-only vads-u-margin-top--0 vads-u-padding--1p5">
+                            <i aria-hidden="true" class="fa fa-exclamation-circle"></i>
+                            Facility Closed
+                          </span>
+                        {% endif %}
+
+                        {% if status.entity.fieldOperatingStatusMoreInfo %}
+                          <div class="vads-u-margin-top--1p5">
+                            {{ status.entity.fieldOperatingStatusMoreInfo }}
+                          </div>
+                        {% endif %}
+                      </div>
+                    </dd>
+                  </div>
+                {% endfor %}
+              </dl>
+            </section>
+          {% endif %}
+
+          {% if fieldLink.0.uri or fieldOperatingStatusEmergInf.value %}
+            <section class="emergency-resources clearfix" id="emergency-resources">
+              <h2>Emergency information</h2>
+
+              {% if fieldOperatingStatusEmergInf.value %}
+                <div>{{ fieldOperatingStatusEmergInf.value }}</div>
+              {% endif %}
+              {% if fieldLinks.0.uri %}
+                <h3 class="vads-u-margin-top--3 vads-u-margin-bottom--2 ">Local emergency resources</h3>
+                {% for link in fieldLinks %}
+                  <p>
+                    <a href="{{ link.uri }}">{{ link.title }}</a>
+                  </p>
+                {% endfor %}
+              {% endif %}
+            </section>
+          {% endif %}
+
+        </article>
+      </div>
+    </div>
+  </main>
 </div>
 {% include "src/site/includes/footer.html" %}
 {% include "src/site/includes/debug.drupal.liquid" %}

--- a/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
+++ b/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
@@ -63,7 +63,7 @@
             </ul>
           </section>
 
-          {% assign situationUpdates = fieldBannerAlert | isFieldSituationUpdates %}
+          {% assign situationUpdates = fieldBannerAlert | hasFieldSituationUpdates %}
           {% if fieldBannerAlert and situationUpdates %}
             {% include "src/site/components/situation_updates.drupal.liquid" with fieldBannerAlert %}
           {% endif %}


### PR DESCRIPTION
## Description
Resolves the issue linked below

It was discovered that the missing content/data was, in fact, not there in the first place (operating statuses needed to be manually input into each facility- this became a separate issue that CMS will handle on their end)

I made changes to handle instances where the the `Facility operating statuses` jumplink and `Situation updates and information` h2 tags will not display if there is no content to show.

Use Wilkes-Barre to preview- http://localhost:3002/preview?nodeId=2369

## Acceptance criteria
- [ ] Both `Facility operating statuses` jumplink and `Situation updates and information` h2 tags will not display if there is no content to show.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
