### PR TITLE
Format metatags template for readability + fix titles on vamc pages

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -944,6 +944,9 @@ module.exports = function registerFilters() {
       formattedTitle = `${formattedTitle} | Veterans Affairs`;
     }
 
+    // Remove ' | | ' from the title.
+    formattedTitle = formattedTitle?.replace(' | | ', ' | ');
+
     return formattedTitle;
   };
 };

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -1150,4 +1150,10 @@ describe('formatTitleTag', () => {
     const expected = 'This Is A-Title | Veterans Affairs';
     expect(liquid.filters.formatTitleTag(title)).to.equal(expected);
   });
+
+  it('formats a title tag with " | | Veteran Affairs"', () => {
+    const title = 'this is a-title | | Veterans Affairs';
+    const expected = 'This Is A-Title | Veterans Affairs';
+    expect(liquid.filters.formatTitleTag(title)).to.equal(expected);
+  });
 });

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -20,28 +20,34 @@
   <meta name="MobileOptimized" content="320">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
+  <!-- Index only pages on production. -->
   {% if buildtype != 'vagovprod' %}
-  <meta name="robots" content="noindex">
+    <meta name="robots" content="noindex">
   {% endif %}
 
+  <!-- Add metatags. -->
   {% if drupalTags %}
-  {% include "src/site/includes/metatags.drupal.liquid" %}
+    {% include "src/site/includes/metatags.drupal.liquid" %}
   {% else %}
-  {% include "src/site/includes/metatags.liquid" %}
+    {% include "src/site/includes/metatags.liquid" %}
   {% endif %}
 
+  <!-- Add polyfills. -->
   <script nonce="**CSP_NONCE**" nomodule data-entry-name="polyfills.js"></script>
 
+  <!-- Add analytics helpers. -->
   <script nonce="**CSP_NONCE**">
     {% include "src/site/assets/js/record-event.js" %}
   </script>
 
+  <!-- Add web components. -->
   <link rel="stylesheet" data-entry-name="web-components.css">
   <script nonce="**CSP_NONCE**" defer data-entry-name="web-components.js"></script>
 
+  <!-- Render GA template. -->
   {% include 'src/site/includes/google-analytics.liquid' %}
 
-  <!-- Icons -->
+  <!-- Add Icons. -->
   <link href="/img/design/icons/apple-touch-icon.png" rel="apple-touch-icon-precomposed" />
   <link href="/img/design/icons/apple-touch-icon-72x72.png" rel="apple-touch-icon-precomposed" sizes="72x72" />
   <link href="/img/design/icons/apple-touch-icon-114x114.png" rel="apple-touch-icon-precomposed" sizes="114x114" />
@@ -52,7 +58,6 @@
   <meta name="msapplication-TileColor" content="#144073">
 
   <!-- Preload main fonts -->
-
   <link rel="preload" href="/generated/sourcesanspro-bold-webfont.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="/generated/sourcesanspro-regular-webfont.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="/generated/bitter-bold.woff2" as="font" type="font/woff2" crossorigin>

--- a/src/site/includes/metatags.drupal.liquid
+++ b/src/site/includes/metatags.drupal.liquid
@@ -1,26 +1,30 @@
+<!-- Canonical URL -->
 <link rel="canonical" href="{{ hostUrl }}{{ entityUrl.path }}/" />
 
+<!-- Last updated -->
 {% if changed %}
   <meta name="DC.Date" scheme="W3CDTF" content="{{ changed| dateFromUnix: 'YYYY-MM-DD' }}">
 {% endif %}
 
+<!-- og:url -->
 {% if entityUrl.path %}
-  <meta content="{{ hostUrl }}{{ entityUrl.path }}/" property="og:url">
+  <meta property="og:url" content="{{ hostUrl }}{{ entityUrl.path }}/">
 {% else %}
-  <meta content="{{ hostUrl }}/" property="og:url">
+  <meta property="og:url" content="{{ hostUrl }}/">
 {% endif %}
 
-<meta content="website" property="og:type">
+<!-- og:type -->
+<meta property="og:type" content="website">
 
+<!-- Custom metatags -->
 {% assign tagsSize = entityMetatags | size %}
 {% if tagsSize > 0 %}
   {% assign sortedEntityMetatags = entityMetatags | sortEntityMetatags %}
-  <!-- Metatags -->
   {% for tag in sortedEntityMetatags %}
     {% case tag.__typename %}
       {% when "MetaValue" %}
         {% if tag.key == "title" %}
-          <title>{{ tag.value }}</title>
+          <title>{{ tag.value | formatTitleTag }}</title>
         {% else %}
           <meta name="{{ tag.key }}" content="{{ tag.value }}">
         {% endif %}
@@ -30,8 +34,10 @@
         <link rel="{{ tag.key }}" href="{{ tag.value }}">
     {% endcase %}
   {% endfor %}
+
+<!-- Default metatags -->
 {% else %}
-  <!-- Metatags -->
+  <!-- Derive the title. -->
   {% if regionOrOffice %}
     {% assign metaTitle = title | append: " | " | append: regionOrOffice %}
   {% elsif fieldOffice %}
@@ -41,15 +47,21 @@
   {% else %}
     {% assign metaTitle = title %}
   {% endif %}
-
   {% assign metaTitle = metaTitle | formatTitleTag %}
-  <meta property="og:site_name" content="Veterans Affairs">
-  <meta content="{{ metaTitle }}" property="og:title">
-  <meta name="twitter:card" content="Summary">
-  <meta name="twitter:site" content="@DeptVetAffairs">
-  <meta name="twitter:image" content="{{ hostUrl }}/img/design/logo/va-og-twitter-image.png">
-  <meta content="{{ metaTitle }}" name="twitter:title" >
 
