### PR TITLE
Fix spelling error on variable assignment

### DIFF
--- a/src/site/paragraphs/downloadable_file.drupal.liquid
+++ b/src/site/paragraphs/downloadable_file.drupal.liquid
@@ -34,7 +34,7 @@
 
     {% if entity.fieldMedia.entity.entityBundle == 'document' %}
         {% assign url = entity.fieldMedia.entity.fieldDocument.entity.url %}
-        {% assign extenstion = url | fileExt %}
+        {% assign extension = url | fileExt %}
         <a
             class="file-download-with-icon"
             target="_blank"


### PR DESCRIPTION
## Description
Slack thread: https://dsva.slack.com/archives/C52CL1PKQ/p1628517568095800

Download links were missing the file type inside parenthesis. This was do to an extra letter in the variable name during assignment that was absent from the references to that variable.

## Testing done


## Screenshots
Before: 
<img width="996" alt="Screen Shot 2021-08-09 at 10 54 46 AM" src="https://user-images.githubusercontent.com/3144003/128727108-e2085038-ea46-4138-9ae8-9cf14d8185ab.png">

After: 
<img width="1059" alt="Screen Shot 2021-08-09 at 10 54 52 AM" src="https://user-images.githubusercontent.com/3144003/128727141-1ba3a0d3-45cd-4f1d-a4b2-1b578c219ec0.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
