### PR TITLE
Remove button styling from link

### DIFF
--- a/src/site/paragraphs/button.drupal.liquid
+++ b/src/site/paragraphs/button.drupal.liquid
@@ -1,7 +1,3 @@
-<a
-  class="usa-button-primary"
-  data-template="paragraphs/button"
-  href="{{ entity.fieldButtonLink.url.path }}"
->
+<a data-template="paragraphs/button" href="{{ entity.fieldButtonLink.url.path }}">
   {{ entity.fieldButtonLabel }}
 </a>


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/29238

For a11y purposes links should not be styled as buttons

## Testing done
local

## Screenshots
Before:
<img width="1787" alt="Screen Shot 2021-09-01 at 3 28 00 PM" src="https://user-images.githubusercontent.com/3144003/131732262-82793517-72c7-4e7b-b8c7-3f14002d94a4.png">

After:
<img width="1787" alt="Screen Shot 2021-09-01 at 3 27 48 PM" src="https://user-images.githubusercontent.com/3144003/131732278-f3a9a867-61ec-4115-8239-ca8480527ab3.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
