### PR TITLE
Fix VAMC info alert inheritcance logic.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,6 +30,7 @@ src/platform/utilities/medical-centers @department-of-veterans-affairs/vsa-authd
 
 # Shared templates
 src/site/includes @department-of-veterans-affairs/vsa-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend @department-of-veterans-affairs/vsa-caregiver-frontend
+src/site/components @department-of-veterans-affairs/vsa-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend @department-of-veterans-affairs/vsa-caregiver-frontend
 
 # Public Websites
 src/platform/site-wide @department-of-veterans-affairs/vsa-public-websites-frontend @department-of-veterans-affairs/frontend-review-group

--- a/src/site/components/fullwidth_banner_alerts.drupal.liquid
+++ b/src/site/components/fullwidth_banner_alerts.drupal.liquid
@@ -1,13 +1,13 @@
 {% for entity in bannerAlert.entities %}
-  {% assign dismissStatus = entity.fieldAlertInheritanceSubpages %}
+  {% assign hideOnSubpages = entity.fieldAlertInheritanceSubpages %}
   {% assign alertType = entity.fieldAlertType %}
 
-  {% if alertType = "information" %}
+  {% if alertType == "information" %}
     {% assign alertType = "info" %}
   {% endif %}
 
-  {% assign region = entityUrl.path  %}
-  {% assign lastArg = entityUrl.path | split: "/" | last | prepend: "/"%}
+  {% assign region = entityUrl.path | regionBasePath | prepend: "/" %}
+  {% assign lastArg = entityUrl.path | split: "/" | last | prepend: "/" %}
 
   {% assign outputStatus = false %}
   {% assign emailUpdates = "" %}
@@ -19,7 +19,7 @@
 
       {% assign outputStatus = true %}
 
-      {% if dismissStatus == true and lastArg != region and lastArg != "/operating-status" %}
+      {% if hideOnSubpages == true and lastArg != region and lastArg != "/operating-status" %}
         {% assign outputStatus = false %}
       {% endif %}
       {% assign emailUpdates = vamc.entity.fieldOffice.entity.fieldLinkFacilityEmergList.uri %}
@@ -29,15 +29,15 @@
 
   {% if outputStatus == true %}
     <div data-template="components/fullwidth_banner_alerts" data-entity-id="{{ entity.entityId }}"
-      aria-labelledby="usa-alert-header-text-{{ entity.entityId }}"
-      class="usa-alert-full-width dismissable-option-header usa-alert-full-width-{{ alertType }}"
-      id="usa-alert-full-width-{{ entity.entityId }}" role="region">
+         aria-labelledby="usa-alert-header-text-{{ entity.entityId }}"
+         class="usa-alert-full-width dismissable-option-header usa-alert-full-width-{{ alertType }}"
+         id="usa-alert-full-width-{{ entity.entityId }}" role="region">
       <div class="usa-alert usa-alert-{{ alertType }}" role="alert">
         {% if entity.fieldAlertDismissable == true %}
           <button id="usa-alert-dismiss-{{ entity.entityId }}"
-            class="va-alert-close usa-alert-dismiss"
-            data-parentwrap="usa-alert-full-width-{{ entity.entityId }}"
-            data-frequency="once" aria-label="Close notification">
+                  class="va-alert-close usa-alert-dismiss"
+                  data-parentwrap="usa-alert-full-width-{{ entity.entityId }}"
+                  data-frequency="once" aria-label="Close notification">
             <i aria-hidden="true" class="fas fa-times-circle"></i>
           </button>
         {% endif %}
@@ -48,12 +48,12 @@
           <div class="additional-info-content usa-alert-text">
             {% capture eventData %}
               {
-                "event": "nav-alert-box-link-click",
-                "alert-box-status": "{{ alertType }}",
-                "alert-box-headline": "{{ entity.title }}",
-                "alert-box-headline-level": "3",
-                "alert-box-background-only": "false",
-                "alert-box-closeable": "false"
+              "event": "nav-alert-box-link-click",
+              "alert-box-status": "{{ alertType }}",
+              "alert-box-headline": "{{ entity.title }}",
+              "alert-box-headline-level": "3",
+              "alert-box-background-only": "false",
+              "alert-box-closeable": "false"
               }
             {% endcapture %}
             {{ entity.fieldBody.processed | trackLinks: eventData }}
