### PR TITLE
add use-cached-assets flag option for build

### DIFF
--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -28,6 +28,10 @@ const DRUPAL_HUB_NAV_FILENAME = 'hubNavNames.json';
 // should pull the latest Drupal data.
 const PULL_DRUPAL_BUILD_ARG = 'pull-drupal';
 
+// If "--use-cached-assets" is passed into the build args, then the
+// build should use the assets saved in cache instead of downloading new ones.
+const USE_CACHED_ASSETS_BUILD_ARG = 'use-cached-assets';
+
 const getDrupalCachePath = buildOptions => {
   return path.join(buildOptions.cacheDirectory, DRUPAL_CACHE_FILENAME);
 };
@@ -258,7 +262,11 @@ async function loadCachedDrupalFiles(buildOptions, files) {
     buildOptions.cacheDirectory,
     'drupal/downloads',
   );
-  if (!buildOptions[PULL_DRUPAL_BUILD_ARG] && fs.existsSync(cachedFilesPath)) {
+  if (
+    (!buildOptions[PULL_DRUPAL_BUILD_ARG] ||
+      buildOptions[USE_CACHED_ASSETS_BUILD_ARG]) &&
+    fs.existsSync(cachedFilesPath)
+  ) {
     const cachedDrupalFiles = await recursiveRead(cachedFilesPath);
     cachedDrupalFiles.forEach(file => {
       const relativePath = path.relative(

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -72,6 +72,9 @@ const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   // isn't actually a part of this list of options, but an error would be thrown
   // without it. Remove this when getOptions is decoupled from the cache script.
   { name: 'fetch', type: Boolean, defaultValue: false },
+
+  // use the --use-cached-assets flag with a build to bypass re-downloading asset files
+  { name: 'use-cached-assets', type: Boolean, defaultValue: false },
 ];
 
 function gatherFromCommandLine() {

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -180,7 +180,7 @@ function deriveHostUrl(options) {
 /**
  * Sets up the CMS feature flags by either querying the CMS for them
  * or using ../../utilities/featureFlags. If we pull from Drupal, it'll
- * also ensure the cache directory exists and is empty.
+ * also ensure the cache directory exists.
  */
 async function setUpFeatureFlags(options) {
   global.buildtype = options.buildtype;
@@ -210,7 +210,6 @@ async function setUpFeatureFlags(options) {
 
     // Write them to .cache/{buildtype}/drupal/feature-flags.json
     fs.ensureDirSync(options.cacheDirectory);
-    fs.emptyDirSync(path.dirname(featureFlagFile));
     fs.writeJsonSync(featureFlagFile, rawFlags, { spaces: 2 });
   } else {
     logDrupal('Using cached feature flags');
@@ -231,6 +230,21 @@ async function setUpFeatureFlags(options) {
   });
 }
 
+/**
+ * If we pull from Drupal, this ensures the cache downloads directory is empty.
+ * Can be overridden with the --use-cached-assets flag.
+ */
+function clearDrupalCacheDirectory(options) {
+  const useCachedAssetsArg = 'use-cached-assets';
+  if (shouldPullDrupal(options) && !options[useCachedAssetsArg]) {
+    const drupalCacheDirectory = path.join(
+      options.cacheDirectory,
+      'drupal/downloads',
+    );
+    fs.emptyDirSync(drupalCacheDirectory);
+  }
+}
+
 async function getOptions(commandLineOptions) {
   const options = commandLineOptions || gatherFromCommandLine();
 
@@ -238,6 +252,7 @@ async function getOptions(commandLineOptions) {
   applyEnvironmentOverrides(options);
   deriveHostUrl(options);
   await setUpFeatureFlags(options);
+  clearDrupalCacheDirectory(options);
 
   // Setting verbosity for the whole content build process as global so we don't
   // have to pass the buildOptions around for just that.

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -209,7 +209,7 @@ async function setUpFeatureFlags(options) {
     }
 
     // Write them to .cache/{buildtype}/drupal/feature-flags.json
-    fs.ensureDirSync(options.cacheDirectory);
+    fs.ensureDirSync(path.dirname(featureFlagFile));
     fs.writeJsonSync(featureFlagFile, rawFlags, { spaces: 2 });
   } else {
     logDrupal('Using cached feature flags');

--- a/src/site/stages/build/plugins/download-drupal-assets.js
+++ b/src/site/stages/build/plugins/download-drupal-assets.js
@@ -106,6 +106,13 @@ async function downloadFile(
 }
 
 function downloadDrupalAssets(options) {
+  const useCachedAssetsArg = 'use-cached-assets';
+  if (options[useCachedAssetsArg]) {
+    log('using cached assets');
+    return;
+  }
+
+  log('not using cached assets');
   const client = getDrupalClient(options);
   return async (files, metalsmith, done) => {
     const buildPath = path.join('build', options.buildtype);

--- a/src/site/stages/build/plugins/download-drupal-assets.js
+++ b/src/site/stages/build/plugins/download-drupal-assets.js
@@ -106,59 +106,52 @@ async function downloadFile(
 }
 
 function downloadDrupalAssets(options) {
-  const useCachedAssetsArg = 'use-cached-assets';
-  const cacheOutputPath = path.join(options.cacheDirectory, 'drupal/downloads');
   const client = getDrupalClient(options);
   return async (files, metalsmith, done) => {
-    if (fs.existsSync(cacheOutputPath) && options[useCachedAssetsArg]) {
-      log('using cached assets');
-      done();
-    } else {
-      const buildPath = path.join('build', options.buildtype);
+    const buildPath = path.join('build', options.buildtype);
 
-      const assetsToDownload = Object.entries(files)
-        .filter(
-          entry =>
-            entry[1].isDrupalAsset &&
-            !fs.existsSync(path.join(buildPath, entry[1].path)),
-        )
-        .map(([key, value]) => ({
-          src: value.source,
-          dest: key,
-        }));
+    const assetsToDownload = Object.entries(files)
+      .filter(
+        entry =>
+          entry[1].isDrupalAsset &&
+          !fs.existsSync(path.join(buildPath, entry[1].path)),
+      )
+      .map(([key, value]) => ({
+        src: value.source,
+        dest: key,
+      }));
 
-      if (assetsToDownload.length) {
-        const downloadResults = {
-          downloadCount: 0,
-          errorCount: 0,
-          total: assetsToDownload.length,
-        };
+    if (assetsToDownload.length) {
+      const downloadResults = {
+        downloadCount: 0,
+        errorCount: 0,
+        total: assetsToDownload.length,
+      };
 
-        const downloadersCount = 5;
+      const downloadersCount = 5;
 
-        await new Promise(everythingDownloaded => {
-          for (let i = 0; i < downloadersCount; i++) {
-            downloadFile(
-              files,
-              options,
-              client,
-              assetsToDownload,
-              downloadResults,
-              everythingDownloaded,
-            );
-          }
-        });
-
-        log(`Downloaded ${downloadResults.downloadCount} asset(s) from Drupal`);
-        if (downloadResults.errorCount) {
-          log(
-            `${downloadResults.errorCount} error(s) downloading assets from Drupal`,
+      await new Promise(everythingDownloaded => {
+        for (let i = 0; i < downloadersCount; i++) {
+          downloadFile(
+            files,
+            options,
+            client,
+            assetsToDownload,
+            downloadResults,
+            everythingDownloaded,
           );
         }
-      }
+      });
 
-      done();
+      log(`Downloaded ${downloadResults.downloadCount} asset(s) from Drupal`);
+      if (downloadResults.errorCount) {
+        log(
+          `${downloadResults.errorCount} error(s) downloading assets from Drupal`,
+        );
+      }
     }
+
+    done();
   };
 }
 


### PR DESCRIPTION
## Description
This PR adds the `--use-cached-assets` flag which can be used together with `--pull-drupal` in order to pull new drupal content but still used cached assets.

## Testing done
locally ran `yarn build`, `yarn build --pull-drupal`, and `yarn build --pull-drupal --use-cached-assets` without issue.

## Screenshots


## Acceptance criteria
- [ ] Able to pull drupal content without re-downloading cached assets
- [ ] Does not affect review instances, staging, or prod

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
