### PR TITLE
Removed fallback image that was violating CSP

### DIFF
--- a/src/site/layouts/publication_listing.drupal.liquid
+++ b/src/site/layouts/publication_listing.drupal.liquid
@@ -167,12 +167,10 @@
                     {% if entity.fieldMedia.entity.entityBundle == 'image' %}
                     {% if entity.fieldMedia.entity.image.url %}
                     <img src="{{entity.fieldMedia.entity.image.url}}"
-                      alt="{{entity.fieldMedia.entity.image.alt}}"
-                      onerror="this.onerror=null;this.src='https://via.placeholder.com/318x212';" />
+                      alt="{{entity.fieldMedia.entity.image.alt}}" />
                     {% elsif entity.derivedFields.absoluteUrl %}
                     <img alt="{{entity.fieldMedia.entity.image.alt}}"
-                      src="{{entity.derivedFields.absoluteUrl}}"
-                      onerror="this.onerror=null;this.src='https://via.placeholder.com/318x212';" />
+                      src="{{entity.derivedFields.absoluteUrl}}" />
                     {% endif %}
                     {% endif %}
 


### PR DESCRIPTION
## Description
Reported Error: 
> [Report Only] Refused to load the image 'https://via.placeholder.com/318x212' because it violates the following Content Security Policy directive: "img-src 'self' data: blob: https://*.gstatic.com https://api.mapbox.com https://www.google-analytics.com https://www.googletagmanager.com https://stats.g.doubleclick.net https://*.va.gov https://optimize.google.com https://gateway.foresee.com https://static.foresee.com https://cdn-prod.kampyle.com https://prod-va-gov-assets.s3-us-gov-west-1.amazonaws.com https://s3-us-gov-west-1.amazonaws.com https://ok6static.oktacdn.com https://dvp-oauth-application-directory-logos.s3-us-gov-west-1.amazonaws.com".

Issue: http://sentry.vfs.va.gov/organizations/vsp/issues/583/?project=4&query=logger%3Acsp+is%3Aunresolved+is%3Aunassigned&sort=freq&statsPeriod=14d

Offending URL: https://www.va.gov/outreach-and-events/outreach-materials/