### PR TITLE
Add noindex metatag when it is a paginated path

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -949,4 +949,15 @@ module.exports = function registerFilters() {
 
     return formattedTitle;
   };
+
+  liquid.filters.isPaginatedPath = path => {
+    // Split the paths into sections.
+    const pathSections = path?.split('/')?.filter(section => !!section);
+
+    // Derive the last section.
+    const lastSection = pathSections?.[pathSections?.length - 1];
+
+    // If the last path section is a number greater than 2, return true.
+    return parseInt(lastSection, 10) >= 2;
+  };
 };

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -1163,3 +1163,20 @@ describe('formatTitleTag', () => {
     expect(liquid.filters.formatTitleTag(title)).to.equal(expected);
   });
 });
+
+describe('isPaginatedPath', () => {
+  it('identifies a paginated path', () => {
+    const path = '/resources/tag/all-veterans/2/';
+    expect(liquid.filters.isPaginatedPath(path)).to.equal(true);
+  });
+
+  it('identifies a non-paginated path', () => {
+    const path = '/';
+    expect(liquid.filters.isPaginatedPath(path)).to.equal(false);
+  });
+
+  it('does not break when the path is undefined', () => {
+    const path = undefined;
+    expect(liquid.filters.isPaginatedPath(path)).to.equal(false);
+  });
+});

--- a/src/site/layouts/support_resources_article_listing.drupal.liquid
+++ b/src/site/layouts/support_resources_article_listing.drupal.liquid
@@ -1,13 +1,13 @@
 {% include "src/site/includes/header.html" with drupalTags = true %}
-
-<!-- Ensure paginated paths are no indexed, e.g. https://www.va.gov/resources/tag/all-veterans/2/ -->
-{% if path | isPaginatedPath %}
-  <meta name="robots" content="noindex">
-{% endif %}
-
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+
+<!-- Ensure paginated paths are no indexed, e.g. https://www.va.gov/resources/tag/all-veterans/2/ -->
+{% assign addNoIndexMetaTag = path | isPaginatedPath %}
+{% if addNoIndexMetaTag %}
+  <meta name="robots" content="noindex">
+{% endif %}
 
 <div id="content" class="interior">
   <main class="va-l-detail-page">

--- a/src/site/layouts/support_resources_article_listing.drupal.liquid
+++ b/src/site/layouts/support_resources_article_listing.drupal.liquid
@@ -1,5 +1,10 @@
 {% include "src/site/includes/header.html" with drupalTags = true %}
 
+<!-- Ensure paginated paths are no indexed, e.g. https://www.va.gov/resources/tag/all-veterans/2/ -->
+{% if path | isPaginatedPath %}
+  <meta name="robots" content="noindex">
+{% endif %}
+
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" %}

--- a/src/site/layouts/support_resources_article_listing.drupal.liquid
+++ b/src/site/layouts/support_resources_article_listing.drupal.liquid
@@ -3,7 +3,7 @@
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" %}
 
-<!-- Ensure paginated paths are no indexed, e.g. https://www.va.gov/resources/tag/all-veterans/2/ -->
+<!-- Ensure paginated paths are not indexed, e.g. https://www.va.gov/resources/tag/all-veterans/2/ -->
 {% assign addNoIndexMetaTag = path | isPaginatedPath %}
 {% if addNoIndexMetaTag %}
   <meta name="robots" content="noindex">


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/27793

This PR adds a no index metatag for the following paginated pages:

https://www.va.gov/resources/other-topics-and-questions/2/
https://www.va.gov/resources/other-topics-and-questions/3/
https://www.va.gov/resources/va-account-and-profile/2/
https://www.va.gov/resources/education-and-training/2/
https://www.va.gov/resources/tag/all-veterans/2/
https://www.va.gov/resources/tag/all-veterans/3/
https://www.va.gov/resources/tag/all-veterans/4/
https://www.va.gov/resources/tag/all-veterans/5/
https://www.va.gov/resources/tag/all-veterans/6/
https://www.va.gov/resources/tag/payments-and-debt/2/

## Testing done

Added unit test.

## Screenshots
N/A

## Acceptance criteria
- [x] Add no index metatag on paginated pages.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
