### PR TITLE
Fixed issue with broken stories link

### DIFF
--- a/src/site/layouts/news_story.drupal.liquid
+++ b/src/site/layouts/news_story.drupal.liquid
@@ -40,7 +40,9 @@
                             {{ fieldFullStory.processed }}
                         </div>
                     </div>
-                    <a onClick="recordEvent({ event: 'nav-secondary-button-click' });" class="vads-u-display--block vads-u-margin-bottom--7" href="{{ fieldListing.entity.entityUrl.path }}">See all stories</a>
+                    {% if fieldListing.entity.entityUrl.path %}
+                        <a onClick="recordEvent({ event: 'nav-secondary-button-click' });" class="vads-u-display--block vads-u-margin-bottom--7" href="{{ fieldListing.entity.entityUrl.path }}">See all stories</a>
+                    {% endif %}
                 </article>
             </div>
         </div>

--- a/src/site/layouts/news_story.drupal.liquid
+++ b/src/site/layouts/news_story.drupal.liquid
@@ -41,7 +41,7 @@
                         </div>
                     </div>
                     {% if fieldListing.entity.entityUrl.path %}
-                        <a onClick="recordEvent({ event: 'nav-secondary-button-click' });" class="vads-u-display--block vads-u-margin-bottom--7" href="{{ fieldListing.entity.entityUrl.path }}">See all stories</a>
+                        <a onClick="recordEvent({ event: 'nav-secondary-button-click' });" class="vads-u-display--block vads-u-margin-bottom--7" href="{{ fieldListing.entity.entityUrl.path }}" id="news-stories-listing-link">See all stories</a>
                     {% endif %}
                 </article>
             </div>

--- a/src/site/layouts/tests/news_story_page/fixtures/news-story-data.json
+++ b/src/site/layouts/tests/news_story_page/fixtures/news-story-data.json
@@ -1,0 +1,52 @@
+{
+  "entityBundle": "news_story",
+  "entityId": "17638",
+  "entityPublished": false,
+  "fieldImageCaption": null,
+  "fieldIntroText": "Dr. Margaret Peak, the Gulf Coast Veterans Health Care System (GCVHCS) chief of Audiology, received the 2021 Joint Defense Veterans Audiology Conference (JDVAC) Lt. Frank B. Walkup IV Distinguished Service Award March 3.",
+  "pid": 17638,
+  "promote": false,
+  "title": "Audiologist Recognized at National Convention",
+  "vid": 500852,
+  "entityUrl": {
+    "breadcrumb": [
+      {
+        "text": "Home",
+        "url": {
+          "path": "/",
+          "routed": true
+        }
+      },
+      {
+        "text": "VA Gulf Coast health care",
+        "url": {
+          "path": "/gulf-coast-health-care",
+          "routed": true
+        }
+      },
+      {
+        "text": "Stories ",
+        "url": {
+          "path": "/gulf-coast-health-care/stories",
+          "routed": true
+        }
+      },
+      {
+        "text": "Audiologist Recognized at National Convention",
+        "url": {
+          "path": "/gulf-coast-health-care/stories/audiologist-recognized-at-national-convention",
+          "routed": true
+        }
+      }
+    ],
+    "path": "/gulf-coast-health-care/stories/audiologist-recognized-at-national-convention"
+  },
+  "fieldListing": {
+    "entity": {
+      "entityUrl": {
+        "path": "/gulf-coast-health-care/stories"
+      }
+    }
+  }
+}
+

