### PR TITLE
Show the upcoming/past event toggle on the past-events page

### DIFF
--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -24,7 +24,7 @@
                 {% endif %}
               </div>
 
-              {% if pastEvents.entities.length > 0 %}
+              {% if pastEvents.entities.length > 0 or entityUrl.path contains 'past-events' %}
                 {% include "src/site/facilities/facilities_events_toggle.drupal.liquid" with url = entityUrl.path %}
               {% endif %}
 


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/va.gov-team/issues/25662

Note: the toggle does not work on the past-events page in preview mode, because that page is constructed only as part of the full build.