### PR TITLE
Create headerFooter in preview server

### DIFF
--- a/script/preview.js
+++ b/script/preview.js
@@ -196,7 +196,9 @@ function fetchAllPageData(nodeId) {
           return resp.json();
         }
         throw new Error(
-          `HTTP error when fetching manifest: ${resp.status} ${resp.statusText}`,
+          options.buildtype !== ENVIRONMENTS.LOCALHOST
+            ? `HTTP error when fetching manifest: ${resp.status} ${resp.statusText}`
+            : 'file-manifest.json is missing. Try running "yarn build" in vets-website.',
         );
       },
     ),

--- a/script/preview.js
+++ b/script/preview.js
@@ -74,7 +74,7 @@ if (options.buildpath === null) {
   options.buildpath = `build/${options.buildtype}`;
 }
 
-// Create symlink to 'vets-website/generated' if it doesn't exist
+// Create symlink to 'vets-website/generated' if one doesn't exist
 // so we don't have to run the content build
 if (
   options.buildtype === ENVIRONMENTS.LOCALHOST &&

--- a/script/preview.js
+++ b/script/preview.js
@@ -23,6 +23,7 @@ const HOSTNAMES = require('../src/site/constants/hostnames');
 const DRUPALS = require('../src/site/constants/drupals');
 const bucketsContent = require('../src/site/constants/buckets-content');
 const singlePageDiff = require('./preview-routes/single-page-diff');
+const createMetalSmithSymlink = require('../src/site/stages/build/plugins/create-symlink');
 
 const defaultBuildtype = ENVIRONMENTS.LOCALHOST;
 const defaultHost = HOSTNAMES[defaultBuildtype];
@@ -73,6 +74,16 @@ if (options.buildpath === null) {
   options.buildpath = `build/${options.buildtype}`;
 }
 
+// Create symlink to 'vets-website/generated' if it doesn't exist
+// so we don't have to run the content build
+if (
+  options.buildtype === ENVIRONMENTS.LOCALHOST &&
+  !fs.existsSync(`${options.buildpath}/generated`)
+) {
+  options['apps-directory-name'] = 'vets-website';
+  createMetalSmithSymlink(options);
+}
+
 const cacheDir = path.join(
   __dirname,
   '../.cache',
@@ -94,7 +105,7 @@ const urls = {
 };
 
 const getContentUrl = env => {
-  return env === 'localhost'
+  return env === ENVIRONMENTS.LOCALHOST
     ? 'http://localhost:3002'
     : bucketsContent[options.buildtype];
 };

--- a/src/site/stages/build/drupal/menus.js
+++ b/src/site/stages/build/drupal/menus.js
@@ -273,7 +273,10 @@ function formatHeaderData(buildOptions, contentData) {
   }
 
   let menuLinks = contentData.data.menuLinkContentQuery.entities;
-  const pages = contentData.data.nodeQuery.entities;
+  const pages = buildOptions.isPreviewServer
+    ? contentData.data.nodes.entities
+    : contentData.data.nodeQuery.entities;
+
   const headerData = [];
   const { hostUrl } = buildOptions;
 

--- a/src/site/stages/preview/index.js
+++ b/src/site/stages/preview/index.js
@@ -14,6 +14,7 @@ const leftRailNavResetLevels = require('../build/plugins/left-rail-nav-reset-lev
 const rewriteVaDomains = require('../build/plugins/rewrite-va-domains');
 const rewriteAWSUrls = require('../build/plugins/rewrite-cms-aws-urls');
 const modifyDom = require('../build/plugins/modify-dom');
+const createHeaderFooter = require('../build/plugins/create-header-footer');
 
 async function createPipeline(options) {
   const BUILD_OPTIONS = await getOptions(options);
@@ -82,6 +83,8 @@ async function createPipeline(options) {
       ],
     }),
   );
+
+  smith.use(createHeaderFooter(BUILD_OPTIONS));
 
   smith.use(
     navigation({


### PR DESCRIPTION
## Description
Currently, when using the preview server locally, we need to run a full content build prior so that `headerFooter.json` is created and a symlink to `file-manifest.json` is made. This PR updates the preview server script, so we don't need to run a content build just to create/reference those two files.

The `create-header-footer` plugin is added to the preview server's Metalsmith pipeline, so now we don't need to fetch that file from the `generated` directory, which would cause an error on the preview server if it didn't exist. Instead `headerFooter.json` is built on demand when viewing a page in the preview server.

A symlink to `generated/file-manifest.json` will be created in the preview script if one doesn't already exist. This avoids the need to run a full content build, since the content build makes a symlink to vets-website's `generated` directory to acomplish this as well.

## Testing done
Tested locally on `/preview` and `/diff`.

## Screenshots


## Acceptance criteria
- [ ] A full content build doesn't need to be executed to use the preview server locally.
- [ ] The preview server functions as it did before.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
