### PR TITLE
Removed aria-hidden prop from map

### DIFF
--- a/src/site/includes/image_and_static_map.liquid
+++ b/src/site/includes/image_and_static_map.liquid
@@ -9,7 +9,6 @@
       onclick = onclick
   %}
   <div data-widget-type="facility-map"
-       data-facility="{{ facilityId }}"
-       aria-hidden="true">
+       data-facility="{{ facilityId }}">
   </div>
 </div>


### PR DESCRIPTION
## Description
Resolves issue linked below

To test/preview: http://localhost:3002/preview?nodeId=1259

Expect to not see this axe-core violation below
<details>
<summary>Screenshot of violation</summary>
<img width="1377" alt="Screen Shot 2021-07-16 at 3 20 43 PM" src="https://user-images.githubusercontent.com/84030819/125998631-57a819ab-61ff-41c2-b3b1-99787279dcde.png">

</details>


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
