### PR TITLE
Create separate mega menus for desktop and mobile

### DIFF
--- a/src/site/includes/top-nav.html
+++ b/src/site/includes/top-nav.html
@@ -31,19 +31,19 @@
     </div>
     {% if !noNavOrLogin %}
       <div id="va-nav-controls"></div>
-      {% if !noMegamenu %}
-        <div class="usa-grid usa-grid-full">
+      {% unless noMegamenu %}
+        <div class="medium-screen:vads-u-display--none usa-grid usa-grid-full">
           <div class="menu-rule usa-one-whole"></div>
           <div class="mega-menu" id="mega-menu-mobile"></div>
         </div>
-      {% endif %}
+      {% endunless %}
       <div id="login-root" class="vet-toolbar"></div>
     {% endif %}
   </div>
-  {% if !noMegamenu %}
+  {% unless noMegamenu %}
     <div class="usa-grid usa-grid-full">
       <div class="menu-rule usa-one-whole"></div>
       <div class="mega-menu" id="mega-menu"></div>
     </div>
-  {% endif %}
+  {% endunless %}
 </header>

--- a/src/site/includes/top-nav.html
+++ b/src/site/includes/top-nav.html
@@ -31,14 +31,19 @@
     </div>
     {% if !noNavOrLogin %}
       <div id="va-nav-controls"></div>
+      {% if !noMegamenu %}
+        <div class="usa-grid usa-grid-full">
+          <div class="menu-rule usa-one-whole"></div>
+          <div class="mega-menu" id="mega-menu-mobile"></div>
+        </div>
+      {% endif %}
       <div id="login-root" class="vet-toolbar"></div>
     {% endif %}
   </div>
   {% if !noMegamenu %}
     <div class="usa-grid usa-grid-full">
-      <div id="menu-rule" class="usa-one-whole"></div>
-      <div id="mega-menu"></div>
-      <!-- for the mega-menu, but if you add the ID the css breaks rn -->
+      <div class="menu-rule usa-one-whole"></div>
+      <div class="mega-menu" id="mega-menu"></div>
     </div>
   {% endif %}
 </header>


### PR DESCRIPTION
## Description
department-of-veterans-affairs/va.gov-team#25659
Creates a mega menu for desktop and one for mobile to allow proper tab ordering
This change is in conjunction with changes to
vets-website: https://github.com/department-of-veterans-affairs/vets-website/pull/18116
veteran-facing-services-tools: https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/655

## Testing done
local

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
