### PR TITLE
Allow concurrent workflows among all commits in master.

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,7 +15,7 @@ env:
 # Cancel in-progress workflows from previous commits in feature branches. TEST
 # Allow concurrent workflows from all commits in master.
 concurrency:
-  group: ${{ fromJSON(format('["{0}", "{1}"]', github.ref, github.sha))[github.ref != 'refs/heads/master'] }}
+  group: ${{ fromJSON(format('["{0}", "{1}"]', github.sha, github.ref))[github.ref != 'refs/heads/master'] }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,7 +12,7 @@ env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
   CHANNEL_ID: C024DUC9S1K # -test-tim-accessibility-gha
 
-# Cancel in-progress workflows from previous commits in feature branches.
+# Cancel in-progress workflows from previous commits in feature branches. TEST
 # Allow concurrent workflows from all commits in master.
 concurrency:
   group: ${{ fromJSON(format('["{0}", "{1}"]', github.ref, github.sha))[github.ref != 'refs/heads/master'] }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,8 +12,10 @@ env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
   CHANNEL_ID: C024DUC9S1K # -test-tim-accessibility-gha
 
+# Cancel in-progress workflows from previous commits in feature branches.
+# Allow concurrent workflows from all commits in master.
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ fromJSON(format('["{0}", "{1}"]', github.ref, github.sha))[github.ref != 'refs/heads/master'] }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,7 +12,8 @@ env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
   CHANNEL_ID: C024DUC9S1K # -test-tim-accessibility-gha
 
-# Cancel in-progress workflows from previous commits in feature branches. TEST
+# TODO: Remove this test comment.
+# Cancel in-progress workflows from previous commits in feature branches.
 # Allow concurrent workflows from all commits in master.
 concurrency:
   group: ${{ fromJSON(format('["{0}", "{1}"]', github.sha, github.ref))[github.ref != 'refs/heads/master'] }}


### PR DESCRIPTION
## Description
- Cancel in-progress workflows from previous commits in feature branches.
- Allow concurrent workflows from all commits in master.

## Testing done
Will observe behavior in `master` branch.

## Acceptance criteria
- [ ] Feature branches should only run CI on the latest commit.
- [ ] `master` branch should allow multiple commits to run CI concurrently.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
