### PR TITLE
DT-26905 Added underline for links per a11y request

### DIFF
--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -186,7 +186,6 @@
                   <li>
                     <h3 class="vads-u-font-size--h4">
                       <a
-                        class="vads-u-text-decoration--none"
                         href="{{ vaFormLinkTeaser.entity.fieldLink.url.path }}"
                         onclick="recordEvent({ event: 'nav-linkslist', 'links-list-header': '{{ vaFormLinkTeaser.entity.fieldLink.title | escape }}', 'links-list-section-header': '{{ linkTeasersHeader | escape }}' })">
                         {{ vaFormLinkTeaser.entity.fieldLink.title }}
@@ -200,7 +199,6 @@
                 <li>
                   <h3 class="vads-u-font-size--h4">
                     <a
-                      class="vads-u-text-decoration--none"
                       href="/change-direct-deposit"
                       onclick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Change your direct deposit information', 'links-list-section-header': '{{ linkTeasersHeader | escape }}' })">
                       Change your direct deposit information
@@ -211,7 +209,6 @@
                 <li>
                   <h3 class="vads-u-font-size--h4">
                     <a
-                      class="vads-u-text-decoration--none"
                       href="/change-address"
                       onclick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Change your address', 'links-list-section-header': '{{ linkTeasersHeader | escape }}' })">
                       Change your address
@@ -222,7 +219,6 @@
                 <li>
                   <h3 class="vads-u-font-size--h4">
                     <a
-                      class="vads-u-text-decoration--none"
                       href="/records/get-military-service-records/"
                       onclick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Request your military records, including DD214', 'links-list-section-header': '{{ linkTeasersHeader | escape }}' })">
                       Request your military records, including DD214
@@ -233,7 +229,6 @@
                 <li>
                   <h3 class="vads-u-font-size--h4">
                     <a
-                      class="vads-u-text-decoration--none"
                       href="/records/"
                       onclick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Get your VA records and documents online', 'links-list-section-header': '{{ linkTeasersHeader | escape }}' })">
                       Get your VA records and documents online

--- a/src/site/paragraphs/linkTeaser.drupal.liquid
+++ b/src/site/paragraphs/linkTeaser.drupal.liquid
@@ -37,7 +37,7 @@
   {% if header === "h3" %}
     {% if link.title != empty %}
         <h3 class="{{ headerClass }}">
-            <a href="{{link.url.path}}"
+            <a href="{{link.url.path}}" class="vads-u-text-decoration--underline"
             {% if linkTeaser.options["target"] %}target="{{ linkTeaser.options["target"] }}"{% endif %}
             >
             {{ link.title }}
@@ -45,7 +45,7 @@
         </h3>
     {% endif %}
   {% else %}
-    <a href="{{link.url.path}}"
+    <a href="{{link.url.path}}" class="vads-u-text-decoration--underline"
     {% if linkTeaser.options["target"] %}target="{{ linkTeaser.options["target"] }}"{% endif %}
     >
         {% if link.title != empty %}


### PR DESCRIPTION
## Issue
https://github.com/department-of-veterans-affairs/va.gov-team/issues/26905

## Description
Adding underline to solve the issue with the usages of color as the only method to provide information.

## Testing done
Built and spun up local env.

## Screenshots
![Screen Shot 2021-09-02 at 12 12 46 PM](https://user-images.githubusercontent.com/26075258/131882036-3dcf1564-3e1c-4152-b6e4-39f1e7f587f9.png)
![Screen Shot 2021-09-02 at 11 05 06 AM](https://user-images.githubusercontent.com/26075258/131882040-ce91fa8c-6bcb-44fe-93fe-a4e995cef4bb.png)


## Acceptance criteria
- [x] Added underline for links

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
