### PR TITLE
DT-26908- vaForm node adding ES lang

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 // Node modules.
 const _ = require('lodash');
 const converter = require('number-to-words');
@@ -1089,6 +1088,7 @@ module.exports = function registerFilters() {
   };
 
   liquid.filters.deriveLanguageTranslation = (lang, whichNode, id) => {
+    // eslint-disable-next-line no-param-reassign
     if (!lang) lang = 'en';
 
     const languages = {

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1088,8 +1088,7 @@ module.exports = function registerFilters() {
   };
 
   liquid.filters.deriveLanguageTranslation = (lang, whichNode, id) => {
-    // eslint-disable-next-line no-param-reassign
-    if (!lang) lang = 'en';
+    const language = lang || 'en';
 
     const languages = {
       es: {
@@ -1100,6 +1099,6 @@ module.exports = function registerFilters() {
       },
     };
 
-    return languages[lang][whichNode];
+    return languages[language][whichNode];
   };
 };

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1086,4 +1086,17 @@ module.exports = function registerFilters() {
         return 'info';
     }
   };
+
+  liquid.filters.deriveLanguageTranslation = (lang = 'en', whichNode, id) => {
+    const languages = {
+      es: {
+        downloadVaForm: `Descargar el formulario VA ${id}`,
+      },
+      en: {
+        downloadVaForm: `Download VA Form ${id}`,
+      },
+    };
+
+    return languages[lang][whichNode];
+  };
 };

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 // Node modules.
 const _ = require('lodash');
 const converter = require('number-to-words');
@@ -1087,7 +1088,9 @@ module.exports = function registerFilters() {
     }
   };
 
