### PR TITLE
Show mobile clinics on locations page in full build

### DIFF
--- a/src/site/layouts/health_care_region_locations_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_locations_page.drupal.liquid
@@ -30,6 +30,14 @@
             {% for other in otherFacilities.entities %}
               {% include 'src/site/includes/facilityListing.drupal.liquid' with entity = other %}
             {% endfor %}
+            {% if mobileFacilities.entities.length %}
+              <h2 class="medium-screen:vads-u-margin-bottom--4" id="mobile-clinic-locations">
+                Mobile clinics
+              </h2>
+              {% for mobile in mobileFacilities.entities %}
+                {% include 'src/site/includes/facilityListing.drupal.liquid' with entity = mobile type = 'mobile' %}
+              {% endfor %}
+            {% endif %}
             {% if fieldOtherVaLocations != empty and fieldOtherVaLocations.length %}
               <h2 class="medium-screen:vads-u-margin-bottom--4" id="other-nearby-va-locations">
                 Other nearby VA locations

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -111,6 +111,7 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
   const locObj = {
     mainFacilities: page.mainFacilities,
     otherFacilities: page.otherFacilities,
+    mobileFacilities: page.mobileFacilities,
     fieldOtherVaLocations: page.fieldOtherVaLocations,
     facilitySidebar: sidebar,
     entityUrl: locEntityUrl,


### PR DESCRIPTION
## Description
A previous [PR](https://github.com/department-of-veterans-affairs/content-build/pull/258) added the mobile clinic section, but it only worked in preview mode.

This is because we are currently using a different template in preview vs. full build.

A [tech debt ticket ](https://github.com/department-of-veterans-affairs/va.gov-team/issues/26301)has been created for this. In the meantime, this PR contains the changes needed to add the mobile clinic section in the full build.

