### PR TITLE
[DO NOT MERGE, POC] Update naming of homepage banner to emergency banner

### DIFF
--- a/package.json
+++ b/package.json
@@ -215,7 +215,6 @@
     "express": "^4.17.1",
     "express-http-proxy": "^1.6.0",
     "git-diff": "^2.0.6",
-    "js-yaml": "^3.14.0",
     "jsesc": "^3.0.2",
     "jsonschema": "^1.1.1",
     "lodash": "^4.17.21",
@@ -241,7 +240,6 @@
   },
   "resolutions": {
     "**/lodash": "4.17.21",
-    "**/js-yaml": "^3.13.1",
     "**/jpeg-js": "^0.4.0",
     "**/dot-prop": "^5.1.1",
     "**/handlebars": "^4.7.7",

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -120,10 +120,13 @@
 
   {% include "src/site/components/fullwidth_banner_alerts.drupal.liquid" %}
 
-  <div data-widget-type="banners" data-homepage-banner-content="{{ homepage_banner.content | escape }}"
-    data-homepage-banner-title="{{ homepage_banner.title | escape }}"
-    data-homepage-banner-type="{{ homepage_banner.type }}" data-homepage-banner-visible="{{ homepage_banner.visible }}">
-  </div>
+  <div
+    data-emergency-banner-content="{{ emergency_banner.content | escape }}"
+    data-emergency-banner-title="{{ emergency_banner.title | escape }}"
+    data-emergency-banner-type="{{ emergency_banner.type }}"
+    data-emergency-banner-visible="{{ emergency_banner.visible }}"
+    data-widget-type="banners"
+  ></div>
 
   <script nonce="**CSP_NONCE**" type="text/javascript">
     (function () {

--- a/src/site/stages/build/drupal/home.js
+++ b/src/site/stages/build/drupal/home.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-param-reassign, no-continue */
 const fs = require('fs-extra');
 const path = require('path');
-const yaml = require('js-yaml');
 const { createEntityUrlObj, createFileObj } = require('./page');
 
 // Processes the data received from the home page query.
@@ -35,9 +34,9 @@ function addHomeContent(contentData, files, metalsmith, buildOptions) {
     );
 
     const fragmentsRoot = metalsmith.path(buildOptions.contentFragments);
-    const bannerLocation = path.join(fragmentsRoot, 'home/banner.yml');
+    const bannerLocation = path.join(fragmentsRoot, 'home/banner.json');
     const bannerFile = fs.readFileSync(bannerLocation);
-    const banner = yaml.safeLoad(bannerFile);
+    const banner = JSON.parse(bannerFile);
 
     homeEntityObj = {
       ...homeEntityObj,
@@ -49,7 +48,7 @@ function addHomeContent(contentData, files, metalsmith, buildOptions) {
       hubs, // Full hub list.
       promos: homePagePromoBlockQuery.itemsOfEntitySubqueueHomePagePromos, // Promo blocks.
       // eslint-disable-next-line camelcase
-      homepage_banner: banner,
+      emergency_banner: banner,
     };
 
     // Let Metalsmith know we're here.


### PR DESCRIPTION
# Description

**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/27701

This PR makes it so that the homepage/emergency banner content is fetched whenever someone lands on https://www.va.gov, making it update on refresh as opposed to the current implementation which requires a content-build deployment.

This does not actually work at the moment due to CORS protections for public github user content. The current proposal is to move the banner config to AWS S3 so that we can fetch it without CORS issues.

**Related PRs:**
https://github.com/department-of-veterans-affairs/vagov-content/pull/784
https://github.com/department-of-veterans-affairs/vets-website/pull/17968
https://github.com/department-of-veterans-affairs/content-build/pull/389