### PR TITLE
Restore HREF's to In the Spotlight links on VAMC pages

### DIFF
--- a/src/site/layouts/tests/vamc/system_home.cypress.spec.js
+++ b/src/site/layouts/tests/vamc/system_home.cypress.spec.js
@@ -68,6 +68,15 @@ Cypress.Commands.add('checkElements', (page, isMobile) => {
 
   cy.get('h2').contains('Get updates');
   cy.get('.social-links').contains('Facebook');
+
+  cy.get('a')
+    .contains('Get help from a patient advocate')
+    .click();
+  cy.location().should(loc => {
+    expect(loc.pathname).to.eq(
+      '/pittsburgh-health-care/health-services/patient-advocates/',
+    );
+  });
 });
 
 describe('VAMC system home page', () => {

--- a/src/site/paragraphs/facilities/list_of_link_teasers_facility.drupal.liquid
+++ b/src/site/paragraphs/facilities/list_of_link_teasers_facility.drupal.liquid
@@ -33,8 +33,9 @@
             <div class="usa-width-one-half vads-u-display--flex vads-u-flex-direction--column">
             {% endif %}
             <a onclick="recordEvent({ event: 'nav-featured-content-link-click', 'featured-content-header': '{{ paragraph.fieldTitle }}', 'featured-content-click-label': '{{ link.title }}' });" 
-                class="vads-u-margin-bottom--2" 
-                >
+                class="vads-u-margin-bottom--2"
+                href="{{ link.url.path }}"
+            >
               {{ link.title }}
             </a>
             {% if forloop.last || everyEndItem == 0 %}


### PR DESCRIPTION
## Description
A [recent change](https://github.com/department-of-veterans-affairs/content-build/pull/297) to our templates accidentally omitted the HREF's for our "In the Spotlight" links.

This PR restores them.