### PR TITLE
Show HTML element in Cypress aXe failures

### DIFF
--- a/src/platform/testing/e2e/cypress/support/commands/axeCheck.js
+++ b/src/platform/testing/e2e/cypress/support/commands/axeCheck.js
@@ -17,6 +17,7 @@ const processAxeCheckResults = violations => {
       impact,
       description,
       target: nodes[0].target,
+      html: nodes[0].html,
       nodes: nodes.length,
     }),
   );


### PR DESCRIPTION
## Description
This PR modifies the Cypress aXe check so that the HTML element that causes an aXe failure is shown in the Cypress output:

<img width="1598" alt="Screen Shot 2021-09-02 at 11 11 11 AM" src="https://user-images.githubusercontent.com/3535749/131879463-e9d490e3-cb1e-45bd-a52e-b72f0cfe0c1c.png">
