### PR TITLE
Add VISN 5, 12, 17 menus to facilitySidebar

### DIFF
--- a/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
+++ b/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
@@ -90,6 +90,14 @@ const FACILITY_MENU_NAMES = [
   'va-jackson-health-care',
   'va-shreveport-health-care',
   'va-southeast-louisiana-health-ca',
+  // VISN 17
+  'va-amarillo-health-care',
+  'va-central-texas-health-care',
+  'va-el-paso-health-care',
+  'va-north-texas-health-care', 
+  'va-south-texas-health-care',
+  'va-texas-valley-health-care',  
+  'va-west-texas-health-care',
   // VISN 19
   'va-cheyenne-health-care',
   'va-eastern-colorado-health-care',

--- a/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
+++ b/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
@@ -36,6 +36,13 @@ const FACILITY_MENU_NAMES = [
   'va-philadelphia-health-care',
   'va-wilkes-barre-health-care',
   'va-wilmington-health-care',
+  // VISN 5
+  'va-beckley-health-care',
+  'va-clarksburg-health-care',
+  'va-huntington-health-care',
+  'va-martinsburg-health-care',
+  'va-maryland-health-care',
+  'va-washington-dc-health-care',
   // VISN 6
   'va-asheville-health-care',
   'va-durham-health-care',
@@ -73,6 +80,15 @@ const FACILITY_MENU_NAMES = [
   'va-indiana-health-care',
   'va-northern-indiana-health-care',
   'va-saginaw-health-care',
+  // VISN 12
+  'lovell-fhcc-health care',
+  'va-chicago health care
+  'va-hines-health-care',
+  'va-illiana-health-care',
+  'va-madison-health-care',
+  'va-iron-mountain-health-care',
+  'va-milwaukee-health-care',
+  'va-tomah-health-care',
   // VISN 15
   'va-columbia-missouri-health-care',
   'va-eastern-kansas-health-care',

--- a/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
+++ b/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
@@ -82,7 +82,7 @@ const FACILITY_MENU_NAMES = [
   'va-saginaw-health-care',
   // VISN 12
   'lovell-fhcc-health care',
-  'va-chicago health care
+  'va-chicago health care',
   'va-hines-health-care',
   'va-illiana-health-care',
   'va-madison-health-care',

--- a/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
+++ b/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
@@ -94,9 +94,9 @@ const FACILITY_MENU_NAMES = [
   'va-amarillo-health-care',
   'va-central-texas-health-care',
   'va-el-paso-health-care',
-  'va-north-texas-health-care', 
+  'va-north-texas-health-care',
   'va-south-texas-health-care',
-  'va-texas-valley-health-care',  
+  'va-texas-valley-health-care',
   'va-west-texas-health-care',
   // VISN 19
   'va-cheyenne-health-care',


### PR DESCRIPTION
## Description

See https://dsva.slack.com/archives/C0FQSS30V/p1625667550138900


## Testing done

None, visual comparison with menu ids stored in Drupal.

Stan may be testing for Central Texas in tugboat

![Release_content___VA_gov_CMS](https://user-images.githubusercontent.com/643678/124793266-ceb4d280-df1b-11eb-816f-be38db7c5a24.png)


## Screenshots


## Acceptance criteria
- [ ] VA Central Texas sidebar shows on those facility pages.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
