### PR TITLE
Github Actions (validate-build-status) -- clearer output on job failed

### DIFF
--- a/script/github-actions/validate-build-status.js
+++ b/script/github-actions/validate-build-status.js
@@ -33,8 +33,12 @@ function getJobsFailed(run_id) {
     .then(({ jobs }) => {
       jobs.forEach(({ name, html_url, conclusion }) => {
         if (conclusion === 'success') return;
-        console.error(
-          `::error::Job "${name}" has failed. For more details, please see ${html_url}`,
+        const isFailure = conclusion === 'failure';
+        const annotationMessage = isFailure
+          ? `::error::Job "${name}" has failed`
+          : `::warning::Job "${name}" has been cancelled`;
+        console.log(
+          `${annotationMessage}. For more details, please see ${html_url}`,
         );
       });
     });


### PR DESCRIPTION
## Description

If some jobs are cancelled, they are still annotated as errors and can be a bit misleading. This PR identifies which is failure and cancelled jobs (as of result of manual or other jobs failed) are identified as warnings
