### PR TITLE
Remove leftover circle CI references in Cypress test specs

### DIFF
--- a/src/site/layouts/tests/vamc/location_home.cypress.spec.js
+++ b/src/site/layouts/tests/vamc/location_home.cypress.spec.js
@@ -82,7 +82,6 @@ Cypress.Commands.add('checkElements', (page, isMobile) => {
 
 describe('VAMC location home page', () => {
   before(function() {
-    if (Cypress.env('CIRCLECI')) this.skip();
     cy.syncFixtures({
       fixtures: path.join(__dirname, 'fixtures'),
     });

--- a/src/site/layouts/tests/vamc/system_home.cypress.spec.js
+++ b/src/site/layouts/tests/vamc/system_home.cypress.spec.js
@@ -80,10 +80,6 @@ Cypress.Commands.add('checkElements', (page, isMobile) => {
 });
 
 describe('VAMC system home page', () => {
-  before(function() {
-    if (Cypress.env('CIRCLECI')) this.skip();
-  });
-
   it('has expected elements on desktop', () => {
     cy.checkElements('/pittsburgh-health-care', false);
   });


### PR DESCRIPTION
## Description
This PR is to remove some leftover CircleCI logic that was hanging around a couple Cypress specs.


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
