### PR TITLE
Don't run icon check on Draft PRs

### DIFF
--- a/.github/workflows/manual-review.yml
+++ b/.github/workflows/manual-review.yml
@@ -1,6 +1,8 @@
 name: Manual Review
 
-on: [pull_request]
+on:
+  pull_request_review:
+    types: [edited, dismissed, submitted]
 
 env:
   BOT_NAME: va-vfs-bot

--- a/.github/workflows/manual-review.yml
+++ b/.github/workflows/manual-review.yml
@@ -1,6 +1,7 @@
 name: Manual Review
 
-on: pull_request:
+on: 
+  pull_request:
       types: [review_requested, ready_for_review]
 
 env:

--- a/.github/workflows/manual-review.yml
+++ b/.github/workflows/manual-review.yml
@@ -2,7 +2,7 @@ name: Manual Review
 
 on:
   pull_request_review:
-    types: [edited, dismissed, submitted]
+    types: [created, edited, dismissed, submitted]
 
 env:
   BOT_NAME: va-vfs-bot

--- a/.github/workflows/manual-review.yml
+++ b/.github/workflows/manual-review.yml
@@ -1,6 +1,8 @@
 name: Manual Review
 
-on: [pull_request]
+on: 
+  pull_request:
+      types: [review_requested, ready_for_review, synchronize, edited, reopened, opened]
 
 env:
   BOT_NAME: va-vfs-bot

--- a/.github/workflows/manual-review.yml
+++ b/.github/workflows/manual-review.yml
@@ -2,7 +2,7 @@ name: Manual Review
 
 on: 
   pull_request:
-      types: [review_requested]
+      types: [review_requested, ready_for_review]
 
 env:
   BOT_NAME: va-vfs-bot

--- a/.github/workflows/manual-review.yml
+++ b/.github/workflows/manual-review.yml
@@ -2,7 +2,7 @@ name: Manual Review
 
 on: 
   pull_request:
-      types: [review_requested, ready_for_review, synchronize, edited, reopened, opened]
+    types: [review_requested, ready_for_review, synchronize, edited, reopened, opened]
 
 env:
   BOT_NAME: va-vfs-bot

--- a/.github/workflows/manual-review.yml
+++ b/.github/workflows/manual-review.yml
@@ -1,8 +1,7 @@
 name: Manual Review
 
-on:
-  pull_request_review:
-    types: [created, edited, dismissed, submitted]
+on: pull_request:
+      types: [review_requested, ready_for_review]
 
 env:
   BOT_NAME: va-vfs-bot

--- a/.github/workflows/manual-review.yml
+++ b/.github/workflows/manual-review.yml
@@ -2,7 +2,7 @@ name: Manual Review
 
 on: 
   pull_request:
-      types: [review_requested, ready_for_review]
+      types: [review_requested, ready_for_review, synchronize]
 
 env:
   BOT_NAME: va-vfs-bot

--- a/.github/workflows/manual-review.yml
+++ b/.github/workflows/manual-review.yml
@@ -2,7 +2,7 @@ name: Manual Review
 
 on: 
   pull_request:
-      types: [ready_for_review]
+      types: [review_requested]
 
 env:
   BOT_NAME: va-vfs-bot

--- a/.github/workflows/manual-review.yml
+++ b/.github/workflows/manual-review.yml
@@ -2,7 +2,7 @@ name: Manual Review
 
 on: 
   pull_request:
-      types: [review_requested, ready_for_review]
+      types: [ready_for_review]
 
 env:
   BOT_NAME: va-vfs-bot

--- a/.github/workflows/manual-review.yml
+++ b/.github/workflows/manual-review.yml
@@ -2,7 +2,7 @@ name: Manual Review
 
 on: 
   pull_request:
-      types: [review_requested, ready_for_review, synchronize]
+      types: [review_requested, ready_for_review, synchronize, edited, reopened]
 
 env:
   BOT_NAME: va-vfs-bot

--- a/.github/workflows/manual-review.yml
+++ b/.github/workflows/manual-review.yml
@@ -1,8 +1,6 @@
 name: Manual Review
 
