### PR TITLE
Revert "Reorder the queries so lists go first (#414)"

### DIFF
--- a/src/site/stages/build/drupal/individual-queries.js
+++ b/src/site/stages/build/drupal/individual-queries.js
@@ -23,10 +23,6 @@ const {
 const { getNewsStoryQueries } = require('./graphql/newStoryPage.graphql');
 
 const {
-  GetNodeStoryListingPages,
-} = require('./graphql/storyListingPage.graphql');
-
-const {
   getPressReleaseQueries,
 } = require('./graphql/pressReleasePage.graphql');
 
@@ -39,6 +35,10 @@ const {
 } = require('./graphql/eventListingPage.graphql');
 
 const { getNodeEventQueries } = require('./graphql/eventPage.graphql');
+
+const {
+  GetNodeStoryListingPages,
+} = require('./graphql/storyListingPage.graphql');
 
 const {
   GetNodeLocationsListingPages,
@@ -92,23 +92,25 @@ const {
 } = require('./graphql/vetCenterLocations.graphql');
 
 function getNodeQueries(entityCounts) {
-  // Make sure Listing page queries run before individual queries
-  // so that the listing pages do not contain individual pages which do not exist.
   return {
-    GetNodePressReleaseListingPages,
-    GetNodeEventListingPage,
-    GetNodeStoryListingPages,
-    GetNodePublicationListingPages,
-    GetNodeLeadershipListingPages,
-    GetNodeLocationsListingPages,
-    ...getNodeHealthServicesListingPageQueries(entityCounts),
     ...getNodePageQueries(entityCounts),
     GetNodeLandingPages,
     ...getNodeVaFormQueries(entityCounts),
     ...getNodeHealthCareRegionPageQueries(entityCounts),
+    ...getNodePersonProfileQueries(entityCounts),
     GetNodeOffices,
     ...getNodeHealthCareLocalFacilityPageQueries(entityCounts),
+    ...getNodeHealthServicesListingPageQueries(entityCounts),
+    ...getNewsStoryQueries(entityCounts),
+    ...getPressReleaseQueries(entityCounts),
+    GetNodePressReleaseListingPages,
+    GetNodeEventListingPage,
+    ...getNodeEventQueries(entityCounts),
+    GetNodeStoryListingPages,
+    GetNodeLocationsListingPages,
+    GetNodeLeadershipListingPages,
     GetNodeVamcOperatingStatusAndAlerts,
+    GetNodePublicationListingPages,
     ...getNodeHealthCareRegionDetailPageQueries(entityCounts),
     ...getNodeQaQueries(entityCounts),
     GetNodeMultipleQaPages,
@@ -122,10 +124,6 @@ function getNodeQueries(entityCounts) {
     ...getVetCenterQueries(entityCounts),
     GetVetCenterLocations,
     GetPolicyPages,
-    ...getPressReleaseQueries(entityCounts),
-    ...getNodeEventQueries(entityCounts),
-    ...getNewsStoryQueries(entityCounts),
-    ...getNodePersonProfileQueries(entityCounts),
   };
 }
 


### PR DESCRIPTION
This reverts commit 5a98e93a2fa0026c59ae8804ae70600b52386c8b.

It broke the /locations pages.