### PR TITLE
Ignore duplicate runs on releases

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,8 +2,8 @@ name: Continuous Integration
 
 on: 
   push:
-    tags-ignore:
-      - '**' # Ignores all tags
+    # tags-ignore:
+    #   - '**' # Ignores all tags
 
 env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,6 +1,9 @@
 name: Continuous Integration
 
-on: [push]
+on: 
+  push:
+    tags-ignore:
+      - '**' # Ignores all tags
 
 env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,8 +2,10 @@ name: Continuous Integration
 
 on: 
   push:
-    # tags-ignore:
-    #   - '**' # Ignores all tags
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
 
 env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver


### PR DESCRIPTION
## Description

Based on observation, duplicate runs are being executed on content-release and daily-deploy. This PR eliminates extra steps appended to the last commit

Ref: [merged_pr](https://github.com/department-of-veterans-affairs/content-build/runs/2917968360)

## Testing done

N/A

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
