### PR TITLE
Added vet center title to metatags

### DIFF
--- a/src/site/includes/metatags.drupal.liquid
+++ b/src/site/includes/metatags.drupal.liquid
@@ -44,7 +44,7 @@
 
   {% assign metaTitle = metaTitle | formatTitleTag %}
   <meta property="og:site_name" content="Veterans Affairs">
-  <meta class="testing" content="{{ metaTitle }}" property="og:title">
+  <meta content="{{ metaTitle }}" property="og:title">
   <meta name="twitter:card" content="Summary">
   <meta name="twitter:site" content="@DeptVetAffairs">
   <meta name="twitter:image" content="{{ hostUrl }}/img/design/logo/va-og-twitter-image.png">

--- a/src/site/includes/metatags.drupal.liquid
+++ b/src/site/includes/metatags.drupal.liquid
@@ -34,14 +34,17 @@
   <!-- Metatags -->
   {% if regionOrOffice %}
     {% assign metaTitle = title | append: " | " | append: regionOrOffice %}
+  {% elsif fieldOffice %}
+    {% assign metaTitle = fieldOffice.entity.title %}
+  {% elsif entityLabel %}
+    {% assign metaTitle = entityLabel %}
   {% else %}
     {% assign metaTitle = title %}
   {% endif %}
 
   {% assign metaTitle = metaTitle | formatTitleTag %}
-
   <meta property="og:site_name" content="Veterans Affairs">
-  <meta content="{{ metaTitle }}" property="og:title">
+  <meta class="testing" content="{{ metaTitle }}" property="og:title">
   <meta name="twitter:card" content="Summary">
   <meta name="twitter:site" content="@DeptVetAffairs">
   <meta name="twitter:image" content="{{ hostUrl }}/img/design/logo/va-og-twitter-image.png">

--- a/src/site/includes/tests/fixtures/metatags.json
+++ b/src/site/includes/tests/fixtures/metatags.json
@@ -1,0 +1,24 @@
+{
+  "titleTest": {
+    "title": "title test"
+  },
+  "entityLabelTest": {
+    "title": "title test",
+    "entityLabel": "entity label test"
+  },
+  "fieldOfficeTest": {
+    "title": "title test",
+    "entityLabel": "entity label test",
+    "fieldOffice": {
+      "entity": {
+        "title": "field office test"
+      }
+    }
+  },
+  "regionOrOfficeTest": {
+    "title": "title test",
+    "entityLabel": "entity label test",
+    "fieldOffice": "field office test",
+    "regionOrOffice": "region or office"
+  }
+}

--- a/src/site/includes/tests/metatags.drupal.unit.spec.js
+++ b/src/site/includes/tests/metatags.drupal.unit.spec.js
@@ -1,0 +1,91 @@
+import { expect } from 'chai';
+import { parseFixture, renderHTML } from '~/site/tests/support';
+
+const layoutPath = 'src/site/includes/metatags.drupal.liquid';
+
+describe('Metatags', () => {
+  let container;
+  const metatagsData = parseFixture(
+    'src/site/includes/tests/fixtures/metatags.json',
+  );
+
+  describe('title', () => {
+    before(async () => {
+      container = await renderHTML(layoutPath, metatagsData.titleTest);
+    });
+
+    it('returns metatag - [title] | Veterans Affairs - when there is only title', () => {
+      expect(
+        container
+          .querySelector("meta[property='og:title']")
+          .getAttribute('content'),
+      ).to.equal('Title Test | Veterans Affairs');
+    });
+
+    it('renders title-tag - [title] | Veterans Affairs - when there is only title', () => {
+      expect(container.querySelector('title').innerHTML).to.equal(
+        'Title Test | Veterans Affairs',
+      );
+    });
+  });
+
+  describe('entityLabel', () => {
+    before(async () => {
+      container = await renderHTML(layoutPath, metatagsData.entityLabelTest);
+    });
+
+    it('renders metatag - [entityLabel] | Veterans Affairs', () => {
+      expect(
+        container
+          .querySelector("meta[property='og:title']")
+          .getAttribute('content'),
+      ).to.equal('Entity Label Test | Veterans Affairs');
+    });
+
+    it('renders title-tag - [entityLabel] | Veterans Affairs', () => {
+      expect(container.querySelector('title').innerHTML).to.equal(
+        'Entity Label Test | Veterans Affairs',
+      );
+    });
+  });
+
+  describe('fieldOffice', () => {
+    before(async () => {
+      container = await renderHTML(layoutPath, metatagsData.fieldOfficeTest);
+    });
+
+    it('renders metatag - [fieldOffice] | Veterans Affairs', () => {
+      expect(
+        container
+          .querySelector("meta[property='og:title']")
+          .getAttribute('content'),
+      ).to.equal('Field Office Test | Veterans Affairs');
+    });
+
+    it('renders title-tag - [fieldOffice] | Veterans Affairs', () => {
+      expect(container.querySelector('title').innerHTML).to.equal(
+        'Field Office Test | Veterans Affairs',
+      );
+    });
+  });
+
+  describe('regionOrOffice', () => {
+    before(async () => {
+      container = await renderHTML(layoutPath, metatagsData.regionOrOfficeTest);
+    });
+
+    it('renders metatag - [title] | [regionOrOffice] | Veterans Affairs', () => {
+      expect(
+        container
+          .querySelector("meta[property='og:title']")
+          .getAttribute('content'),
+      ).to.equal('Title Test | Region Or Office | Veterans Affairs');
+    });
+
+    it('renders title-tag - [title] | [regionOrOffice] | Veterans Affairs', () => {
+      expect(container.querySelector('title').innerHTML).to.equal(
+        'Title Test | Region Or Office | Veterans Affairs',
+      );
+    });
+  });
+});

