### PR TITLE
Fix HLR breadcrumb

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -292,7 +292,7 @@
           "path": "decision-reviews/higher-level-review/"
         },
         {
-          "name": "Request a Higher‑Level Review with VA Form 20‑0996",
+          "name": "Request a Higher‑Level Review",
           "path": "decision-reviews/higher-level-review/request-higher-level-review-form-20-0996"
         }
       ]


### PR DESCRIPTION
## Description

The Higher-Level Review form breadcrumbs don't match the page title on most pages. This PR removes the "with VA Form 20‑0996" suffix.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/28896

## Testing done

N/A

## Screenshots

![](https://user-images.githubusercontent.com/136959/129799802-5bc4381f-ff88-45a0-a56d-6347fbacbe72.png)

## Acceptance criteria

- [x] Remove suffix from HLR breadcrumb

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
