### PR TITLE
Replace usa-accordion with va-accordion

### DIFF
--- a/src/site/facilities/facility_health_service.drupal.liquid
+++ b/src/site/facilities/facility_health_service.drupal.liquid
@@ -1,29 +1,21 @@
-<div data-template="facilities/facilities_health_service" class="usa-accordion-bordered facilities_health_service">
-  <ul class="usa-unstyled-list">
+<div data-template="facilities/facilities_health_service" class="facilities_health_service">
+  <va-accordion bordered>
     {% assign serviceTaxonomy = healthService.fieldServiceNameAndDescripti.entity %}
-    <li class="vads-u-margin-bottom--1">
-      <h3>
-        {% comment %}
-          See Google Analytics datalayer handling in src/applications/static-pages/subscribeAccordionEvents.js
-        {% endcomment %}
-        <button
-            class="usa-accordion-button usa-button-unstyled vads-u-padding-y--2 vads-u-padding-left--2p5 vads-u-line-height--4"
-            aria-expanded="false"
-            aria-controls="{{ serviceTaxonomy.entityBundle }}-{{ serviceTaxonomy.entityId }}"
-            data-label="{{ serviceTaxonomy.name }}"
-            data-childlabel="{{ serviceTaxonomy.fieldAlsoKnownAs }}"
-        >
-          {{ serviceTaxonomy.name }}
-          {% if serviceTaxonomy.fieldAlsoKnownAs %}
-            <p class="vads-u-font-weight--normal vads-u-margin--0">{{ serviceTaxonomy.fieldAlsoKnownAs }}</p>
-          {% endif %}
-        </button>
-      </h3>
-      <div id="{{ serviceTaxonomy.entityBundle }}-{{ serviceTaxonomy.entityId }}" class="usa-accordion-content"
-           aria-hidden="true">
+    <va-accordion-item
+      header="{{ serviceTaxonomy.name }}"
+      {% if serviceTaxonomy.fieldAlsoKnownAs %}
+        subheader="{{ serviceTaxonomy.fieldAlsoKnownAs }}"
+      {% endif %}
+      data-label="{{ serviceTaxonomy.name }}"
+      data-childlabel="{{ serviceTaxonomy.fieldAlsoKnownAs }}"
+    >
+      <div
+        id="{{ serviceTaxonomy.entityBundle }}-{{ serviceTaxonomy.entityId }}"
+        aria-hidden="true"
+      >
         {% if serviceTaxonomy.fieldCommonlyTreatedCondition %}
-          <div class="vads-u-margin-bottom--2"><span
-            class="vads-u-font-style--italic">Common conditions: </span>{{ serviceTaxonomy.fieldCommonlyTreatedCondition }}
+          <div class="vads-u-margin-bottom--2">
+            <span class="vads-u-font-style--italic">Common conditions: </span>{{ serviceTaxonomy.fieldCommonlyTreatedCondition }}
           </div>
         {% endif %}
 
@@ -37,14 +29,16 @@
           <div>{{ localServiceDescription }}</div>
         {% endif %}
 
-        <div data-widget-type="facility-appointment-wait-times-widget"
-             data-facility="{{ fieldFacilityLocatorApiId | widgetFacilityDetail | escape }}"
-             data-service="{{ serviceTaxonomy | healthServiceApiId | escape }}"></div>
+        <div
+          data-widget-type="facility-appointment-wait-times-widget"
+          data-facility="{{ fieldFacilityLocatorApiId | widgetFacilityDetail | escape }}"
+          data-service="{{ serviceTaxonomy | healthServiceApiId | escape }}"
+        ></div>
 
         {% if healthService.fieldBody.processed %}
           <div>{{ healthService.fieldBody.processed | replace: 'h3', 'h4' }}</div>
         {% endif %}
       </div>
-    </li>
-  </ul>
+    </va-accordion-item>
+  </va-accordion>
 </div>

--- a/src/site/facilities/health_service.drupal.liquid
+++ b/src/site/facilities/health_service.drupal.liquid
@@ -1,21 +1,20 @@
-<div data-template="facilities/health_service" class="usa-accordion-bordered service-accordion-output">
-    <ul class="usa-unstyled-list">
+<div data-template="facilities/health_service" class="service-accordion-output">
+    <va-accordion bordered>
         {% assign serviceTaxonomy = healthService.fieldServiceNameAndDescripti.entity %}
