### PR TITLE
Github Actions (CI) -- Fix concurrency for master branch

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,10 +10,10 @@ on:
 # TODO: Change to correct channel_id when ready
 env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
-  CHANNEL_ID: C024DUC9S1K # -test-tim-accessibility-gha TEST 
+  CHANNEL_ID: C024DUC9S1K # -test-tim-accessibility-gha
 
 concurrency:
-  group: ${{ github.ref != 'refs/heads/master' && github.ref || github.sha  }}
+  group: ${{ github.ref != 'refs/heads/fix/github-actions/concurrency-condition' && github.ref || github.sha  }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,10 +10,10 @@ on:
 # TODO: Change to correct channel_id when ready
 env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
-  CHANNEL_ID: C024DUC9S1K # -test-tim-accessibility-gha
+  CHANNEL_ID: C024DUC9S1K # -test-tim-accessibility-gha TEST COMMIT
 
 concurrency:
-  group: ${{ github.ref != 'refs/heads/master' && github.ref || ci-${{ github.ref }}  }}
+  group: ${{ github.ref != 'refs/heads/master' && github.ref || github.sha  }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -13,7 +13,7 @@ env:
   CHANNEL_ID: C024DUC9S1K # -test-tim-accessibility-gha
 
 concurrency:
-  group: ${{ github.ref != 'refs/heads/fix/github-actions/concurrency-condition' && github.ref || github.sha  }}
+  group: ${{ github.ref != 'refs/heads/master' && github.ref || github.sha  }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,7 +10,7 @@ on:
 # TODO: Change to correct channel_id when ready
 env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
-  CHANNEL_ID: C024DUC9S1K # -test-tim-accessibility-gha TEST COMMIT
+  CHANNEL_ID: C024DUC9S1K # -test-tim-accessibility-gha TEST 
 
 concurrency:
   group: ${{ github.ref != 'refs/heads/master' && github.ref || github.sha  }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -13,7 +13,7 @@ env:
   CHANNEL_ID: C024DUC9S1K # -test-tim-accessibility-gha
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.ref != 'refs/heads/master' && github.ref || ci-${{ github.ref }}  }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:


### PR DESCRIPTION
## Description
- Cancel in-progress workflows from previous commits in feature branches.
- Allow concurrent workflows from all commits in master.

## Testing done
Tested against [ref group](https://github.com/department-of-veterans-affairs/content-build/actions/runs/1028149729) -- cancelled as expected 
Tested against [sha group](https://github.com/department-of-veterans-affairs/content-build/actions/runs/1028200139) -- continued as expected 
Tested against [new ref group](https://github.com/department-of-veterans-affairs/content-build/actions/runs/1028205080) -- continued as expected and cancelled previous run

## Acceptance criteria
- [ ] Feature branches should only run CI on the latest commit.
- [ ] `master` branch should allow multiple commits to run CI concurrently.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
