### PR TITLE
Switch replace for replaceAll

### DIFF
--- a/src/site/stages/build/drupal/page.js
+++ b/src/site/stages/build/drupal/page.js
@@ -171,7 +171,7 @@ function generateBreadCrumbs(pathString) {
       const dehandlized =
         value === 'pittsburgh-health-care'
           ? 'VA Pittsburgh health care'
-          : value.charAt(0).toUpperCase() + value.replaceAll('-', ' ').slice(1);
+          : value.charAt(0).toUpperCase() + value.replace(/-/g, ' ').slice(1);
       entityUrlObj.breadcrumb.push({
         url: {
           path: `${previous}${value}`,


### PR DESCRIPTION
# Description

**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/17521

This PR replaces all instances of hyphens in breadcrumbs instead of just the first.

## Acceptance Criteria

- [x] Replace all instances of `-` in breadcrumbs.
