### PR TITLE
Github Actions (CI) -- add more flags to build

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -86,7 +86,7 @@ jobs:
         run: echo "DRUPAL_ADDRESS=${{ matrix.drupal-address }}" >> $GITHUB_ENV
 
       - name: Build
-        run: yarn build --buildtype=${{ matrix.buildtype }} --asset-source=local --drupal-address=${{ env.DRUPAL_ADDRESS }} --pull-drupal --drupal-max-parallel-requests=15 ${{ matrix.no-drpual-proxy }}
+        run: yarn build --buildtype=${{ matrix.buildtype }} --drupal-address=${{ env.DRUPAL_ADDRESS }} --drupal-max-parallel-requests=15 ${{ matrix.no-drpual-proxy }}
         env:
           NODE_ENV: production
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -30,7 +30,6 @@ jobs:
       # Sandbox Drupal address is used on branches other than master.
       DRUPAL_ADDRESS: https://cms-vets-website-branch-builds-lo9uhqj18nwixunsjadvjsynuni7kk1u.ci.cms.va.gov
       NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
-      NO-DRUPAL-PROXY: --no-drupal-proxy
 
     strategy:
       fail-fast: true
@@ -39,13 +38,10 @@ jobs:
         include:
           - buildtype: vagovdev
             drupal-address: https://cms-vets-website-branch-builds-lo9uhqj18nwixunsjadvjsynuni7kk1u.ci.cms.va.gov
-            no-drupal-proxy: --no-drupal-proxy
           - buildtype: vagovstaging
             drupal-address: https://cms-vets-website-branch-builds-lo9uhqj18nwixunsjadvjsynuni7kk1u.ci.cms.va.gov
-            no-drupal-proxy: --no-drupal-proxy
           - buildtype: vagovprod
             drupal-address: http://internal-dsva-vagov-prod-cms-2000800896.us-gov-west-1.elb.amazonaws.com
-            no-drupal-proxy: ''
 
     steps:
       - name: Checkout vagov-content
@@ -84,12 +80,10 @@ jobs:
 
       - name: Set Drupal address & proxy
         if: ${{ github.ref == 'refs/heads/master' }}
-        run: |
-          echo "DRUPAL_ADDRESS=${{ matrix.drupal-address }}" >> $GITHUB_ENV
-          echo "NO-DRUPAL-PROXY=${{ matrix.no-drupal-proxy }}" >> $GITHUB_ENV
+        run: echo "DRUPAL_ADDRESS=${{ matrix.drupal-address }}" >> $GITHUB_ENV
 
       - name: Build
-        run: yarn build --buildtype=${{ matrix.buildtype }} --asset-source=local --drupal-address=${{ env.DRUPAL_ADDRESS }} --pull-drupal --drupal-max-parallel-requests=15 ${{ env.NO-DRUPAL-PROXY }}
+        run: yarn build --buildtype=${{ matrix.buildtype }} --asset-source=local --drupal-address=${{ env.DRUPAL_ADDRESS }} --pull-drupal --drupal-max-parallel-requests=15 --no-drupal-proxy
         env:
           NODE_ENV: production
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -86,7 +86,7 @@ jobs:
         run: echo "DRUPAL_ADDRESS=${{ matrix.drupal-address }}" >> $GITHUB_ENV
 
       - name: Build
-        run: yarn build --buildtype=${{ matrix.buildtype }} --drupal-address=${{ env.DRUPAL_ADDRESS }} --drupal-max-parallel-requests=15 ${{ matrix.no-drpual-proxy }}
+        run: yarn build --buildtype=${{ matrix.buildtype }} --asset-source=local --drupal-address=${{ env.DRUPAL_ADDRESS }} --pull-drupal --drupal-max-parallel-requests=15 ${{ matrix.no-drupal-proxy }}
         env:
           NODE_ENV: production
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -86,7 +86,7 @@ jobs:
         run: echo "DRUPAL_ADDRESS=${{ matrix.drupal-address }}" >> $GITHUB_ENV
 
       - name: Build
-        run: yarn build --buildtype=${{ matrix.buildtype }} --asset-source=local --drupal-address=${{ env.DRUPAL_ADDRESS }} --pull-drupal --drupal-max-parallel-requests=15 ${{ matrix.no-drupal-proxy }}
+        run: yarn build --buildtype=${{ matrix.buildtype }} --asset-source=local --drupal-address=${{ env.DRUPAL_ADDRESS }} --drupal-max-parallel-requests=15 ${{ matrix.no-drupal-proxy }}
         env:
           NODE_ENV: production
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -30,6 +30,7 @@ jobs:
       # Sandbox Drupal address is used on branches other than master.
       DRUPAL_ADDRESS: https://cms-vets-website-branch-builds-lo9uhqj18nwixunsjadvjsynuni7kk1u.ci.cms.va.gov
       NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
+      NO-DRUPAL-PROXY: --no-drupal-proxy
 
     strategy:
       fail-fast: true
@@ -83,10 +84,12 @@ jobs:
 
       - name: Set Drupal address
         if: ${{ github.ref == 'refs/heads/master' }}
