### PR TITLE
remove sharableLink filter and usage

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -252,15 +252,6 @@ module.exports = function registerFilters() {
     return _.slice(arr, startIndex);
   };
 
-  liquid.filters.formatSharableLinkID = (id, description) => {
-    if (!id) return '';
-    if (!description) return id;
-    const truncatedText = description.substring(0, 30);
-    const escaped = liquid.filters.escape(truncatedText);
-    const hyphenatedDesc = _.kebabCase(escaped);
-    return `${hyphenatedDesc}-${id}`;
-  };
-
   liquid.filters.benefitTerms = data => {
     if (data === null) return null;
     let output = 'General benefits information';

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -712,41 +712,6 @@ describe('timezoneAbbrev', () => {
   });
 });
 
-describe('formatSharableID', () => {
-  it('formats ID correctly less than 30 chars', () => {
-    expect(
-      liquid.filters.formatSharableLinkID(123, 'How Can i protect myself'),
-    ).to.eq('how-can-i-protect-myself-123');
-  });
-
-  it('formats ID correctly more than 30 chars', () => {
-    expect(
-      liquid.filters.formatSharableLinkID(
-        13060,
-        'Why should I consider volunteering for coronavirus research at VA',
-      ),
-    ).to.eq('why-should-i-consider-voluntee-13060');
-  });
-
-  it('formats ID correctly in Spanish', () => {
-    expect(
-      liquid.filters.formatSharableLinkID(
-        27792,
-        '¿Debo usar una mascarilla cuando vaya a un hospital del VA u a otro lugar?',
-      ),
-    ).to.eq('debo-usar-una-mascarilla-cuan-27792');
-  });
-
-  it('formats ID correctly in Tagalog', () => {
-    expect(
-      liquid.filters.formatSharableLinkID(
-        30316,
-        'Kailangan ko bang magsuot ng mask kapag pumunta ako sa isang ospital ng VA o ibang lokasyon?',
-      ),
-    ).to.eq('kailangan-ko-bang-magsuot-ng-m-30316');
-  });
-});
-
 describe('detectLang', () => {
   it('detects english', () => {
     expect(liquid.filters.detectLang('some-url')).to.eq('en');

--- a/src/site/paragraphs/collapsible_panel.drupal.liquid
+++ b/src/site/paragraphs/collapsible_panel.drupal.liquid
@@ -34,7 +34,7 @@
     >
         {% for accordionItem in entity.fieldVaParagraphs %}
             {% assign item = accordionItem.entity %}
-            {% assign id= item.entityId | formatSharableLinkID: item.fieldQuestion   %}
+            {% assign id= item.entityId %}
             <va-accordion-item header="{{ item.fieldTitle }}">
                 <div
                     id={{id}}

--- a/src/site/paragraphs/collapsible_panel.drupal.liquid
+++ b/src/site/paragraphs/collapsible_panel.drupal.liquid
@@ -34,7 +34,7 @@
     >
         {% for accordionItem in entity.fieldVaParagraphs %}
             {% assign item = accordionItem.entity %}
-            {% assign id= item.entityId %}
+            {% assign id = item.entityId %}
             <va-accordion-item header="{{ item.fieldTitle }}">
                 <div
                     id={{id}}

--- a/src/site/paragraphs/q_a.collapsible_panel.drupal.liquid
+++ b/src/site/paragraphs/q_a.collapsible_panel.drupal.liquid
@@ -5,7 +5,7 @@
 
     {% for accordionItem in questions %}
         {% assign item = accordionItem.entity %}
-        {% assign id= item.entityId | formatSharableLinkID: item.fieldQuestion   %}
+        {% assign id= item.entityId %}
       <va-accordion-item header="{{ item.fieldQuestion }}">
         <div
           id={{id}}

--- a/src/site/paragraphs/q_a.drupal.liquid
+++ b/src/site/paragraphs/q_a.drupal.liquid
@@ -17,7 +17,7 @@
 {% endcomment %}
 
 {% assign headingTag = "h3" %}
-{% assign id = entity.entityId | formatSharableLinkID: entity.fieldQuestion %}
+{% assign id = entity.entityId %}
 
 {% if entity.parentFieldName == "field_questions" and sectionHeader == blank %}
   {% assign headingTag = "h2" %}
@@ -28,8 +28,6 @@
     <div class="vads-u-display--flex">
       <{{ headingTag }} itemprop="name">
         {{ entity.fieldQuestion }}
-        <span data-widget-type="sharable-link" parentId="{{id}}" sharableText="{{entity.fieldQuestion}}">
-        </span>
       </{{ headingTag }}>
 
     </div>
@@ -38,8 +36,8 @@
         {% assign bundleComponent = "src/site/paragraphs/" | append: answer.entity.entityBundle | append: ".drupal.liquid" %}
         {% include {{ bundleComponent }} with entity = answer.entity %}
       {% endfor %}
-     
+
     </div>
   </div>
-   
+
 </div>


### PR DESCRIPTION
## Description

Issue: [#28290](https://github.com/department-of-veterans-affairs/va.gov-team/issues/28290)

It has been decided that we are no longer going to be moving forward with using the SharableLink widget, and so I have been instructed to remove it from the platform. Since it was an experimental component, it was only used on [a single page](https://www.va.gov/coronavirus-veteran-frequently-asked-questions/), so the impact of removing this widget is relatively low.

This PR will be the first of two, in that I will also be [removing the react widget from vets-website](https://github.com/department-of-veterans-affairs/vets-website/pull/18277).

## Testing done
Removed widget from drupal template, checked for any other usages, and verified that template still renders correctly and is built in metalsmith without error.

## Acceptance criteria
- [x] Removed instance of SharableLink widget from drupal templates

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
