### PR TITLE
Updated filterUpcomingEvents test

### DIFF
--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -177,6 +177,17 @@ describe('filterPastEvents', () => {
 });
 
 describe('filterUpcomingEvents', () => {
+  // addOneDayToDate adds 1 full day to the current date
+  // this allows us to always have upcoming events.
+  const addOneDayToDate = () => {
+    const d = new Date();
+    return Math.round(d.getTime() + 1000 * 60 * 60 * 24);
+  };
+  const clonedData = _.cloneDeep(eventsMockData);
+  clonedData[3].fieldDatetimeRangeTimezone.value = addOneDayToDate();
+  clonedData[4].fieldDatetimeRangeTimezone.value = addOneDayToDate();
+  // const cleanupBlockEventStartValue = clonedData[3].fieldDatetimeRangeTimezone.value = addOneDayToDate()
+  // const holidayOfficeDinnerStartValue = clonedData[4].fieldDatetimeRangeTimezone.value = addOneDayToDate()
   it('returns null when null is passed', () => {
     expect(liquid.filters.filterUpcomingEvents(null)).to.eq(null);
   });
@@ -191,14 +202,14 @@ describe('filterUpcomingEvents', () => {
 
   it('returns events that occured AFTER the current date and time', () => {
     expect(
-      liquid.filters.filterUpcomingEvents(eventsMockData),
+      liquid.filters.filterUpcomingEvents(clonedData),
     ).to.deep.include.members([
       {
         title: 'Clean-up Block Event',
         fieldDatetimeRangeTimezone: {
           endValue: 1628355741,
           timezone: 'America/New_York',
-          value: 1628348541,
+          value: clonedData[3].fieldDatetimeRangeTimezone.value,
         },
       },
       {
@@ -206,7 +217,7 @@ describe('filterUpcomingEvents', () => {
         fieldDatetimeRangeTimezone: {
           endValue: 1639670421,
           timezone: 'America/New_York',
-          value: 1639659621,
+          value: clonedData[4].fieldDatetimeRangeTimezone.value,
         },
       },
     ]);

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -177,17 +177,17 @@ describe('filterPastEvents', () => {
 });
 
 describe('filterUpcomingEvents', () => {
-  // addOneDayToDate adds 1 full day to the current date
+  // addOneDayToDate() adds 1 full day to the current date
   // this allows us to always have upcoming events.
   const addOneDayToDate = () => {
     const d = new Date();
     return Math.round(d.getTime() + 1000 * 60 * 60 * 24);
   };
+
   const clonedData = _.cloneDeep(eventsMockData);
   clonedData[3].fieldDatetimeRangeTimezone.value = addOneDayToDate();
   clonedData[4].fieldDatetimeRangeTimezone.value = addOneDayToDate();
-  // const cleanupBlockEventStartValue = clonedData[3].fieldDatetimeRangeTimezone.value = addOneDayToDate()
-  // const holidayOfficeDinnerStartValue = clonedData[4].fieldDatetimeRangeTimezone.value = addOneDayToDate()
+
   it('returns null when null is passed', () => {
     expect(liquid.filters.filterUpcomingEvents(null)).to.eq(null);
   });


### PR DESCRIPTION
## Description
This PR addresses the issue with `filterUpcomingEvents` test failing
The mock data used for the test had an event start time that has now passed causing the test to fail because that particular even is no longer an upcoming event.

To resolve this, I added a function that would add a whole day to the current date so that those events would always be considered upcoming.

## Acceptance criteria
- [ ] Tests pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
