### PR TITLE
Github Actions (daily-deploys) -- Persistent runners

### DIFF
--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -131,7 +131,7 @@ jobs:
           YARN_CACHE_FOLDER: ~/.cache/yarn
 
       - name: Validate build status
-        run: node ./script/github-actions/validate-build-status.js ${{ github.sha }}
+        run: node ./script/github-actions/validate-build-status.js 793ea26c70a0323c41a1ab91217daaa7ab51a507
 
   notify-start:
     name: Notify Start

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -15,6 +15,64 @@ env:
   CHANNEL_ID: C024DUC9S1K # -test-tim-accessibility-gha
 
 jobs:
+  start-runner:
+    runs-on: ubuntu-latest
+    outputs:
+      label: ${{ steps.start-ec2-runner.outputs.label }}
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    env:
+      INSTANCE_TYPE: c5.4xlarge
+
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Get bot token from Parameter Store 
+        uses: marvinpinto/action-inject-ssm-secrets@latest 
+        with: 
+          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN  
+
+      - name: Get latest GHA Runner AMI ID # AMI images are rebuilt every 15 days, use the latest one
+        run: |
+          echo "RUNNER_AMI_ID=$(aws ec2 describe-images \
+          --owners 008577686731 \
+          --filters Name=state,Values=available \
+          --filters Name=name,Values=packer-gha-runner-ubuntu2004* \
+          --query 'sort_by(Images,&CreationDate)[-1].ImageId' \
+          --output text)" >> $GITHUB_ENV
+
+      - name: Get Subnet with the most free IPs # We will run these in the dsva-vagov-utility-2x subnet, so filter for those
+        run: |
+          echo "SUBNET_ID=$(aws ec2 describe-subnets \
+          --filters "Name=tag:Name,Values=dsva-vagov-utility-subnet-2*" \
+          --query 'sort_by(Subnets,&AvailableIpAddressCount)[-1].SubnetId' \
+          --output text)" >> $GITHUB_ENV
+
+      - name: Start EC2 Runner
+        id: start-ec2-runner
+        uses: machulav/ec2-github-runner@v2
+        with:
+          mode: start
+          github-token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
+          ec2-image-id: ${{ env.RUNNER_AMI_ID }}
+          ec2-instance-type: ${{ env.INSTANCE_TYPE }}
+          subnet-id: ${{ env.SUBNET_ID }}
+          security-group-id: sg-0e23b56be3798e3a1
+          aws-resource-tags: >
+            [
+              {"Key": "Name", "Value": "dsva-vagov-vets-website-on-demand-runner"},
+              {"Key": "project", "Value": "vagov"},
+              {"Key": "office", "Value": "dsva"},
+              {"Key": "application", "Value": "on-demand-gha-runner"},
+              {"Key": "VAECID", "Value": "AWG20180517003"},
+              {"Key": "environment", "Value": "utility"}
+            ]
+
   set-env:
     name: Set Env Variables
     runs-on: ubuntu-latest
@@ -124,8 +182,8 @@ jobs:
   
   build:
     name: Build
-    runs-on: [self-hosted, asg]
-    needs: [notify-start, validate-build-status]
+    runs-on: ${{ needs.start-runner.outputs.label }}
+    needs: [notify-start, validate-build-status, start-runner]
     defaults:
       run:
         working-directory: content-build
@@ -196,29 +254,29 @@ jobs:
       - name: Prearchive
         run: node ./script/prearchive.js --buildtype=${{ env.BUILDTYPE }}
 
-      - name: Compress prearchived ${{ env.BUILDTYPE }} build
-        run: tar -jcvf ${{ env.BUILDTYPE }}.tar.bz2 build/${{ env.BUILDTYPE }}
-
-      - name: Upload artifact ${{ env.BUILDTYPE }} build for archive
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.BUILDTYPE }}.tar.bz2
-          path: content-build/${{ env.BUILDTYPE }}.tar.bz2
-          retention-days: 1
+      - name: Persist prearchived build
+        run: |
+          mkdir -p /tmp/${{ github.run_id }}
+          rm -rf /tmp/${{ github.run_id }}/${{ env.BUILDTYPE }}
+          mv build/${{ env.BUILDTYPE }} /tmp/${{ github.run_id }}
 
   archive:
     name: Archive
-    runs-on: ubuntu-latest
-    needs: build
+    runs-on: ${{ needs.start-runner.outputs.label }}
+    needs: [build, start-runner]
 
     env:
       BUILDTYPE: vagovprod
 
     steps:
-      - name: Download build artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: ${{ env.BUILDTYPE }}.tar.bz2
+      - name: Restore vagovprod build
+        run: |
+          mkdir -p build
+          cp -R /tmp/${{ github.run_id }}/${{ env.BUILDTYPE }} build/${{ env.BUILDTYPE }}
+          du -h build/${{ env.BUILDTYPE }}
+
+      - name: Compress ${{ env.BUILDTYPE }} build
+        run: tar -jcvf ${{ env.BUILDTYPE }}.tar.bz2 build/${{ env.BUILDTYPE }}
 
       - name: Configure AWS credentials (1)
         uses: aws-actions/configure-aws-credentials@v1
@@ -364,3 +422,33 @@ jobs:
         slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
         attachments: '[{"mrkdwn_in": ["text"], "color": "danger", "text": "Production deploy for content-build has failed!: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"}]'
         channel_id: ${{ env.CHANNEL_ID }}
+
+  stop-runner:
+    name: Stop on-demand-runner
+    needs: [archive, start-runner]
+    runs-on: ubuntu-latest
+    if: ${{ always() }} # Even if an error happened, let's stop the runner
+    env:
+      INSTANCE_TYPE: c5.4xlarge
+
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Get bot token from Parameter Store 
+        uses: marvinpinto/action-inject-ssm-secrets@latest 
+        with: 
+          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN 
+
+      - name: Stop Runner
+        uses: machulav/ec2-github-runner@v2
+        with:
+          mode: stop
+          github-token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
+          label: ${{ needs.start-runner.outputs.label }}
+          ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -1,7 +1,6 @@
 name: Daily Production Deploy
 
 on:
-  push:
   workflow_dispatch:
     inputs:
       release_wait:
@@ -131,7 +130,7 @@ jobs:
           YARN_CACHE_FOLDER: ~/.cache/yarn
 
       - name: Validate build status
-        run: node ./script/github-actions/validate-build-status.js 793ea26c70a0323c41a1ab91217daaa7ab51a507
+        run: node ./script/github-actions/validate-build-status.js ${{ github.sha }}
 
   notify-start:
     name: Notify Start

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -1,6 +1,7 @@
 name: Daily Production Deploy
 
 on:
+  push:
   workflow_dispatch:
     inputs:
       release_wait:


### PR DESCRIPTION
## Description

This PR addresses the following:
- Use persistent/on-demand runners for build job
- Transition away from upload build as an artifact, but store in persistent runner
- Restore and compress build during archive step to upload to s3

## Testing done

[RUN](https://github.com/department-of-veterans-affairs/content-build/runs/3313600216?check_suite_focus=true)