### PR TITLE
Change Cypress a11y test start time on GitHub Actions

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -3,7 +3,7 @@ name: Accessibility Tests
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 12 * * 1-5'
+    - cron: '0 10 * * 1-5'
 
 env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver


### PR DESCRIPTION
## Description
This PR modifies the scheduled start time for Cypress a11y tests on GitHub Actions so that they finish at around 8 AM ET.

## Acceptance criteria
- [ ] N/A