### PR TITLE
Use optionLabel over event.target.value

### DIFF
--- a/src/site/includes/how-do-you-rate.drupal.liquid
+++ b/src/site/includes/how-do-you-rate.drupal.liquid
@@ -43,6 +43,16 @@
 </form>
 
 <script nonce="**CSP_NONCE**" type="text/javascript">
+  function deriveOptionLabel(goodChecked, badChecked) {
+    if (goodChecked) {
+      return 'Good';
+    }
+
+    if (badChecked) {
+      return 'Bad';
+    }
+  }
+
   function onRatingChange(event) {
     // Derive the elements on the page.
     var ratingOptionsElement = document.getElementById("rating-options");
@@ -82,7 +92,7 @@
     }
 
     // Record the event in analytics.
-    var optionLabel = goodChecked ? 'Good' : (badChecked ? 'Bad' : undefined);
+    var optionLabel = deriveOptionLabel(goodChecked, badChecked);
     if (recordEvent && optionLabel) {
       recordEvent({
         'event': 'int-radio-button-option-click',

--- a/src/site/includes/how-do-you-rate.drupal.liquid
+++ b/src/site/includes/how-do-you-rate.drupal.liquid
@@ -82,12 +82,12 @@
     }
 
     // Record the event in analytics.
-    var optionLabel = goodChecked ? 'Good' : (badChecked ? 'Bad' : '');
+    var optionLabel = goodChecked ? 'Good' : (badChecked ? 'Bad' : undefined);
     if (recordEvent && optionLabel) {
       recordEvent({
         'event': 'int-radio-button-option-click',
         'radio-button-label': "{{ ratingOptionsQuestion }}",
-        'radio-button-optionLabel': event.target.value, // "Good" | "Bad"
+        'radio-button-optionLabel': optionLabel, // "Good" | "Bad"
         'radio-button-required': false,
       })
     }


### PR DESCRIPTION
# Description

**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/26434

This PR resolves an analytics bug for the how do you rate component where the option label was always undefined. It now resolves to "good" + "bad".

## Testing

Locally.

## Screenshots

#### Before

![image](https://user-images.githubusercontent.com/12773166/124005639-8edb7180-d996-11eb-9852-17a8c8b5501a.png)

#### After

![image](https://user-images.githubusercontent.com/12773166/124008799-0f4fa180-d99a-11eb-846a-ae3845a45750.png)

## Acceptance Criteria

- [x] Fix optionLabel for the analytic event in how do you rate
