### PR TITLE
Hi resolution download link fix

### DIFF
--- a/src/site/layouts/person_profile.drupal.liquid
+++ b/src/site/layouts/person_profile.drupal.liquid
@@ -85,7 +85,7 @@
 
                     {% if fieldPhotoAllowHiresDownload and fieldMedia %}
                     <div class="vads-u-align-content--flex-end va-c-margin-top--auto vads-u-margin-bottom--2" id="download-full-size-photo-link">
-                        <i class="va-c-social-icon fas fa-download"></i> <a href="{{ fieldMedia.hiRes.image.derivative.url }}"
+                        <i class="va-c-social-icon fas fa-download" aria-hidden="true"></i> <a href="{{ fieldMedia.hiRes.image.derivative.url }}"
                             download>Download full size photo</a>
                     </div>
                     {% endif %}

--- a/src/site/layouts/person_profile.drupal.liquid
+++ b/src/site/layouts/person_profile.drupal.liquid
@@ -15,9 +15,9 @@
             <div class="usa-width-three-fourths">
                 <article class="usa-content">
                     <div class="usa-grid usa-grid-full vads-u-margin-bottom--2 vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row">
-                        {% if fieldMedia.entity.image != empty %}
+                        {% if fieldMedia.thumbnail.image != empty %}
                             <div class="vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0 vads-u-margin-right--3">
-                                {% assign image = fieldMedia.entity.image %}
+                                {% assign image = fieldMedia.thumbnail.image %}
                                 <img class="person-profile-detail-page-image" src="{{ image.derivative.url }}" alt="{{ image.alt }}" title="{{ image.title }}">
                             </div>
                         {% endif %}
@@ -85,7 +85,7 @@
 
                     {% if fieldPhotoAllowHiresDownload and fieldMedia %}
                     <div class="vads-u-align-content--flex-end va-c-margin-top--auto vads-u-margin-bottom--2" id="download-full-size-photo-link">
-                        <i class="va-c-social-icon fas fa-download"></i> <a href="{{ fieldMedia.entity.image.derivative.url }}"
+                        <i class="va-c-social-icon fas fa-download"></i> <a href="{{ fieldMedia.hiRes.image.derivative.url }}"
                             download>Download full size photo</a>
                     </div>
                     {% endif %}

--- a/src/site/layouts/person_profile.drupal.liquid
+++ b/src/site/layouts/person_profile.drupal.liquid
@@ -82,9 +82,10 @@
                         {{ fieldBody.processed }}
                     </div>
                     {% endif %}
-                    {% if fieldPhotoAllowHiresDownload %}
-                    <div class="vads-u-align-content--flex-end va-c-margin-top--auto vads-u-margin-bottom--2">
-                        <i class="va-c-social-icon fas fa-download"></i> <a href="{{ image.url }}"
+
+                    {% if fieldPhotoAllowHiresDownload and fieldMedia %}
+                    <div class="vads-u-align-content--flex-end va-c-margin-top--auto vads-u-margin-bottom--2" id="download-full-size-photo-link">
+                        <i class="va-c-social-icon fas fa-download"></i> <a href="{{ fieldMedia.entity.image.derivative.url }}"
                             download>Download full size photo</a>
                     </div>
                     {% endif %}

--- a/src/site/layouts/tests/person_profile/fixtures/download-full-size-photo-link.json
+++ b/src/site/layouts/tests/person_profile/fixtures/download-full-size-photo-link.json
@@ -1,0 +1,90 @@
+{
+  "trueFieldPhotoAllowHiresDownloadAndHasImageUrl": {
+    "entityUrl": {
+      "breadcrumb": [
+        {
+          "text": "text",
+          "url": {
+            "path": "/",
+            "routed": true
+          }
+        }
+      ],
+      "path": "/houston-health-care/staff-profiles/arnisha-carter"
+    },
+    "fieldPhotoAllowHiresDownload": true,
+    "fieldMedia": {
+      "entity": {
+        "image": {
+          "alt": "alt text",
+          "derivative": {
+            "height": 123,
+            "url": "url text",
+            "width": 321
+          },
+          "title": ""
+        }
+      }
+    }
+  },
+  "trueFieldPhotoAllowHiresDownloadAndNoFieldMedia": {
+    "entityUrl": {
+      "breadcrumb": [
+        {
+          "text": "text",
+          "url": {
+            "path": "/",
+            "routed": true
+          }
+        }
+      ],
+      "path": "/houston-health-care/staff-profiles/arnisha-carter"
+    },
+    "fieldPhotoAllowHiresDownload": true,
+    "fieldMedia": null
+  },
+  "falseFieldPhotoAllowHiresDownloadAndHasImageUrl": {
+    "entityUrl": {
+      "breadcrumb": [
+        {
+          "text": "text",
+          "url": {
+            "path": "/",
+            "routed": true
+          }
+        }
+      ],
+      "path": "/houston-health-care/staff-profiles/arnisha-carter"
+    },
+    "fieldPhotoAllowHiresDownload": false,
+    "fieldMedia": {
+      "entity": {
+        "image": {
+          "alt": "alt text",
+          "derivative": {
+            "height": 123,
+            "url": "url text",
+            "width": 321
+          },
+          "title": ""
+        }
+      }
+    }
+  },
+  "falseFieldPhotoAllowHiresDownloadAndNoFieldMedia": {
+    "entityUrl": {
+      "breadcrumb": [
+        {
+          "text": "text",
+          "url": {
+            "path": "/",
+            "routed": true
+          }
+        }
+      ],
+      "path": "/houston-health-care/staff-profiles/arnisha-carter"
+    },
+    "fieldPhotoAllowHiresDownload": false,
+    "fieldMedia": null
+  }
+}

