### PR TITLE
Add position relative class to back-to-top-container first child

### DIFF
--- a/src/site/components/up_to_top_button.html
+++ b/src/site/components/up_to_top_button.html
@@ -12,10 +12,10 @@ Used as quick navigate back to top for long article pages.
 {% endcomment %}
 
 <div id="back-to-top-container">
-  <div class="usa-grid usa-grid-full">
+  <div class="usa-grid usa-grid-full va-c-position--relative">
     {% if isCampaignLandingPage %}
       <div class="usa-content" style="max-width: 100rem;">
-        <button type="button" className="usa-button">
+        <button class="usa-button" type="button">
           <span>
             <i aria-hidden="true" class="fas fa-arrow-up" role="img"></i>
           </span>
@@ -25,7 +25,7 @@ Used as quick navigate back to top for long article pages.
     {% else %}
       <div class="usa-width-three-fourths">
         <div class="usa-content">
-          <button type="button" className="usa-button">
+          <button class="usa-button" type="button">
             <span>
               <i aria-hidden="true" class="fas fa-arrow-up" role="img"></i>
             </span>

--- a/src/site/components/up_to_top_button.html
+++ b/src/site/components/up_to_top_button.html
@@ -12,7 +12,7 @@ Used as quick navigate back to top for long article pages.
 {% endcomment %}
 
 <div id="back-to-top-container">
-  <div class="usa-grid usa-grid-full va-c-position--relative">
+  <div class="usa-grid usa-grid-full vads-u-position--relative">
     {% if isCampaignLandingPage %}
       <div class="usa-content" style="max-width: 100rem;">
         <button class="usa-button" type="button">


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/29126

For the back to top button the `position: relative` element is in the correct place for some pages but not for others. This adds `position: relative` to an outer container that works for all pages. A companion PR will be needed to remove the styling in `veteran-facing-services-tools`: https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/670

## Testing done
local

## Screenshots
`/decision-reviews/supplemental-claim/` Before:
<img width="1791" alt="Screen Shot 2021-09-02 at 10 32 01 AM" src="https://user-images.githubusercontent.com/3144003/131864851-b5872d6c-4068-4bb1-ad00-561222d36d25.png">

`/decision-reviews/supplemental-claim/` After: 
<img width="1788" alt="Screen Shot 2021-09-02 at 10 32 22 AM" src="https://user-images.githubusercontent.com/3144003/131864896-0c0ff9bb-3552-49c2-9093-c2d623816f63.png">

`/resources/how-to-get-free-language-assistance-from-va/` Before:
<img width="1789" alt="Screen Shot 2021-09-02 at 10 32 11 AM" src="https://user-images.githubusercontent.com/3144003/131864966-34bb9775-7e06-43c3-ae79-c44aab37147c.png">

`/resources/how-to-get-free-language-assistance-from-va/` After:
<img width="1787" alt="Screen Shot 2021-09-02 at 10 32 37 AM" src="https://user-images.githubusercontent.com/3144003/131865001-e8c2c1c3-2482-4786-a6cf-b798611ae708.png">

**Both had `position: relative` disabled manually for the `.usa-content` div, the code for which lives in `veteran-facing-services-tools` meaning this change will not fix the issue on its own in a one-off environment or locally until the corresponding `veteran-facing-services-tools` gets in as well, but it also will not negatively affect the positioning until then either.**

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
