### PR TITLE
Use appropriate Drupal addresses in GHA builds.

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,6 +28,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
+        buildtype: [vagovdev, vagovstaging, vagovprod]
         include:
           - buildtype: vagovdev
             drupal-address: http://internal-dsva-vagov-dev-cms-812329399.us-gov-west-1.elb.amazonaws.com
@@ -485,6 +486,7 @@ jobs:
 
 #   strategy:
 #     matrix:
+#       environment: [vagovdev, vagovstaging]
 #       include:
 #         - environment: vagovdev
 #           bucket: content.dev.va.gov

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -95,12 +95,12 @@ jobs:
           EOF
 
       - name: Compress E2E test build
-        if: ${{ matrix.buildType == 'vagovprod' }}
+        if: ${{ matrix.buildtype == 'vagovprod' }}
         run: tar -C build/vagovprod -cjf test-build.tar.bz2 .
 
       - name: Upload E2E test build artifact
         uses: actions/upload-artifact@v2
-        if: ${{ matrix.buildType == 'vagovprod' }}
+        if: ${{ matrix.buildtype == 'vagovprod' }}
         with:
           name: test-build.tar.bz2
           path: content-build/test-build.tar.bz2
@@ -110,13 +110,13 @@ jobs:
         run: node ./script/prearchive.js --buildtype=${{ matrix.buildtype }}
 
       - name: Compress prearchived build
-        run: tar -C build/${{ matrix.buildType }} -cjf ${{ matrix.buildType }}.tar.bz2 .
+        run: tar -C build/${{ matrix.buildtype }} -cjf ${{ matrix.buildtype }}.tar.bz2 .
 
       - name: Upload prearchived build artifact
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.buildtype }}.tar.bz2
-          path: content-build/${{ matrix.buildType }}.tar.bz2
+          path: content-build/${{ matrix.buildtype }}.tar.bz2
           retention-days: 1
 
       - name: Configure AWS credentials

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -36,8 +36,6 @@ jobs:
           - buildtype: vagovprod
             drupal-address: http://internal-dsva-vagov-prod-cms-2000800896.us-gov-west-1.elb.amazonaws.com
 
-        buildtype: [vagovdev, vagovstaging, vagovprod]
-
     steps:
       - name: Checkout vagov-content
         uses: actions/checkout@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,6 +1,6 @@
 name: Continuous Integration
 
-on: 
+on:
   push:
     branches:
       - '**'
@@ -21,11 +21,21 @@ jobs:
         working-directory: content-build
 
     env:
+      # Sandbox Drupal address is used on branches other than master.
+      DRUPAL_ADDRESS: https://cms-vets-website-branch-builds-lo9uhqj18nwixunsjadvjsynuni7kk1u.ci.cms.va.gov
       NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
 
     strategy:
       fail-fast: true
       matrix:
+        include:
+          - buildtype: vagovdev
+            drupal-address: http://internal-dsva-vagov-dev-cms-812329399.us-gov-west-1.elb.amazonaws.com
+          - buildtype: vagovstaging
+            drupal-address: http://internal-dsva-vagov-staging-cms-1188006.us-gov-west-1.elb.amazonaws.com
+          - buildtype: vagovprod
+            drupal-address: http://internal-dsva-vagov-prod-cms-2000800896.us-gov-west-1.elb.amazonaws.com
+
         buildtype: [vagovdev, vagovstaging, vagovprod]
 
     steps:
@@ -63,8 +73,12 @@ jobs:
         env:
           YARN_CACHE_FOLDER: ~/.cache/yarn
 
+      - name: Set Drupal address
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: echo "DRUPAL_ADDRESS=${{ matrix.drupal-address }}" >> $GITHUB_ENV
+
       - name: Build
-        run: yarn build --buildtype=${{ matrix.buildtype }} --drupal-address="https://cms-vets-website-branch-builds-lo9uhqj18nwixunsjadvjsynuni7kk1u.ci.cms.va.gov" --no-drupal-proxy
+        run: yarn build --buildtype=${{ matrix.buildtype }} --drupal-address=${{ env.DRUPAL_ADDRESS }} --no-drupal-proxy
         env:
           NODE_ENV: production
 


### PR DESCRIPTION
## Description
This sets the Drupal addresses for GHA builds to the actual environments on `master` instead of always using the sandbox.

## Testing done
Verified that builds in feature branch still use the sandbox.

Will verify when merged to `master` that the actual environments are used.

## Acceptance criteria
- [ ] GHA builds in feature branches should use the sandbox Drupal address.
- [ ] GHA builds on `master` should use the addresses for the actual environments.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
