### PR TITLE
Remove react-dom dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -225,7 +225,6 @@
     "number-to-words": "^1.2.4",
     "raven": "^2.6.4",
     "react": "^16.13.1",
-    "react-dom": "^16.13.1",
     "regenerator-runtime": "^0.13.7",
     "syswide-cas": "^5.3.0",
     "tar-fs": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10341,16 +10341,6 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@^16.13.1:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
-  integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
-
 react-is@^16.12.0, react-is@^16.13.1, react-is@^16.8.1, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
## Description
Remove an unused dependency. `react-dom` is only being used in `vets-website`

## Original issue(s)
department-of-veterans-affairs/va.gov-team#27348

## Testing done
Locally

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
