### PR TITLE
Remove last bits of useTomeSync to sunset CMS Export code

### DIFF
--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -380,7 +380,7 @@ def archiveAll(dockerContainer, String ref) {
 
 def cacheDrupalContent(dockerContainer, envUsedCache) {
   stage("Cache Drupal Content") {
-    if (!isDeployable()) { return }
+    // if (!isDeployable()) { return }
 
     try {
       def archives = [:]

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -380,7 +380,7 @@ def archiveAll(dockerContainer, String ref) {
 
 def cacheDrupalContent(dockerContainer, envUsedCache) {
   stage("Cache Drupal Content") {
-    // if (!isDeployable()) { return }
+    if (!isDeployable()) { return }
 
     try {
       def archives = [:]

--- a/src/site/stages/build/drupal/api.js
+++ b/src/site/stages/build/drupal/api.js
@@ -240,15 +240,15 @@ function getDrupalClient(buildOptions, clientOptionsArg) {
       });
     },
 
-    getNonNodeContent(onlyPublishedContent = true) {
-      say('Querying for non-node content');
-      return this.query({
-        query: getQuery(queries.GET_ALL_PAGES, { useTomeSync: true }),
-        variables: {
-          onlyPublishedContent,
-        },
-      });
-    },
+    // getNonNodeContent(onlyPublishedContent = true) {
+    //   say('Querying for non-node content');
+    //   return this.query({
+    //     query: getQuery(queries.GET_ALL_PAGES, { useTomeSync: true }),
+    //     variables: {
+    //       onlyPublishedContent,
+    //     },
+    //   });
+    // },
 
     getLatestPageById(nodeId) {
       return this.query({

--- a/src/site/stages/build/drupal/api.js
+++ b/src/site/stages/build/drupal/api.js
@@ -240,16 +240,6 @@ function getDrupalClient(buildOptions, clientOptionsArg) {
       });
     },
 
-    // getNonNodeContent(onlyPublishedContent = true) {
-    //   say('Querying for non-node content');
-    //   return this.query({
-    //     query: getQuery(queries.GET_ALL_PAGES, { useTomeSync: true }),
-    //     variables: {
-    //       onlyPublishedContent,
-    //     },
-    //   });
-    // },
-
     getLatestPageById(nodeId) {
       return this.query({
         query: getQuery(queries.GET_LATEST_PAGE_BY_ID),

--- a/src/site/stages/build/drupal/api.js
+++ b/src/site/stages/build/drupal/api.js
@@ -240,15 +240,15 @@ function getDrupalClient(buildOptions, clientOptionsArg) {
       });
     },
 
-    // getNonNodeContent(onlyPublishedContent = true) {
-    //   say('Querying for non-node content');
-    //   return this.query({
-    //     query: getQuery(queries.GET_ALL_PAGES, { useTomeSync: true }),
-    //     variables: {
-    //       onlyPublishedContent,
-    //     },
-    //   });
-    // },
+    getNonNodeContent(onlyPublishedContent = true) {
+      say('Querying for non-node content');
+      return this.query({
+        query: getQuery(queries.GET_ALL_PAGES, { useTomeSync: true }),
+        variables: {
+          onlyPublishedContent,
+        },
+      });
+    },
 
     getLatestPageById(nodeId) {
       return this.query({

--- a/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
@@ -58,12 +58,10 @@ queryParamToBeChanged.forEach(param => {
 
 const regex = new RegExp(`${regString}`, 'g');
 
-// const buildQuery = ({ useTomeSync }) => {
-//   const nodeContentFragments = useTomeSync
-//     ? ''
-//     : `
-const buildQuery = () => {
-  const nodeContentFragments = `
+const buildQuery = ({ useTomeSync }) => {
+  const nodeContentFragments = useTomeSync
+    ? ''
+    : `
   ${ALL_FRAGMENTS}
   ${landingPage.fragment}
   ${page.fragment}

--- a/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
@@ -94,13 +94,11 @@ const buildQuery = ({ useTomeSync }) => {
   ${vamcPolicyPages.fragment}
 `;
 
-  // const todayQueryVar = useTomeSync ? '' : '$today: String!,';
-  const todayQueryVar = '$today: String!,';
+  const todayQueryVar = useTomeSync ? '' : '$today: String!,';
 
-  // const nodeQuery = useTomeSync
-  //   ? ''
-  //   : `
-  const nodeQuery = `
+  const nodeQuery = useTomeSync
+    ? ''
+    : `
     nodeQuery(limit: 5000, filter: {
       conditions: [
         { field: "status", value: ["1"], enabled: $onlyPublishedContent }

--- a/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
@@ -58,10 +58,12 @@ queryParamToBeChanged.forEach(param => {
 
 const regex = new RegExp(`${regString}`, 'g');
 
-const buildQuery = ({ useTomeSync }) => {
-  const nodeContentFragments = useTomeSync
-    ? ''
-    : `
+// const buildQuery = ({ useTomeSync }) => {
+//   const nodeContentFragments = useTomeSync
+//     ? ''
+//     : `
+const buildQuery = () => {
+  const nodeContentFragments = `
   ${ALL_FRAGMENTS}
   ${landingPage.fragment}
   ${page.fragment}
@@ -94,11 +96,13 @@ const buildQuery = ({ useTomeSync }) => {
   ${vamcPolicyPages.fragment}
 `;
 
-  const todayQueryVar = useTomeSync ? '' : '$today: String!,';
+  // const todayQueryVar = useTomeSync ? '' : '$today: String!,';
+  const todayQueryVar = '$today: String!,';
 
-  const nodeQuery = useTomeSync
-    ? ''
-    : `
+  // const nodeQuery = useTomeSync
+  //   ? ''
+  //   : `
+  const nodeQuery = `
     nodeQuery(limit: 5000, filter: {
       conditions: [
         { field: "status", value: ["1"], enabled: $onlyPublishedContent }

--- a/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
@@ -58,10 +58,6 @@ queryParamToBeChanged.forEach(param => {
 
 const regex = new RegExp(`${regString}`, 'g');
 
-// const buildQuery = ({ useTomeSync }) => {
-//   const nodeContentFragments = useTomeSync
-//     ? ''
-//     : `
 const buildQuery = () => {
   const nodeContentFragments = `
   ${ALL_FRAGMENTS}
@@ -96,12 +92,8 @@ const buildQuery = () => {
   ${vamcPolicyPages.fragment}
 `;
 
-  // const todayQueryVar = useTomeSync ? '' : '$today: String!,';
   const todayQueryVar = '$today: String!,';
 
-  // const nodeQuery = useTomeSync
-  //   ? ''
-  //   : `
   const nodeQuery = `
     nodeQuery(limit: 5000, filter: {
       conditions: [

--- a/src/site/stages/build/drupal/queries.js
+++ b/src/site/stages/build/drupal/queries.js
@@ -3,18 +3,18 @@ const queries = {
   GET_LATEST_PAGE_BY_ID: './graphql/GetLatestPageById.graphql',
 };
 
-// function getQuery(query, { useTomeSync } = {}) {
-//   if (query === queries.GET_ALL_PAGES) {
-//     // eslint-disable-next-line import/no-dynamic-require
-//     return require(query)({ useTomeSync });
-//   }
-//   // eslint-disable-next-line import/no-dynamic-require
-//   return require(query);
-// }
-function getQuery(query) {
+function getQuery(query, { useTomeSync } = {}) {
+  if (query === queries.GET_ALL_PAGES) {
+    // eslint-disable-next-line import/no-dynamic-require
+    return require(query)({ useTomeSync });
+  }
   // eslint-disable-next-line import/no-dynamic-require
   return require(query);
 }
+// function getQuery(query) {
+//   // eslint-disable-next-line import/no-dynamic-require
+//   return require(query);
+// }
 
 module.exports = {
   getQuery,

--- a/src/site/stages/build/drupal/queries.js
+++ b/src/site/stages/build/drupal/queries.js
@@ -3,11 +3,15 @@ const queries = {
   GET_LATEST_PAGE_BY_ID: './graphql/GetLatestPageById.graphql',
 };
 
-function getQuery(query, { useTomeSync } = {}) {
-  if (query === queries.GET_ALL_PAGES) {
-    // eslint-disable-next-line import/no-dynamic-require
-    return require(query)({ useTomeSync });
-  }
+// function getQuery(query, { useTomeSync } = {}) {
+//   if (query === queries.GET_ALL_PAGES) {
+//     // eslint-disable-next-line import/no-dynamic-require
+//     return require(query)({ useTomeSync });
+//   }
+//   // eslint-disable-next-line import/no-dynamic-require
+//   return require(query);
+// }
+function getQuery(query) {
   // eslint-disable-next-line import/no-dynamic-require
   return require(query);
 }

--- a/src/site/stages/build/drupal/queries.js
+++ b/src/site/stages/build/drupal/queries.js
@@ -3,18 +3,18 @@ const queries = {
   GET_LATEST_PAGE_BY_ID: './graphql/GetLatestPageById.graphql',
 };
 
-function getQuery(query, { useTomeSync } = {}) {
-  if (query === queries.GET_ALL_PAGES) {
-    // eslint-disable-next-line import/no-dynamic-require
-    return require(query)({ useTomeSync });
-  }
-  // eslint-disable-next-line import/no-dynamic-require
-  return require(query);
-}
-// function getQuery(query) {
+// function getQuery(query, { useTomeSync } = {}) {
+//   if (query === queries.GET_ALL_PAGES) {
+//     // eslint-disable-next-line import/no-dynamic-require
+//     return require(query)({ useTomeSync });
+//   }
 //   // eslint-disable-next-line import/no-dynamic-require
 //   return require(query);
 // }
+function getQuery(query) {
+  // eslint-disable-next-line import/no-dynamic-require
+  return require(query);
+}
 
 module.exports = {
   getQuery,

--- a/src/site/stages/build/drupal/queries.js
+++ b/src/site/stages/build/drupal/queries.js
@@ -3,13 +3,11 @@ const queries = {
   GET_LATEST_PAGE_BY_ID: './graphql/GetLatestPageById.graphql',
 };
 
-function getQuery(query, { useTomeSync } = {}) {
-  // if (query === queries.GET_ALL_PAGES) {
-  //   // eslint-disable-next-line import/no-dynamic-require
-  //   return require(query)({ useTomeSync });
-  // }
-  // eslint-disable-next-line no-console
-  console.log(useTomeSync);
+function getQuery(query) {
+  if (query === queries.GET_ALL_PAGES) {
+    // eslint-disable-next-line import/no-dynamic-require
+    return require(query)();
+  }
   // eslint-disable-next-line import/no-dynamic-require
   return require(query);
 }

--- a/src/site/stages/build/drupal/queries.js
+++ b/src/site/stages/build/drupal/queries.js
@@ -4,17 +4,15 @@ const queries = {
 };
 
 function getQuery(query, { useTomeSync } = {}) {
-  if (query === queries.GET_ALL_PAGES) {
-    // eslint-disable-next-line import/no-dynamic-require
-    return require(query)({ useTomeSync });
-  }
+  // if (query === queries.GET_ALL_PAGES) {
+  //   // eslint-disable-next-line import/no-dynamic-require
+  //   return require(query)({ useTomeSync });
+  // }
+  // eslint-disable-next-line no-console
+  console.log(useTomeSync);
   // eslint-disable-next-line import/no-dynamic-require
   return require(query);
 }
-// function getQuery(query) {
-//   // eslint-disable-next-line import/no-dynamic-require
-//   return require(query);
-// }
 
 module.exports = {
   getQuery,


### PR DESCRIPTION
## Description
Cleaning up the last bit of CMS Export code with useTomeSync. This was previously merged, but broke the master CI runs because of a caching step that isn't presenting PRs. The previous code was merged with https://github.com/department-of-veterans-affairs/content-build/pull/282

## Testing Done
Passing CI, but also passing GHA's Continuous Integration / Drupal Cache Test (push) and a separate run that executes Jenkins master caching. Also downloaded the fine results from S3 and did a visual spot check.

