### PR TITLE
Update footer link

### DIFF
--- a/src/platform/static-data/footer-links.json
+++ b/src/platform/static-data/footer-links.json
@@ -25,7 +25,7 @@
     "href": "https://www.patientcare.va.gov/lgbt/",
     "order": 4,
     "target": "",
-    "title": "LGBT Veterans",
+    "title": "LGBTQ+ Veterans",
     "rel": "noopener noreferrer"
   },
   {


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/26858

This PR changes the footer link from `LGBT` to `LGBTQ+`.

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Update LGBT to LGBTQ+ in footer

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
