### PR TITLE
Use h2 for alert heading for a11y

### DIFF
--- a/src/site/includes/alerts.drupal.liquid
+++ b/src/site/includes/alerts.drupal.liquid
@@ -1,14 +1,14 @@
 {% for entity in alert.entities %}
   {% comment %}
-If there isn't a ref, that's a sitewide alert.
-{% endcomment %}
+    If there isn't a ref, that's a sitewide alert.
+  {% endcomment %}
   {% if entity.fieldNodeReference.0.targetId == null %}
     {% assign status = "print" %}
   {% endif %}
 
   {% comment %}
-Loop through refs, check for match for page entity.
-{% endcomment %}
+    Loop through refs, check for match for page entity.
+  {% endcomment %}
   {% for ef in entity.fieldNodeReference %}
     {% if ef.targetId == pid %}
       {% assign status = "print" %}
@@ -20,21 +20,39 @@ Loop through refs, check for match for page entity.
   {% endif %}
 
   {% comment %}
-If we have a hit, show the alert.
-{% endcomment %}
+    If we have a hit, show the alert.
+  {% endcomment %}
   {% if status == "print" %}
-    <div data-template="includes/alerts" data-entity-id="{{ entity.id }}"
-      aria-labelledby="usa-alert-heading-{{ entity.id }}" class="usa-alert-full-width dismissable-option-header usa-alert-full-width-{{ entity.fieldAlertType }}" id="usa-alert-full-width-{{ entity.id }}" role="region">
-      <div aria-live="assertive" class="usa-alert usa-alert-{{ entity.fieldAlertType }}" id="usa-alert-{{ entity.id }}" role="alert">
+    <div
+      data-template="includes/alerts"
+      data-entity-id="{{ entity.id }}"
+      aria-labelledby="usa-alert-heading-{{ entity.id }}"
+      class="usa-alert-full-width dismissable-option-header usa-alert-full-width-{{ entity.fieldAlertType }}"
+      id="usa-alert-full-width-{{ entity.id }}"
+      role="region"
+    >
+      <div
+        aria-live="assertive"
+        class="usa-alert usa-alert-{{ entity.fieldAlertType }}"
+        id="usa-alert-{{ entity.id }}"
+        role="alert"
+      >
         {% if entity.fieldAlertDismissable == true %}
-        <button id="usa-alert-dismiss-{{ entity.id }}" class="va-alert-close usa-alert-dismiss" data-parentwrap="usa-alert-full-width-{{ entity.id }}" data-frequency="{{ entity.fieldAlertFrequency }}" aria-label="Close notification">
-          <i aria-hidden="true" class="fas fa-times-circle"></i>
-        </button>
+          <button
+            id="usa-alert-dismiss-{{ entity.id }}"
+            class="va-alert-close usa-alert-dismiss"
+            data-parentwrap="usa-alert-full-width-{{ entity.id }}"
+            data-frequency="{{ entity.fieldAlertFrequency }}"
+            aria-label="Close notification"
+          >
+            <i aria-hidden="true" class="fas fa-times-circle"></i>
+          </button>
         {% endif %}
 
         <div class="usa-alert-body" id="usa-alert-body-{{ entity.id }}">
-          <h3 class="usa-alert-heading" id="usa-alert-heading-{{ entity.id }}">
-            {{ entity.fieldAlertTitle}}</h3>
+          <h2 class="usa-alert-heading" id="usa-alert-heading-{{ entity.id }}">
+            {{ entity.fieldAlertTitle}}
+          </h2>
           <div class="usa-alert-text" id="usa-alert-text-{{ entity.id }}">
             {{ entity.fieldAlertContent.entity.entityRendered }}
           </div>

--- a/src/site/includes/tests/alerts.drupal.unit.spec.js
+++ b/src/site/includes/tests/alerts.drupal.unit.spec.js
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import { parseFixture, renderHTML } from '~/site/tests/support';
+import axeCheck from '~/site/tests/support/axe';
+
+const layoutPath = 'src/site/includes/alerts.drupal.liquid';
+
+describe('Alerts', () => {
+  let container;
+  const data = parseFixture('src/site/includes/tests/fixtures/alerts.json');
+
+  before(async () => {
+    container = await renderHTML(layoutPath, data);
+  });
+
+  it('reports no axe violations', async () => {
+    const violations = await axeCheck(container);
+    expect(violations.length).to.equal(0);
+  });
+
+  it('renders field alert title as h2', async () => {
+    expect(
+      container
+        .querySelector('h2')
+        .innerHTML.replace(/\s+/g, ' ')
+        .trim(),
+    ).to.equal('Take a look at banner, Michael!');
+  });
+});

--- a/src/site/includes/tests/fixtures/alerts.json
+++ b/src/site/includes/tests/fixtures/alerts.json
@@ -1,0 +1,20 @@
+{
+  "alert": {
+    "entities": [
+      {
+        "id": 4815162342,
+        "fieldAlertTitle": "Take a look at banner, Michael!",
+        "fieldAlertType": "information",
+        "fieldAlertDismissable": true,
+        "fieldAlertFrequency": "once",
+        "fieldIsThisAHeaderAlert": "banner_alert",
+        "fieldNodeReference": [{ "targetId": null }],
+        "fieldAlertContent": {
+          "entity": {
+            "entityRendered": "Family Love Michael"
+          }
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/6375
https://github.com/department-of-veterans-affairs/content-build/pull/437/files?diff=split&w=1

This changes the headings in alerts.drupal.liquid from `h3`s to `h2`s since they are not preceded by `h2`s.

## Testing done
local and unit

## Screenshots
Before:
<img width="1791" alt="Screen Shot 2021-08-10 at 11 16 17 AM" src="https://user-images.githubusercontent.com/3144003/128893259-2c7458a5-1c42-4b6f-80db-09b3e4ad1acb.png">

After:
<img width="1792" alt="Screen Shot 2021-08-10 at 11 16 30 AM" src="https://user-images.githubusercontent.com/3144003/128893287-376e0f98-a5ba-4eb4-830c-e317dba1c235.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