-        run: echo "DRUPAL_ADDRESS=${{ matrix.drupal-address }}" >> $GITHUB_ENV
+        run: |
+          echo "DRUPAL_ADDRESS=${{ matrix.drupal-address }}" >> $GITHUB_ENV
+          echo "NO-DRUPAL-PROXY=${{ matrix.no-drupal-proxy }}" >> $GITHUB_ENV
 
       - name: Build
-        run: yarn build --buildtype=${{ matrix.buildtype }} --asset-source=local --drupal-address=${{ env.DRUPAL_ADDRESS }} --drupal-max-parallel-requests=15 ${{ matrix.no-drupal-proxy }}
+        run: yarn build --buildtype=${{ matrix.buildtype }} --asset-source=local --drupal-address=${{ env.DRUPAL_ADDRESS }} --pull-drupal --drupal-max-parallel-requests=15 ${{ env.NO-DRUPAL-PROXY }}
         env:
           NODE_ENV: production
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -82,8 +82,8 @@ jobs:
         env:
           YARN_CACHE_FOLDER: ~/.cache/yarn
 
-      - name: Set Drupal address
-        if: ${{ github.ref == 'refs/heads/master' }}
+      - name: Set Drupal address & proxy
+        if: ${{ github.ref == 'refs/heads/fix/github-actions/ci' }}
         run: |
           echo "DRUPAL_ADDRESS=${{ matrix.drupal-address }}" >> $GITHUB_ENV
           echo "NO-DRUPAL-PROXY=${{ matrix.no-drupal-proxy }}" >> $GITHUB_ENV

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -78,7 +78,7 @@ jobs:
         env:
           YARN_CACHE_FOLDER: ~/.cache/yarn
 
-      - name: Set Drupal address & proxy
+      - name: Set Drupal address
         if: ${{ github.ref == 'refs/heads/master' }}
         run: echo "DRUPAL_ADDRESS=${{ matrix.drupal-address }}" >> $GITHUB_ENV
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -83,7 +83,7 @@ jobs:
           YARN_CACHE_FOLDER: ~/.cache/yarn
 
       - name: Set Drupal address & proxy
-        if: ${{ github.ref == 'refs/heads/fix/github-actions/ci' }}
+        if: ${{ github.ref == 'refs/heads/master' }}
         run: |
           echo "DRUPAL_ADDRESS=${{ matrix.drupal-address }}" >> $GITHUB_ENV
           echo "NO-DRUPAL-PROXY=${{ matrix.no-drupal-proxy }}" >> $GITHUB_ENV

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -38,10 +38,10 @@ jobs:
         buildtype: [vagovdev, vagovstaging, vagovprod]
         include:
           - buildtype: vagovdev
-            drupal-address: http://internal-dsva-vagov-dev-cms-812329399.us-gov-west-1.elb.amazonaws.com
+            drupal-address: https://cms-vets-website-branch-builds-lo9uhqj18nwixunsjadvjsynuni7kk1u.ci.cms.va.gov
             no-drupal-proxy: --no-drupal-proxy
           - buildtype: vagovstaging
-            drupal-address: http://internal-dsva-vagov-staging-cms-1188006.us-gov-west-1.elb.amazonaws.com
+            drupal-address: https://cms-vets-website-branch-builds-lo9uhqj18nwixunsjadvjsynuni7kk1u.ci.cms.va.gov
             no-drupal-proxy: --no-drupal-proxy
           - buildtype: vagovprod
             drupal-address: http://internal-dsva-vagov-prod-cms-2000800896.us-gov-west-1.elb.amazonaws.com

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -38,10 +38,13 @@ jobs:
         include:
           - buildtype: vagovdev
             drupal-address: http://internal-dsva-vagov-dev-cms-812329399.us-gov-west-1.elb.amazonaws.com
+            no-drupal-proxy: --no-drupal-proxy
           - buildtype: vagovstaging
             drupal-address: http://internal-dsva-vagov-staging-cms-1188006.us-gov-west-1.elb.amazonaws.com
+            no-drupal-proxy: --no-drupal-proxy
           - buildtype: vagovprod
             drupal-address: http://internal-dsva-vagov-prod-cms-2000800896.us-gov-west-1.elb.amazonaws.com
+            no-drupal-proxy: ''
 
     steps:
       - name: Checkout vagov-content
@@ -83,7 +86,7 @@ jobs:
         run: echo "DRUPAL_ADDRESS=${{ matrix.drupal-address }}" >> $GITHUB_ENV
 
       - name: Build
-        run: yarn build --buildtype=${{ matrix.buildtype }} --drupal-address=${{ env.DRUPAL_ADDRESS }} --no-drupal-proxy
+        run: yarn build --buildtype=${{ matrix.buildtype }} --asset-source=local --drupal-address=${{ env.DRUPAL_ADDRESS }} --pull-drupal --drupal-max-parallel-requests=15 ${{ matrix.no-drpual-proxy }}
         env:
           NODE_ENV: production
 


### PR DESCRIPTION
## Description

Overtime the CI portion kept failing due to `503 Unavailable` in master when it is passing in Jenkins. This PR changes drupal address to align closely and not fail in master branch.

Additionally added flags to align as close as possible to Jenkins

## Testing done

[run](https://github.com/department-of-veterans-affairs/content-build/runs/3174216490?check_suite_focus=true) -- cancelled purposefully to not publish info