### PR TITLE
[WIP] Format metatags

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -915,4 +915,35 @@ module.exports = function registerFilters() {
       return /\S/.test(newStr);
     } else return /\S/.test(str);
   };
+
+  liquid.filters.formatTitleTag = title => {
+    let formattedTitle = _.trim(title);
+
+    // Escape early if no title is provided.
+    if (!formattedTitle) {
+      return formattedTitle;
+    }
+
+    // Ensure every word is capitalized.
+    formattedTitle = formattedTitle
+      ?.split(' ')
+      ?.map(word => _.upperFirst(word))
+      ?.join(' ');
+
+    // Ensure every word is capitalized following a hyphen.
+    formattedTitle = formattedTitle
+      ?.split('-')
+      ?.map(word => _.upperFirst(word))
+      ?.join('-');
+
+    // Add ' | Veterans Affairs' to the end of the title.
+    if (!_.endsWith(_.toLower(formattedTitle), ' | veterans affairs')) {
+      formattedTitle = `${formattedTitle} | Veterans Affairs`;
+    }
+
+    // Decode the title.
+    formattedTitle = he.decode(formattedTitle);
+
+    return formattedTitle;
+  };
 };

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -924,6 +924,9 @@ module.exports = function registerFilters() {
       return formattedTitle;
     }
 
+    // Decode the title.
+    formattedTitle = he.decode(formattedTitle);
+
     // Ensure every word is capitalized.
     formattedTitle = formattedTitle
       ?.split(' ')
@@ -940,9 +943,6 @@ module.exports = function registerFilters() {
     if (!_.endsWith(_.toLower(formattedTitle), ' | veterans affairs')) {
       formattedTitle = `${formattedTitle} | Veterans Affairs`;
     }
-
-    // Decode the title.
-    formattedTitle = he.decode(formattedTitle);
 
     return formattedTitle;
   };

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -1141,13 +1141,13 @@ describe('phoneLinks', () => {
 describe('formatTitleTag', () => {
   it('formats a title tag without " | Veteran Affairs"', () => {
     const title = 'this is a-title';
-    const expected = 'This Is A-Title | Veteran Affairs';
+    const expected = 'This Is A-Title | Veterans Affairs';
     expect(liquid.filters.formatTitleTag(title)).to.equal(expected);
   });
 
   it('formats a title tag with " | Veteran Affairs"', () => {
-    const title = 'this is a-title | Veteran Affairs';
-    const expected = 'This Is A-Title | Veteran Affairs';
+    const title = 'this is a-title | Veterans Affairs';
+    const expected = 'This Is A-Title | Veterans Affairs';
     expect(liquid.filters.formatTitleTag(title)).to.equal(expected);
   });
-}
+});

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -1137,3 +1137,17 @@ describe('phoneLinks', () => {
     expect(liquid.filters.phoneLinks(html)).to.equal(html);
   });
 });
