### PR TITLE
inject lang attribute if missing

### DIFF
--- a/src/site/components/tests/image.drupal.unit.spec.js
+++ b/src/site/components/tests/image.drupal.unit.spec.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { renderHTML } from '~/site/tests/support';
+import axeCheck from '~/site/tests/support/axe.js';
 
 const layoutPath = 'src/site/components/image.drupal.liquid';
 
@@ -101,5 +102,12 @@ describe('image tag template', () => {
     const container = await renderHTML(layoutPath, data);
 
     expect(container.querySelector('img')).not.to.exist;
+  });
+
+  it('reports no axe violations', async () => {
+    const container = await renderHTML(layoutPath);
+    const violations = await axeCheck(container);
+
+    expect(violations.length).to.equal(0);
   });
 });

--- a/src/site/tests/support/index.js
+++ b/src/site/tests/support/index.js
@@ -86,10 +86,6 @@ const updateHTML = (files, options) => {
 
 const isHeadMissing = html => !html.includes('<head>');
 
-const injectLangAttribute = document => {
-  document.documentElement.lang = 'en';
-};
-
 const renderHTML = (layoutPath, data, dataName) => {
   const options = getOptions();
   const siteWideMetadata = {
@@ -133,7 +129,7 @@ const renderHTML = (layoutPath, data, dataName) => {
         });
 
         if (isFragement) {
-          injectLangAttribute(dom.window.document);
+          dom.window.document.documentElement.lang = 'en';
         }
 
         resolve(dom.window.document);

--- a/src/site/tests/support/index.js
+++ b/src/site/tests/support/index.js
@@ -84,6 +84,15 @@ const updateHTML = (files, options) => {
   modifyDom(options)(files, null, done);
 };
 
+const langAttributeNotPresent = dom => {
+  const langValue = dom.window.document.getElementsByTagName('html')[0].getAttribute('lang');
+  return langValue === null;
+};
+
+const injectLangAttribute = dom => {
+  dom.window.document.documentElement.lang = 'en';
+};
+
 const renderHTML = (layoutPath, data, dataName) => {
   const options = getOptions();
   const siteWideMetadata = {
@@ -124,6 +133,10 @@ const renderHTML = (layoutPath, data, dataName) => {
         const dom = new JSDOM(files[htmlFileName].contents, {
           runScripts: 'dangerously',
         });
+
+        if (langAttributeNotPresent(dom)) {
+          injectLangAttribute(dom);
+        }
 
         resolve(dom.window.document);
       }

--- a/src/site/tests/support/index.js
+++ b/src/site/tests/support/index.js
@@ -84,11 +84,9 @@ const updateHTML = (files, options) => {
   modifyDom(options)(files, null, done);
 };
 
-const isHeadPresent = html => html.includes('<head>');
+const isHeadMissing = html => !html.includes('<head>');
 
-const injectLangAttribute = dom => {
-  dom.window.document.documentElement.lang = 'en';
-};
+const injectLangAttribute = document => document.documentElement.lang = 'en';
 
 const renderHTML = (layoutPath, data, dataName) => {
   const options = getOptions();
@@ -115,7 +113,7 @@ const renderHTML = (layoutPath, data, dataName) => {
         reject(err);
       } else {
         const html = context.getBuffer();
-        const headPresent = isHeadPresent(html);
+        const isFragement = isHeadMissing(html);
         const htmlFileName = makeHTMLFileName(layoutPath, dataName);
         const files = {
           [htmlFileName]: { contents: html, isDrupalPage: true },
@@ -132,8 +130,8 @@ const renderHTML = (layoutPath, data, dataName) => {
           runScripts: 'dangerously',
         });
 
-        if (!headPresent) {
-          injectLangAttribute(dom);
+        if (isFragement) {
+          injectLangAttribute(dom.window.document);
         }
 
         resolve(dom.window.document);

--- a/src/site/tests/support/index.js
+++ b/src/site/tests/support/index.js
@@ -86,7 +86,9 @@ const updateHTML = (files, options) => {
 
 const isHeadMissing = html => !html.includes('<head>');
 
-const injectLangAttribute = document => document.documentElement.lang = 'en';
+const injectLangAttribute = document => {
+  document.documentElement.lang = 'en';
+};
 
 const renderHTML = (layoutPath, data, dataName) => {
   const options = getOptions();

--- a/src/site/tests/support/index.js
+++ b/src/site/tests/support/index.js
@@ -84,10 +84,7 @@ const updateHTML = (files, options) => {
   modifyDom(options)(files, null, done);
 };
 
-const langAttributeNotPresent = dom => {
-  const langValue = dom.window.document.getElementsByTagName('html')[0].getAttribute('lang');
-  return langValue === null;
-};
+const isHeadPresent = html => html.includes('<head>');
 
 const injectLangAttribute = dom => {
   dom.window.document.documentElement.lang = 'en';
@@ -118,6 +115,7 @@ const renderHTML = (layoutPath, data, dataName) => {
         reject(err);
       } else {
         const html = context.getBuffer();
+        const headPresent = isHeadPresent(html);
         const htmlFileName = makeHTMLFileName(layoutPath, dataName);
         const files = {
           [htmlFileName]: { contents: html, isDrupalPage: true },
@@ -134,7 +132,7 @@ const renderHTML = (layoutPath, data, dataName) => {
           runScripts: 'dangerously',
         });
 
-        if (langAttributeNotPresent(dom)) {
+        if (!headPresent) {
           injectLangAttribute(dom);
         }
 


### PR DESCRIPTION
## Description
Resolves ticket #26212 - https://app.zenhub.com/workspaces/vsp-5cedc9cce6e3335dc5a49fc4/issues/department-of-veterans-affairs/va.gov-team/26212

Injects `lang` attribute if it's missing so Axe tests can pass.

All liquid template unit tests pass:

```
  41 passing (18s)
```