-  liquid.filters.deriveLanguageTranslation = (lang = 'en', whichNode, id) => {
+  liquid.filters.deriveLanguageTranslation = (lang, whichNode, id) => {
+    if (!lang) lang = 'en';
+
     const languages = {
       es: {
         downloadVaForm: `Descargar el formulario VA ${id}`,

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -1426,6 +1426,13 @@ describe('formatAlertType', () => {
       ).to.equal('Download VA Form 10-10EZ');
       expect(
         liquid.filters.deriveLanguageTranslation(
+          undefined,
+          'downloadVaForm',
+          '10-10EZ',
+        ),
+      ).to.equal('Download VA Form 10-10EZ');
+      expect(
+        liquid.filters.deriveLanguageTranslation(
           'en',
           'downloadVaForm',
           '10-10EZ',

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -1404,4 +1404,33 @@ describe('formatAlertType', () => {
     expect(liquid.filters.formatAlertType('SUCCESS')).to.equal('success');
     expect(liquid.filters.formatAlertType('success')).to.equal('success');
   });
+
+  describe('it deriveLanguageTranslation', () => {
+    it('returns spanish translation of Download VA Form', () => {
+      expect(
+        liquid.filters.deriveLanguageTranslation(
+          'es',
+          'downloadVaForm',
+          '10-10EZ (esp)',
+        ),
+      ).to.equal('Descargar el formulario VA 10-10EZ (esp)');
+    });
+
+    it('returns english of Download VA Form', () => {
+      expect(
+        liquid.filters.deriveLanguageTranslation(
+          null,
+          'downloadVaForm',
+          '10-10EZ',
+        ),
+      ).to.equal('Download VA Form 10-10EZ');
+      expect(
+        liquid.filters.deriveLanguageTranslation(
+          'en',
+          'downloadVaForm',
+          '10-10EZ',
+        ),
+      ).to.equal('Download VA Form 10-10EZ');
+    });
+  });
 });

--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -95,12 +95,8 @@
               class="fas fa-download fa-lg vads-u-margin-right--1 va-form-layout--remove-pointer-events"
               role="presentation"
             > </i>
-
-          {% if fieldVaFormLanguage === "es" %}
-            Descargar el formulario {{ fieldVaFormNumber }} (PDF)
-          {% else %}
-            Download VA Form {{ fieldVaFormNumber }} (PDF)
-          {% endif %}
+          {% assign translatedDownloadText = fieldVaFormLanguage | deriveLanguageTranslation: 'downloadVaForm', fieldVaFormNumber %}
+          {{ translatedDownloadText }} (PDF) 
         </a>
 
         {% if fieldAlert.length %}
@@ -166,11 +162,8 @@
                       class="fas fa-download fa-lg vads-u-margin-right--1 va-form-layout--remove-pointer-events"
                       role="presentation"
                     > </i>
-                    {% if vaForm.entity.fieldVaFormLanguage === "es" %}
-                      Descargar el formulario {{ vaForm.entity.fieldVaFormNumber }} (PDF)
-                    {% else %}
-                      Download VA Form {{ vaForm.entity.fieldVaFormNumber }} (PDF)
-                    {% endif %}
+                    {% assign translatedDownloadText = vaForm.entity.fieldVaFormLanguage | deriveLanguageTranslation: 'downloadVaForm', vaForm.entity.fieldVaFormNumber %}
+                    {{ translatedDownloadText }} (PDF) 
                 </a>
               </li>
             {% endfor %}

--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -81,35 +81,27 @@
           {% endif %}
 
           <h3 class="vads-u-margin-bottom--2">Downloadable PDF</h3>
-          <a
-            href="{{ fieldVaFormUrl.uri }}"
-            target="_blank"
-            download
-            data-widget-type="find-va-forms-invalid-pdf-alert"
-            data-form-number="{{ fieldVaFormNumber }}">
-              <i
-                aria-hidden="true"
-                class="fas fa-download fa-lg vads-u-margin-right--1 va-form-layout--remove-pointer-events"
-                role="presentation"
-              > </i>
-            Download VA Form {{ fieldVaFormNumber }} (PDF)
-          </a>
-        {% else %}
-          <a
-            class="vads-u-margin-top--4"
-            href="{{ fieldVaFormUrl.uri }}"
-            target="_blank"
-            download
-            data-widget-type="find-va-forms-invalid-pdf-alert"
-            data-form-number="{{ fieldVaFormNumber }}">
-              <i
-                aria-hidden="true"
-                class="fas fa-download fa-lg vads-u-margin-right--1 va-form-layout--remove-pointer-events"
-                role="presentation"
-              > </i>
-            Download VA Form {{ fieldVaFormNumber }} (PDF)
-          </a>
         {% endif %}
+        <a
+          href="{{ fieldVaFormUrl.uri }}"
+          target="_blank"
+          download
+          data-widget-type="find-va-forms-invalid-pdf-alert"
+          data-form-number="{{ fieldVaFormNumber }}"
+          lang="{{ fieldVaFormLanguage }}"
+          >
+            <i
+              aria-hidden="true"
+              class="fas fa-download fa-lg vads-u-margin-right--1 va-form-layout--remove-pointer-events"
+              role="presentation"
+            > </i>
+
+          {% if fieldVaFormLanguage === "es" %}
+            Descargar el formulario {{ fieldVaFormNumber }} (PDF)
+          {% else %}
+            Download VA Form {{ fieldVaFormNumber }} (PDF)
+          {% endif %}
+        </a>
 
         {% if fieldAlert.length %}
           {% for alert in fieldAlert %}
@@ -160,19 +152,25 @@
                   </p>
 
                 {{ vaForm.entity.fieldVaFormUsage.processed }}
-
+                
                 <a
                   href="{{ vaForm.entity.fieldVaFormUrl.uri }}"
                   target="_blank"
                   download
                   data-widget-type="find-va-forms-invalid-pdf-alert"
-                  data-form-number="{{ vaForm.entity.fieldVaFormNumber }}">
+                  data-form-number="{{ vaForm.entity.fieldVaFormNumber }}"
+                  lang="{{ vaForm.entity.fieldVaFormLanguage }}"
+                  >
                     <i
                       aria-hidden="true"
                       class="fas fa-download fa-lg vads-u-margin-right--1 va-form-layout--remove-pointer-events"
                       role="presentation"
                     > </i>
-                  Download VA Form {{ vaForm.entity.fieldVaFormNumber }} (PDF)
+                    {% if vaForm.entity.fieldVaFormLanguage === "es" %}
+                      Descargar el formulario {{ vaForm.entity.fieldVaFormNumber }} (PDF)
+                    {% else %}
+                      Download VA Form {{ vaForm.entity.fieldVaFormNumber }} (PDF)
+                    {% endif %}
                 </a>
               </li>
             {% endfor %}

--- a/src/site/stages/build/drupal/graphql/vaFormPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vaFormPage.graphql.js
@@ -62,6 +62,7 @@ fragment vaFormPage on NodeVaForm {
           path
           routed
         }
+        fieldVaFormLanguage
         fieldVaFormNumber
         fieldVaFormName
         fieldVaFormUsage {


### PR DESCRIPTION
## Issue
https://github.com/department-of-veterans-affairs/va.gov-team/issues/26908

## Description
Now that we have es from content, we can add the needed translations for a11y.
Related PR => https://github.com/department-of-veterans-affairs/vets-website/pull/18452

## Testing done
Spun up local env

## Screenshots
![Screen Shot 2021-08-30 at 4 57 49 PM](https://user-images.githubusercontent.com/26075258/131513614-4944c995-7b71-4f2a-aa10-d8011a2d24b6.png)


## Acceptance criteria
- [x] Translations are showing up

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
