### PR TITLE
Daily Deploy (Github Actions) -- validate-build-status using octokit

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -84,7 +84,7 @@ jobs:
           YARN_CACHE_FOLDER: ~/.cache/yarn
 
       - name: Validate build status
-        run: node ./script/github-actions/validate-build-status.js ${{github.repository}} ${{ needs.set-env.outputs.REF }}
+        run: node ./script/github-actions/validate-build-status.js ${{ needs.set-env.outputs.REF }}
 
   notify-start:
     name: Notify Start

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -72,7 +72,7 @@ jobs:
           YARN_CACHE_FOLDER: ~/.cache/yarn
 
       - name: Validate build status
-        run: node ./script/github-actions/validate-build-status.js ${{ github.repository }} ${{ github.sha }}
+        run: node ./script/github-actions/validate-build-status.js ${{ github.sha }}
 
   notify-start:
     name: Notify Start

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -72,7 +72,7 @@ jobs:
           YARN_CACHE_FOLDER: ~/.cache/yarn
 
       - name: Validate build status
-        run: node ./script/github-actions/validate-build-status.js ${{ github.repository }}
+        run: node ./script/github-actions/validate-build-status.js ${{ github.repository }} ${{ github.sha }}
 
   notify-start:
     name: Notify Start

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "@babel/preset-env": "^7.10.2",
     "@babel/preset-react": "^7.10.1",
     "@babel/register": "^7.10.3",
-    "@octokit/rest": "^18.0.0",
+    "@octokit/rest": "^18.6.7",
     "@sentry/browser": "^5.4.0",
     "@testing-library/cypress": "^7.0.1",
     "JSONStream": "^1.3.5",