--- a/src/site/layouts/tests/vet_center/vet_center.drupal.unit.spec.js
+++ b/src/site/layouts/tests/vet_center/vet_center.drupal.unit.spec.js
@@ -23,6 +23,20 @@ describe('Vet Center Main Page', () => {
     expect(violations.length).to.equal(0);
   });
 
+  it('renders vet center name in metatag - [Vet Center] | Veterans Affairs', () => {
+    expect(
+      container
+        .querySelector("meta[property='og:title']")
+        .getAttribute('content'),
+    ).to.equal('Escanaba Vet Center | Veterans Affairs');
+  });
+
+  it('renders vet center name in title-tag', () => {
+    expect(container.querySelector('title').innerHTML).to.equal(
+      'Escanaba Vet Center | Veterans Affairs',
+    );
+  });
+
   it('renders a-tag with caret within the spotlight featured content section if there is call to action data', () => {
     expect(
       container

--- a/src/site/layouts/tests/vet_center/vet_center.drupal.unit.spec.js
+++ b/src/site/layouts/tests/vet_center/vet_center.drupal.unit.spec.js
@@ -31,7 +31,7 @@ describe('Vet Center Main Page', () => {
     ).to.equal('Escanaba Vet Center | Veterans Affairs');
   });
 
-  it('renders vet center name in title-tag', () => {
+  it('renders vet center name in title-tag - [Vet Center] | Veterans Affairs', () => {
     expect(container.querySelector('title').innerHTML).to.equal(
       'Escanaba Vet Center | Veterans Affairs',
     );

--- a/src/site/layouts/tests/vet_center/vet_center_locations_list.drupal.unit.spec.js
+++ b/src/site/layouts/tests/vet_center/vet_center_locations_list.drupal.unit.spec.js
@@ -22,7 +22,7 @@ describe('Vet Center Locations Page', () => {
     ).to.equal('Escanaba Vet Center | Veterans Affairs');
   });
 
-  it('renders vet center name in title-tag', () => {
+  it('renders vet center name in title-tag - [Vet Center] | Veterans Affairs', () => {
     expect(container.querySelector('title').innerHTML).to.equal(
       'Escanaba Vet Center | Veterans Affairs',
     );

--- a/src/site/layouts/tests/vet_center/vet_center_locations_list.drupal.unit.spec.js
+++ b/src/site/layouts/tests/vet_center/vet_center_locations_list.drupal.unit.spec.js
@@ -1,0 +1,30 @@
+import { expect } from 'chai';
+import { beforeEach } from 'mocha';
+import { parseFixture, renderHTML } from '~/site/tests/support';
+
+const layoutPath = 'src/site/layouts/vet_center_locations_list.drupal.liquid';
+
+describe('Vet Center Locations Page', () => {
+  let container;
+  const data = parseFixture(
+    'src/site/layouts/tests/vet_center/fixtures/vet_center_escanaba_data.json',
+  );
+
+  beforeEach(async () => {
+    container = await renderHTML(layoutPath, data);
+  });
+
+  it('renders vet center name in metatag - [Vet Center] | Veterans Affairs', () => {
+    expect(
+      container
+        .querySelector("meta[property='og:title']")
+        .getAttribute('content'),
+    ).to.equal('Escanaba Vet Center | Veterans Affairs');
+  });
+
+  it('renders vet center name in title-tag', () => {
+    expect(container.querySelector('title').innerHTML).to.equal(
+      'Escanaba Vet Center | Veterans Affairs',
+    );
+  });
+});


### PR DESCRIPTION
## Description
Resolves issue linked below

To preview use:
escanaba main page - http://localhost:3002/preview?nodeId=3756
escanaba locations page - http://localhost:3002/preview?nodeId=16478
 
<details>
<summary>Screenshot</summary>

<img width="599" alt="Screen Shot 2021-07-12 at 2 00 11 PM" src="https://user-images.githubusercontent.com/84030819/125343117-b1b93e80-e323-11eb-8375-50c9c65298de.png">

</details>

## Acceptance criteria
- [ ] Vet Center name appears in metatag

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