+
+describe('formatTitleTag', () => {
+  it('formats a title tag without " | Veteran Affairs"', () => {
+    const title = 'this is a-title';
+    const expected = 'This Is A-Title | Veteran Affairs';
+    expect(liquid.filters.formatTitleTag(title)).to.equal(expected);
+  });
+
+  it('formats a title tag with " | Veteran Affairs"', () => {
+    const title = 'this is a-title | Veteran Affairs';
+    const expected = 'This Is A-Title | Veteran Affairs';
+    expect(liquid.filters.formatTitleTag(title)).to.equal(expected);
+  });
+}

--- a/src/site/includes/metatags.drupal.liquid
+++ b/src/site/includes/metatags.drupal.liquid
@@ -31,7 +31,7 @@
     {% endcase %}
   {% endfor %}
 {% else %}
-<!-- Metatags -->
+  <!-- Metatags -->
   {% if regionOrOffice %}
     {% assign metaTitle = title | append: " | " | append: regionOrOffice %}
     {% if regionOrOffice == "VA Pittsburgh health care" %}
@@ -42,7 +42,8 @@
     {% assign metaTitle = title %}
   {% endif %}
 
-  {% assign metaTitle = metaTitle | append: " | Veterans Affairs" %}
+  {% assign metaTitle = metaTitle | formatTitleTag %}
+
   <meta property="og:site_name" content="Veterans Affairs">
   <meta content="{{ metaTitle }}" property="og:title">
   <meta name="twitter:card" content="Summary">

--- a/src/site/includes/metatags.liquid
+++ b/src/site/includes/metatags.liquid
@@ -10,9 +10,11 @@
   <meta name="DC.Date" content="{{lastupdate| date: '%Y-%m-%d'}}" property="http://purl.org/dc/terms/date">
 {% endif %}
 
-{% if title %}
-  <meta content="{{ title }}" property="og:title">
-  <meta content="VA.gov - {{ title }}" name="twitter:title" >
+{% assign metaTitle = title | formatTitleTag %}
+
+{% if metaTitle %}
+  <meta content="{{ metaTitle }}" property="og:title">
+  <meta content="{{ metaTitle }}" name="twitter:title" >
 {% else %}
   <meta content="{{ hostUrl }}" property="og:title">
   <meta content="{{ hostUrl }}" name="twitter:title">
@@ -45,5 +47,5 @@
 {% if title === 'Home' %}
   <title>VA.gov</title>
 {% else %}
-  <title>{{ title }} | Veterans Affairs</title>
+  <title>{{ metaTitle }}</title>
 {% endif %}


### PR DESCRIPTION
# Description

**Issues:** 
https://github.com/department-of-veterans-affairs/va.gov-team/issues/24383
https://github.com/department-of-veterans-affairs/va.gov-team/issues/23082
https://github.com/department-of-veterans-affairs/va.gov-team/issues/26679

This PR updates the following title metatags (before/after):

```diff
- 28-1900 Veteran Readiness
+ 28-1900 Veteran Readiness | Veterans Affairs
```

```diff
- 686C-674
+ 686C-674 | Veterans Affairs
```

```diff
- All articles in: Burials and memorials
+ All Articles In: Burials And Memorials | Veterans Affairs
```

```diff
- All articles in: Decision reviews and appeals
+ All Articles In: Decision Reviews And Appeals | Veterans Affairs
```

```diff
- All articles in: Disability
+ All Articles In: Disability | Veterans Affairs
```

```diff
- All articles in: Education and training
+ All Articles In: Education And Training | Veterans Affairs
```

```diff
- All articles in: Education and training
+ All Articles In: Education And Training | Veterans Affairs
```

```diff
- All articles in: Health care
+ All Articles In: Health Care | Veterans Affairs
```

```diff
- All articles in: Housing assistance and home loans
+ All Articles In: Housing Assistance And Home Loans | Veterans Affairs
```

```diff
- All articles in: Life insurance
+ All Articles In: Life Insurance | Veterans Affairs
```

```diff
- All articles in: Other topics and questions
+ All Articles In: Other Topics And Questions | Veterans Affairs
```

```diff
- All articles in: Other topics and questions
+ All Articles In: Other Topics And Questions | Veterans Affairs
```

```diff
- All articles in: Other topics and questions
+ All Articles In: Other Topics And Questions | Veterans Affairs
```

```diff
- All articles in: Pension
+ All Articles In: Pension | Veterans Affairs
```

```diff
- All articles in: Records
+ All Articles In: Records | Veterans Affairs
```

```diff
- All articles in: VA account and profile
+ All Articles In: VA Account And Profile | Veterans Affairs
```

```diff
- All articles in: VA account and profile
+ All Articles In: VA Account And Profile | Veterans Affairs
```

```diff
- All articles tagged: All Veterans
+ All Articles Tagged: All Veterans | Veterans Affairs
```

```diff
- All articles tagged: All Veterans
+ All Articles Tagged: All Veterans | Veterans Affairs
```

```diff
- All articles tagged: All Veterans
+ All Articles Tagged: All Veterans | Veterans Affairs
```

```diff
- All articles tagged: All Veterans
+ All Articles Tagged: All Veterans | Veterans Affairs
```

```diff
- All articles tagged: All Veterans
+ All Articles Tagged: All Veterans | Veterans Affairs
```

```diff
- All articles tagged: All Veterans
+ All Articles Tagged: All Veterans | Veterans Affairs
```

```diff
- All articles tagged: Claims and appeals status
+ All Articles Tagged: Claims And Appeals Status | Veterans Affairs
```

```diff
- All articles tagged: Payments and debt
+ All Articles Tagged: Payments And Debt | Veterans Affairs
```

```diff
- All articles tagged: Payments and debt
+ All Articles Tagged: Payments And Debt | Veterans Affairs
```

```diff
- All articles tagged: Sign in
+ All Articles Tagged: Sign In | Veterans Affairs
```

```diff
- Alpha&#58; Design, Prototype &amp; Plan
+ Alpha: Design, Prototype & Plan | Veterans Affairs
```

```diff
- Analytics Opt-Out
+ Analytics Opt-Out | Veterans Affairs
```

```diff
- Apply For Education Benefits
+ Apply For Education Benefits | Veterans Affairs
```

```diff
- Apply For Education Benefits
+ Apply For Education Benefits | Veterans Affairs
```

```diff
- Apply For Education Benefits
+ Apply For Education Benefits | Veterans Affairs
```

```diff
- Apply For Education Benefits
+ Apply For Education Benefits | Veterans Affairs
```

```diff
- Apply For Pension Benefits
+ Apply For Pension Benefits | Veterans Affairs
```

```diff
- Apply for Burial Benefits (VA Form 21P-530)
+ Apply For Burial Benefits (VA Form 21P-530) | Veterans Affairs
```

```diff
- Apply for Certificate of Eligibility
+ Apply For Certificate Of Eligibility | Veterans Affairs
```

```diff
- Apply for Health Care
+ Apply For Health Care | Veterans Affairs
```

```diff
- Apply for education benefits
+ Apply For Education Benefits | Veterans Affairs
```

```diff
- Apply for the Rogers STEM Scholarship
+ Apply For The Rogers STEM Scholarship | Veterans Affairs
```

```diff
- Apply for the Veteran Rapid Retraining Assistance Program (VRRAP)
+ Apply For The Veteran Rapid Retraining Assistance Program (VRRAP) | Veterans Affairs
```

```diff
- Apply online for pre-need determination of eligibility in a VA National Cemetery
+ Apply Online For Pre-Need Determination Of Eligibility In A VA National Cemetery | Veterans Affairs
```

```diff
- Appoint VSO as representative
+ Appoint VSO As Representative | Veterans Affairs
```

```diff
- Auth
+ Auth | Veterans Affairs
```

```diff
- Beta&#58; Iterate and Build
+ Beta: Iterate And Build | Veterans Affairs
```

```diff
- COVID-19 screening tool
+ COVID-19 Screening Tool | Veterans Affairs
```

```diff
- CT Redesign Sandbox
+ CT Redesign Sandbox | Veterans Affairs
```

```diff
- Caregiver Application for Benefits
+ Caregiver Application For Benefits | Veterans Affairs
```

```diff
- Cerner staging
+ Cerner Staging | Veterans Affairs
```

```diff
- Cerner test environment - Appointments
+ Cerner Test Environment - Appointments | Veterans Affairs
```

```diff
- Cerner test environment - Messaging
+ Cerner Test Environment - Messaging | Veterans Affairs
```

```diff
- Cerner test environment - Prescriptions
+ Cerner Test Environment - Prescriptions | Veterans Affairs
```

```diff
- Cerner test environment - Records
+ Cerner Test Environment - Records | Veterans Affairs
```

```diff
- Cerner test environment - Results
+ Cerner Test Environment - Results | Veterans Affairs
```

```diff
- Check Your Post-9/11 GI Bill Benefits Status
+ Check Your Post-9/11 GI Bill Benefits Status | Veterans Affairs
```

```diff
- Code
+ Code | Veterans Affairs
```

```diff
- Components
+ Components | Veterans Affairs
```

```diff
- Contact Us
+ Contact Us | Veterans Affairs
```

```diff
- Coronavirus Research - Volunteer
+ Coronavirus Research - Volunteer | Veterans Affairs
```

```diff
- Demonstration Videos
+ Demonstration Videos | Veterans Affairs
```

```diff
- Dependents Request For Change
+ Dependents Request For Change | Veterans Affairs
```

```diff
- Design
+ Design | Veterans Affairs
```

```diff
- Discover
+ Discover | Veterans Affairs
```

```diff
- Download VA Letters and Documents
+ Download VA Letters And Documents | Veterans Affairs
```

```diff
- Editorial Guide
+ Editorial Guide | Veterans Affairs
```

```diff
- File for disability benefits
+ File For Disability Benefits | Veterans Affairs
```

```diff
- Financial Status Report
+ Financial Status Report | Veterans Affairs
```

```diff
- Find A Yellow Ribbon School | Veterans Affairs
+ Find A Yellow Ribbon School | Veterans Affairs
```

```diff
- Find VA Locations
+ Find VA Locations | Veterans Affairs
```

```diff
- Form detail dummy page
+ Form Detail Dummy Page | Veterans Affairs
```

```diff
- GI Bill Comparison Tool
+ GI Bill Comparison Tool | Veterans Affairs
```

```diff
- GI Bill® School Feedback Tool
+ GI Bill® School Feedback Tool | Veterans Affairs
```

```diff
- Go Live
+ Go Live | Veterans Affairs
```

```diff
- Governance
+ Governance | Veterans Affairs
```

```diff
- Health care Questionnaire
+ Health Care Questionnaire | Veterans Affairs
```

```diff
- How To Apply For A Discharge Upgrade
+ How To Apply For A Discharge Upgrade | Veterans Affairs
```

```diff
- Human Centered Design
+ Human Centered Design | Veterans Affairs
```

```diff
- Kickoff
+ Kickoff | Veterans Affairs
```

```diff
- Locations | VA Albany health care
+ Locations | VA Albany Health Care | Veterans Affairs
```

```diff
- Locations | VA Alexandria health care
+ Locations | VA Alexandria Health Care | Veterans Affairs
```

```diff
- Locations | VA Altoona health care
+ Locations | VA Altoona Health Care | Veterans Affairs
```

```diff
- Locations | VA Asheville health care
+ Locations | VA Asheville Health Care | Veterans Affairs
```

```diff
- Locations | VA Atlanta health care
+ Locations | VA Atlanta Health Care | Veterans Affairs
```

```diff
- Locations | VA Augusta health care
+ Locations | VA Augusta Health Care | Veterans Affairs
```

```diff
- Locations | VA Bay Pines health care
+ Locations | VA Bay Pines Health Care | Veterans Affairs
```

```diff
- Locations | VA Birmingham health care
+ Locations | VA Birmingham Health Care | Veterans Affairs
```

```diff
- Locations | VA Black Hills health care
+ Locations | VA Black Hills Health Care | Veterans Affairs
```

```diff
- Locations | VA Bronx health care
+ Locations | VA Bronx Health Care | Veterans Affairs
```

```diff
- Locations | VA Butler health care
+ Locations | VA Butler Health Care | Veterans Affairs
```

```diff
- Locations | VA Caribbean health care
+ Locations | VA Caribbean Health Care | Veterans Affairs
```

```diff
- Locations | VA Central Alabama health care
+ Locations | VA Central Alabama Health Care | Veterans Affairs
```

```diff
- Locations | VA Central Arkansas health care
+ Locations | VA Central Arkansas Health Care | Veterans Affairs
```

```diff
- Locations | VA Central California health care
+ Locations | VA Central California Health Care | Veterans Affairs
```

```diff
- Locations | VA Central Iowa health care
+ Locations | VA Central Iowa Health Care | Veterans Affairs
```

```diff
- Locations | VA Charleston health care
+ Locations | VA Charleston Health Care | Veterans Affairs
```

```diff
- Locations | VA Cheyenne health care
+ Locations | VA Cheyenne Health Care | Veterans Affairs
```

```diff
- Locations | VA Coatesville health care
+ Locations | VA Coatesville Health Care | Veterans Affairs
```

```diff
- Locations | VA Columbia South Carolina health care
+ Locations | VA Columbia South Carolina Health Care | Veterans Affairs
```

```diff
- Locations | VA Dublin health care
+ Locations | VA Dublin Health Care | Veterans Affairs
```

```diff
- Locations | VA Durham health care
+ Locations | VA Durham Health Care | Veterans Affairs
```

```diff
- Locations | VA Eastern Colorado health care
+ Locations | VA Eastern Colorado Health Care | Veterans Affairs
```

```diff
- Locations | VA Eastern Oklahoma health care
+ Locations | VA Eastern Oklahoma Health Care | Veterans Affairs
```

```diff
- Locations | VA Erie health care
+ Locations | VA Erie Health Care | Veterans Affairs
```

```diff
- Locations | VA Fargo health care
+ Locations | VA Fargo Health Care | Veterans Affairs
```

```diff
- Locations | VA Fayetteville Arkansas health care
+ Locations | VA Fayetteville Arkansas Health Care | Veterans Affairs
```

```diff
- Locations | VA Fayetteville Coastal health care
+ Locations | VA Fayetteville Coastal Health Care | Veterans Affairs
```

```diff
- Locations | VA Finger Lakes health care
+ Locations | VA Finger Lakes Health Care | Veterans Affairs
```

```diff
- Locations | VA Gulf Coast health care
+ Locations | VA Gulf Coast Health Care | Veterans Affairs
```

```diff
- Locations | VA Hampton health care
+ Locations | VA Hampton Health Care | Veterans Affairs
```

```diff
- Locations | VA Houston health care
+ Locations | VA Houston Health Care | Veterans Affairs
```

```diff
- Locations | VA Hudson Valley health care
+ Locations | VA Hudson Valley Health Care | Veterans Affairs
```

```diff
- Locations | VA Iowa City health care
+ Locations | VA Iowa City Health Care | Veterans Affairs
```

```diff
- Locations | VA Jackson health care
+ Locations | VA Jackson Health Care | Veterans Affairs
```

```diff
- Locations | VA Lebanon health care
+ Locations | VA Lebanon Health Care | Veterans Affairs
```

```diff
- Locations | VA Miami health care
+ Locations | VA Miami Health Care | Veterans Affairs
```

```diff
- Locations | VA Minneapolis health care
+ Locations | VA Minneapolis Health Care | Veterans Affairs
```

```diff
- Locations | VA Montana health care
+ Locations | VA Montana Health Care | Veterans Affairs
```

```diff
- Locations | VA Nebraska-Western Iowa health care
+ Locations | VA Nebraska-Western Iowa Health Care | Veterans Affairs
```

```diff
- Locations | VA New Jersey health care
+ Locations | VA New Jersey Health Care | Veterans Affairs
```

```diff
- Locations | VA New York Harbor health care
+ Locations | VA New York Harbor Health Care | Veterans Affairs
```

```diff
- Locations | VA North Florida health care
+ Locations | VA North Florida Health Care | Veterans Affairs
```

```diff
- Locations | VA Northern California health care
+ Locations | VA Northern California Health Care | Veterans Affairs
```

```diff
- Locations | VA Northport health care
+ Locations | VA Northport Health Care | Veterans Affairs
```

```diff
- Locations | VA Oklahoma City health care
+ Locations | VA Oklahoma City Health Care | Veterans Affairs
```

```diff
- Locations | VA Orlando health care
+ Locations | VA Orlando Health Care | Veterans Affairs
```

```diff
- Locations | VA Pacific Islands health care
+ Locations | VA Pacific Islands Health Care | Veterans Affairs
```

```diff
- Locations | VA Palo Alto health care
+ Locations | VA Palo Alto Health Care | Veterans Affairs
```

```diff
- Locations | VA Philadelphia health care
+ Locations | VA Philadelphia Health Care | Veterans Affairs
```

```diff
- Locations | VA Richmond health care
+ Locations | VA Richmond Health Care | Veterans Affairs
```

```diff
- Locations | VA Salem health care
+ Locations | VA Salem Health Care | Veterans Affairs
```

```diff
- Locations | VA Salisbury health care
+ Locations | VA Salisbury Health Care | Veterans Affairs
```

```diff
- Locations | VA Salt Lake City health care
+ Locations | VA Salt Lake City Health Care | Veterans Affairs
```

```diff
- Locations | VA San Francisco health care
+ Locations | VA San Francisco Health Care | Veterans Affairs
```

```diff
- Locations | VA Sheridan health care
+ Locations | VA Sheridan Health Care | Veterans Affairs
```

```diff
- Locations | VA Shreveport health care
+ Locations | VA Shreveport Health Care | Veterans Affairs
```

```diff
- Locations | VA Sierra Nevada health care
+ Locations | VA Sierra Nevada Health Care | Veterans Affairs
```

```diff
- Locations | VA Sioux Falls health care
+ Locations | VA Sioux Falls Health Care | Veterans Affairs
```

```diff
- Locations | VA Southeast Louisiana health care
+ Locations | VA Southeast Louisiana Health Care | Veterans Affairs
```

```diff
- Locations | VA Southern Nevada health care
+ Locations | VA Southern Nevada Health Care | Veterans Affairs
```

```diff
- Locations | VA St Cloud health care
+ Locations | VA St Cloud Health Care | Veterans Affairs
```

```diff
- Locations | VA Syracuse health care
+ Locations | VA Syracuse Health Care | Veterans Affairs
```

```diff
- Locations | VA Tampa health care
+ Locations | VA Tampa Health Care | Veterans Affairs
```

```diff
- Locations | VA Tuscaloosa health care
+ Locations | VA Tuscaloosa Health Care | Veterans Affairs
```

```diff
- Locations | VA West Palm Beach health care
+ Locations | VA West Palm Beach Health Care | Veterans Affairs
```

```diff
- Locations | VA Western Colorado health care
+ Locations | VA Western Colorado Health Care | Veterans Affairs
```

```diff
- Locations | VA Western New York health care
+ Locations | VA Western New York Health Care | Veterans Affairs
```

```diff
- Locations | VA Wilkes-Barre health care
+ Locations | VA Wilkes-Barre Health Care | Veterans Affairs
```

```diff
- Locations | VA Wilmington health care
+ Locations | VA Wilmington Health Care | Veterans Affairs
```

```diff
- Login Page
+ Login Page | Veterans Affairs
```

```diff
- Logout
+ Logout | Veterans Affairs
```

```diff
- Maintenance
+ Maintenance | Veterans Affairs
```

```diff
- Migration Strategy
+ Migration Strategy | Veterans Affairs
```

```diff
- My Documents
+ My Documents | Veterans Affairs
```

```diff
- My Education Benefits
+ My Education Benefits | Veterans Affairs
```

```diff
- My Health Account Validation
+ My Health Account Validation | Veterans Affairs
```

```diff
- My VA
+ My VA | Veterans Affairs
```

```diff
- My messages
+ My Messages | Veterans Affairs
```

```diff
- Operating status | VA Albany health care
+ Operating Status | VA Albany Health Care | Veterans Affairs
```

```diff
- Operating status | VA Alexandria health care
+ Operating Status | VA Alexandria Health Care | Veterans Affairs
```

```diff
- Operating status | VA Altoona health care
+ Operating Status | VA Altoona Health Care | Veterans Affairs
```

```diff
- Operating status | VA Asheville health care
+ Operating Status | VA Asheville Health Care | Veterans Affairs
```

```diff
- Operating status | VA Atlanta health care
+ Operating Status | VA Atlanta Health Care | Veterans Affairs
```

```diff
- Operating status | VA Augusta health care
+ Operating Status | VA Augusta Health Care | Veterans Affairs
```

```diff
- Operating status | VA Bay Pines health care
+ Operating Status | VA Bay Pines Health Care | Veterans Affairs
```

```diff
- Operating status | VA Birmingham health care
+ Operating Status | VA Birmingham Health Care | Veterans Affairs
```

```diff
- Operating status | VA Black Hills health care
+ Operating Status | VA Black Hills Health Care | Veterans Affairs
```

```diff
- Operating status | VA Bronx health care
+ Operating Status | VA Bronx Health Care | Veterans Affairs
```

```diff
- Operating status | VA Butler health care
+ Operating Status | VA Butler Health Care | Veterans Affairs
```

```diff
- Operating status | VA Caribbean health care
+ Operating Status | VA Caribbean Health Care | Veterans Affairs
```

```diff
- Operating status | VA Central Alabama health care
+ Operating Status | VA Central Alabama Health Care | Veterans Affairs
```

```diff
- Operating status | VA Central Arkansas health care
+ Operating Status | VA Central Arkansas Health Care | Veterans Affairs
```

```diff
- Operating status | VA Central California health care
+ Operating Status | VA Central California Health Care | Veterans Affairs
```

```diff
- Operating status | VA Central Iowa health care
+ Operating Status | VA Central Iowa Health Care | Veterans Affairs
```

```diff
- Operating status | VA Charleston health care
+ Operating Status | VA Charleston Health Care | Veterans Affairs
```

```diff
- Operating status | VA Cheyenne health care
+ Operating Status | VA Cheyenne Health Care | Veterans Affairs
```

```diff
- Operating status | VA Coatesville health care
+ Operating Status | VA Coatesville Health Care | Veterans Affairs
```

```diff
- Operating status | VA Columbia South Carolina health care
+ Operating Status | VA Columbia South Carolina Health Care | Veterans Affairs
```

```diff
- Operating status | VA Dublin health care
+ Operating Status | VA Dublin Health Care | Veterans Affairs
```

```diff
- Operating status | VA Durham health care
+ Operating Status | VA Durham Health Care | Veterans Affairs
```

```diff
- Operating status | VA Eastern Colorado health care
+ Operating Status | VA Eastern Colorado Health Care | Veterans Affairs
```

```diff
- Operating status | VA Eastern Oklahoma health care
+ Operating Status | VA Eastern Oklahoma Health Care | Veterans Affairs
```

```diff
- Operating status | VA Erie health care
+ Operating Status | VA Erie Health Care | Veterans Affairs
```

```diff
- Operating status | VA Fargo health care
+ Operating Status | VA Fargo Health Care | Veterans Affairs
```

```diff
- Operating status | VA Fayetteville Arkansas health care
+ Operating Status | VA Fayetteville Arkansas Health Care | Veterans Affairs
```

```diff
- Operating status | VA Fayetteville Coastal health care
+ Operating Status | VA Fayetteville Coastal Health Care | Veterans Affairs
```

```diff
- Operating status | VA Finger Lakes health care
+ Operating Status | VA Finger Lakes Health Care | Veterans Affairs
```

```diff
- Operating status | VA Gulf Coast health care
+ Operating Status | VA Gulf Coast Health Care | Veterans Affairs
```

```diff
- Operating status | VA Hampton health care
+ Operating Status | VA Hampton Health Care | Veterans Affairs
```

```diff
- Operating status | VA Houston health care
+ Operating Status | VA Houston Health Care | Veterans Affairs
```

```diff
- Operating status | VA Hudson Valley health care
+ Operating Status | VA Hudson Valley Health Care | Veterans Affairs
```

```diff
- Operating status | VA Iowa City health care
+ Operating Status | VA Iowa City Health Care | Veterans Affairs
```

```diff
- Operating status | VA Jackson health care
+ Operating Status | VA Jackson Health Care | Veterans Affairs
```

```diff
- Operating status | VA Lebanon health care
+ Operating Status | VA Lebanon Health Care | Veterans Affairs
```

```diff
- Operating status | VA Miami health care
+ Operating Status | VA Miami Health Care | Veterans Affairs
```

```diff
- Operating status | VA Minneapolis health care
+ Operating Status | VA Minneapolis Health Care | Veterans Affairs
```

```diff
- Operating status | VA Montana health care
+ Operating Status | VA Montana Health Care | Veterans Affairs
```

```diff
- Operating status | VA Nebraska-Western Iowa health care
+ Operating Status | VA Nebraska-Western Iowa Health Care | Veterans Affairs
```

```diff
- Operating status | VA New Jersey health care
+ Operating Status | VA New Jersey Health Care | Veterans Affairs
```

```diff
- Operating status | VA New York Harbor health care
+ Operating Status | VA New York Harbor Health Care | Veterans Affairs
```

```diff
- Operating status | VA North Florida health care
+ Operating Status | VA North Florida Health Care | Veterans Affairs
```

```diff
- Operating status | VA Northern California health care
+ Operating Status | VA Northern California Health Care | Veterans Affairs
```

```diff
- Operating status | VA Northport health care
+ Operating Status | VA Northport Health Care | Veterans Affairs
```

```diff
- Operating status | VA Oklahoma City health care
+ Operating Status | VA Oklahoma City Health Care | Veterans Affairs
```

```diff
- Operating status | VA Orlando health care
+ Operating Status | VA Orlando Health Care | Veterans Affairs
```

```diff
- Operating status | VA Pacific Islands health care
+ Operating Status | VA Pacific Islands Health Care | Veterans Affairs
```

```diff
- Operating status | VA Palo Alto health care
+ Operating Status | VA Palo Alto Health Care | Veterans Affairs
```

```diff
- Operating status | VA Philadelphia health care
+ Operating Status | VA Philadelphia Health Care | Veterans Affairs
```

```diff
- Operating status | VA Richmond health care
+ Operating Status | VA Richmond Health Care | Veterans Affairs
```

```diff
- Operating status | VA Salem health care
+ Operating Status | VA Salem Health Care | Veterans Affairs
```

```diff
- Operating status | VA Salisbury health care
+ Operating Status | VA Salisbury Health Care | Veterans Affairs
```

```diff
- Operating status | VA Salt Lake City health care
+ Operating Status | VA Salt Lake City Health Care | Veterans Affairs
```

```diff
- Operating status | VA San Francisco health care
+ Operating Status | VA San Francisco Health Care | Veterans Affairs
```

```diff
- Operating status | VA Sheridan health care
+ Operating Status | VA Sheridan Health Care | Veterans Affairs
```

```diff
- Operating status | VA Shreveport health care
+ Operating Status | VA Shreveport Health Care | Veterans Affairs
```

```diff
- Operating status | VA Sierra Nevada health care
+ Operating Status | VA Sierra Nevada Health Care | Veterans Affairs
```

```diff
- Operating status | VA Sioux Falls health care
+ Operating Status | VA Sioux Falls Health Care | Veterans Affairs
```

```diff
- Operating status | VA Southeast Louisiana health care
+ Operating Status | VA Southeast Louisiana Health Care | Veterans Affairs
```

```diff
- Operating status | VA Southern Nevada health care
+ Operating Status | VA Southern Nevada Health Care | Veterans Affairs
```

```diff
- Operating status | VA St Cloud health care
+ Operating Status | VA St Cloud Health Care | Veterans Affairs
```

```diff
- Operating status | VA Syracuse health care
+ Operating Status | VA Syracuse Health Care | Veterans Affairs
```

```diff
- Operating status | VA Tampa health care
+ Operating Status | VA Tampa Health Care | Veterans Affairs
```

```diff
- Operating status | VA Tuscaloosa health care
+ Operating Status | VA Tuscaloosa Health Care | Veterans Affairs
```

```diff
- Operating status | VA West Palm Beach health care
+ Operating Status | VA West Palm Beach Health Care | Veterans Affairs
```

```diff
- Operating status | VA Western Colorado health care
+ Operating Status | VA Western Colorado Health Care | Veterans Affairs
```

```diff
- Operating status | VA Western New York health care
+ Operating Status | VA Western New York Health Care | Veterans Affairs
```

```diff
- Operating status | VA Wilkes-Barre health care
+ Operating Status | VA Wilkes-Barre Health Care | Veterans Affairs
```

```diff
- Operating status | VA Wilmington health care
+ Operating Status | VA Wilmington Health Care | Veterans Affairs
```

```diff
- Operations and Maintenance (O&amp;M)
+ Operations And Maintenance (O&M) | Veterans Affairs
```

```diff
- Opt Out Of Sharing VA Education Benefits Information
+ Opt Out Of Sharing VA Education Benefits Information | Veterans Affairs
```

```diff
- Order hearing aid batteries and accessories
+ Order Hearing Aid Batteries And Accessories | Veterans Affairs
```

```diff
- Personalized Career Planning and Guidance Chapter 36 Form 28-8832
+ Personalized Career Planning And Guidance Chapter 36 Form 28-8832 | Veterans Affairs
```

```diff
- Platform
+ Platform | Veterans Affairs
```

```diff
- Playbook
+ Playbook | Veterans Affairs
```

```diff
- Policies
+ Policies | Veterans Affairs
```

```diff
- Policies
+ Policies | Veterans Affairs
```

```diff
- Policies
+ Policies | Veterans Affairs
```

```diff
- Policies
+ Policies | Veterans Affairs
```

```diff
- Policies
+ Policies | Veterans Affairs
```

```diff
- Policies
+ Policies | Veterans Affairs
```

```diff
- Policies
+ Policies | Veterans Affairs
```

```diff
- Policies
+ Policies | Veterans Affairs
```

```diff
- Policies
+ Policies | Veterans Affairs
```

```diff
- Policies
+ Policies | Veterans Affairs
```

```diff
- Policies
+ Policies | Veterans Affairs
```

```diff
- Policies
+ Policies | Veterans Affairs
```

```diff
- Policies
+ Policies | Veterans Affairs
```

```diff
- Policies
+ Policies | Veterans Affairs
```

```diff
- Policies
+ Policies | Veterans Affairs
```

```diff
- Policies
+ Policies | Veterans Affairs
```

```diff
- Policies
+ Policies | Veterans Affairs
```

```diff
- Policies
+ Policies | Veterans Affairs
```

```diff
- Policies
+ Policies | Veterans Affairs
```

```diff
- Policies
+ Policies | Veterans Affairs
```

```diff
- Policies
+ Policies | Veterans Affairs
```

```diff
- Policies
+ Policies | Veterans Affairs
```

```diff
- Policies
+ Policies | Veterans Affairs
```

```diff
- Policies
+ Policies | Veterans Affairs
```

```diff
- Policies
+ Policies | Veterans Affairs
```

```diff
- Policies
+ Policies | Veterans Affairs
```

```diff
- Policies
+ Policies | Veterans Affairs
```

```diff
- Policies
+ Policies | Veterans Affairs
```

```diff
- Policies
+ Policies | Veterans Affairs
```

```diff
- Pre-flight
+ Pre-Flight | Veterans Affairs
```

```diff
- Product Development Roles
+ Product Development Roles | Veterans Affairs
```

```diff
- Product Methodology
+ Product Methodology | Veterans Affairs
```

```diff
- Product definition
+ Product Definition | Veterans Affairs
```

```diff
- Questionnaire List
+ Questionnaire List | Veterans Affairs
```

```diff
- Rated Disabilities
+ Rated Disabilities | Veterans Affairs
```

```diff
- Request a Board Appeal
+ Request A Board Appeal | Veterans Affairs
```

```diff
- Request a Higher-Level Review
+ Request A Higher-Level Review | Veterans Affairs
```

```diff
- Resources and support
+ Resources And Support | Veterans Affairs
```

```diff
- Resources for schools
+ Resources For Schools | Veterans Affairs
```

```diff
- Search Results
+ Search Results | Veterans Affairs
```

```diff
- Session Expired
+ Session Expired | Veterans Affairs
```

```diff
- Sign up to get a COVID-19 vaccine at VA
+ Sign Up To Get A COVID-19 Vaccine At VA | Veterans Affairs
```

```diff
- Sign up to get a vaccine
+ Sign Up To Get A Vaccine | Veterans Affairs
```

```diff
- Sunset
+ Sunset | Veterans Affairs
```

```diff
- Templates
+ Templates | Veterans Affairs
```

```diff
- Terms and Conditions for Medical Information
+ Terms And Conditions For Medical Information | Veterans Affairs
```

```diff
- Track Claims
+ Track Claims | Veterans Affairs
```

```diff
- VA Online Scheduling
+ VA Online Scheduling | Veterans Affairs
```

```diff
- VA Pittsburgh Health Care | Locations
+ VA Pittsburgh Health Care | Locations | Veterans Affairs
```

```diff
- VA Pittsburgh Health Care | Operating Status
+ VA Pittsburgh Health Care | Operating Status | Veterans Affairs
```

```diff
- VA coronavirus chatbot
+ VA Coronavirus Chatbot | Veterans Affairs
```

```diff
- VA.gov
+ VA.gov | Veterans Affairs
```

```diff
- VA.gov
+ VA.gov | Veterans Affairs
```

```diff
- VA.gov Home
+ VA.gov Home | Veterans Affairs
```

```diff
- VSA
+ VSA | Veterans Affairs
```

```diff
- VSA design patterns and components
+ VSA Design Patterns And Components | Veterans Affairs
```

```diff
- Verify
+ Verify | Veterans Affairs
```

```diff
- Veteran ID Card
+ Veteran ID Card | Veterans Affairs
```

```diff
- Veteran Request For Change
+ Veteran Request For Change | Veterans Affairs
```

```diff
- Veterans Community Care Program Eligibility Tool
+ Veterans Community Care Program Eligibility Tool | Veterans Affairs
```

```diff
- View Dependents
+ View Dependents | Veterans Affairs
```

```diff
- View Payments
+ View Payments | Veterans Affairs
```

```diff
- View your representative
+ View Your Representative | Veterans Affairs
```

```diff
- Virtual Agent
+ Virtual Agent | Veterans Affairs
```

```diff
- Visual Design
+ Visual Design | Veterans Affairs
```

```diff
- Your Profile
+ Your Profile | Veterans Affairs
```

```diff
- Your VA Debt
+ Your VA Debt | Veterans Affairs
```

```diff
- check-in
+ Check-In | Veterans Affairs
```

## Testing

Created unit test.

## Acceptance Criteria

- [x] Format title metatags to capitalize each word and always append | Veteran Affairs