--- a/script/github-actions/validate-build-status.js
+++ b/script/github-actions/validate-build-status.js
@@ -136,6 +136,7 @@ async function main() {
       console.log(`Check runs still pending. Sleeping for ${timeout} minutes`);
       await sleep(timeout);
       await main();
+      return;
     }
 
     if (!success) {

--- a/script/github-actions/validate-build-status.js
+++ b/script/github-actions/validate-build-status.js
@@ -2,13 +2,11 @@
 /* eslint-disable camelcase */
 const { Octokit } = require('@octokit/rest');
 
-const {
-  GITHUB_TOKEN: auth, // Auth token used for the Github API
-} = process.env;
+const { GITHUB_TOKEN: auth, GITHUB_REPOSITORY } = process.env;
 const args = process.argv.slice(2);
 const timeout = 2; // minutes
-const [githubInfo, commitSHA] = args;
-const [owner, repo] = githubInfo.split('/');
+const commitSHA = args[0];
+const [owner, repo] = GITHUB_REPOSITORY.split('/');
 
 const octokit = new Octokit({
   timeZone: 'America/New_York',

--- a/script/github-actions/validate-build-status.js
+++ b/script/github-actions/validate-build-status.js
@@ -12,7 +12,7 @@ const octokit = new Octokit({ auth });
 
 /**
  * uses octokit request for github action run_id provided
- * @param {number} id
+ * @param {number} run_id
  */
 function getJobsFailed(run_id) {
   const params = {

--- a/script/github-actions/validate-build-status.js
+++ b/script/github-actions/validate-build-status.js
@@ -102,9 +102,7 @@ function sleep(minutes) {
  */
 function validateWorkflowSuccess(workflow) {
   const { status, conclusion, head_commit, html_url } = workflow;
-  console.log(
-    `Validating latest commit ${head_commit.id}. Workflow associated ${html_url}`,
-  );
+  console.log(`Validating commit ${head_commit.id}. Workflow: ${html_url}`);
 
   if (conclusion === 'failure') return false;
 

--- a/script/github-actions/validate-build-status.js
+++ b/script/github-actions/validate-build-status.js
@@ -2,6 +2,9 @@
 /* eslint-disable camelcase */
 const { Octokit } = require('@octokit/rest');
 
+const {
+  GITHUB_TOKEN: auth, // Auth token used for the Github API
+} = process.env;
 const args = process.argv.slice(2);
 const timeout = 2; // minutes
 const [githubInfo, commitSHA] = args;
@@ -9,6 +12,7 @@ const [owner, repo] = githubInfo.split('/');
 
 const octokit = new Octokit({
   timeZone: 'America/New_York',
+  auth,
   baseUrl: 'https://api.github.com',
 });
 

--- a/script/github-actions/validate-build-status.js
+++ b/script/github-actions/validate-build-status.js
@@ -4,8 +4,8 @@ const { Octokit } = require('@octokit/rest');
 
 const args = process.argv.slice(2);
 const timeout = 2; // minutes
-const [repoInfo, releaseSHA] = args;
-const [owner, repo] = repoInfo.split('/');
+const [githubInfo, commitSHA] = args;
+const [owner, repo] = githubInfo.split('/');
 
 const octokit = new Octokit({
   timeZone: 'America/New_York',
@@ -78,16 +78,12 @@ async function getLatestWorkflow(page) {
         throw new Error('No workflows found. Aborting.');
       }
 
-      // If SHA passed, get workflow information. Otherwise get the most recent
-      if (releaseSHA) {
-        const validWorkflow = workflow_runs.find(
-          ({ head_sha }) => head_sha === releaseSHA,
-        );
-        if (validWorkflow) return validWorkflow;
-        console.log('Workflow not found in current page. Checking next page.');
-        await getLatestWorkflow(page + 1);
-      }
-      return workflow_runs[0];
+      const workflow = workflow_runs.find(
+        ({ head_sha }) => head_sha === commitSHA,
+      );
+      if (workflow) return workflow;
+      console.log('Workflow not found in current page. Checking next page.');
+      return getLatestWorkflow(page + 1);
     });
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1084,16 +1084,17 @@
   dependencies:
     "@octokit/types" "^6.0.0"
 
-"@octokit/core@^3.2.3":
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-3.2.4.tgz#5791256057a962eca972e31818f02454897fd106"
-  integrity sha512-d9dTsqdePBqOn7aGkyRFe7pQpCXdibSJ5SFnrTr0axevObZrpz3qkWm7t/NjYv5a66z6vhfteriaq4FRz3e0Qg==
+"@octokit/core@^3.5.0":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-3.5.1.tgz#8601ceeb1ec0e1b1b8217b960a413ed8e947809b"
+  integrity sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==
   dependencies:
     "@octokit/auth-token" "^2.4.4"
     "@octokit/graphql" "^4.5.8"
-    "@octokit/request" "^5.4.12"
+    "@octokit/request" "^5.6.0"
+    "@octokit/request-error" "^2.0.5"
     "@octokit/types" "^6.0.3"
-    before-after-hook "^2.1.0"
+    before-after-hook "^2.2.0"
     universal-user-agent "^6.0.0"
 
 "@octokit/endpoint@^6.0.1":
@@ -1119,6 +1120,11 @@
   resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-2.0.0.tgz#6d8f8ad9db3b75a39115f5def2654df8bed39f28"
   integrity sha512-J4bfM7lf8oZvEAdpS71oTvC1ofKxfEZgU5vKVwzZKi4QPiL82udjpseJwxPid9Pu2FNmyRQOX4iEj6W1iOSnPw==
 
+"@octokit/openapi-types@^8.2.1":
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-8.2.1.tgz#102e752a7378ff8d21057c70fd16f1c83856d8c5"
+  integrity sha512-BJz6kWuL3n+y+qM8Pv+UGbSxH6wxKf/SBs5yzGufMHwDefsa+Iq7ZGy1BINMD2z9SkXlIzk1qiu988rMuGXEMg==
+
 "@octokit/plugin-paginate-rest@^2.6.2":
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.6.2.tgz#45d13dbf5ff8aed54f1a3716b1d57fdc62720c5f"
@@ -1131,12 +1137,12 @@
   resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.2.tgz#394d59ec734cd2f122431fbaf05099861ece3c44"
   integrity sha512-oTJSNAmBqyDR41uSMunLQKMX0jmEXbwD1fpz8FG27lScV3RhtGfBa1/BBLym+PxcC16IBlF7KH9vP1BUYxA+Eg==
 
-"@octokit/plugin-rest-endpoint-methods@4.4.1":
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.4.1.tgz#105cf93255432155de078c9efc33bd4e14d1cd63"
-  integrity sha512-+v5PcvrUcDeFXf8hv1gnNvNLdm4C0+2EiuWt9EatjjUmfriM1pTMM+r4j1lLHxeBQ9bVDmbywb11e3KjuavieA==
+"@octokit/plugin-rest-endpoint-methods@5.4.1":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.4.1.tgz#540ec90bb753dcaa682ee9f2cd6efdde9132fa90"
+  integrity sha512-Nx0g7I5ayAYghsLJP4Q1Ch2W9jYYM0FlWWWZocUro8rNxVwuZXGfFd7Rcqi9XDWepSXjg1WByiNJnZza2hIOvQ==
   dependencies:
-    "@octokit/types" "^6.1.0"
+    "@octokit/types" "^6.18.1"
     deprecation "^2.3.1"
 
 "@octokit/request-error@^2.0.0":
@@ -1148,7 +1154,16 @@
     deprecation "^2.0.0"
     once "^1.4.0"
 
-"@octokit/request@^5.3.0", "@octokit/request@^5.4.12":
+"@octokit/request-error@^2.0.5", "@octokit/request-error@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.1.0.tgz#9e150357831bfc788d13a4fd4b1913d60c74d677"
+  integrity sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+    deprecation "^2.0.0"
+    once "^1.4.0"
+
+"@octokit/request@^5.3.0":
   version "5.4.12"
   resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.4.12.tgz#b04826fa934670c56b135a81447be2c1723a2ffc"
   integrity sha512-MvWYdxengUWTGFpfpefBBpVmmEYfkwMoxonIB3sUGp5rhdgwjXL1ejo6JbgzG/QD9B/NYt/9cJX1pxXeSIUCkg==
@@ -1162,23 +1177,42 @@
     once "^1.4.0"
     universal-user-agent "^6.0.0"
 
-"@octokit/rest@^18.0.0":
-  version "18.0.12"
-  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-18.0.12.tgz#278bd41358c56d87c201e787e8adc0cac132503a"
-  integrity sha512-hNRCZfKPpeaIjOVuNJzkEL6zacfZlBPV8vw8ReNeyUkVvbuCvvrrx8K8Gw2eyHHsmd4dPlAxIXIZ9oHhJfkJpw==
+"@octokit/request@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.6.0.tgz#6084861b6e4fa21dc40c8e2a739ec5eff597e672"
+  integrity sha512-4cPp/N+NqmaGQwbh3vUsYqokQIzt7VjsgTYVXiwpUP2pxd5YiZB2XuTedbb0SPtv9XS7nzAKjAuQxmY8/aZkiA==
   dependencies:
-    "@octokit/core" "^3.2.3"
+    "@octokit/endpoint" "^6.0.1"
+    "@octokit/request-error" "^2.1.0"
+    "@octokit/types" "^6.16.1"
+    is-plain-object "^5.0.0"
+    node-fetch "^2.6.1"
+    universal-user-agent "^6.0.0"
+
+"@octokit/rest@^18.6.7":
+  version "18.6.7"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-18.6.7.tgz#89b8ecd13edd9603f00453640d1fb0b4175d4b31"
+  integrity sha512-Kn6WrI2ZvmAztdx+HEaf88RuJn+LK72S8g6OpciE4kbZddAN84fu4fiPGxcEu052WmqKVnA/cnQsbNlrYC6rqQ==
+  dependencies:
+    "@octokit/core" "^3.5.0"
     "@octokit/plugin-paginate-rest" "^2.6.2"
     "@octokit/plugin-request-log" "^1.0.2"
-    "@octokit/plugin-rest-endpoint-methods" "4.4.1"
+    "@octokit/plugin-rest-endpoint-methods" "5.4.1"
 
-"@octokit/types@^6.0.0", "@octokit/types@^6.0.1", "@octokit/types@^6.0.3", "@octokit/types@^6.1.0":
+"@octokit/types@^6.0.0", "@octokit/types@^6.0.1", "@octokit/types@^6.0.3":
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.1.1.tgz#bc88b3eb5f447b025a2a1a8177a72db216e8d4ca"
   integrity sha512-btm3D6S7VkRrgyYF31etUtVY/eQ1KzrNRqhFt25KSe2mKlXuLXJilglRC6eDA2P6ou94BUnk/Kz5MPEolXgoiw==
   dependencies:
     "@octokit/openapi-types" "^2.0.0"
     "@types/node" ">= 8"
+
+"@octokit/types@^6.16.1", "@octokit/types@^6.18.1":
+  version "6.18.1"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.18.1.tgz#a6db178536e649fd5d67a7b747754bcc43940be4"
+  integrity sha512-5YsddjO1U+xC8ZYKV8yZYebW55PCc7qiEEeZ+wZRr6qyclynzfyD65KZ5FdtIeP0/cANyFaD7hV69qElf1nMsQ==
+  dependencies:
+    "@octokit/openapi-types" "^8.2.1"
 
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.1"
@@ -2541,10 +2575,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-before-after-hook@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.1.0.tgz#b6c03487f44e24200dd30ca5e6a1979c5d2fb635"
-  integrity sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==
+before-after-hook@^2.2.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.2.tgz#a6e8ca41028d90ee2c24222f201c90956091613e"
+  integrity sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==
 
 big.js@^5.2.2:
   version "5.2.2"


### PR DESCRIPTION
## Description

- This PR changes using fetch to the octokit library. The functionality and output is primarily the same (with minor changes)
- the `validate-build-script` must now pass in SHA at all times. This is because when pulling from the latest, if a commit got recently merged it will attempt to get the new one merged rather the commit it is on.

## Testing done

Locally

