### PR TITLE
Add VISN 9 menus to facilitySidebar

### DIFF
--- a/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
+++ b/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
@@ -68,6 +68,12 @@ const FACILITY_MENU_NAMES = [
   'va-orlando-health-care',
   'va-tampa-health-care',
   'va-west-palm-beach-health-care',
+  // VISN 9
+  'va-lexington-health-care',
+  'va-louisville-health-care',
+  'va-memphis-health-care',
+  'va-mountain-home-health-care',
+  'va-tennessee-valley-health-care',
   // VISN 10
   'va-ann-arbor-health-care',
   'va-central-ohio-health-care',


### PR DESCRIPTION
## Description

The VISN 9 menus are missing from the facilitySidebar query, see https://dsva.slack.com/archives/C0FQSS30V/p1625667550138900 for discussion of a similar past issue.

## Testing done

Attempting content build on the test environment for Lexington: https://master-knqezgo3rvzktwi7is3knvy2dkpn62vk.demo.cms.va.gov/admin/content/deploy

## Screenshots

<img width="878" alt="Screen Shot 2021-08-24 at 8 50 03 AM" src="https://user-images.githubusercontent.com/101649/130638710-1c1862f6-8d46-4ae3-94c1-3e9de117c200.png">

## Acceptance criteria
- [ ] Content build succeeds with a VISN 9 facility published.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