+  <!-- og:site_name -->
+  <meta property="og:site_name" content="Veterans Affairs">
+
+  <!-- og:title -->
+  <meta property="og:title" content="{{ metaTitle }}">
+
+  <!-- Twitter metatags -->
+  <meta name="twitter:card" content="Summary">
+  <meta name="twitter:image" content="{{ hostUrl }}/img/design/logo/va-og-twitter-image.png">
+  <meta name="twitter:site" content="@DeptVetAffairs">
+  <meta name="twitter:title" content="{{ metaTitle }}">
+
+  <!-- Derive the meta description. -->
   {% if fieldClinicalHealthServi %}
     {% assign description = fieldClinicalHealthServi.processed | strip_html %}
   {% elsif fieldPressReleaseBlurb %}
@@ -60,12 +72,16 @@
     {% assign description = fieldIntroText.processed | strip_html %}
   {% endif %}
 
+  <!-- Add meta description tags. -->
   {% if description %}
     <meta content="{{ description }}" property="og:description">
     <meta content="{{ description }}" name="twitter:description" >
     <meta content="{{ description }}" name="description">
   {% endif %}
 
+  <!-- og:image -->
   <meta content="{{ hostUrl }}/img/design/logo/va-og-image.png" property="og:image">
+
+  <!-- Title tag -->
   <title>{{ metaTitle }}</title>
 {% endif %}

--- a/src/site/includes/metatags.liquid
+++ b/src/site/includes/metatags.liquid
@@ -1,49 +1,59 @@
+<!-- og:site_name -->
 <meta content="VA.gov" property="og:site_name">
-<!--twitter cards-->
-<meta name="twitter:card" content="summary">
-<meta name="twitter:site" content="@DeptVetAffairs">
-<!-- description, title tags added below-->
-<meta name="twitter:image:src" content="{{ hostUrl }}/img/design/logo/va-og-twitter-image.png">
-<!-- end twitter cards -->
 
+<!-- Twitter metatags -->
+<meta name="twitter:card" content="Summary">
+<meta name="twitter:image" content="{{ hostUrl }}/img/design/logo/va-og-twitter-image.png">
+<meta name="twitter:site" content="@DeptVetAffairs">
+
+<!-- Last updated -->
 {% if lastupdate %}
   <meta name="DC.Date" content="{{lastupdate| date: '%Y-%m-%d'}}" property="http://purl.org/dc/terms/date">
 {% endif %}
 
+<!-- Derive the title. -->
 {% assign metaTitle = title | formatTitleTag %}
 
+<!-- og:title + Twitter title metatag -->
 {% if metaTitle %}
-  <meta content="{{ metaTitle }}" property="og:title">
-  <meta content="{{ metaTitle }}" name="twitter:title" >
+  <meta property="og:title" content="{{ metaTitle }}">
+  <meta name="twitter:title" content="{{ metaTitle }}">
 {% else %}
-  <meta content="{{ hostUrl }}" property="og:title">
-  <meta content="{{ hostUrl }}" name="twitter:title">
+  <meta property="og:title" content="{{ hostUrl }}">
+  <meta name="twitter:title" content="{{ hostUrl }}">
 {% endif %}
 
-<meta content="website" property="og:type">
+<!-- og:type -->
+<meta property="og:type" content="website">
 
+<!-- og:url -->
 {% if path %}
-  <meta content="{{ hostUrl }}/{{ path }}" property="og:url">
+  <meta property="og:url" content="{{ hostUrl }}/{{ path }}">
 {% endif %}
 
+<!-- Add meta description tags. -->
 {% if description %}
-  <meta content="{{ description }}" property="og:description">
-  <meta content="{{ description }}" name="twitter:description" >
-  <meta content="{{ description }}" name="description">
+  <meta name="description" content="{{ description }}">
+  <meta name="twitter:description" content="{{ description }}">
+  <meta property="og:description" content="{{ description }}">
 {% endif %}
 
-<meta content="{{ hostUrl }}/img/design/logo/va-og-image.png" property="og:image">
+<!-- og:image -->
+<meta property="og:image" content="{{ hostUrl }}/img/design/logo/va-og-image.png">
 
+<!-- article:tags -->
 {% if tags %}
   {% for tag in tags %}
-    <meta content="{{ tag }}" property="article:tag">
+    <meta property="article:tag" content="{{ tag }}">
   {% endfor %}
 {% endif %}
 
+<!-- keywords -->
 {% if keywords %}
   <meta name ="keywords" content="{{keywords}}">
 {% endif %}
 
+<!-- Title tag -->
 {% if title === 'Home' %}
   <title>VA.gov</title>
 {% else %}


### PR DESCRIPTION
# Description

**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/24383

This PR formats the metatag templates for readability. It also should fix titles on VAMC pages (which were using custom metatags). It also replaces any instances of when the title has ` | | ` due to a missing field office.

## Screenshots

![image](https://user-images.githubusercontent.com/12773166/125673633-be1d9b3d-f7af-46af-8e06-5990df3236d1.png)

## Testing

Added unit test:

![image](https://user-images.githubusercontent.com/12773166/125664704-69281895-e2b1-4039-ba7d-5b77b94147cd.png)

## Acceptance Criteria

- [x] Format metatag templates
- [x] Ensure we format titles on pages that use custom metatags
- [x] Add a check to replace ` | | ` with ` | ` when formatting titles
