### PR TITLE
VA Form node change for a11y needs

### DIFF
--- a/src/site/layouts/page.drupal.liquid
+++ b/src/site/layouts/page.drupal.liquid
@@ -62,7 +62,7 @@
           <div class="row">
             <div class="usa-content">
               <aside class="va-nav-linkslist va-nav-linkslist--related">
-                {% include 'src/site/paragraphs/list_of_link_teasers.drupal.liquid' entity = fieldRelatedLinks.entity %}
+                {% include 'src/site/paragraphs/list_of_link_teasers.drupal.liquid' with entity = fieldRelatedLinks.entity %}
               </aside>
             </div>
           </div>

--- a/src/site/layouts/page.drupal.liquid
+++ b/src/site/layouts/page.drupal.liquid
@@ -60,7 +60,7 @@
           {% endfor %}
           {% if fieldRelatedLinks != empty %}
           <div class="row">
-            <div class="usa-content columns">
+            <div class="usa-content">
               <aside class="va-nav-linkslist va-nav-linkslist--related">
                 {% include 'src/site/paragraphs/list_of_link_teasers.drupal.liquid' entity = fieldRelatedLinks.entity %}
               </aside>

--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -181,7 +181,7 @@
         {% endif %}
 
         <section>
-          <div class="vads-u-background-color--gray-lightest vads-u-padding--3 vads-u-margin-y--4">
+          <div class="vads-u-background-color--gray-lightest vads-u-padding-x--2 vads-u-padding-y--2p5 vads-u-margin-y--4">
             <h2 class="vads-u-font-size--h3 vads-u-margin-top--0 vads-u-padding-bottom--1 vads-u-border-bottom--1px vads-u-border-color--gray-light">
               {% assign linkTeasersHeader = 'Helpful links' %}
               {% if fieldVaFormLinkTeasers.length > 0 %}
@@ -193,7 +193,7 @@
               {% if fieldVaFormLinkTeasers.length > 0 %}
                 {% for vaFormLinkTeaser in fieldVaFormLinkTeasers %}
                   <li>
-                    <h3 class="vads-u-font-size--h4 vads-u-margin-bottom--0 vads-u-font-family--sans">
+                    <h3 class="vads-u-font-size--h4">
                       <a
                         class="vads-u-text-decoration--none"
                         href="{{ vaFormLinkTeaser.entity.fieldLink.url.path }}"
@@ -201,13 +201,13 @@
                         {{ vaFormLinkTeaser.entity.fieldLink.title }}
                       </a>
                     </h3>
-                    <p>{{ vaFormLinkTeaser.entity.fieldLinkSummary }}</p>
+                    <p class="vads-u-margin--0">{{ vaFormLinkTeaser.entity.fieldLinkSummary }}</p>
                   </li>
                 {% endfor %}
               {% else %}
                 {% comment %} The default related links if custom links aren't defined {% endcomment %}
                 <li>
-                  <h3 class="vads-u-font-size--h4 vads-u-margin-bottom--0 vads-u-font-family--sans">
+                  <h3 class="vads-u-font-size--h4">
                     <a
                       class="vads-u-text-decoration--none"
                       href="/change-direct-deposit"
@@ -215,10 +215,10 @@
                       Change your direct deposit information
                     </a>
                   </h3>
-                  <p>Find out how to update your direct deposit information online for disability compensation, pension, or education benefits. </p>
+                  <p class="vads-u-margin--0">Find out how to update your direct deposit information online for disability compensation, pension, or education benefits. </p>
                 </li>
                 <li>
-                  <h3 class="vads-u-font-size--h4 vads-u-margin-bottom--0 vads-u-font-family--sans">
+                  <h3 class="vads-u-font-size--h4">
                     <a
                       class="vads-u-text-decoration--none"
                       href="/change-address"
@@ -226,10 +226,10 @@
                       Change your address
                     </a>
                   </h3>
-                  <p>Find out how to change your address and other information in your VA.gov profile for disability compensation, claims and appeals, VA health care, and other benefits.</p>
+                  <p class="vads-u-margin--0">Find out how to change your address and other information in your VA.gov profile for disability compensation, claims and appeals, VA health care, and other benefits.</p>
                 </li>
                 <li>