-        <li>
-            <button
-                    class="usa-accordion-button usa-button-unstyled"
-                    aria-expanded="false"
-                    aria-controls="{{ serviceTaxonomy.entityBundle }}-{{ serviceTaxonomy.entityId }}"
-                    data-label="{{ serviceTaxonomy.name }}"
-                    data-childlabel="{{ serviceTaxonomy.fieldAlsoKnownAs }}"
-            >
-                {{ serviceTaxonomy.name }}
-                {% if serviceTaxonomy.fieldAlsoKnownAs %}
-                    <p class="vads-u-font-weight--normal vads-u-margin--0">{{ serviceTaxonomy.fieldAlsoKnownAs }}</p>
+        <va-accordion-item
+            header="{{ serviceTaxonomy.name }}"
+            {% if serviceTaxonomy.fieldAlsoKnownAs %}
+                subheader="{{ serviceTaxonomy.fieldAlsoKnownAs }}"
+            {% endif %}
+            data-label="{{ serviceTaxonomy.name }}"
+            data-childlabel="{{ serviceTaxonomy.fieldAlsoKnownAs }}"
+        >
+            <div id="{{ serviceTaxonomy.entityBundle }}-{{ serviceTaxonomy.entityId }}">
+                {% if serviceTaxonomy.fieldCommonlyTreatedCondition %}
+                    <div class="vads-u-margin-bottom--2">
+                        <span class="vads-u-font-style--italic">Common conditions: </span>{{ serviceTaxonomy.fieldCommonlyTreatedCondition }}
+                    </div>
                 {% endif %}
-            </button>
-            <div id="{{ serviceTaxonomy.entityBundle }}-{{ serviceTaxonomy.entityId }}" class="usa-accordion-content" aria-hidden="true">
-                {% if serviceTaxonomy.fieldCommonlyTreatedCondition %}<div class="vads-u-margin-bottom--2"><span class="vads-u-font-style--italic">Common conditions: </span>{{ serviceTaxonomy.fieldCommonlyTreatedCondition }}</div>{% endif %}
                 {% if serviceTaxonomy.description.processed  %}
                     <div>{{ serviceTaxonomy.description.processed }}</div>
                 {% endif %}
@@ -36,7 +35,9 @@
                                                 'accordion-section-label': '{{ sectionName }}'
 
                                             })"
-                                        href="{{ facility.entityUrl.path }}">{{ facility.title }}
+                                        href="{{ facility.entityUrl.path }}"
+                                    >
+                                        {{ facility.title }}
                                     </a>
                                 </li>
                             {% endif %}
@@ -48,6 +49,6 @@
                     <div>{{ healthService.fieldBody.processed }}</div>
                 {% endif %}
             </div>
-        </li>
-    </ul>
+        </va-accordion-item>
+    </va-accordion>
 </div>

--- a/src/site/facilities/health_service.drupal.liquid
+++ b/src/site/facilities/health_service.drupal.liquid
@@ -5,9 +5,9 @@
             header="{{ serviceTaxonomy.name }}"
             {% if serviceTaxonomy.fieldAlsoKnownAs %}
                 subheader="{{ serviceTaxonomy.fieldAlsoKnownAs }}"
+                data-childlabel="{{ serviceTaxonomy.fieldAlsoKnownAs }}"
             {% endif %}
             data-label="{{ serviceTaxonomy.name }}"
-            data-childlabel="{{ serviceTaxonomy.fieldAlsoKnownAs }}"
         >
             <div id="{{ serviceTaxonomy.entityBundle }}-{{ serviceTaxonomy.entityId }}">
                 {% if serviceTaxonomy.fieldCommonlyTreatedCondition %}

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -455,23 +455,22 @@
             <h2 class="vads-u-margin-top--0">Frequently asked questions</h2>
 
             <!-- Questions/Answers -->
