### PR TITLE
add concurrency to CI workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,6 +12,10 @@ env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
   CHANNEL_ID: C024DUC9S1K # -test-tim-accessibility-gha
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,7 +10,7 @@ on:
 # TODO: Change to correct channel_id when ready
 env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
-  CHANNEL_ID: C024DUC9S1K # -test-tim-accessibility-gha
+  CHANNEL_ID: C024DUC9S1K # -test-tim-accessibility-gha TEST COMMIT
 
 concurrency:
   group: ${{ github.ref }}


### PR DESCRIPTION
## Description

PR adds concurrency. It will only cancel workflow if it is in feature branch

## Testing done

[Flow cancelled by concurrency](https://github.com/department-of-veterans-affairs/content-build/actions/runs/1027947954)
[New flow](https://github.com/department-of-veterans-affairs/content-build/actions/runs/1027951503)

