### PR TITLE
Add type to pdf file download links

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -176,7 +176,13 @@ module.exports = function registerFilters() {
   liquid.filters.removeUnderscores = data =>
     data && data.length ? data.replace('_', ' ') : data;
 
-  liquid.filters.fileSize = data => `${(data / 1000000).toFixed(2)}MB`;
+  liquid.filters.fileSize = data => {
+    if (data < 10000) {
+      return `${(data / 1000).toFixed(2)}KB`;
+    }
+
+    return `${(data / 1000000).toFixed(2)}MB`;
+  };
 
   liquid.filters.fileExt = data => {
     if (!data) return null;
@@ -185,6 +191,18 @@ module.exports = function registerFilters() {
       .split('.')
       .slice(-1)
       .pop();
+  };
+
+  liquid.filters.fileDisplayName = data => {
+    if (!data) return null;
+
+    const match = data.toString().match(/[^/]+$/);
+
+    if (match && match.length) {
+      return data.toString().match(/[^/]+$/)[0] || data.toString();
+    }
+
+    return data.toString();
   };
 
   liquid.filters.breakIntoSingles = data => {

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -566,6 +566,16 @@ describe('hashReference', () => {
   });
 });
 
+describe('fileSize', () => {
+  it('returns file size in MB when over 10,000 bytes in size', () => {
+    expect(liquid.filters.fileSize(48151)).to.eq('0.05MB');
+  });
+
+  it('returns file size in KB when under 10,000 bytes in size', () => {
+    expect(liquid.filters.fileSize(2342)).to.eq('2.34KB');
+  });
+});
+
 describe('fileExt', () => {
   it('returns the following string - testing', () => {
     expect(liquid.filters.fileExt('testing')).to.eq('testing');
@@ -601,6 +611,48 @@ describe('fileExt', () => {
 
   it('returns an empty string when an empty array is passed', () => {
     expect(liquid.filters.fileExt([])).to.eq('');
+  });
+});
+
+describe('fileDisplayName', () => {
+  it('returns the name of a file when provided only a name', () => {
+    expect(liquid.filters.fileDisplayName('file.txt')).to.eq('file.txt');
+  });
+
+  it('returns the name of a file when provided a filepath of depth 1', () => {
+    expect(liquid.filters.fileDisplayName('files/file.txt')).to.eq('file.txt');
+  });
+
+  it('returns name of a file when provided a filepath of depth > 1', () => {
+    expect(liquid.filters.fileDisplayName('file/texts/file.txt')).to.eq(
+      'file.txt',
+    );
+  });
+
+  it('returns name of a file with multiple extenstions', () => {
+    expect(liquid.filters.fileDisplayName('file.test.txt')).to.eq(
+      'file.test.txt',
+    );
+  });
+
+  it('returns name of a file when in an array', () => {
+    expect(liquid.filters.fileDisplayName(['file.txt'])).to.eq('file.txt');
+  });
+
+  it('returns null when null is passed', () => {
+    expect(liquid.filters.fileDisplayName(null)).to.eq(null);
+  });
+
+  it('returns null when undefined is passed', () => {
+    expect(liquid.filters.fileDisplayName(undefined)).to.eq(null);
+  });
+
+  it('returns null when empty string is passed', () => {
+    expect(liquid.filters.fileDisplayName('')).to.eq(null);
+  });
+
+  it('returns an empty string when an empty array is passed', () => {
+    expect(liquid.filters.fileDisplayName([])).to.eq('');
   });
 });
 

--- a/src/site/layouts/publication_listing.drupal.liquid
+++ b/src/site/layouts/publication_listing.drupal.liquid
@@ -210,16 +210,23 @@
                   large-screen:vads-u-margin-bottom--3">
                       {% if entity.fieldMedia.entity.entityBundle == 'document' %}
                       {% assign url = entity.fieldMedia.entity.fieldDocument.entity.url %}
+                      {% assign extension = url | fileExt %}
                       {% if entity.derivedFields.absoluteUrl %}
                       {% assign url = entity.derivedFields.absoluteUrl %}
                       {% endif %}
-                      <a aria-label="Download {{url | fileExt | upcase}} {{entity.title}}"
-                        class="file-download-with-icon" target="_blank"
-                        href="{{url}}" download="{{url}}"><i
+                      <a
+                        aria-label="Download {{extension | upcase}} {{entity.title}}"
+                        class="file-download-with-icon"
+                        target="_blank"
+                        href="{{url}}"
+                        download="{{url | fileDisplayName}}"
+                        {% if extension == 'pdf' %}
+                          type="application/{{ extension }}"
+                        {% endif %}
+                      ><i
                           class="fas fa-download vads-u-padding-right--1"></i>Download
-                        {{url | fileExt | upcase}}
-                        ({{entity.fieldMedia.entity.fieldDocument.entity.filesize | fileSize}})
-                      </a>
+                        {{extension | upcase}}
+                        ({{entity.fieldMedia.entity.fieldDocument.entity.filesize | fileSize}})</a>
                       {% endif %}
 
                       {% if entity.fieldMedia.entity.entityBundle == 'video' %}

--- a/src/site/layouts/tests/publication_listing/fixtures/docxFileData.json
+++ b/src/site/layouts/tests/publication_listing/fixtures/docxFileData.json
@@ -1,0 +1,23 @@
+{
+  "entityId": 43,
+  "outreachAssetsDataArray": {
+    "entities": [
+      {
+        "fieldListing": {
+          "targetId": 43
+        },
+        "fieldMedia": {
+          "entity": {
+            "entityBundle": "document",
+            "fieldDocument": {
+              "entity": {
+                "url": "files/word.docx",
+                "filesize": 162342
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/src/site/layouts/tests/publication_listing/fixtures/pdfFileData.json
+++ b/src/site/layouts/tests/publication_listing/fixtures/pdfFileData.json
@@ -1,0 +1,24 @@
+{
+  "entityId": 42,
+  "outreachAssetsDataArray": {
+    "entities": [
+      {
+        "title": "Dharma Initiative Annual Report - 1974",
+        "fieldListing": {
+          "targetId": 42
+        },
+        "fieldMedia": {
+          "entity": {
+            "entityBundle": "document",
+            "fieldDocument": {
+              "entity": {
+                "url": "files/file.pdf",
+                "filesize": 481516
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/src/site/layouts/tests/publication_listing/publication_listing.drupal.unit.spec.js
+++ b/src/site/layouts/tests/publication_listing/publication_listing.drupal.unit.spec.js
@@ -1,0 +1,48 @@
+import { expect } from 'chai';
+import { parseFixture, renderHTML } from '~/site/tests/support';
+import axeCheck from '~/site/tests/support/axe';
+
+const layoutPath = 'src/site/layouts/publication_listing.drupal.liquid';
+
+describe('Vet Center Main Page', () => {
+  let container;
+  const pdfFiledata = parseFixture(
+    'src/site/layouts/tests/publication_listing/fixtures/pdfFileData.json',
+  );
+  const docxFiledata = parseFixture(
+    'src/site/layouts/tests/publication_listing/fixtures/docxFileData.json',
+  );
+
+  it('reports no axe violations', async () => {
+    container = await renderHTML(layoutPath, pdfFiledata);
+
+    const violations = await axeCheck(container);
+    expect(violations.length).to.equal(0);
+  });
+
+  it('add type attribute "application/pdf" to pdf files', async () => {
+    container = await renderHTML(layoutPath, pdfFiledata);
+
+    const downloadLink = container.querySelector('.file-download-with-icon');
+
+    expect(downloadLink.getAttribute('type')).to.equal('application/pdf');
+    expect(downloadLink.getAttribute('download')).to.equal('file.pdf');
+    expect(downloadLink.getAttribute('aria-label')).to.equal(
+      'Download PDF Dharma Initiative Annual Report - 1974',
+    );
+    expect(downloadLink.text.replace(/\s+/g, ' ')).to.equal(
+      'Download PDF (0.48MB)',
+    );
+  });
+
+  it('add does not include type attribute for non-pdf files', async () => {
+    container = await renderHTML(layoutPath, docxFiledata);
+
+    const downloadLink = container.querySelector('.file-download-with-icon');
+
+    expect(downloadLink.getAttribute('type')).to.equal(null);
+    expect(downloadLink.text.replace(/\s+/g, ' ')).to.equal(
+      'Download DOCX (0.16MB)',
+    );
+  });
+});

--- a/src/site/paragraphs/downloadable_file.drupal.liquid
+++ b/src/site/paragraphs/downloadable_file.drupal.liquid
@@ -34,10 +34,18 @@
 
     {% if entity.fieldMedia.entity.entityBundle == 'document' %}
         {% assign url = entity.fieldMedia.entity.fieldDocument.entity.url %}
-        <a class="file-download-with-icon" target="_blank"
-           href="{{url}}" download="{{url}}">
+        {% assign extenstion = url | fileExt %}
+        <a
+            class="file-download-with-icon"
+            target="_blank"
+            href="{{url}}"
+            download="{{url | fileDisplayName}}"
+            {% if extension == 'pdf' %}
+                type="application/{{extension}}"
+            {% endif %}
+        >
             <i class="fas fa-download vads-u-margin--0p5" aria-label="Download"></i>
-            {{entity.fieldTitle}} ({{url | fileExt | upcase}})
+            {{entity.fieldTitle}} ({{extension | upcase}})
         </a>
     {% endif %}
 


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/14614

I added the `fileDisplayName` filter to change generated file names from things like `files/documents/file.txt` to just `file.txt`. Additionally, I noticed that the fileSize filter would display 0.00MB for files that were smaller than 10,000B so I changed the logic to use KB for files < 10,000KB.

## Testing done
local and mocha testing of template output

## Screenshots
<img width="1470" alt="Screen Shot 2021-07-26 at 1 37 17 PM" src="https://user-images.githubusercontent.com/3144003/127034252-87ad163c-d43d-4081-9731-2be96bcc6f8e.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
