### PR TITLE
Improve Cypress accessibility reporting

### DIFF
--- a/src/platform/testing/e2e/cypress/support/commands/axeCheck.js
+++ b/src/platform/testing/e2e/cypress/support/commands/axeCheck.js
@@ -16,6 +16,7 @@ const processAxeCheckResults = violations => {
       id,
       impact,
       description,
+      target: nodes[0].target,
       nodes: nodes.length,
     }),
   );


### PR DESCRIPTION
## Description
This PR modifies Cypress accessibility reporting so that the target element is shown when an accessibility violation is detected:
<img width="1138" alt="Screen Shot 2021-09-02 at 10 18 20 AM" src="https://user-images.githubusercontent.com/3535749/131870668-1ce4f93c-934d-44b0-a257-49c2d8bf6b85.png">