-                  <h3 class="vads-u-font-size--h4 vads-u-margin-bottom--0 vads-u-font-family--sans">
+                  <h3 class="vads-u-font-size--h4">
                     <a
                       class="vads-u-text-decoration--none"
                       href="/records/get-military-service-records/"
@@ -237,10 +237,10 @@
                       Request your military records, including DD214
                     </a>
                   </h3>
-                  <p>Submit an online request to get your DD214 or other military service records through the milConnect website.</p>
+                  <p class="vads-u-margin--0">Submit an online request to get your DD214 or other military service records through the milConnect website.</p>
                 </li>
                 <li>
-                  <h3 class="vads-u-font-size--h4 vads-u-margin-bottom--0 vads-u-font-family--sans">
+                  <h3 class="vads-u-font-size--h4">
                     <a
                       class="vads-u-text-decoration--none"
                       href="/records/"
@@ -248,7 +248,7 @@
                       Get your VA records and documents online
                     </a>
                   </h3>
-                  <p>Learn how to access your VA records, benefit letters, and documents online.</p>
+                  <p class="vads-u-margin--0">Learn how to access your VA records, benefit letters, and documents online.</p>
                 </li>
               {% endif %}
             </ul>

--- a/src/site/paragraphs/linkTeaser.drupal.liquid
+++ b/src/site/paragraphs/linkTeaser.drupal.liquid
@@ -33,9 +33,21 @@
   data-links-list-header="{{ link.title | escape }}"
   data-links-list-section-header="{{ section_header | escape }}"
   {% if parentFieldName === 'field_spokes' %}class="hub-page-link-list__item"{% endif %}>
+
+  {% if header === "h3" %}
+    {% if link.title != empty %}
+        <h3 class="{{ headerClass }}">
+            <a href="{{link.url.path}}"
+            {% if linkTeaser.options["target"] %}target="{{ linkTeaser.options["target"] }}"{% endif %}
+            >
+            {{ link.title }}
+            </a>
+        </h3>
+    {% endif %}
+  {% else %}
     <a href="{{link.url.path}}"
-      {% if linkTeaser.options["target"] %}target="{{ linkTeaser.options["target"] }}"{% endif %}
-      >
+    {% if linkTeaser.options["target"] %}target="{{ linkTeaser.options["target"] }}"{% endif %}
+    >
         {% if link.title != empty %}
             <{{ header }} class="{{ headerClass }}">{{ link.title }}</{{ header }}>
             {% if parentFieldName === "field_spokes" %}
@@ -43,7 +55,8 @@
             {% endif %}
         {% endif %}
     </a>
-    {% if linkTeaser.fieldLinkSummary != empty %}
-        <p class="va-nav-linkslist-description">{{ linkTeaser.fieldLinkSummary }}</p>
-    {% endif %}
+{% endif %}
+{% if linkTeaser.fieldLinkSummary != empty %}
+    <p class="va-nav-linkslist-description">{{ linkTeaser.fieldLinkSummary }}</p>
+{% endif %}
 </li>


### PR DESCRIPTION
## Issue
https://github.com/department-of-veterans-affairs/va.gov-team/issues/26906

## Description
Updated padding and font to make Find forms and Find Forms detail page consistent (Va Form node).


## Testing done
Spun up local preview server. See screen shots. 

## Screenshots
**Before**: `columns` class removal
![Screen Shot 2021-08-06 at 11 21 51 AM](https://user-images.githubusercontent.com/26075258/128539816-049dff0e-9b0c-4327-94c6-bf24269b2d81.png)
**After**: `columns` class removal
![Screen Shot 2021-08-06 at 11 40 18 AM](https://user-images.githubusercontent.com/26075258/128539815-30d9742e-0beb-4465-8352-7e68dc9580c7.png)
**Heading good to go**
![Screen Shot 2021-08-06 at 11 20 17 AM](https://user-images.githubusercontent.com/26075258/128539818-1a0ae67c-b0cf-4b60-b7d1-d68600830615.png)


## Acceptance criteria
- [x] Address the needed changes in this screen shot => 
![Screen Shot 2021-08-06 at 12 15 42 PM](https://user-images.githubusercontent.com/26075258/128540765-909bf971-bc62-406d-9f9f-6e8044b6811b.png)


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
