### PR TITLE
Hide map from screenreader in Vet Center

### DIFF
--- a/src/site/includes/image_and_static_map.liquid
+++ b/src/site/includes/image_and_static_map.liquid
@@ -9,6 +9,7 @@
              height="{{ image.derivative.height }}" />
     {% endif %}
     <div data-widget-type="facility-map"
-         data-facility="{{ facilityId }}">
+         data-facility="{{ facilityId }}"
+         aria-hidden="true">
     </div>
 </div>


### PR DESCRIPTION
## Description
resolves - https://github.com/department-of-veterans-affairs/va.gov-team/issues/25011

Use this vet center to preview - http://localhost:3002/preview?nodeId=3756

## Acceptance criteria
- [ ] When using a screenreader, it should not detect the map

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
