### PR TITLE
remove sharableLink usage from accordions

### DIFF
--- a/src/site/paragraphs/collapsible_panel.drupal.liquid
+++ b/src/site/paragraphs/collapsible_panel.drupal.liquid
@@ -50,11 +50,6 @@
                             {% include {{ bundleComponent }} with entity = paragraph.entity %}
                         {%  endfor %}
 
-                        <div
-                            data-widget-type="sharable-link"
-                            parentId="{{id}}"
-                            sharableText="{{item.fieldTitle}}"
-                        ></div>
                     </div>
                 </div>
             </va-accordion-item>

--- a/src/site/paragraphs/q_a.collapsible_panel.drupal.liquid
+++ b/src/site/paragraphs/q_a.collapsible_panel.drupal.liquid
@@ -22,11 +22,6 @@
               {% endfor %}
             </div>
 
-            <div
-              data-widget-type="sharable-link"
-              parentId="{{id}}"
-              sharableText="{{item.fieldQuestion}}"
-            ></div>
           </div>
         </div>
       </va-accordion-item>


### PR DESCRIPTION
## Description
Removes two implementations of the SharableLink react widget component specifically when they are used in the expandable content of the `va-accordion` web component.

The reason for needing to remove these is noted in this ticket comment: [#26744](https://github.com/department-of-veterans-affairs/va.gov-team/issues/26744#issuecomment-889268802)

Removing these results only one instance of SharableLink via [q_a.drupal.liquid](https://github.com/department-of-veterans-affairs/content-build/blob/master/src/site/paragraphs/q_a.drupal.liquid#L31) and this instance works correctly because it is not nested within a web component.

Further work will be done at a later time to refactor this component to work appropriately since it is currently shown on only a single page in an experimental fashion. [coronavirus-veteran-frequently-asked-questions](https://www.va.gov/coronavirus-veteran-frequently-asked-questions/)


## Testing done
Tested on local content build. Verified removal.

## Screenshots

![Screen Shot 2021-07-29 at 9 54 29 PM](https://user-images.githubusercontent.com/8332986/127597852-e6f4872e-6706-493f-a98c-2863fa28b64a.png)


## Acceptance criteria
- [ ] The SharableLink component is not seen within accordions on the coronavirus-veteran-frequently-asked-questions page.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
