### PR TITLE
Github Actions (CI) -- ensure on-demand runners are shutting down correctly in matrix

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -624,7 +624,7 @@ jobs:
       INSTANCE_TYPE: c5.4xlarge
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         buildtype: [vagovdev, vagovstaging, vagovprod]
         include:

--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
     "watch": "concurrently \"node --max-old-space-size=5000 --expose-gc script/build-content.js --watch\" \"http-server build/localhost -s -c-1 -p 3002\"",
     "watch:css-sourcemaps": "node --max-old-space-size=5000 --expose-gc script/build-content.js --watch --local-css-sourcemaps",
     "watch:review": "node ./script/run-review-instance-api.js",
-    "watch:static": "concurrently -n metalsmith,webpack \"npm:watch:content\" \"npm run watch -- --env.entry=static-pages --progress=false\"",
-    "prepare": "husky install"
+    "watch:static": "concurrently -n metalsmith,webpack \"npm:watch:content\" \"npm run watch -- --env.entry=static-pages --progress=false\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

To ensure that our on-demand runners shutdown properly, ensuring the `stop-runner` completes irregardless of if dev,stage,prod runs is not able to find information.


## Testing
[Run](https://github.com/department-of-veterans-affairs/content-build/runs/3465031682?check_suite_focus=true) that failed to shut down correctly