### PR TITLE
Only check broken links in GitHub Actions prod build

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -83,6 +83,7 @@ jobs:
 
       - name: Check broken links
         id: get-broken-link-info
+        if: ${{ matrix.buildtype == 'vagovprod '}}
         run: node ./script/github-actions/check-broken-links.js ${{ matrix.buildtype }}
 
       - name: Generate build details

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Check broken links
         id: get-broken-link-info
-        if: ${{ matrix.buildtype == 'vagovprod '}}
+        if: ${{ matrix.buildtype == 'vagovprod' }}
         run: node ./script/github-actions/check-broken-links.js ${{ matrix.buildtype }}
 
       - name: Generate build details


### PR DESCRIPTION
## Description
This will only run the broken link check on prod builds, which mirrors the Jenkins pipeline more closely.

The check is currently breaking on the other environments in `master`, so this will hopefully produce a fully passing workflow once merged to `master`.

## Testing done
CI passes.

## Acceptance criteria
- [ ] Broken link check should only run on production build.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
