### PR TITLE
Daily deploy (github actions) -- default time change

### DIFF
--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -6,7 +6,7 @@ on:
       release_wait:
         description: "Minutes to wait before creating release"
         required: false
-        default: 60
+        default: 5
   schedule:
     - cron: "0 18 * * 1-5"
 


### PR DESCRIPTION
## Description

Changing default time to 5 mins rather than manually doing so
