### PR TITLE
Show only future events on health care region page

### DIFF
--- a/src/site/stages/build/drupal/api.js
+++ b/src/site/stages/build/drupal/api.js
@@ -156,7 +156,7 @@ function getDrupalClient(buildOptions, clientOptionsArg) {
         const request = this.query({
           query,
           variables: {
-            today: moment().format('YYYY-MM-DD'),
+            today: getCurrentDayAsUnixTimestamp().toString(),
             onlyPublishedContent,
           },
         });

--- a/src/site/stages/build/drupal/api.js
+++ b/src/site/stages/build/drupal/api.js
@@ -11,6 +11,8 @@ const {
   CountEntityTypes,
 } = require('./individual-queries');
 
+const { getCurrentDayAsUnixTimestamp } = require('./utilities-drupal');
+
 function encodeCredentials({ user, password }) {
   const credentials = `${user}:${password}`;
   return Buffer.from(credentials).toString('base64');
@@ -234,7 +236,7 @@ function getDrupalClient(buildOptions, clientOptionsArg) {
       return this.query({
         query: getQuery(queries.GET_ALL_PAGES),
         variables: {
-          today: moment().format('YYYY-MM-DD'),
+          today: getCurrentDayAsUnixTimestamp().toString(),
           onlyPublishedContent,
         },
       });
@@ -245,7 +247,7 @@ function getDrupalClient(buildOptions, clientOptionsArg) {
         query: getQuery(queries.GET_LATEST_PAGE_BY_ID),
         variables: {
           id: nodeId,
-          today: moment().format('YYYY-MM-DD'),
+          today: getCurrentDayAsUnixTimestamp().toString(),
           onlyPublishedContent: false,
         },
       });

--- a/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
@@ -92,8 +92,6 @@ const buildQuery = () => {
   ${vamcPolicyPages.fragment}
 `;
 
-  const todayQueryVar = '$today: String!,';
-
   const nodeQuery = `
     nodeQuery(limit: 5000, filter: {
       conditions: [
@@ -141,7 +139,7 @@ const buildQuery = () => {
 
   ${nodeContentFragments}
 
-  query GetAllPages(${todayQueryVar} $onlyPublishedContent: Boolean!) {
+  query GetAllPages($today: String!, $onlyPublishedContent: Boolean!) {
     ${nodeQuery}
     ${icsFileQuery.partialQuery}
     ${sidebarQuery.partialQuery}

--- a/src/site/stages/build/drupal/utilities-drupal.js
+++ b/src/site/stages/build/drupal/utilities-drupal.js
@@ -44,9 +44,16 @@ function getRelatedHubByPath(link, pages) {
   return hub[0];
 }
 
+function getCurrentDayAsUnixTimestamp() {
+  const now = new Date();
+  const startOfDay = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  return startOfDay.getTime() / 1000;
+}
+
 module.exports = {
   logDrupal,
   facilityLocationPath,
   getDrupalCacheKey,
   getRelatedHubByPath,
+  getCurrentDayAsUnixTimestamp,
 };


### PR DESCRIPTION
VAMC health care region pages (e.g. /pittsburgh-health-care) are showing events marked as "featured" but with start dates in the past.

Confirmed: the "today" GraphQL query variable is using a string format for the current date ('YYYY-MM-DD"), but the data is in UNIX timestamp format. So the `eventTeasersFeatured` query [filter](https://github.com/department-of-veterans-affairs/content-build/blob/c00c759cac79f12ae1838435cc3973a0123b4216/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js#L140) that's supposed to filter out past events isn't working.

This PR fixes this, but it needs to be tested thoroughly because it impacts every query that uses the "today" variable (all events pages, including outreach-and-events).
