### PR TITLE
[DO NOT MERGE, POC] Make HP banner dependent on alert ID 42

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -900,4 +900,20 @@ module.exports = function registerFilters() {
     const hasContent = e => _.get(e, path)?.length > 0;
     return rootArray.some(hasContent);
   };
+
+  liquid.filters.findHomepageBannerAlertInAlerts = alerts => {
+    // Escape early if there are no alerts.
+    if (_.isEmpty(alerts?.entities)) return null;
+
+    // Find the homepage banner alert.
+    const homepageAlert = _.find(alerts?.entities, ['id', 42]);
+
+    // Return the formatted homepage banner alert.
+    return {
+      content: homepageAlert?.fieldAlertContent?.entity?.entityRendered,
+      title: homepageAlert?.fieldAlertTitle,
+      type: 'info',
+      visible: homepageAlert?.entityPublished ? 'true' : 'false',
+    };
+  };
 };

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -1099,3 +1099,41 @@ describe('phoneLinks', () => {
     expect(liquid.filters.phoneLinks(html)).to.equal(html);
   });
 });
+
+describe('findHomepageBannerAlertInAlerts', () => {
+  it('returns the first alert with the correct type', () => {
+    const alerts = {
+      entities: [
+        {
+          id: 42,
+          fieldAlertContent: {
+            entity: {
+              entityRendered: '<p>Hello</p>',
+            },
+          },
+          fieldAlertTitle: 'Some title',
+          entityPublished: true,
+        },
+        {
+          id: 3,
+          fieldAlertContent: {
+            entity: {
+              entityRendered: '<p>Hello again</p>',
+            },
+          },
+          fieldAlertTitle: 'Some other title',
+          entityPublished: true,
+        },
+      ],
+    };
+
+    expect(
+      liquid.filters.findHomepageBannerAlertInAlerts(alerts),
+    ).to.deep.equal({
+      content: '<p>Hello</p>',
+      title: 'Some title',
+      type: 'info',
+      visible: 'true',
+    });
+  });
+});

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -115,9 +115,15 @@
 
   {% include "src/site/components/fullwidth_banner_alerts.drupal.liquid" %}
 
-  <div data-widget-type="banners" data-homepage-banner-content="{{ homepage_banner.content | escape }}"
+  {% assign homepage_banner = alerts | findHomepageBannerAlertInAlerts %}
+
+  <div
+    data-homepage-banner-content="{{ homepage_banner.content | escape }}"
     data-homepage-banner-title="{{ homepage_banner.title | escape }}"
-    data-homepage-banner-type="{{ homepage_banner.type }}" data-homepage-banner-visible="{{ homepage_banner.visible }}">
+    data-homepage-banner-type="{{ homepage_banner.type }}"
+    data-homepage-banner-visible="{{ homepage_banner.visible }}"
+    data-widget-type="banners"
+  >
   </div>
 
   <script nonce="**CSP_NONCE**" type="text/javascript">

--- a/src/site/stages/build/drupal/home.js
+++ b/src/site/stages/build/drupal/home.js
@@ -22,6 +22,7 @@ function addHomeContent(contentData, files, _metalsmith, _buildOptions) {
       (hub, i) => {
         // We want 3 cards per row.
         if ((i + 1) % 3 === 0) {
+          // eslint-disable-next-line no-param-reassign
           hub = {
             ...hub,
             endRow: true,
@@ -44,6 +45,7 @@ function addHomeContent(contentData, files, _metalsmith, _buildOptions) {
     };
 
     // Let Metalsmith know we're here.
+    // eslint-disable-next-line no-param-reassign
     files[`./index.html`] = createFileObj(homeEntityObj, 'home.drupal.liquid');
   }
 }

--- a/src/site/stages/build/drupal/home.js
+++ b/src/site/stages/build/drupal/home.js
@@ -14,6 +14,7 @@ function addHomeContent(contentData, files, metalsmith, buildOptions) {
     let homeEntityObj = createEntityUrlObj('/');
     const {
       data: {
+        alerts,
         homePageMenuQuery,
         homePageHubListQuery,
         homePagePromoBlockQuery,
@@ -34,13 +35,9 @@ function addHomeContent(contentData, files, metalsmith, buildOptions) {
       },
     );
 
-    const fragmentsRoot = metalsmith.path(buildOptions.contentFragments);
-    const bannerLocation = path.join(fragmentsRoot, 'home/banner.yml');
-    const bannerFile = fs.readFileSync(bannerLocation);
-    const banner = yaml.safeLoad(bannerFile);
-
     homeEntityObj = {
       ...homeEntityObj,
+      alerts, // Alerts.
       // Since homepage is not an independent node, we don't have a source for metatags. So we need to hard-code these for now.
       title: 'VA.gov Home',
       description:
@@ -48,8 +45,6 @@ function addHomeContent(contentData, files, metalsmith, buildOptions) {
       cards: homePageMenuQuery.links.slice(0, menuLength), // Top Tasks menu. We have a hard limit.
       hubs, // Full hub list.
       promos: homePagePromoBlockQuery.itemsOfEntitySubqueueHomePagePromos, // Promo blocks.
-      // eslint-disable-next-line camelcase
-      homepage_banner: banner,
     };
 
     // Let Metalsmith know we're here.

--- a/src/site/stages/build/drupal/home.js
+++ b/src/site/stages/build/drupal/home.js
@@ -1,11 +1,7 @@
-/* eslint-disable no-param-reassign, no-continue */
-const fs = require('fs-extra');
-const path = require('path');
-const yaml = require('js-yaml');
 const { createEntityUrlObj, createFileObj } = require('./page');
 
 // Processes the data received from the home page query.
-function addHomeContent(contentData, files, metalsmith, buildOptions) {
+function addHomeContent(contentData, files, _metalsmith, _buildOptions) {
   // We cannot limit menu items in Drupal, so we must do it here.
   const menuLength = 4;
 


### PR DESCRIPTION
# This is a POC, DO NOT merge this PR.

## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/26968

This PR makes the homepage banner dependent on alert ID `42` instead of the [banner.yml](https://github.com/department-of-veterans-affairs/vagov-content/blob/master/fragments/home/banner.yml) file in `vagov-content`.

## Testing done
Locally

## Screenshots

#### Before

![image](https://user-images.githubusercontent.com/12773166/124629113-5d532200-de3e-11eb-893a-b180405f98d0.png)

#### After

![image (1)](https://user-images.githubusercontent.com/12773166/124629134-63e19980-de3e-11eb-81d4-84e71158f2b2.png)

## Acceptance criteria
- [x] Make homepage banner dependent on alert ID 42 instead of the `banner.yml` file.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
