### PR TITLE
Add blocklisted-from-prod entities functionality

### DIFF
--- a/src/site/constants/blocklistedEntities.js
+++ b/src/site/constants/blocklistedEntities.js
@@ -1,0 +1,10 @@
+// Entity IDs that should not go to production: e.g. '20078'
+const BLOCKLIST_ENTITY_IDS = [];
+
+// Entity bundles that should not go to production: e.g. 'campaign_landing_page'
+const BLOCKLIST_ENTITY_BUNDLES = [];
+
+module.exports = {
+  BLOCKLIST_ENTITY_IDS,
+  BLOCKLIST_ENTITY_BUNDLES,
+};

--- a/src/site/stages/build/plugins/create-environment-filter.js
+++ b/src/site/stages/build/plugins/create-environment-filter.js
@@ -1,5 +1,9 @@
 /* eslint-disable no-param-reassign, no-console */
 const ENVIRONMENTS = require('../../../constants/environments');
+const {
+  BLOCKLIST_ENTITY_BUNDLES,
+  BLOCKLIST_ENTITY_IDS,
+} = require('../../../constants/blocklistedEntities');
 
 function createEnvironmentFilter(options) {
   const environmentName = options.buildtype;
@@ -8,6 +12,21 @@ function createEnvironmentFilter(options) {
     for (const fileName of Object.keys(files)) {
       const file = files[fileName];
 
+      // Derive if the file is blocklisted.
+      const isBlocklisted =
+        BLOCKLIST_ENTITY_BUNDLES.includes(file.entityBundle) ||
+        BLOCKLIST_ENTITY_IDS.includes(file.entityId);
+
+      // Do not include blocklisted pages on production (except for the preview server).
+      if (
+        !options.isPreviewServer &&
+        environmentName === ENVIRONMENTS.VAGOVPROD &&
+        isBlocklisted
+      ) {
+        delete files[fileName];
+      }
+
+      // Do not include draft pages (except locally).
       if (
         environmentName !== ENVIRONMENTS.LOCALHOST &&
         file.status === 'draft'
@@ -15,6 +34,7 @@ function createEnvironmentFilter(options) {
         delete files[fileName];
       }
 
+      // Do not include file if it is excluded from the current environment.
       if (file[environmentName] === false) {
         console.log(`File excluded from current buildtype: ${fileName}`);
         delete files[fileName];


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/25435

This PR creates config functionality for removing specific node IDs + entityBundles from environments. This work is being done as it's been requested twice now and it would be more convenient to have a single config file for adding this functionality in the future.

## Testing done
Locally

## Screenshots
N/A

## Acceptance criteria
- [x] create config functionality for removing specific node IDs + entityBundles from production environments (except preview server)

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
