### PR TITLE
Remove trailing commas in function params

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,7 +4,7 @@
   "useTabs": false,
   "semi": true,
   "singleQuote": true,
-  "trailingComma": "all",
+  "trailingComma": "es5",
   "bracketSpacing": true,
   "jsxBracketSameLine": false,
   "proseWrap": "preserve",

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,7 +4,7 @@
   "useTabs": false,
   "semi": true,
   "singleQuote": true,
-  "trailingComma": "es5",
+  "trailingComma": "all",
   "bracketSpacing": true,
   "jsxBracketSameLine": false,
   "proseWrap": "preserve",
@@ -13,6 +13,12 @@
       "files": "*.scss",
       "options": {
         "singleQuote": false
+      }
+    },
+    {
+      "files": "**/site/assets/js/**/*.js",
+      "options": {
+        "trailingComma": "es5"
       }
     }
   ]

--- a/src/site/assets/js/execute-axe-check.js
+++ b/src/site/assets/js/execute-axe-check.js
@@ -99,6 +99,6 @@ function processAxeCheckResults(error, results) {
         'color-contrast': { enabled: false },
       },
     },
-    processAxeCheckResults,
+    processAxeCheckResults
   );
 })();

--- a/src/site/assets/js/medallia/vagovprod.js
+++ b/src/site/assets/js/medallia/vagovprod.js
@@ -1,7 +1,7 @@
 // Medallia Embed Script
 (function(g) {
   var isStaging = window.location.host.includes('staging');
-  if (!isStaging) return
+  if (!isStaging) return;
 
   var teamSitePathnames = [
     // `/ORMDI` redirects to include a trailing slash (`/ORMDI/`)
@@ -22,8 +22,8 @@
     /\/adr\/$/i,
   ];
   var pathname = window.location.pathname;
-  var isApprovedPathname = teamSitePathnames.some(x => x.test(pathname))
-  if (!isApprovedPathname) return
+  var isApprovedPathname = teamSitePathnames.some(x => x.test(pathname));
+  if (!isApprovedPathname) return;
 
   var d = document,
     am = d.createElement('script'),

--- a/src/site/assets/js/static-page-widgets.js
+++ b/src/site/assets/js/static-page-widgets.js
@@ -9,13 +9,13 @@ function mountWidgets(widgets, slowLoadingThreshold) {
     if (timeout > slowLoadingThreshold) {
       setTimeout(function() {
         var replacedWithWidget = !widget.querySelector(
-          '.static-widget-content',
+          '.static-widget-content'
         );
         var slowMessage = widget.querySelector(
-          '.loading-indicator-message--slow',
+          '.loading-indicator-message--slow'
         );
         var regularMessage = widget.querySelector(
-          '.loading-indicator-message--normal',
+          '.loading-indicator-message--normal'
         );
 
         if (!replacedWithWidget && regularMessage) {
@@ -33,11 +33,11 @@ function mountWidgets(widgets, slowLoadingThreshold) {
     if (timeout > 0) {
       setTimeout(function() {
         var replacedWithWidget = !widget.querySelector(
-          '.static-widget-content',
+          '.static-widget-content'
         );
         var errorMessage = widget.querySelector('.sip-application-error');
         var loadingMessage = widget.querySelector(
-          '.loading-indicator-container',
+          '.loading-indicator-container'
         );
 
         if (!replacedWithWidget && loadingMessage) {

--- a/src/site/components/navigation-sidebar-trigger.html
+++ b/src/site/components/navigation-sidebar-trigger.html
@@ -24,10 +24,10 @@ used in a template with navigation-sidebar.html
   var mobileMediaQuery = window.matchMedia('(max-width: 767px)')
   var navTrigger = document.getElementsByClassName('va-btn-sidebarnav-trigger')[0]
   var buttonWrapper = document.querySelector(
-    '.va-btn-sidebarnav-trigger .button-wrapper',
+    '.va-btn-sidebarnav-trigger .button-wrapper'
   )
   var buttonBackground = document.querySelector(
-    '.va-btn-sidebarnav-trigger .button-background',
+    '.va-btn-sidebarnav-trigger .button-background'
   )
   var navTriggerPlaceholder = document.querySelector('.trigger-placeholder')
   var navTriggerPosition
@@ -96,7 +96,7 @@ used in a template with navigation-sidebar.html
       // browser widths
       pinTrigger()
     },
-    false,
+    false
   )
 
   window.addEventListener(
@@ -110,6 +110,6 @@ used in a template with navigation-sidebar.html
       // viewport
       pinTrigger()
     },
-    false,
+    false
   )
 </script>


### PR DESCRIPTION
## Description
Found while working on issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/25103
It appears that we have syntax errors in IE11 that stop JavaScript rom running due to trailing commas in function parameters: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas#browser_compatibility
<img width="223" alt="Screen Shot 2021-08-02 at 9 57 16 AM" src="https://user-images.githubusercontent.com/3144003/127873327-5ad632b3-784e-41fc-b401-ac04c9c24421.png">
<img width="217" alt="Screen Shot 2021-08-02 at 9 57 05 AM" src="https://user-images.githubusercontent.com/3144003/127873328-e5808845-77f8-48be-8758-e35156940310.png">
I'll have to either modify the build to strip these out or remove them manually. This could be a lot of work

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