-            <div class="usa-accordion-bordered vads-u-margin-y--2">
-              <ul class="usa-unstyled-list">
-                {% for faqParagraph in fieldClpFaqParagraphs %}
-                  {% if faqParagraph.entity %}
-                    <li data-faq-entity-id="{{ faqParagraph.entity.entityId }}">
-                      <button aria-controls="{{ faqParagraph.entity.entityBundle }}-{{ faqParagraph.entity.entityId }}" class="usa-accordion-button usa-button-unstyled" aria-expanded="false" type="button">{{ faqParagraph.entity.fieldQuestion }}</button>
-                      <div id="{{ faqParagraph.entity.entityBundle }}-{{ faqParagraph.entity.entityId }}" class="usa-accordion-content" aria-hidden="true">
-                        {% assign fieldAnswer = faqParagraph.entity.fieldAnswer | first %}
-                        {% assign bundleComponent = "src/site/paragraphs/" | append: fieldAnswer.entity.entityBundle %}
-                        {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
-                        {% include {{ bundleComponentWithExtension }} with entity = fieldAnswer.entity %}
-                      </div>
-                    </li>
-                  {% endif %}
-                {% endfor %}
-              </ul>
-            </div>
+            <va-accordion bordered>
+              {% for faqParagraph in fieldClpFaqParagraphs %}
+                {% if faqParagraph.entity %}
+                  <va-accordion-item
+                    header="{{ faqParagraph.entity.fieldQuestion }}"
+                    level="3"
+                    data-faq-entity-id="{{ faqParagraph.entity.entityId }}"
+                  >
+                    {% assign fieldAnswer = faqParagraph.entity.fieldAnswer | first %}
+                    {% assign bundleComponent = "src/site/paragraphs/" | append: fieldAnswer.entity.entityBundle %}
+                    {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
+                    {% include {{ bundleComponentWithExtension }} with entity = fieldAnswer.entity %}
+                  </va-accordion-item>
+                {% endif %}
+              {% endfor %}
+            </va-accordion>
           </div>
         </div>
 

--- a/src/site/layouts/faq_multiple_q_a.drupal.liquid
+++ b/src/site/layouts/faq_multiple_q_a.drupal.liquid
@@ -59,10 +59,12 @@
                         header="{{ fieldQA.entity.title }}"
                         data-faq-entity-id="{{ fieldQA.entity.entityId }}"
                       >
-                        {% assign fieldAnswer = fieldQA.entity.fieldAnswer %}
-                        {% assign bundleComponent = "src/site/paragraphs/" | append: fieldAnswer.entity.entityBundle %}
-                        {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
-                        {% include {{ bundleComponentWithExtension }} with entity = fieldAnswer.entity %}
+                        <div id="{{ fieldQA.entity.entityBundle }}-{{ fieldQA.entity.entityId }}">
+                          {% assign fieldAnswer = fieldQA.entity.fieldAnswer %}
+                          {% assign bundleComponent = "src/site/paragraphs/" | append: fieldAnswer.entity.entityBundle %}
+                          {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
+                          {% include {{ bundleComponentWithExtension }} with entity = fieldAnswer.entity %}
+                        </div>
                       </va-accordion-item>
                     {% endif %}
                   {% endfor %}

--- a/src/site/layouts/faq_multiple_q_a.drupal.liquid
+++ b/src/site/layouts/faq_multiple_q_a.drupal.liquid
@@ -52,26 +52,21 @@
               {% endif %}
 
               {% if fieldQAGroup.entity.fieldAccordionDisplay %}
-                <div class="usa-accordion-bordered">
-                  <ul class="usa-unstyled-list">
-                    {% for fieldQA in fieldQAGroup.entity.fieldQAs %}
-                      {% if fieldQA.entity %}
-                        <li data-faq-entity-id="{{ fieldQA.entity.entityId }}">
-                          <button type="button" aria-controls="{{ fieldQA.entity.entityBundle }}-{{ fieldQA.entity.entityId }}"
-                            class="usa-accordion-button usa-button-unstyled"
-                            aria-expanded="false">{{ fieldQA.entity.title }}</button>
-                          <div id="{{ fieldQA.entity.entityBundle }}-{{ fieldQA.entity.entityId }}" class="usa-accordion-content"
-                            aria-hidden="true">
-                            {% assign fieldAnswer = fieldQA.entity.fieldAnswer %}
-                            {% assign bundleComponent = "src/site/paragraphs/" | append: fieldAnswer.entity.entityBundle %}
-                            {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
-                            {% include {{ bundleComponentWithExtension }} with entity = fieldAnswer.entity %}
-                          </div>
-                        </li>
-                      {% endif %}
-                    {% endfor %}
-                  </ul>
-                </div>
+                <va-accordion bordered>
+                  {% for fieldQA in fieldQAGroup.entity.fieldQAs %}
+                    {% if fieldQA.entity %}
+                      <va-accordion-item
+                        header="{{ fieldQA.entity.title }}"
+                        data-faq-entity-id="{{ fieldQA.entity.entityId }}"
+                      >
+                        {% assign fieldAnswer = fieldQA.entity.fieldAnswer %}
+                        {% assign bundleComponent = "src/site/paragraphs/" | append: fieldAnswer.entity.entityBundle %}
+                        {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
+                        {% include {{ bundleComponentWithExtension }} with entity = fieldAnswer.entity %}
+                      </va-accordion-item>
+                    {% endif %}
+                  {% endfor %}
+                </va-accordion>
               {% else %}
                   {% assign fieldSectionHeaderTag = 'h2' %}
                   {% if fieldQAGroup.entity.fieldSectionHeader %}

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -141,7 +141,9 @@
                     level="3"
                     data-label="{{ item.fieldTitle }}"
                   >
-                    {% include "src/site/paragraphs/wysiwyg.drupal.liquid" entity = item %}
+                    <div id="{{ item.entityBundle }}-{{ item.entityId }}">
+                      {% include "src/site/paragraphs/wysiwyg.drupal.liquid" entity = item %}
+                    </div>
                   </va-accordion-item>
                 {% endfor %}
               </va-accordion>
@@ -162,10 +164,10 @@
             <section class="local-health-services" id="local-health-services" data-label="Health services">
 
               {% assign localHealthServices = fieldLocalHealthCareService | sortObjectsBy: 'entity.fieldRegionalHealthService.entity.fieldServiceNameAndDescripti.entity.name' %}
-              {{ localHealthServices.length }}
               {% for localService in localHealthServices %}
                 {% assign localHealthService = localService.entity | featureFieldRegionalHealthService %}
                 {% if localHealthService != empty and localService.entity.status == true %}
+
                   {% include "src/site/facilities/facility_health_service.drupal.liquid" with
                       healthService = localHealthService
                       locationEntity = localService.entity

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -130,32 +130,21 @@
                   class="vads-u-margin-top--0 vads-u-font-size--lg small-screen:vads-u-font-size--xl vads-u-margin-bottom--2">
                 Prepare for your visit</h2>
               <p>Click on a topic for more details.</p>
-              <div class="usa-accordion-bordered">
-                <ul class="usa-unstyled-list">
-                  {% for accordionItem in fieldLocationServices %}
-                    {% assign item = accordionItem.entity %}
-                    <li class="vads-u-margin-bottom--1">
-                      <h3 class="vads-u-margin--0">
-                        {% comment %}
-                          See Google Analytics datalayer handling in src/applications/static-pages/subscribeAccordionEvents.js
-                        {% endcomment %}
-                        <button
-                            class="usa-accordion-button usa-button-unstyled vads-u-padding-y--2 vads-u-padding-left--2p5 vads-u-line-height--4"
-                            aria-expanded="false"
-                            aria-controls="{{ item.entityBundle }}-{{ item.entityId }}"
-                            data-label="{{ item.fieldTitle }}"
-                        >
-                          {{ item.fieldTitle }}
-                        </button>
-                      </h3>
-                      <div id="{{ item.entityBundle }}-{{ item.entityId }}"
-                           class="usa-accordion-content" aria-hidden="true">
-                        {% include "src/site/paragraphs/wysiwyg.drupal.liquid" entity = item %}
-                      </div>
-                    </li>
-                  {% endfor %}
-                </ul>
-              </div>
+              <va-accordion bordered>
+                {% for accordionItem in fieldLocationServices %}
+                  {% assign item = accordionItem.entity %}
+                  {% comment %}
+                    See Google Analytics datalayer handling in src/applications/static-pages/subscribeAccordionEvents.js
+                  {% endcomment %}
+                  <va-accordion-item
+                    header="{{ item.fieldTitle }}"
+                    level="3"
+                    data-label="{{ item.fieldTitle }}"
+                  >
+                    {% include "src/site/paragraphs/wysiwyg.drupal.liquid" entity = item %}
+                  </va-accordion-item>
+                {% endfor %}
+              </va-accordion>
             </section>
           {% endunless %}
 
@@ -173,10 +162,10 @@
             <section class="local-health-services" id="local-health-services" data-label="Health services">
 
               {% assign localHealthServices = fieldLocalHealthCareService | sortObjectsBy: 'entity.fieldRegionalHealthService.entity.fieldServiceNameAndDescripti.entity.name' %}
+              {{ localHealthServices.length }}
               {% for localService in localHealthServices %}
                 {% assign localHealthService = localService.entity | featureFieldRegionalHealthService %}
                 {% if localHealthService != empty and localService.entity.status == true %}
-
                   {% include "src/site/facilities/facility_health_service.drupal.liquid" with
                       healthService = localHealthService
                       locationEntity = localService.entity

--- a/src/site/layouts/tests/vamc/location_home.cypress.spec.js
+++ b/src/site/layouts/tests/vamc/location_home.cypress.spec.js
@@ -35,13 +35,15 @@ Cypress.Commands.add('checkElements', (page, isMobile) => {
     .should('exist');
   cy.get('h2').contains('Prepare for your visit');
   cy.get('#health_care_local_facility_servi-4202').should('not.be.visible');
-  cy.get('button')
+  cy.get('va-accordion-item')
+    .shadow()
     .contains('Parking')
     .click()
     .then(() => {
       cy.get('#health_care_local_facility_servi-4202').should('be.visible');
     });
-  cy.get('button')
+  cy.get('va-accordion-item')
+    .shadow()
     .contains('Parking')
     .click()
     .then(() => {

--- a/src/site/navigation/facility_no_drupal_page_sidebar_nav.drupal.liquid
+++ b/src/site/navigation/facility_no_drupal_page_sidebar_nav.drupal.liquid
@@ -19,95 +19,29 @@
     {% assign depth = deepLinksObj.depth %}
     {% assign deepLinks = deepLinksObj.link.links %}
 
-    {% if depth <= 2 %}
-      <ul class="usa-accordion">
-        {% for link in deepLinksObj.link.links %}
-          <li>
+    <div class="sidenav-previous-page">
+      <a href="{{ deepLinksObj.parent.url.path }}">{{ deepLinksObj.parent.label }}</a>
+    </div>
 
-            {% assign isRoot = entityUrl.path | isRootPage %}
-            {% assign expanded = false %}
-            {% assign activeItem = path | prepend: "/" %}
-
-            {% if forloop.first == true and isRoot == true and isInAbout == false %}
-              {% assign expanded = true %}
-            {% endif %}
-
-            <button class="usa-accordion-button"
-                    aria-expanded="{{ expanded }}"
-                    aria-controls="a{{ forloop.index }}">
-              {{ link.label }}
-            </button>
-            <div id="a{{ forloop.index }}" class="usa-accordion-content" aria-hidden="false">
-              {% assign listSize = link.links | size %}
-              {% if listSize > 0 %}
-                <ul class="usa-sidenav-list">
-                  {% for link in link.links %}
-                    <li {% if entityUrl.path contains link.url.path %} class="active-level" {% endif %}>
-                      <a {% if entityUrl.path contains link.url.path %} class="usa-current" {% endif %}
-                        href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
-                      {% assign subListSize = link.links | size %}
-                      {% if subListSize > 0 %}
-                        <ul class="usa-sidenav-sub_list">
-                          {% for link in link.links %}
-                            {% assign subSubListSize = link.links | size %}
-                            {% if subSubListSize > 0 %}
-                              <li {% if entityUrl.path contains link.url.path %} class="active-level" {% endif %}>
-                                <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
-                                  href="{{ link.url.path }}"
-                                  onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
-                                <ul class="usa-sidenav-sub_list">
-                                  {% for link in link.links %}
-                                    <li>
-                                      <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
-                                        href="{{ link.url.path }}"
-                                        onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
-                                    </li>
-                                  {% endfor %}
-                                </ul>
-                              </li>
-                            {% else %}
-                              <li>
-                                <a {% if entityUrl.path contains link.url.path %} class="usa-current" {% endif %}
-                                  href="{{ link.url.path }}"
-                                  onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
-                              </li>
-                            {% endif %}
-                          {% endfor %}
-                        </ul>
-                      {% endif %}
-                    </li>
-                  {% endfor %}
-                </ul>
-              {% endif %}
-            </div>
+    <ul class="usa-sidenav-list">
+      {% for link in deepLinks %}
+      <li {% if entityUrl.path == link.url.path %} class="active-level" {% endif %}>
+        <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
+          href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
+        {% if link.links.length %}
+          <ul class="usa-sidenav-sub_list">
+            {% for link in link.links %}
+              <li>
+                <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
+                  href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
+              </li>
+            {% endfor %}
+          </ul>
           </li>
-        {% endfor %}
-      </ul>
-    {% else %}
-      <div class="sidenav-previous-page">
-        <a href="{{ deepLinksObj.parent.url.path }}">{{ deepLinksObj.parent.label }}</a>
-      </div>
-
-      <ul class="usa-sidenav-list">
-        {% for link in deepLinks %}
-        <li {% if entityUrl.path == link.url.path %} class="active-level" {% endif %}>
-          <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
-            href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
-          {% if link.links.length %}
-            <ul class="usa-sidenav-sub_list">
-              {% for link in link.links %}
-                <li>
-                  <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
-                    href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
-                </li>
-              {% endfor %}
-            </ul>
-            </li>
-          {% else %}
-            </li>
-          {% endif %}
-        {% endfor %}
-      </ul>
-    {% endif %}
+        {% else %}
+          </li>
+        {% endif %}
+      {% endfor %}
+    </ul>
   </div>
 </nav>

--- a/src/site/paragraphs/collapsible_panel.drupal.liquid
+++ b/src/site/paragraphs/collapsible_panel.drupal.liquid
@@ -22,39 +22,38 @@
     }
   }
 {% endcomment %}
-{% assign accordionClass = 'usa-accordion' %}
-{% if entity.fieldCollapsiblePanelBordered %}
-    {% assign accordionClass = 'usa-accordion-bordered' %}
-{% endif %}
-<div data-template="paragraphs/collapsible_panel" data-entity-id="{{ entity.entityId }}" class="{{ accordionClass }}" data-multiselectable="{{ entity.fieldCollapsiblePanelMulti }}">
-    <ul class="usa-unstyled-list">
+<div
+    data-template="paragraphs/collapsible_panel"
+    data-entity-id="{{ entity.entityId }}"
+    data-multiselectable="{{ entity.fieldCollapsiblePanelMulti }}"
+>
+    <va-accordion>
         {% for accordionItem in entity.fieldVaParagraphs %}
             {% assign item = accordionItem.entity %}
-            {% assign id = item.entityId | formatSharableLinkID: item.fieldTitle %}
-            <li id={{id}}
-              data-template="paragraphs/collapsible_panel__panel"
-              data-entity-id="{{ item.entityId }}"
-              data-analytics-faq-text="{{ item.fieldTitle | escape }}">
-                <button
-                        class="usa-accordion-button usa-button-unstyled"
-                        aria-expanded="{{ entity.fieldCollapsiblePanelExpand }}"
-                        aria-controls="{{ item.entityBundle }}-{{ item.entityId }}"
-                        >
-                    {{ item.fieldTitle }}
-                    
-                </button>
-                
-                <div id="{{ item.entityBundle }}-{{ item.entityId }}" class="usa-accordion-content" aria-hidden="{{ !entity.fieldCollapsiblePanelExpand }}">
-                    {% include "src/site/paragraphs/wysiwyg.drupal.liquid" entity = item %}
+            {% assign id= item.entityId | formatSharableLinkID: item.fieldQuestion   %}
+            <va-accordion-item header="{{ item.fieldTitle }}">
+                <div
+                    id={{id}}
+                    data-template="paragraphs/collapsible_panel__panel"
+                    data-entity-id="{{ item.entityId }}"
+                    data-analytics-faq-text="{{ item.fieldTitle | escape }}"
+                >
+                    <div id="{{ item.entityBundle }}-{{ item.entityId }}">
+                        {% include "src/site/paragraphs/wysiwyg.drupal.liquid" entity = item %}
 
-                    {% for paragraph in item.fieldVaParagraphs %}
-                        {%  assign bundleComponent = "src/site/paragraphs/" | append: paragraph.entity.entityBundle | append: ".drupal.liquid" %}
-                        {% include {{ bundleComponent }} with entity = paragraph.entity %}
-                    {%  endfor %}
+                        {% for paragraph in item.fieldVaParagraphs %}
+                            {%  assign bundleComponent = "src/site/paragraphs/" | append: paragraph.entity.entityBundle | append: ".drupal.liquid" %}
+                            {% include {{ bundleComponent }} with entity = paragraph.entity %}
+                        {%  endfor %}
 
-                    <div data-widget-type="sharable-link" parentId="{{id}}" sharableText="{{item.fieldTitle}}"></div>                
+                        <div
+                            data-widget-type="sharable-link"
+                            parentId="{{id}}"
+                            sharableText="{{item.fieldTitle}}"
+                        ></div>
+                    </div>
                 </div>
-            </li>
+            </va-accordion-item>
         {% endfor %}
-    </ul>
+    </va-accordion>
 </div>

--- a/src/site/paragraphs/collapsible_panel.drupal.liquid
+++ b/src/site/paragraphs/collapsible_panel.drupal.liquid
@@ -27,7 +27,11 @@
     data-entity-id="{{ entity.entityId }}"
     data-multiselectable="{{ entity.fieldCollapsiblePanelMulti }}"
 >
-    <va-accordion>
+    <va-accordion
+        {% if entity.fieldCollapsiblePanelBordered %}
+            bordered
+        {% endif %}
+    >
         {% for accordionItem in entity.fieldVaParagraphs %}
             {% assign item = accordionItem.entity %}
             {% assign id= item.entityId | formatSharableLinkID: item.fieldQuestion   %}

--- a/src/site/paragraphs/q_a.collapsible_panel.drupal.liquid
+++ b/src/site/paragraphs/q_a.collapsible_panel.drupal.liquid
@@ -1,36 +1,35 @@
 <div data-template="paragraphs/q_a.collapsible_panel">
-  <div class="usa-accordion">
-    <ul class="usa-unstyled-list">
-      {% assign questions = entity.fieldQuestions %}
-      {% assign sectionHeader = entity.fieldSectionHeader %}
+  <va-accordion>
+    {% assign questions = entity.fieldQuestions %}
+    {% assign sectionHeader = entity.fieldSectionHeader %}
 
-      {% for accordionItem in questions %}
+    {% for accordionItem in questions %}
         {% assign item = accordionItem.entity %}
         {% assign id= item.entityId | formatSharableLinkID: item.fieldQuestion   %}
-        <li id={{id}}
-            data-template="paragraphs/q_a.collapsible_panel__qa"
-            data-entity-id="{{ item.entityId }}"
-            data-analytics-faq-section="{{ sectionHeader | escape }}"
-            data-analytics-faq-text="{{ item.fieldQuestion | escape }}">
-          <div itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
-            <button class="usa-accordion-button usa-button-unstyled" aria-controls="{{ item.entityBundle }}-{{ item.entityId }}">
-              <span itemprop="name">{{ item.fieldQuestion }}</span>
-
-            </button>
-            <div id="{{ item.entityBundle }}-{{ item.entityId }}" class="usa-accordion-content">
-              <div itemprop="acceptedAnswer" itemscope="" itemtype="http://schema.org/Answer">
-                {% for answer in item.fieldAnswer %}
-                  {%  assign bundleComponent = "src/site/paragraphs/" | append: answer.entity.entityBundle | append: ".drupal.liquid" %}
-                  {% include {{ bundleComponent }} with entity = answer.entity %}
-                {% endfor %}
-              </div>
-
-              <div data-widget-type="sharable-link" parentId="{{id}}" sharableText="{{item.fieldQuestion}}" ></div>
+      <va-accordion-item header="{{ item.fieldQuestion }}">
+        <div
+          id={{id}}
+          data-template="paragraphs/q_a.collapsible_panel__qa"
+          data-entity-id="{{ item.entityId }}"
+          data-analytics-faq-section="{{ sectionHeader | escape }}"
+          data-analytics-faq-text="{{ item.fieldQuestion | escape }}"
+        >
+          <div id="{{ item.entityBundle }}-{{ item.entityId }}">
+            <div itemprop="acceptedAnswer" itemscope="" itemtype="http://schema.org/Answer">
+              {% for answer in item.fieldAnswer %}
+                {%  assign bundleComponent = "src/site/paragraphs/" | append: answer.entity.entityBundle | append: ".drupal.liquid" %}
+                {% include {{ bundleComponent }} with entity = answer.entity %}
+              {% endfor %}
             </div>
-          </div>
 
-        </li>
-      {% endfor %}
-    </ul>
-  </div>
+            <div
+              data-widget-type="sharable-link"
+              parentId="{{id}}"
+              sharableText="{{item.fieldQuestion}}"
+            ></div>
+          </div>
+        </div>
+      </va-accordion-item>
+    {% endfor %}
+  </va-accordion>
 </div>


### PR DESCRIPTION
## Description
Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/27200

## Testing done


## Screenshots
`src/site/layouts/faq_multiple_q_a.drupal.liquid`
<img width="722" alt="Screen Shot 2021-07-19 at 10 45 17 AM" src="https://user-images.githubusercontent.com/3144003/126179039-b36b23b8-c972-47bc-9f2e-473c051a9613.png">

`src/site/layouts/faq_multiple_q_a.drupal.liquid`
<img width="724" alt="Screen Shot 2021-07-19 at 10 46 16 AM" src="https://user-images.githubusercontent.com/3144003/126179188-ac9adfcb-26d2-4f1f-9db6-47985e44cd9b.png">

`src/site/layouts/campaign_landing_page.drupal.liquid`
<img width="698" alt="Screen Shot 2021-07-19 at 10 47 44 AM" src="https://user-images.githubusercontent.com/3144003/126179385-4365948e-d98e-40b4-8b48-d664a6f2c8d2.png">

`src/site/paragraphs/q_a.collapsible_panel.drupal.liquid`
<img width="731" alt="Screen Shot 2021-07-19 at 10 49 33 AM" src="https://user-images.githubusercontent.com/3144003/126179674-3b76df6d-acef-4e7b-8341-868c7897760b.png">

`src/site/paragraphs/collapsible_panel.drupal.liquid`
<img width="726" alt="Screen Shot 2021-07-19 at 10 50 23 AM" src="https://user-images.githubusercontent.com/3144003/126179830-2d61f854-a258-43f4-9c14-c22b3111aaa7.png">

`src/site/facilities/health_service.drupal.liquid`
<img width="725" alt="Screen Shot 2021-07-19 at 10 55 00 AM" src="https://user-images.githubusercontent.com/3144003/126180618-9aa6b885-b53c-49bd-ae67-71efae8f3514.png">


`src/site/facilities/facility_health_service.drupal.liquid`
<img width="735" alt="Screen Shot 2021-07-19 at 10 53 14 AM" src="https://user-images.githubusercontent.com/3144003/126180365-8823ee72-5f05-42df-84b2-0976324f8d7b.png">

## Acceptance criteria
- [x] src/site/layouts/faq_multiple_q_a.drupal.liquid updated to use `<va-accordion>` web component.
- [x] src/site/layouts/health_care_local_facility.drupal.liquid updated to use `<va-accordion>` web component.
- [x] src/site/navigation/facility_no_drupal_page_sidebar_nav.drupal.liquid updated to use `<va-accordion>` web component.
- [x] src/site/layouts/campaign_landing_page.drupal.liquid updated to use `<va-accordion>` web component.
- [x] src/site/stages/build/plugins/modify-dom/add-id-to-subheadings.js updated to use `<va-accordion>` web component.
- [x] src/site/paragraphs/q_a.collapsible_panel.drupal.liquid updated to use `<va-accordion>` web component.
- [x] src/site/paragraphs/collapsible_panel.drupal.liquid updated to use `<va-accordion>` web component.
- [x] src/site/facilities/health_service.drupal.liquid updated to use `<va-accordion>` web component.
- [x] src/site/facilities/facility_health_service.drupal.liquid updated to use `<va-accordion>` web component.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