-on: 
-  pull_request:
-      types: [review_requested, ready_for_review, synchronize, edited, reopened]
+on: [pull_request]
 
 env:
   BOT_NAME: va-vfs-bot
@@ -71,6 +69,7 @@ jobs:
   icon-check:
     name: Icon Check
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/src/site/components/administration-hub-rail.drupal.liquid
+++ b/src/site/components/administration-hub-rail.drupal.liquid
@@ -13,7 +13,7 @@
         <li>
           <a href="{{ administration.fieldEmailUpdatesUrl }}"
             onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });">
-            <i class="fas fa-envelope vads-u-padding-right--1"></i>
+            <i class="fas fa-envelope vads-u-padding-right--1">.</i>
               {{ administration.fieldEmailUpdatesLinkText }}
           </a>
         </li>

--- a/src/site/components/administration-hub-rail.drupal.liquid
+++ b/src/site/components/administration-hub-rail.drupal.liquid
@@ -13,7 +13,7 @@
         <li>
           <a href="{{ administration.fieldEmailUpdatesUrl }}"
             onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });">
-            <i class="fas fa-envelope vads-u-padding-right--1"></i>
+            <i class="fas fa-envelope vads-u-padding-right--1">.</i>
               {{ administration.fieldEmailUpdatesLinkText }}
           </a>
         </li>
@@ -32,7 +32,7 @@
               <li>
                 <a href="http://youtube.com/channel/{{ socialLink.value }}"
                   onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });">
-                  <i class="fab fa-youtube vads-u-padding-right--1"></i>
+                  <i class="fab fa-youtube vads-u-padding-right--1">?</i>
                     {{ administration.name }} {{ socialPlatform | remove: '_' | capitalize }}
                 </a>
               </li>

--- a/src/site/components/administration-hub-rail.drupal.liquid
+++ b/src/site/components/administration-hub-rail.drupal.liquid
@@ -13,7 +13,7 @@
         <li>
           <a href="{{ administration.fieldEmailUpdatesUrl }}"
             onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });">
-            <i class="fas fa-envelope vads-u-padding-right--1">.</i>
+            <i class="fas fa-envelope vads-u-padding-right--1"></i>
               {{ administration.fieldEmailUpdatesLinkText }}
           </a>
         </li>
@@ -32,7 +32,7 @@
               <li>
                 <a href="http://youtube.com/channel/{{ socialLink.value }}"
                   onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });">
-                  <i class="fab fa-youtube vads-u-padding-right--1">?</i>
+                  <i class="fab fa-youtube vads-u-padding-right--1"></i>
                     {{ administration.name }} {{ socialPlatform | remove: '_' | capitalize }}
                 </a>
               </li>

--- a/src/site/components/administration-hub-rail.drupal.liquid
+++ b/src/site/components/administration-hub-rail.drupal.liquid
@@ -32,7 +32,7 @@
               <li>
                 <a href="http://youtube.com/channel/{{ socialLink.value }}"
                   onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });">
-                  <i class="fab fa-youtube vads-u-padding-right--1"></i>
+                  <i class="fab fa-youtube vads-u-padding-right--1">?</i>
                     {{ administration.name }} {{ socialPlatform | remove: '_' | capitalize }}
                 </a>
               </li>

--- a/src/site/components/administration-hub-rail.drupal.liquid
+++ b/src/site/components/administration-hub-rail.drupal.liquid
@@ -13,7 +13,7 @@
         <li>
           <a href="{{ administration.fieldEmailUpdatesUrl }}"
             onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });">
-            <i class="fas fa-envelope vads-u-padding-right--1">.</i>
+            <i class="fas fa-envelope vads-u-padding-right--1"></i>
               {{ administration.fieldEmailUpdatesLinkText }}
           </a>
         </li>


### PR DESCRIPTION
## Description
Addressing a request to have manual checks only run when a PR is ready for review.

Issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/26651

## Testing done
1. Open Draft PR (no icon checks) -> "Ready for review" (manual icon runs)
2. Open normal PR manual check runs)
3. Open Draft (no icon checks) -> -> "Ready for review" (manual icon runs) -> Edit PR (manual icon runs)