### PR TITLE
Add additional replace for | |

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -945,8 +945,7 @@ module.exports = function registerFilters() {
     }
 
     // Remove ' | | ' and ' |  | ' from the title.
-    formattedTitle = formattedTitle?.replace(' | | ', ' | ');
-    formattedTitle = formattedTitle?.replace(' |  | ', ' | ');
+    formattedTitle = formattedTitle?.replace(/\s*\|\s*\|\s*/, ' | ');
 
     return formattedTitle;
   };

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -944,8 +944,9 @@ module.exports = function registerFilters() {
       formattedTitle = `${formattedTitle} | Veterans Affairs`;
     }
 
-    // Remove ' | | ' from the title.
+    // Remove ' | | ' and ' |  | ' from the title.
     formattedTitle = formattedTitle?.replace(' | | ', ' | ');
+    formattedTitle = formattedTitle?.replace(' |  | ', ' | ');
 
     return formattedTitle;
   };

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -1156,4 +1156,10 @@ describe('formatTitleTag', () => {
     const expected = 'This Is A-Title | Veterans Affairs';
     expect(liquid.filters.formatTitleTag(title)).to.equal(expected);
   });
+
+  it('formats a title tag with " |  | Veteran Affairs"', () => {
+    const title = 'this is a-title |  | Veterans Affairs';
+    const expected = 'This Is A-Title | Veterans Affairs';
+    expect(liquid.filters.formatTitleTag(title)).to.equal(expected);
+  });
 });


### PR DESCRIPTION
## Description

This PR fixes an edge case where `" |  | "` is being sent from the CMS as a custom metatag, e.g. on the /resources page.

## Testing done
Updated unit test

## Screenshots
N/A

## Acceptance criteria
- [x] Fix double pipe edge case for title tags 

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
