### PR TITLE
Daily Deploy (Github Actions) -- change workflow order (notification)

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -89,7 +89,6 @@ jobs:
   notify-start:
     name: Notify Start
     runs-on: ubuntu-latest
-    needs: validate-build-status
 
     steps:
       - name: Configure AWS credentials
@@ -137,7 +136,7 @@ jobs:
   build:
     name: Build
     runs-on: self-hosted
-    needs: [set-env, notify-start]
+    needs: [set-env, validate-build-status]
     defaults:
       run:
         working-directory: content-build

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -136,7 +136,7 @@ jobs:
   build:
     name: Build
     runs-on: self-hosted
-    needs: [set-env, validate-build-status]
+    needs: [set-env, notify-start, validate-build-status]
     defaults:
       run:
         working-directory: content-build

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -77,7 +77,7 @@ jobs:
   notify-start:
     name: Notify Start
     runs-on: ubuntu-latest
-    needs: [set-env, validate-build-status]
+    needs: set-env
 
     steps:
       - name: Configure AWS credentials
@@ -125,7 +125,7 @@ jobs:
   build:
     name: Build
     runs-on: self-hosted
-    needs: notify-start
+    needs: [validate-build-status]
     defaults:
       run:
         working-directory: content-build

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -125,7 +125,7 @@ jobs:
   build:
     name: Build
     runs-on: self-hosted
-    needs: [validate-build-status]
+    needs: [notify-start, validate-build-status]
     defaults:
       run:
         working-directory: content-build


### PR DESCRIPTION
## Description

Currently, in order for the notification to get sent on Slack, it must pass the `validate-build-status`. That being said, if the validate-build-status is still pending, until it passes/fails it could be mins/hours before notification, which could be misleading that the workflow is never triggered.

This PR does the following:
Send notification as soon as workflow gets triggered. Remainder of workflow remains the same (build only proceeds if `validate-build-status` succeeds)