--- a/src/site/layouts/tests/person_profile/fixtures/download-full-size-photo-link.json
+++ b/src/site/layouts/tests/person_profile/fixtures/download-full-size-photo-link.json
@@ -14,12 +14,23 @@
     },
     "fieldPhotoAllowHiresDownload": true,
     "fieldMedia": {
-      "entity": {
+      "thumbnail": {
         "image": {
-          "alt": "alt text",
+          "alt": "alt thumbnail text",
           "derivative": {
             "height": 123,
-            "url": "url text",
+            "url": "url thumbnail text",
+            "width": 321
+          },
+          "title": ""
+        }
+      },
+      "hiRes": {
+        "image": {
+          "alt": "alt hi res text",
+          "derivative": {
+            "height": 123,
+            "url": "url hi res text",
             "width": 321
           },
           "title": ""
@@ -58,13 +69,24 @@
     },
     "fieldPhotoAllowHiresDownload": false,
     "fieldMedia": {
-      "entity": {
+      "thumbnail": {
         "image": {
-          "alt": "alt text",
+          "alt": "alt thumbnail text",
           "derivative": {
             "height": 123,
-            "url": "url text",
+            "url": "url thumbnail text",
             "width": 321
+          },
+          "title": ""
+        }
+      },
+      "hiRes": {
+        "image": {
+          "alt": "alt hi res text",
+          "derivative": {
+            "height": 567,
+            "url": "url hi res text",
+            "width": 765
           },
           "title": ""
         }

--- a/src/site/layouts/tests/person_profile/person_profile.unit.spec.js
+++ b/src/site/layouts/tests/person_profile/person_profile.unit.spec.js
@@ -1,0 +1,65 @@
+import { expect } from 'chai';
+import { parseFixture, renderHTML } from '~/site/tests/support';
+
+const layoutPath = 'src/site/layouts/person_profile.drupal.liquid';
+const data = parseFixture(
+  'src/site/layouts/tests/person_profile/fixtures/download-full-size-photo-link.json',
+);
+
+describe('person-profile', () => {
+  describe('fieldPhotoAllowHiresDownload equals true and has image url', () => {
+    it('displays download-full-size-photo-link', async () => {
+      const container = await renderHTML(
+        layoutPath,
+        data.trueFieldPhotoAllowHiresDownloadAndHasImageUrl,
+        'trueFieldPhotoAllowHiresDownloadAndHasImageUrl',
+      );
+
+      expect(
+        container.querySelector('#download-full-size-photo-link a').href,
+      ).to.equal(
+        data.trueFieldPhotoAllowHiresDownloadAndHasImageUrl.fieldMedia.entity
+          .image.derivative.url,
+      );
+    });
+  });
+
+  describe('fieldPhotoAllowHiresDownload equals true and has no fieldMedia', () => {
+    it('does not display download-full-size-photo-link', async () => {
+      const container = await renderHTML(
+        layoutPath,
+        data.trueFieldPhotoAllowHiresDownloadAndNoFieldMedia,
+        'trueFieldPhotoAllowHiresDownloadAndNoFieldMedia',
+      );
+
+      expect(container.querySelector('#download-full-size-photo-link')).to.not
+        .exist;
+    });
+  });
+
+  describe('fieldPhotoAllowHiresDownload equals false and has image url', () => {
+    it('does not display download-full-size-photo-link', async () => {
+      const container = await renderHTML(
+        layoutPath,
+        data.falseFieldPhotoAllowHiresDownloadAndHasImageUrl,
+        'falseFieldPhotoAllowHiresDownloadAndHasImageUrl',
+      );
+
+      expect(container.querySelector('#download-full-size-photo-link')).to.not
+        .exist;
+    });
+  });
+
+  describe('fieldPhotoAllowHiresDownload equals false and has no fieldMedia', () => {
+    it('does not display download-full-size-photo-link', async () => {
+      const container = await renderHTML(
+        layoutPath,
+        data.falseFieldPhotoAllowHiresDownloadAndNoFieldMedia,
+        'falseFieldPhotoAllowHiresDownloadAndNoFieldMedia',
+      );
+
+      expect(container.querySelector('#download-full-size-photo-link')).to.not
+        .exist;
+    });
+  });
+});

--- a/src/site/layouts/tests/person_profile/person_profile.unit.spec.js
+++ b/src/site/layouts/tests/person_profile/person_profile.unit.spec.js
@@ -18,7 +18,7 @@ describe('person-profile', () => {
       expect(
         container.querySelector('#download-full-size-photo-link a').href,
       ).to.equal(
-        data.trueFieldPhotoAllowHiresDownloadAndHasImageUrl.fieldMedia.entity
+        data.trueFieldPhotoAllowHiresDownloadAndHasImageUrl.fieldMedia.hiRes
           .image.derivative.url,
       );
     });

--- a/src/site/layouts/tests/person_profile/person_profile.unit.spec.js
+++ b/src/site/layouts/tests/person_profile/person_profile.unit.spec.js
@@ -7,6 +7,36 @@ const data = parseFixture(
 );
 
 describe('person-profile', () => {
+  describe('has fieldMedia', () => {
+    it('displays person profile detail page thumbnail image', async () => {
+      const container = await renderHTML(
+        layoutPath,
+        data.trueFieldPhotoAllowHiresDownloadAndHasImageUrl,
+        'trueFieldPhotoAllowHiresDownloadAndHasImageUrl',
+      );
+
+      expect(
+        container.querySelector('.person-profile-detail-page-image').src,
+      ).to.equal(
+        data.trueFieldPhotoAllowHiresDownloadAndHasImageUrl.fieldMedia.thumbnail
+          .image.derivative.url,
+      );
+    });
+  });
+
+  describe('has no fieldMedia', () => {
+    it('does not display person profile detail page thumbnail image', async () => {
+      const container = await renderHTML(
+        layoutPath,
+        data.falseFieldPhotoAllowHiresDownloadAndNoFieldMedia,
+        'falseFieldPhotoAllowHiresDownloadAndNoFieldMedia',
+      );
+
+      expect(container.querySelector('.person-profile-detail-page-image')).to
+        .not.exist;
+    });
+  });
+
   describe('fieldPhotoAllowHiresDownload equals true and has image url', () => {
     it('displays download-full-size-photo-link', async () => {
       const container = await renderHTML(

--- a/src/site/stages/build/drupal/graphql/bioPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/bioPage.graphql.js
@@ -33,7 +33,7 @@ const personProfileFragment = `
         image {
           alt
           title
-          derivative(style: _23MEDIUMTHUMBNAIL) {
+          derivative(style: ORIGINAL) {
             url
             width
             height

--- a/src/site/stages/build/drupal/graphql/bioPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/bioPage.graphql.js
@@ -28,7 +28,20 @@ const personProfileFragment = `
   fieldIntroText
   fieldPhotoAllowHiresDownload
   fieldMedia {
-    entity {
+    thumbnail: entity {
+      ... on MediaImage {
+        image {
+          alt
+          title
+          derivative(style: _23MEDIUMTHUMBNAIL) {
+            url
+            width
+            height
+          }
+        }
+      }
+    }
+    hiRes: entity {
       ... on MediaImage {
         image {
           alt
@@ -40,7 +53,7 @@ const personProfileFragment = `
           }
         }
       }
-    }
+    }    
   }
   fieldBody {
     processed


### PR DESCRIPTION
## Description
resolves issue linked below

I confirmed that when an image is not added by the editor - `fieldMedia: null`

Tugboat instance - https://web-xzcrb121xmxquzas9jcd9p86dgwpkuam.demo.cms.va.gov/pittsburgh-health-care/staff-profiles/lovetta-ford/


## Testing done
Unit tests added to cover the following use cases when displaying the `Download full size photo` link

- if `fieldPhotoAllowHiresDownload = true` and we have an image (`fieldMedia`)
- if `fieldPhotoAllowHiresDownload = true` and we do not have an image (`fieldMedia`)
- if `fieldPhotoAllowHiresDownload = false` and we have an image (`fieldMedia`)
- if `fieldPhotoAllowHiresDownload = false` and we do not have an image (`fieldMedia`)
