### PR TITLE
Add hostUrl prefix to og:image custom metatags

### DIFF
--- a/src/site/includes/metatags.drupal.liquid
+++ b/src/site/includes/metatags.drupal.liquid
@@ -52,7 +52,11 @@
           <meta name="{{ tag.key }}" content="{{ tag.value }}">
         {% endif %}
       {% when "MetaProperty" %}
-        <meta property="{{ tag.key }}" content="{{ tag.value }}">
+        {% if tag.key == "og:image" %}
+          <meta property="og:image" content="{{ hostUrl }}{{ tag.value }}">
+        {% else %}
+          <meta property="{{ tag.key }}" content="{{ tag.value }}">
+        {% endif %}
       {% when "MetaLink" %}
         <link rel="{{ tag.key }}" href="{{ tag.value }}">
     {% endcase %}


### PR DESCRIPTION
# Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/28223

This PR adds `hostUrl` prefix to `og:image` custom metatags.

## Screenshots

![image](https://user-images.githubusercontent.com/12773166/128038259-2ab76a78-1110-4f37-b6ee-4ec1d55f3ca9.png)

## Acceptance Criteria

- [x] Add `hostUrl` prefix to `og:image` custom metatags.