@@ -61,9 +61,9 @@
             {% if entity.fieldAlertOperatingStatusCta == true and statusUrl.length %}
               <p>
                 <a href="{{ statusUrl }}" onclick="recordEvent({
-                  'event':'nav-warning-alert-box-content-link-click',
-                  'alertBoxHeading': '{{entity.title}}'
-                  });">Get updates on affected services and facilities</a>
+                    'event':'nav-warning-alert-box-content-link-click',
+                    'alertBoxHeading': '{{ entity.title }}'
+                    });">Get updates on affected services and facilities</a>
               </p>
             {% endif %}
 

--- a/src/site/components/tests/fixtures/banner_alerts_inherit.json
+++ b/src/site/components/tests/fixtures/banner_alerts_inherit.json
@@ -1,0 +1,85 @@
+{
+  "entityUrl": {
+    "breadcrumb": [
+      {
+        "url": {
+          "path": "/",
+          "routed": true
+        },
+        "text": "Home"
+      },
+      {
+        "url": {
+          "path": "/louisville-health-care",
+          "routed": true
+        },
+        "text": "VA Louisville health care"
+      },
+      {
+        "url": {
+          "path": "",
+          "routed": true
+        },
+        "text": "ABOUT VA LOUISVILLE"
+      },
+      {
+        "url": {
+          "path": "/louisville-health-care/about-us",
+          "routed": true
+        },
+        "text": "About us"
+      },
+      {
+        "url": {
+          "path": "",
+          "routed": true
+        },
+        "text": "History"
+      }
+    ],
+    "path": "/louisville-health-care/about-us/history"
+  },
+  "bannerAlert": {
+    "entities": [
+      {
+        "title": "Website coming soon - Not the official Louisville health care website",
+        "fieldBody": {
+          "processed": "<p>We hope you enjoy your look at our new website. This is NOT our official website at this time, but will be soon. To continue your health care journey in the Louisville Healthcare System, please return to our <a href=\"https://www.louisville.va.gov/\">official Louisville health care website</a>.</p>"
+        },
+        "entityId": "15641",
+        "fieldAlertType": "information",
+        "fieldAlertDismissable": false,
+        "fieldAlertFindFacilitiesCta": false,
+        "fieldAlertOperatingStatusCta": false,
+        "fieldAlertEmailUpdatesButton": false,
+        "fieldAlertInheritanceSubpages": false,
+        "fieldAdministration": {
+          "entity": {
+            "entityId": "183"
+          }
+        },
+        "fieldOperatingStatusSendemail": false,
+        "fieldBannerAlertSituationinfo": null,
+        "fieldSituationUpdates": [],
+        "fieldBannerAlertVamcs": [
+          {
+            "entity": {
+              "title": "Operating status - VA Louisville health care",
+              "entityUrl": {
+                "path": "/louisville-health-care/operating-status"
+              },
+              "fieldOffice": {
+                "entity": {
+                  "title": "VA Louisville health care",
+                  "entityUrl": {
+                    "path": "/louisville-health-care"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/site/components/tests/fixtures/banner_alerts_no_inherit.json
+++ b/src/site/components/tests/fixtures/banner_alerts_no_inherit.json
@@ -1,0 +1,85 @@
+{
+  "entityUrl": {
+    "breadcrumb": [
+      {
+        "url": {
+          "path": "/",
+          "routed": true
+        },
+        "text": "Home"
+      },
+      {
+        "url": {
+          "path": "/louisville-health-care",
+          "routed": true
+        },
+        "text": "VA Louisville health care"
+      },
+      {
+        "url": {
+          "path": "",
+          "routed": true
+        },
+        "text": "ABOUT VA LOUISVILLE"
+      },
+      {
+        "url": {
+          "path": "/louisville-health-care/about-us",
+          "routed": true
+        },
+        "text": "About us"
+      },
+      {
+        "url": {
+          "path": "",
+          "routed": true
+        },
+        "text": "History"
+      }
+    ],
+    "path": "/louisville-health-care/about-us/history"
+  },
+  "bannerAlert": {
+    "entities": [
+      {
+        "title": "Website coming soon - Not the official Louisville health care website",
+        "fieldBody": {
+          "processed": "<p>We hope you enjoy your look at our new website. This is NOT our official website at this time, but will be soon. To continue your health care journey in the Louisville Healthcare System, please return to our <a href=\"https://www.louisville.va.gov/\">official Louisville health care website</a>.</p>"
+        },
+        "entityId": "15641",
+        "fieldAlertType": "information",
+        "fieldAlertDismissable": false,
+        "fieldAlertFindFacilitiesCta": false,
+        "fieldAlertOperatingStatusCta": false,
+        "fieldAlertEmailUpdatesButton": false,
+        "fieldAlertInheritanceSubpages": true,
+        "fieldAdministration": {
+          "entity": {
+            "entityId": "183"
+          }
+        },
+        "fieldOperatingStatusSendemail": false,
+        "fieldBannerAlertSituationinfo": null,
+        "fieldSituationUpdates": [],
+        "fieldBannerAlertVamcs": [
+          {
+            "entity": {
+              "title": "Operating status - VA Louisville health care",
+              "entityUrl": {
+                "path": "/louisville-health-care/operating-status"
+              },
+              "fieldOffice": {
+                "entity": {
+                  "title": "VA Louisville health care",
+                  "entityUrl": {
+                    "path": "/louisville-health-care"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/site/components/tests/fullwidth_banner_alerts.drupal.unit.spec.js
+++ b/src/site/components/tests/fullwidth_banner_alerts.drupal.unit.spec.js
@@ -1,0 +1,23 @@
+import { expect } from 'chai';
+import { renderHTML, parseFixture } from '~/site/tests/support';
+
+const layoutPath = 'src/site/components/fullwidth_banner_alerts.drupal.liquid';
+
+describe('fullwidth_banner_alerts', () => {
+  // Note: fieldAlertInheritanceSubpages behaves the opposite of its name.
+  it('renders the alert on subpage when fieldAlertInheritanceSubpages is false', async () => {
+    const data = parseFixture(
+      'src/site/components/tests/fixtures/banner_alerts_inherit.json',
+    );
+    const container = await renderHTML(layoutPath, data, 'inherit');
+    expect(container.getElementById(`usa-alert-full-width-15641`)).to.exist;
+  });
+
+  it('hides the alert on subpage when fieldAlertInheritanceSubpages is true', async () => {
+    const data = parseFixture(
+      'src/site/components/tests/fixtures/banner_alerts_no_inherit.json',
+    );
+    const container = await renderHTML(layoutPath, data, 'noInherit');
+    expect(container.getElementById(`usa-alert-full-width-15641`)).not.to.exist;
+  });
+});


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/va.gov-team/issues/29459

To verify, visit any VAMC that does NOT have the "Limit banner display to the home and the Operating Status page(s)" checkbox checked in Drupal, e.g. 

https://master-ldij0hdlillzgrlzsgjk8keqbcknof2i.demo.cms.va.gov/va-pittsburgh-health-care/vamc-banner-alert/2021-01-19/website-coming-soon-not-the-official-erie

Then visit the corresponding VAMC and note that the full width info banner shows on ALL pages, not just the system page. E.g.

https://web-ldij0hdlillzgrlzsgjk8keqbcknof2i.demo.cms.va.gov/erie-health-care/health-services/
https://web-ldij0hdlillzgrlzsgjk8keqbcknof2i.demo.cms.va.gov/erie-health-care/locations/
https://web-ldij0hdlillzgrlzsgjk8keqbcknof2i.demo.cms.va.gov/erie-health-care/events/
... etc.

Contrast with production, where the info banner only renders on the system page:
https://www.va.gov/erie-health-care/health-services/
https://www.va.gov/erie-health-care/locations/
... etc.
