### PR TITLE
Bump timeout for a11y tests that are timing out

### DIFF
--- a/src/platform/site-wide/tests/sitemap/sitemap-1.spec.js
+++ b/src/platform/site-wide/tests/sitemap/sitemap-1.spec.js
@@ -9,7 +9,7 @@ const Timeouts = require('../../../testing/e2e/timeouts.js');
 module.exports = {
   'sitemap 1/4': client => {
     // Setting a large timeout so reduced memory doesn't cause failures
-    client.timeoutsAsyncScript(Timeouts.verySlow);
+    client.timeoutsAsyncScript(Timeouts.extremelySlow);
     SitemapHelpers.sitemapURLs().then(function runFirstAxeCheck({
       urls,
       onlyTest508Rules, // eslint-disable-line no-unused-vars

--- a/src/platform/site-wide/tests/sitemap/sitemap-2.spec.js
+++ b/src/platform/site-wide/tests/sitemap/sitemap-2.spec.js
@@ -4,7 +4,7 @@ const Timeouts = require('../../../testing/e2e/timeouts.js');
 module.exports = {
   'sitemap 2/4': client => {
     // Setting a large timeout so reduced memory doesn't cause failures
-    client.timeoutsAsyncScript(Timeouts.verySlow);
+    client.timeoutsAsyncScript(Timeouts.extremelySlow);
     SitemapHelpers.sitemapURLs().then(function runSecondAxeCheck({
       urls,
       onlyTest508Rules,

--- a/src/platform/site-wide/tests/sitemap/sitemap-3.spec.js
+++ b/src/platform/site-wide/tests/sitemap/sitemap-3.spec.js
@@ -4,7 +4,7 @@ const Timeouts = require('../../../testing/e2e/timeouts.js');
 module.exports = {
   'sitemap 3/4': client => {
     // Setting a large timeout so reduced memory doesn't cause failures
-    client.timeoutsAsyncScript(Timeouts.verySlow);
+    client.timeoutsAsyncScript(Timeouts.extremelySlow);
     SitemapHelpers.sitemapURLs().then(function runThirdAxeCheck({
       urls,
       onlyTest508Rules,

--- a/src/platform/site-wide/tests/sitemap/sitemap-4.spec.js
+++ b/src/platform/site-wide/tests/sitemap/sitemap-4.spec.js
@@ -4,7 +4,7 @@ const Timeouts = require('../../../testing/e2e/timeouts.js');
 module.exports = {
   'sitemap 4/4': client => {
     // Setting a large timeout so reduced memory doesn't cause failures
-    client.timeoutsAsyncScript(Timeouts.verySlow);
+    client.timeoutsAsyncScript(Timeouts.extremelySlow);
     SitemapHelpers.sitemapURLs().then(function runFourthAxeCheck({
       urls,
       onlyTest508Rules,

--- a/src/platform/site-wide/tests/sitemap/sitemap-helpers.js
+++ b/src/platform/site-wide/tests/sitemap/sitemap-helpers.js
@@ -61,7 +61,7 @@ function runTests(client, segment, only508List) {
     client
       .perform(() => {})
       .openUrl(url)
-      .waitForElementVisible('body', Timeouts.verySlow)
+      .waitForElementVisible('body', Timeouts.extremelySlow)
       .axeCheck(
         'document',
         only508

--- a/src/platform/testing/e2e/timeouts.js
+++ b/src/platform/testing/e2e/timeouts.js
@@ -2,6 +2,7 @@ const timeouts = {
   normal: 2000, // The normal timeout to use. For most opreations w/o a server roundtrip, this should be more than fast enough.
   slow: 5000, // A slow timeout incase the page is doing something complex.
   verySlow: 20000,
+  extremelySlow: 60000, // 1 minute
 };
 
 if (process.env.SAUCE_ACCESS_KEY) {


### PR DESCRIPTION
## Description
Extending the timeout for daily accessibility tests because they are sometimes failing with the previous 20 second timeout limit.