### PR TITLE
Wrap footer in role=contentinfo section for consistent landmarks

### DIFF
--- a/src/site/includes/footer.html
+++ b/src/site/includes/footer.html
@@ -1,7 +1,9 @@
-<div id="announcement-root"></div>
-<footer class="footer" role="contentinfo">
-  <div id="footerNav"></div> <!-- let's try this React thing -->
-</footer>
+<section role="contentinfo">
+  <div id="announcement-root"></div>
+  <footer class="footer">
+    <div id="footerNav"></div> <!-- let's try this React thing -->
+  </footer>
+</section>
 
 <!--
 “To care for him who shall have borne the battle and for his widow, and his orphan.”

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -120,9 +120,14 @@
 
   {% include "src/site/components/fullwidth_banner_alerts.drupal.liquid" %}
 
-  <div data-widget-type="banners" data-homepage-banner-content="{{ homepage_banner.content | escape }}"
+  <div
+    data-widget-type="banners"
+    data-homepage-banner-content="{{ homepage_banner.content | escape }}"
     data-homepage-banner-title="{{ homepage_banner.title | escape }}"
-    data-homepage-banner-type="{{ homepage_banner.type }}" data-homepage-banner-visible="{{ homepage_banner.visible }}">
+    data-homepage-banner-type="{{ homepage_banner.type }}"
+    data-homepage-banner-visible="{{ homepage_banner.visible }}"
+    role="region"
+  >
   </div>
 
   <script nonce="**CSP_NONCE**" type="text/javascript">

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -127,6 +127,7 @@
     data-homepage-banner-type="{{ homepage_banner.type }}"
     data-homepage-banner-visible="{{ homepage_banner.visible }}"
     role="region"
+    aria-label="{{ homepage_banner.title | escape }}"
   >
   </div>
 


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/7425

Footer announcements under `#announcement-root` exist outside of a landmark, so this moves both the `footer` and `#announcement-root` under a `section` with `role="contentinfo"` This is inside of a `section` because a `footer` automatically gets `role="contentinfo"` unless it is contained within a small subset of tags with `section` being the most appropriate of this subset. see https://www.w3.org/TR/wai-aria-practices/examples/landmarks/HTML5.html

## Testing done
local testing with http://matatk.agrip.org.uk/landmarks/

## Screenshots
<img width="1791" alt="Screen Shot 2021-07-23 at 3 00 31 PM" src="https://user-images.githubusercontent.com/3144003/126829160-72c904d3-92b8-48d2-ae60-948cbf24c3d5.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
