### PR TITLE
27514 update 686 root url

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -233,7 +233,7 @@
   {
     "appName": "686C-674",
     "entryName": "686C-674",
-    "rootUrl": "/view-change-dependents/add-remove-form-686c",
+    "rootUrl": "/view-change-dependents/add-remove-form-21-686c",
     "template": {
       "layout": "page-react.html",
       "vagovprod": true,
@@ -244,7 +244,7 @@
           "name": "View or change your dependents"
         },
         {
-          "path": "view-change-dependents/add-remove-form-686c/",
+          "path": "view-change-dependents/add-remove-form-21-686c/",
           "name": "Add or remove dependents form 21‑686c"
         }
       ]


### PR DESCRIPTION
## Description
This pull request updates the 686 root url in registry.json

Related PRs:
- https://github.com/department-of-veterans-affairs/vets-website/pull/18177
- https://github.com/department-of-veterans-affairs/devops/pull/9743
- https://github.com/department-of-veterans-affairs/vets-api/pull/7604

## Testing done
local

## Acceptance criteria
- [x] root url is updated

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
