### PR TITLE
Support new <Banner /> component

### DIFF
--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -124,6 +124,7 @@
   <div
     aria-label="{{ legacy_homepage_banner.title | escape }}"
     data-content="{{ legacy_homepage_banner.content | escape }}"
+    data-dismissible-status="dismiss"
     data-title="{{ legacy_homepage_banner.title | escape }}"
     data-type="{{ legacy_homepage_banner.type }}"
     data-visible="{{ legacy_homepage_banner.visible }}"


### PR DESCRIPTION
# Description

**Issues:**

https://github.com/department-of-veterans-affairs/va.gov-team/issues/29069
https://github.com/department-of-veterans-affairs/va.gov-team/issues/29209
https://github.com/department-of-veterans-affairs/va.gov-team/issues/28933
https://github.com/department-of-veterans-affairs/va.gov-team/issues/29071
https://github.com/department-of-veterans-affairs/va.gov-team/issues/28295
https://github.com/department-of-veterans-affairs/va.gov-team/issues/28296

**Related PRs:**

1. https://github.com/department-of-veterans-affairs/content-build/pull/485
1. https://github.com/department-of-veterans-affairs/vets-website/pull/18426
1. https://github.com/department-of-veterans-affairs/component-library/pull/147

This PR is part of a series of PRs to support the modified `EmergencyBanner` component and its switch to the new `Banner` component.

## Screenshots

![image](https://user-images.githubusercontent.com/12773166/131177097-3a43da5f-0441-42e1-bb17-bbbf57141b09.png)

![image](https://user-images.githubusercontent.com/12773166/131177122-b710ec05-90b2-4871-90bc-4366db543964.png)

![image](https://user-images.githubusercontent.com/12773166/131177137-3c322f47-5dda-4559-9045-72c9fbe88175.png)

## Changes

1. Adds `data-dismissible-status="dismiss"` to the legacy homepage banner so it will continue working on prod even after we migrate to using the new `<Banner />` reusable component.

