### PR TITLE
Github Actions (CI) -- revert retry on build and use network concurrency instead

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -74,11 +74,7 @@ jobs:
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
-        uses: nick-invision/retry@v2
-        with:
-          command: yarn install --frozen-lockfile --prefer-offline
-          max_attempts: 3
-          timeout_minutes: 5
+        run: yarn install --frozen-lockfile --prefer-offline
         env:
           YARN_CACHE_FOLDER: ~/.cache/yarn
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -208,14 +208,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ~/.cache/yarn
+            .cache/yarn
             node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline
         env:
-          YARN_CACHE_FOLDER: ~/.cache/yarn
+          YARN_CACHE_FOLDER: .cache/yarn
 
       - name: Create test results folder
         run: mkdir -p test-results
@@ -262,14 +262,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ~/.cache/yarn
+            .cache/yarn
             node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline
         env:
-          YARN_CACHE_FOLDER: ~/.cache/yarn
+          YARN_CACHE_FOLDER: .cache/yarn
 
       - name: Annotate ESLint results
         run: yarn run eslint --ext .js --ext .jsx  --format ./script/github-actions/eslint-annotation-format.js .
@@ -314,14 +314,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ~/.cache/yarn
+            .cache/yarn
             node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline
         env:
-          YARN_CACHE_FOLDER: ~/.cache/yarn
+          YARN_CACHE_FOLDER: .cache/yarn
 
       - name: Fetch Drupal cache
         run: yarn fetch-drupal-cache
@@ -363,14 +363,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ~/.cache/yarn
+            .cache/yarn
             node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline
         env:
-          YARN_CACHE_FOLDER: ~/.cache/yarn
+          YARN_CACHE_FOLDER: .cache/yarn
 
       - name: Start server
         run: node src/platform/testing/e2e/test-server.js --buildtype vagovprod --port=3002 &
@@ -433,14 +433,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ~/.cache/yarn
+            .cache/yarn
             node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline
         env:
-          YARN_CACHE_FOLDER: ~/.cache/yarn
+          YARN_CACHE_FOLDER: .cache/yarn
 
       - name: Start server
         run: node src/platform/testing/e2e/test-server.js --buildtype vagovprod --port=3002 &

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -73,12 +73,17 @@ jobs:
             node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
+      # - name: Install dependencies
+      #   uses: nick-invision/retry@v2
+      #   with:
+      #     command: yarn install --frozen-lockfile --prefer-offline --verbose
+      #     max_attempts: 3
+      #     timeout_minutes: 5
+      #   env:
+      #     YARN_CACHE_FOLDER: ~/.cache/yarn
+
       - name: Install dependencies
-        uses: nick-invision/retry@v2
-        with:
-          command: yarn install --frozen-lockfile --prefer-offline --verbose
-          max_attempts: 3
-          timeout_minutes: 5
+        run: yarn install --frozen-lockfile --prefer-offline --verbose
         env:
           YARN_CACHE_FOLDER: ~/.cache/yarn
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -69,7 +69,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            .cache/yarn
+            ~/.cache/yarn
             node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
@@ -80,7 +80,7 @@ jobs:
           max_attempts: 3
           timeout_minutes: 5
         env:
-          YARN_CACHE_FOLDER: .cache/yarn
+          YARN_CACHE_FOLDER: ~/.cache/yarn
 
       # - name: Install dependencies
       #   run: yarn install --frozen-lockfile --prefer-offline --verbose
@@ -208,14 +208,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            .cache/yarn
+            ~/.cache/yarn
             node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline
         env:
-          YARN_CACHE_FOLDER: .cache/yarn
+          YARN_CACHE_FOLDER: ~/.cache/yarn
 
       - name: Create test results folder
         run: mkdir -p test-results
@@ -262,14 +262,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            .cache/yarn
+            ~/.cache/yarn
             node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline
         env:
-          YARN_CACHE_FOLDER: .cache/yarn
+          YARN_CACHE_FOLDER: ~/.cache/yarn
 
       - name: Annotate ESLint results
         run: yarn run eslint --ext .js --ext .jsx  --format ./script/github-actions/eslint-annotation-format.js .
@@ -314,14 +314,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            .cache/yarn
+            ~/.cache/yarn
             node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline
         env:
-          YARN_CACHE_FOLDER: .cache/yarn
+          YARN_CACHE_FOLDER: ~/.cache/yarn
 
       - name: Fetch Drupal cache
         run: yarn fetch-drupal-cache
@@ -363,14 +363,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            .cache/yarn
+            ~/.cache/yarn
             node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline
         env:
-          YARN_CACHE_FOLDER: .cache/yarn
+          YARN_CACHE_FOLDER: ~/.cache/yarn
 
       - name: Start server
         run: node src/platform/testing/e2e/test-server.js --buildtype vagovprod --port=3002 &
@@ -433,14 +433,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            .cache/yarn
+            ~/.cache/yarn
             node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline
         env:
-          YARN_CACHE_FOLDER: .cache/yarn
+          YARN_CACHE_FOLDER: ~/.cache/yarn
 
       - name: Start server
         run: node src/platform/testing/e2e/test-server.js --buildtype vagovprod --port=3002 &

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -69,23 +69,23 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ~/.cache/yarn
+            .cache/yarn
             node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
+      - name: Install dependencies
+        uses: nick-invision/retry@v2
+        with:
+          command: yarn install --frozen-lockfile --prefer-offline --verbose
+          max_attempts: 3
+          timeout_minutes: 5
+        env:
+          YARN_CACHE_FOLDER: .cache/yarn
+
       # - name: Install dependencies
-      #   uses: nick-invision/retry@v2
-      #   with:
-      #     command: yarn install --frozen-lockfile --prefer-offline --verbose
-      #     max_attempts: 3
-      #     timeout_minutes: 5
+      #   run: yarn install --frozen-lockfile --prefer-offline --verbose
       #   env:
       #     YARN_CACHE_FOLDER: ~/.cache/yarn
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile --prefer-offline --verbose
-        env:
-          YARN_CACHE_FOLDER: ~/.cache/yarn
 
       - name: Set Drupal address
         if: ${{ github.ref == 'refs/heads/master' }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -74,7 +74,11 @@ jobs:
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile --prefer-offline
+        uses: nick-invision/retry@v2
+        with:
+          command: yarn install --frozen-lockfile --prefer-offline --verbose
+          max_attempts: 3
+          timeout_minutes: 5
         env:
           YARN_CACHE_FOLDER: ~/.cache/yarn
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -74,18 +74,9 @@ jobs:
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
-        uses: nick-invision/retry@v2
-        with:
-          command: yarn install --frozen-lockfile --prefer-offline --verbose
-          max_attempts: 3
-          timeout_minutes: 5
+        run: yarn install --frozen-lockfile --prefer-offline --network-concurrency 1
         env:
           YARN_CACHE_FOLDER: ~/.cache/yarn
-
-      # - name: Install dependencies
-      #   run: yarn install --frozen-lockfile --prefer-offline --verbose
-      #   env:
-      #     YARN_CACHE_FOLDER: ~/.cache/yarn
 
       - name: Set Drupal address
         if: ${{ github.ref == 'refs/heads/master' }}


### PR DESCRIPTION
## Description

Reverting #417 as it was causing the build to fail. Upon investigating, it seemed that it was not detecting the cache folder, thus causing the flakiness.

This PR reverts and adds `network-concurrency 1` to still address flaky install fails

## Testing done

[run](https://github.com/department-of-veterans-affairs/content-build/runs/3235807371?check_suite_focus=true) -- will most likely fail at vagovprod