--- a/src/site/layouts/tests/news_story_page/fixtures/news-story-data.json
+++ b/src/site/layouts/tests/news_story_page/fixtures/news-story-data.json
@@ -1,52 +1,295 @@
 {
-  "entityBundle": "news_story",
-  "entityId": "17638",
-  "entityPublished": false,
-  "fieldImageCaption": null,
-  "fieldIntroText": "Dr. Margaret Peak, the Gulf Coast Veterans Health Care System (GCVHCS) chief of Audiology, received the 2021 Joint Defense Veterans Audiology Conference (JDVAC) Lt. Frank B. Walkup IV Distinguished Service Award March 3.",
-  "pid": 17638,
-  "promote": false,
-  "title": "Audiologist Recognized at National Convention",
-  "vid": 500852,
-  "entityUrl": {
-    "breadcrumb": [
+  "entityBundle":"news_story",
+  "entityId":"17638",
+  "entityPublished":true,
+  "title":"Audiologist Recognized at National Convention",
+  "vid":480990,
+  "entityUrl":{
+    "breadcrumb":[
       {
-        "text": "Home",
-        "url": {
-          "path": "/",
-          "routed": true
-        }
+        "url":{
+          "path":"/",
+          "routed":true
+        },
+        "text":"Home"
       },
       {
-        "text": "VA Gulf Coast health care",
-        "url": {
-          "path": "/gulf-coast-health-care",
-          "routed": true
-        }
+        "url":{
+          "path":"/gulf-coast-health-care",
+          "routed":true
+        },
+        "text":"VA Gulf Coast health care"
       },
       {
-        "text": "Stories ",
-        "url": {
-          "path": "/gulf-coast-health-care/stories",
-          "routed": true
-        }
+        "url":{
+          "path":"/gulf-coast-health-care/stories",
+          "routed":true
+        },
+        "text":"Stories "
       },
       {
-        "text": "Audiologist Recognized at National Convention",
-        "url": {
-          "path": "/gulf-coast-health-care/stories/audiologist-recognized-at-national-convention",
-          "routed": true
-        }
+        "url":{
+          "path":"/gulf-coast-health-care/stories/audiologist-recognized-at-national-convention",
+          "routed":true
+        },
+        "text":"Audiologist Recognized at National Convention"
       }
     ],
-    "path": "/gulf-coast-health-care/stories/audiologist-recognized-at-national-convention"
+      "path":"/gulf-coast-health-care/stories/audiologist-recognized-at-national-convention"
   },
-  "fieldListing": {
-    "entity": {
-      "entityUrl": {
-        "path": "/gulf-coast-health-care/stories"
+  "entityMetatags":[
+    {
+      "__typename":"MetaValue",
+      "key":"description",
+      "value":"Dr. Margaret Peak, the Gulf Coast Veterans Health Care System (GCVHCS) chief of Audiology, received the 2021 Joint Defense Veterans Audiology Conference (JDVAC) Lt. Frank B. Walkup IV Distinguished Service Award March 3."
+    },
+    {
+      "__typename":"MetaLink",
+      "key":"image_src",
+      "value":"https://prod.cms.va.gov/sites/default/files/2021-03/Gulf_Coast_Audiology_Story.jpg"
+    },
+    {
+      "__typename":"MetaProperty",
+      "key":"og:description",
+      "value":"Dr. Margaret Peak, the Gulf Coast Veterans Health Care System (GCVHCS) chief of Audiology, received the 2021 Joint Defense Veterans Audiology Conference (JDVAC) Lt. Frank B. Walkup IV Distinguished Service Award March 3."
+    },
+    {
+      "__typename":"MetaProperty",
+      "key":"og:image:alt",
+      "value":"Doctor Margaret Peak, Chief of Audiology."
+    },
+    {
+      "__typename":"MetaProperty",
+      "key":"og:site_name",
+      "value":"Veterans Affairs"
+    },
+    {
+      "__typename":"MetaProperty",
+      "key":"og:title",
+      "value":"Audiologist Recognized at National Convention | VA Gulf Coast health care | Veterans Affairs"
+    },
+    {
+      "__typename":"MetaValue",
+      "key":"title",
+      "value":"Audiologist Recognized at National Convention | VA Gulf Coast health care | Veterans Affairs"
+    },
+    {
+      "__typename":"MetaValue",
+      "key":"twitter:card",
+      "value":"summary_large_image"
+    },
+    {
+      "__typename":"MetaValue",
+      "key":"twitter:description",
+      "value":"Dr. Margaret Peak, the Gulf Coast Veterans Health Care System (GCVHCS) chief of Audiology, received the 2021 Joint Defense Veterans Audiology Conference (JDVAC) Lt. Frank B. Walkup IV Distinguished Service Award March 3."
+    },
+    {
+      "__typename":"MetaValue",
+      "key":"twitter:image",
+      "value":"https://prod.cms.va.gov/sites/default/files/2021-03/Gulf_Coast_Audiology_Story.jpg"
+    },
+    {
+      "__typename":"MetaValue",
+      "key":"twitter:image:alt",
+      "value":"Doctor Margaret Peak, Chief of Audiology."
+    },
+    {
+      "__typename":"MetaValue",
+      "key":"twitter:site",
+      "value":"@DeptVetAffairs"
+    },
+    {
+      "__typename":"MetaValue",
+      "key":"twitter:title",
+      "value":"Audiologist Recognized at National Convention | VA Gulf Coast health care | Veterans Affairs"
+    }
+  ],
+  "promote":false,
+  "created":1617165977,
+  "fieldAuthor":{
+    "entity":{
+      "title":"VA Gulf Coast Healthcare System Public Affairs Office",
+      "fieldDescription":null
+    }
+  },
+  "fieldImageCaption":null,
+  "fieldIntroText":"Dr. Margaret Peak, the Gulf Coast Veterans Health Care System (GCVHCS) chief of Audiology, received the 2021 Joint Defense Veterans Audiology Conference (JDVAC) Lt. Frank B. Walkup IV Distinguished Service Award March 3. ",
+  "fieldMedia":{
+    "entity":{
+      "image":{
+        "alt":"Doctor Margaret Peak, Chief of Audiology.",
+        "title":"",
+        "derivative":{
+          "url":"https://prod.cms.va.gov/sites/default/files/styles/2_1_medium_thumbnail/public/2021-03/Gulf_Coast_Audiology_Story.jpg",
+          "width":480,
+          "height":240
+        }
       }
     }
-  }
+  },
+  "fieldListing":{
+    "entity":{
+      "entityUrl":{
+        "path":"/gulf-coast-health-care/stories"
+      }
+    }
+  },
+  "fieldFullStory":{
+    "processed":"BILOXI, Miss. - The annual award is designed to recognize special contributions made to the Association of VA Audiologists (AVAA) or to VA Audiology through VA-related activities. (Official Gulf Coast Veterans Health Care System (GCVHCS) photo by Wayne Alley, GCVHCS Medical Media)\n\nA Gulf Coast Veterans Health Care System (GCVHCS) employee was recognized for organization-wide sustained superior performance at the 2021 Joint Defense Veterans Audiology Conference (JDVAC) March 3.\n\nDr. Margaret Peak, Ph.D., the GCVHCS Chief of Audiology, received the JDVAC Lt. Frank B. Walkup IV Distinguished Service Award during the virtual convention, a recognition she said that although individual, is indicative of the continued efforts of the organizational approach GCVHCS audiology professionals serving Veterans along the Gulf Coast in Mississippi, Alabama and Florida employ.\n\n“The GCVHCS Audiology Service is truly a team, and we work together to ensure the Veterans we serve have the resources, opportunities and medical treatment they need to ensure continuity of their quality of life,” she said. “Our employees are known for their integrity, compassion, advocacy and respect, and our Veterans always have been – and will be – the focal point of our service.”\n\nThe award, named for Tennessee native Frank B. Walkup IV, an Army Ranger killed in Rashaad, Iraq in 2007 and the son of a VA audiologist, recognizes special contributions made to the Association of VA Audiologists (AVAA) or to VA Audiology through VA-related activities.\n\nThe JDVAC is an annual meeting between the AVAA and the Military Audiology Association (MAA), providing opportunities for networking and collaboration between audiologists treating active-duty service members and those working with Veterans.\n\nOriginally scheduled in Las Vegas, the 2021 JDVAC was a virtual event this year due to ongoing Centers for Disease Control and Prevention (CDC) physical distancing recommendations and Department of Veterans Affairs (VA) guidelines. The three-day convention historically features guest speakers, networking opportunities and collaborative sessions covering all aspects of audiology from prevention and conservation through treatment and rehabilitation.\n\nAccording to Peak, VA and GCVHCS audiologists are licensed healthcare professionals, caring for Veterans through the prevention, diagnosis and treatment of hearing disorders including hearing loss, balance impairment and tinnitus.\n\n“We counsel patients and families regarding good hearing health practices and advise them on appropriate management strategies,” she said. “Our state-of-the art facilities allow us to use comprehensive diagnostic audiology tests to assess the hearing of GCVHCS beneficiaries so we’re able to provide the best treatment options which could include hearing aids, personal amplifiers, assistive technologies or cochlear implants.”\n\nPeak, who has served at the VA since 1972, said that she has seen audiology services within the VA expand; the GCVHCS has audiology clinics in Biloxi, Mississippi; Mobile, Alabama; and Pensacola and Panama City Beach, Florida. She added that GCVHCS issued nearly 11,000 hearing aids in 2019; facilitated the repair of 7,300 hearing aids through the Denver Logistics Center’s (DLC), which provides supply chain management for the VA National Hearing Aid and Home Telehealth Programs; and repaired nearly 12,000 hearing aids in GCVHCS clinics.\n\nPeak added that the GCVHCS Audiology Service encompasses speech needs of Veterans as well, offering a variety of services for Veterans diagnosed with communication issues.\n\n“We use multiple methods to work with Veterans, ranging from face-to-face clinic visits to using telehealth to connect Veterans in their homes to provide care,” she said. “This is a combined service that also serves the speech communication needs of Veterans, working through to help Veterans regain communication skills after a stroke or laryngeal surgery as well as help with cognitive organizational skill after a stroke or brain injury.”\n\nThe Biloxi VA Medical Center and the Mobile, Pensacola, Eglin and Panama City Beach VA Community-based Outpatient Clinics (CBOCs) are all part of the Gulf Coast Veterans Healthcare System (GCVHCS) which is headquartered in Biloxi, Mississippi, and provide a variety of medical outpatient services to more than 75,000 Veterans."
+  },
+  "facilitySidebar":{
+    "links":[]
+  },
+  "outreachSidebar":{
+    "name":"Outreach and events",
+    "description":"",
+    "links":[
+      {
+        "label":"Outreach and events",
+        "expanded":true,
+        "description":null,
+        "url":{
+          "path":""
+        },
+        "links":[
+          {
+            "label":"Outreach and events",
+            "expanded":true,
+            "description":null,
+            "url":{
+              "path":"/outreach-and-events"
+            },
+            "links":[
+              {
+                "label":"Outreach materials",
+                "expanded":false,
+                "description":null,
+                "url":{
+                  "path":"/outreach-and-events/outreach-materials"
+                },
+                "links":[]
+              },
+              {
+                "label":"Outreach events",
+                "expanded":false,
+                "description":null,
+                "url":{
+                  "path":"/outreach-and-events/events"
+                },
+                "links":[]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "alert":{
+    "entities":[
+      {
+        "id":42,
+        "entityPublished":true,
+        "fieldAlertDismissable":true,
+        "fieldAlertFrequency":"once",
+        "fieldNodeReference":[
+          {
+            "targetId":71}
+          ,
+          {
+            "targetId":72
+          },
+          {
+            "targetId":73
+          },
+          {"targetId":74},{"targetId":77},{"targetId":78},{"targetId":79},{"targetId":809},{"targetId":810},{"targetId":3071},{"targetId":2},{"targetId":3},{"targetId":4},{"targetId":5},{"targetId":6},{"targetId":7},{"targetId":8},{"targetId":9},{"targetId":10},{"targetId":11},{"targetId":14},{"targetId":17},{"targetId":18},{"targetId":19},{"targetId":20},{"targetId":22},{"targetId":23},{"targetId":24},{"targetId":25},{"targetId":26},{"targetId":28},{"targetId":29},{"targetId":30},{"targetId":32},{"targetId":33},{"targetId":34},{"targetId":35},{"targetId":36},{"targetId":38},{"targetId":39},{"targetId":40},{"targetId":41},{"targetId":297},{"targetId":471},{"targetId":472},{"targetId":473},{"targetId":474},{"targetId":488},{"targetId":491},{"targetId":585},{"targetId":588},{"targetId":589},{"targetId":591},{"targetId":672},{"targetId":705},{"targetId":706},{"targetId":708},{"targetId":709},{"targetId":710},{"targetId":711},{"targetId":712},{"targetId":713},{"targetId":714},{"targetId":715},{"targetId":716},{"targetId":717},{"targetId":718},{"targetId":719},{"targetId":720},{"targetId":721},{"targetId":722},{"targetId":723},{"targetId":724},{"targetId":725},{"targetId":726},{"targetId":728},{"targetId":729},{"targetId":730},{"targetId":731},{"targetId":732},{"targetId":733},{"targetId":734},{"targetId":747},{"targetId":748},{"targetId":749},{"targetId":750},{"targetId":751},{"targetId":752},{"targetId":753},{"targetId":754},{"targetId":755},{"targetId":762},{"targetId":763},{"targetId":765},{"targetId":766},{"targetId":768},{"targetId":770},{"targetId":771},{"targetId":854},{"targetId":855},{"targetId":856},{"targetId":857},{"targetId":858},{"targetId":859},{"targetId":860},{"targetId":861},{"targetId":862},{"targetId":863},{"targetId":864},{"targetId":865},{"targetId":866},{"targetId":867},{"targetId":868},{"targetId":869},{"targetId":870},{"targetId":872},{"targetId":882},{"targetId":883},{"targetId":886},{"targetId":887},{"targetId":888},{"targetId":891},{"targetId":892},{"targetId":893},{"targetId":894},{"targetId":895},{"targetId":896},{"targetId":897},{"targetId":898},{"targetId":899},{"targetId":900},{"targetId":902},{"targetId":912},{"targetId":914},{"targetId":915},{"targetId":916},{"targetId":917},{"targetId":918},{"targetId":919},{"targetId":920},{"targetId":921},{"targetId":922},{"targetId":923},{"targetId":924},{"targetId":925},{"targetId":926},{"targetId":927},{"targetId":928},{"targetId":929},{"targetId":930},{"targetId":931},{"targetId":932},{"targetId":933},{"targetId":934},{"targetId":935},{"targetId":936},{"targetId":937},{"targetId":938},{"targetId":939},{"targetId":940},{"targetId":941},{"targetId":942},{"targetId":943},{"targetId":944},{"targetId":945},{"targetId":946},{"targetId":947},{"targetId":948},{"targetId":950},{"targetId":951},{"targetId":952},{"targetId":983},{"targetId":984},{"targetId":986},{"targetId":989},{"targetId":990},{"targetId":991},{"targetId":993},{"targetId":1013},{"targetId":1012},{"targetId":2346},{"targetId":2347},{"targetId":2352},{"targetId":2354},{"targetId":2408},{"targetId":2431},{"targetId":3007},{"targetId":3008},{"targetId":3009},{"targetId":3010},{"targetId":3013},{"targetId":3014},{"targetId":3016},{"targetId":3025},{"targetId":3102},{"targetId":3103},{"targetId":4714},{"targetId":736},{"targetId":2755},{"targetId":2592},{"targetId":2756},{"targetId":2594},{"targetId":2534},{"targetId":2600},{"targetId":2544},{"targetId":2477},{"targetId":2486},{"targetId":2540},{"targetId":2478},{"targetId":2461},{"targetId":2456},{"targetId":5776},{"targetId":5722},{"targetId":6148},{"targetId":5804},{"targetId":6046},{"targetId":6059},{"targetId":6107},{"targetId":5745},{"targetId":6124},{"targetId":6115},{"targetId":6110},{"targetId":5949},{"targetId":5763},{"targetId":5733},{"targetId":6074},{"targetId":5709},{"targetId":5756},{"targetId":5966},{"targetId":6119},{"targetId":5703},{"targetId":5846},{"targetId":6022},{"targetId":6088},{"targetId":6131}
+        ],
+        "fieldIsThisAHeaderAlert":"banner_alert",
+        "fieldAlertType":"information",
+        "fieldAlertTitle":"COVID-19 vaccines at VA",
+        "fieldAlertContent":{
+          "entity":{
+            "entityRendered":"\n\n \n\n \nWe continue to offer COVID-19 vaccines to Veterans, spouses, caregivers, and CHAMPVA recipients as quickly and safely as we can.\n\nFind how to get a COVID-19 vaccine at VA\n \n\n"
+          }
+        }
+      },
+      {
+        "id":41,
+        "entityPublished":true,
+        "fieldAlertDismissable":false,
+        "fieldAlertFrequency":"always",
+        "fieldNodeReference":[
+          {
+            "targetId":5090
+          }
+        ],
+        "fieldIsThisAHeaderAlert":"in_page_alert",
+        "fieldAlertType":"information",
+        "fieldAlertTitle":"You can choose to receive improved pension benefits",
+        "fieldAlertContent":{
+          "entity":{
+            "entityRendered":"\n\n \n\n\nText Expander\n\n Learn more about changing your pension benefits program\n\n\n\n\nFull Text\nIf you're currently receiving payments from a Section 306 or old law pension, you can elect to change your benefits to begin receiving payments through the current, improved VA pension program. If you have questions about your benefits, please call us at 877-294-6380.\n\nView the current rates for improved pension programs:Veterans Pension ratesSurvivors Pension rates\n\nIf you've lost entitlement to your Section 306 or old law pension, you can't apply again for these benefits. But you can apply for an improved Veterans Pension or Survivors Pension.\n\n\n\n"
+          }
+        }
+      },
+      {
+        "id":39,
+        "entityPublished":true,
+        "fieldAlertDismissable":false,
+        "fieldAlertFrequency":"always",
+        "fieldNodeReference":[
+          {
+            "targetId":3071
+          }
+        ],
+        "fieldIsThisAHeaderAlert":"in_page_alert",
+        "fieldAlertType":"information",
+        "fieldAlertTitle":"Mark your calendar",
+        "fieldAlertContent":{
+          "entity":{
+            "entityRendered":"\n\n \n\n \nIn most situations you have one year from the date on your decision letter to request a decision review. The deadline to file may be different if you have a fiduciary claim or a contested claim, or you’re filing a Supplemental Claim.\n \n\n"
+          }
+        }
+      },
+      {
+        "id":48,
+        "entityPublished":true,
+        "fieldAlertDismissable":false,
+        "fieldAlertFrequency":"always",
+        "fieldNodeReference":[
+          {
+            "targetId":914
+          }
+        ],
+        "fieldIsThisAHeaderAlert":"in_page_alert",
+        "fieldAlertType":"information",
+        "fieldAlertTitle":"Claim exam updates during the coronavirus pandemic",
+        "fieldAlertContent":{
+          "entity":{
+            "entityRendered":"\n\n \n\n \nGet the latest updates on claim exams. And find out what to do if your claim requires an in-person exam.Go to our coronavirus FAQs\n \n\n"
+          }
+        }
+      },
+      {
+        "id":37,
+        "entityPublished":true,
+        "fieldAlertDismissable":false,
+        "fieldAlertFrequency":"always",
+        "fieldNodeReference":[
+          {
+            "targetId":912
+          }
+        ],
+        "fieldIsThisAHeaderAlert":"in_page_alert",
+        "fieldAlertType":"information",
+        "fieldAlertTitle":"Our offices are temporarily closed for in-person assistance",
+        "fieldAlertContent":{
+          "entity":{
+            "entityRendered":"\n\n \n\n \nWe're still open for business to help you by email. Contact us by the email listed below for your location. Benefits and services, like payments, will continue to be delivered. Check this page for future updates.\n \n\n"
+          }
+        }
+      }
+    ]
+  },
+"pid":17638
 }
 

--- a/src/site/layouts/tests/news_story_page/news_story.unit.spec.js
+++ b/src/site/layouts/tests/news_story_page/news_story.unit.spec.js
@@ -22,15 +22,11 @@ describe('News Story Page', () => {
     expect(violations.length).to.equal(0);
   });
 
-  it('href should include path (/(name)-health-care/stories) to stories', async () => {
-    expect(
-      container.querySelector('article > a').getAttribute('href'),
-    ).to.equal('/gulf-coast-health-care/stories');
-  });
+  it('renders "See all stories" link with path(/(name)-health-care/stories) to see all stories', async () => {
+    expect(container.getElementById('news-stories-listing-link')).to.exist;
 
-  it('renders "See all stories" link with path(href) to see all stories', async () => {
-    expect(container.querySelector('article').innerHTML).to.include(
-      `<a onclick="recordEvent({ event: 'nav-secondary-button-click' });" class="vads-u-display--block vads-u-margin-bottom--7" href="/gulf-coast-health-care/stories">See all stories</a>`,
+    expect(container.getElementById('news-stories-listing-link').href).to.equal(
+      '/gulf-coast-health-care/stories',
     );
   });
 
@@ -40,8 +36,8 @@ describe('News Story Page', () => {
 
     const newContainer = await renderHTML(layoutPath, clonedData);
 
-    expect(newContainer.querySelector('article').innerHTML).to.not.include(
-      `<a onclick="recordEvent({ event: 'nav-secondary-button-click' });" class="vads-u-display--block vads-u-margin-bottom--7" href="/gulf-coast-health-care/stories">See all stories</a>`,
+    expect(newContainer.getElementById('news-stories-listing-link')).to.equal(
+      null,
     );
   });
 });

--- a/src/site/layouts/tests/news_story_page/news_story.unit.spec.js
+++ b/src/site/layouts/tests/news_story_page/news_story.unit.spec.js
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+import { parseFixture, renderHTML } from '~/site/tests/support';
+
+const _ = require('lodash');
+
+const layoutPath = 'src/site/layouts/news_story.drupal.liquid';
+const data = parseFixture(
+  'src/site/layouts/tests/news_story_page/fixtures/news-story-data.json',
+);
+
+describe('News Story Page', () => {
+  let container;
+
+  beforeEach(async () => {
+    container = await renderHTML(layoutPath, data);
+  });
+  it('renders "See all stories" link with path(href) to see all stories', async () => {
+    expect(
+      container.querySelector('article > a').getAttribute('href'),
+    ).to.equal('/gulf-coast-health-care/stories');
+  });
+
+  it('should not render "See all stories" link if href is empty', async () => {
+    const clonedData = _.cloneDeep(data);
+    clonedData.fieldListing.entity.entityUrl.path = '';
+
+    const newContainer = await renderHTML(layoutPath, clonedData);
+
+    expect(newContainer.querySelector('article').innerHTML).to.not.include(
+      `<a onclick="recordEvent({ event: 'nav-secondary-button-click' });" class="testing vads-u-display--block vads-u-margin-bottom--7" href="/gulf-coast-health-care/stories">See all stories</a>`,
+    );
+  });
+});

--- a/src/site/layouts/tests/news_story_page/news_story.unit.spec.js
+++ b/src/site/layouts/tests/news_story_page/news_story.unit.spec.js
@@ -1,19 +1,27 @@
 import { expect } from 'chai';
 import { parseFixture, renderHTML } from '~/site/tests/support';
+import axeCheck from '~/site/tests/support/axe';
 
 const _ = require('lodash');
 
 const layoutPath = 'src/site/layouts/news_story.drupal.liquid';
-const data = parseFixture(
-  'src/site/layouts/tests/news_story_page/fixtures/news-story-data.json',
-);
 
 describe('News Story Page', () => {
+  const data = parseFixture(
+    'src/site/layouts/tests/news_story_page/fixtures/news-story-data.json',
+  );
+
   let container;
 
-  beforeEach(async () => {
+  before(async () => {
     container = await renderHTML(layoutPath, data);
   });
+
+  it('reports no axe violations', async () => {
+    const violations = await axeCheck(container);
+    expect(violations.length).to.equal(0);
+  });
+
   it('renders "See all stories" link with path(href) to see all stories', async () => {
     expect(
       container.querySelector('article > a').getAttribute('href'),
@@ -27,7 +35,7 @@ describe('News Story Page', () => {
     const newContainer = await renderHTML(layoutPath, clonedData);
 
     expect(newContainer.querySelector('article').innerHTML).to.not.include(
-      `<a onclick="recordEvent({ event: 'nav-secondary-button-click' });" class="testing vads-u-display--block vads-u-margin-bottom--7" href="/gulf-coast-health-care/stories">See all stories</a>`,
+      `<a onclick="recordEvent({ event: 'nav-secondary-button-click' });" class="vads-u-display--block vads-u-margin-bottom--7" href="/gulf-coast-health-care/stories">See all stories</a>`,
     );
   });
 });

--- a/src/site/layouts/tests/news_story_page/news_story.unit.spec.js
+++ b/src/site/layouts/tests/news_story_page/news_story.unit.spec.js
@@ -22,10 +22,16 @@ describe('News Story Page', () => {
     expect(violations.length).to.equal(0);
   });
 
-  it('renders "See all stories" link with path(href) to see all stories', async () => {
+  it('href should include path (/(name)-health-care/stories) to stories', async () => {
     expect(
       container.querySelector('article > a').getAttribute('href'),
     ).to.equal('/gulf-coast-health-care/stories');
+  });
+
+  it('renders "See all stories" link with path(href) to see all stories', async () => {
+    expect(container.querySelector('article').innerHTML).to.include(
+      `<a onclick="recordEvent({ event: 'nav-secondary-button-click' });" class="vads-u-display--block vads-u-margin-bottom--7" href="/gulf-coast-health-care/stories">See all stories</a>`,
+    );
   });
 
   it('should not render "See all stories" link if href is empty', async () => {


### PR DESCRIPTION
## Description
Resolves issue linked below

Link to an example news story page - https://www.va.gov/gulf-coast-health-care/stories/audiologist-recognized-at-national-convention/

## Testing done
Added unit tests

## Acceptance criteria
- [ ] If `href` is empty, the anchor tag will not render for `See all stories` link within the news story page (see original issue for screenshot of page/link)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
