### PR TITLE
Add link and aria-label to tty 711 service

### DIFF
--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -95,13 +95,23 @@
                   {% assign service = supportService.entity %}
                   <li>
                     {% if service.fieldPhoneNumber %}
-                    <a href="{{ service.fieldLink.url.path }}"
-                      onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Ask questions' });">
-                      <span>{{ service.title }}</span><br>
-                      <span>{{ service.fieldPhoneNumber }}</span>
-                    </a>
+                      <a href="{{ service.fieldLink.url.path }}"
+                        onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Ask questions' });">
+                        <span>{{ service.title }}</span><br>
+                        <span>{{ service.fieldPhoneNumber }}</span>
+                      </a>
+                    <!-- It was requested that we hardcode in the aria-label and href for the TTY service -->
+                    <!-- see: https://github.com/department-of-veterans-affairs/va.gov-team/issues/18151#issuecomment-879993959 -->
+                    {% elsif service.title contains "TTY: 711" %}
+                      <a
+                        href="tel:+1711"
+                        aria-label="TTY: 7 1 1."
+                        onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Ask questions' });"
+                      >
+                        <span>{{ service.title }}</span><br>
+                      </a>
                     {% else %}
-                    {{ service.title }}
+                      {{ service.title }}
                     {% endif %}
                   </li>
                   {% endfor %}

--- a/src/site/layouts/tests/landing_page/fixtures/landing_page.json
+++ b/src/site/layouts/tests/landing_page/fixtures/landing_page.json
@@ -22,5 +22,28 @@
     ],
     "path": "/records"
   },
-  "fieldIntroText": "Access your VA records and documents online to more easily manage your benefits."
+  "fieldIntroText": "Access your VA records and documents online to more easily manage your benefits.",
+  "fieldSupportServices": [
+    {
+      "entity": {
+        "title": "Jenny",
+        "fieldPhoneNumber": "312-867-5309",
+        "fieldLink": {
+          "url": {
+            "path": "tel+13128675309"
+          }
+        }
+      }
+    },
+    {
+      "entity": {
+        "title": "TTY: 711"
+      }
+    },
+    {
+      "entity": {
+        "title": "Missing link"
+      }
+    }
+  ]
 }

--- a/src/site/layouts/tests/landing_page/landing_page.unit.spec.js
+++ b/src/site/layouts/tests/landing_page/landing_page.unit.spec.js
@@ -81,4 +81,57 @@ describe('intro', () => {
       expect(ogUrl).to.equal('https://dev.va.gov/records/');
     });
   });
+
+  describe('fieldSupportServices links', () => {
+    let container;
+    const data = parseFixture(
+      'src/site/layouts/tests/landing_page/fixtures/landing_page.json',
+    );
+
+    it('creates a link for a properly formatted fieldSupportService', async () => {
+      container = await renderHTML(layoutPath, {
+        ...data,
+        fieldSupportServices: data.fieldSupportServices.slice(0, 1),
+      });
+
+      const supportLink = container.querySelector(
+        '.va-nav-linkslist-list a[href="tel+13128675309"]',
+      );
+
+      expect(supportLink.text.trim().replace(/\W{2,}/g, ' ')).to.equal(
+        'Jenny 312-867-5309',
+      );
+    });
+
+    it('creates a link for a TTY 711 fieldSupportService', async () => {
+      container = await renderHTML(layoutPath, {
+        ...data,
+        fieldSupportServices: data.fieldSupportServices.slice(1, 2),
+      });
+
+      const supportLink = container.querySelector(
+        '.va-nav-linkslist-list a[href="tel:+1711"]',
+      );
+
+      expect(supportLink.text.trim().replace(/\W{2,}/g, ' ')).to.equal(
+        'TTY 711',
+      );
+      expect(supportLink.getAttribute('aria-label')).to.equal('TTY: 7 1 1.');
+    });
+
+    it('creates a link for a fieldSupportService with a url or filedPhoneNumber', async () => {
+      container = await renderHTML(layoutPath, {
+        ...data,
+        fieldSupportServices: data.fieldSupportServices.slice(2),
+      });
+
+      const supportLink = container.querySelectorAll(
+        '.va-nav-linkslist-list li',
+      )[1];
+
+      expect(supportLink.innerHTML.trim().replace(/\W{2,}/g, ' ')).to.equal(
+        'Missing link',
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/18151

## Testing done
local browser and unit testing

## Screenshots
<img width="1470" alt="Screen Shot 2021-07-29 at 3 10 59 PM" src="https://user-images.githubusercontent.com/3144003/127551875-495016bc-5431-40ac-8b39-543a75824275.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
