### PR TITLE
Update footer links (1-3)

### DIFF
--- a/src/platform/static-data/footer-links.json
+++ b/src/platform/static-data/footer-links.json
@@ -148,8 +148,15 @@
   },
   {
     "column": 3,
-    "href": "https://public.govdelivery.com/accounts/USVA/subscriber/new/",
+    "href": "https://www.va.gov/opa/pressrel",
     "order": 2,
+    "target": null,
+    "title": "News releases"
+  },
+  {
+    "column": 3,
+    "href": "https://public.govdelivery.com/accounts/USVA/subscriber/new/",
+    "order": 3,
     "target": "_blank",
     "title": "Email updates",
     "rel": "noopener noreferrer"
@@ -157,7 +164,7 @@
   {
     "column": 3,
     "href": "https://www.facebook.com/VeteransAffairs",
-    "order": 3,
+    "order": 4,
     "target": "_blank",
     "title": "Facebook",
     "rel": "noopener noreferrer"
@@ -165,7 +172,7 @@
   {
     "column": 3,
     "href": "https://www.instagram.com/deptvetaffairs/",
-    "order": 4,
+    "order": 5,
     "target": "_blank",
     "title": "Instagram",
     "rel": "noopener noreferrer"
@@ -173,7 +180,7 @@
   {
     "column": 3,
     "href": "https://www.twitter.com/DeptVetAffairs/",
-    "order": 5,
+    "order": 6,
     "target": "_blank",
     "title": "Twitter",
     "rel": "noopener noreferrer"
@@ -181,7 +188,7 @@
   {
     "column": 3,
     "href": "https://www.flickr.com/photos/VeteransAffairs/",
-    "order": 6,
+    "order": 7,
     "target": "_blank",
     "title": "Flickr",
     "rel": "noopener noreferrer"
@@ -189,7 +196,7 @@
   {
     "column": 3,
     "href": "https://www.youtube.com/user/DeptVetAffairs",
-    "order": 7,
+    "order": 8,
     "target": "_blank",
     "title": "YouTube",
     "rel": "noopener noreferrer"
@@ -197,7 +204,7 @@
   {
     "column": 3,
     "href": "https://www.va.gov/opa/socialmedia.asp",
-    "order": 8,
+    "order": 9,
     "target": null,
     "title": "All VA social media"
   },

--- a/src/platform/static-data/footer-links.json
+++ b/src/platform/static-data/footer-links.json
@@ -263,50 +263,57 @@
   },
   {
     "column": "bottom_rail",
-    "href": "https://www.va.gov/ormdi/NOFEAR_Select.asp",
+    "href": "https://www.va.gov/resources/your-civil-rights-and-how-to-file-a-discrimination-complaint/",
     "order": 2,
+    "target": null,
+    "title": "Civil Rights"
+  },
+  {
+    "column": "bottom_rail",
+    "href": "https://www.va.gov/ormdi/NOFEAR_Select.asp",
+    "order": 3,
     "target": null,
     "title": "No FEAR Act Data"
   },
   {
     "column": "bottom_rail",
     "href": "https://www.va.gov/oig/",
-    "order": 3,
+    "order": 4,
     "target": null,
     "title": "Office of Inspector General"
   },
   {
     "column": "bottom_rail",
     "href": "https://www.va.gov/opa/Plain_Language.asp",
-    "order": 4,
+    "order": 5,
     "target": null,
     "title": "Plain language"
   },
   {
     "column": "bottom_rail",
     "href": "https://www.va.gov/privacy-policy/",
-    "order": 5,
+    "order": 6,
     "target": null,
     "title": "Privacy, policies, and legal information"
   },
   {
     "column": "bottom_rail",
     "href": "https://www.va.gov/privacy/",
-    "order": 6,
+    "order": 7,
     "target": null,
     "title": "VA Privacy Service"
   },
   {
     "column": "bottom_rail",
     "href": "https://www.va.gov/foia/",
-    "order": 7,
+    "order": 8,
     "target": null,
     "title": "Freedom of Information Act (FOIA)"
   },
   {
     "column": "bottom_rail",
     "href": "https://www.usa.gov/",
-    "order": 8,
+    "order": 9,
     "target": "_blank",
     "title": "USA.gov",
     "rel": "noopener noreferrer"
@@ -314,7 +321,7 @@
   {
     "column": "bottom_rail",
     "href": "https://www.va.gov/veterans-portrait-project/",
-    "order": 9,
+    "order": 10,
     "target": null,
     "title": "Veterans Portrait Project"
   }

--- a/src/platform/static-data/footer-links.json
+++ b/src/platform/static-data/footer-links.json
@@ -209,6 +209,13 @@
     "title": "All VA social media"
   },
   {
+    "column": "bottom_rail",
+    "href": "https://www.va.gov/performance-dashboard/",
+    "order": 10,
+    "target": null,
+    "title": "VA performance dashboard"
+  },
+  {
     "column": 4,
     "href": "https://www.va.gov/resources/",
     "order": 1,
@@ -306,15 +313,8 @@
   },
   {
     "column": "bottom_rail",
-    "href": "https://www.va.gov/performance-dashboard/",
-    "order": 9,
-    "target": null,
-    "title": "VA performance dashboard"
-  },
-  {
-    "column": "bottom_rail",
     "href": "https://www.va.gov/veterans-portrait-project/",
-    "order": 10,
+    "order": 9,
     "target": null,
     "title": "Veterans Portrait Project"
   }

--- a/src/platform/static-data/footer-links.json
+++ b/src/platform/static-data/footer-links.json
@@ -270,10 +270,10 @@
   },
   {
     "column": "bottom_rail",
-    "href": "https://www.va.gov/ormdi/NOFEAR_Select.asp",
+    "href": "https://www.va.gov/foia/",
     "order": 3,
     "target": null,
-    "title": "No FEAR Act Data"
+    "title": "Freedom of Information Act (FOIA)"
   },
   {
     "column": "bottom_rail",
@@ -305,10 +305,10 @@
   },
   {
     "column": "bottom_rail",
-    "href": "https://www.va.gov/foia/",
+    "href": "https://www.va.gov/ormdi/NOFEAR_Select.asp",
     "order": 8,
     "target": null,
-    "title": "Freedom of Information Act (FOIA)"
+    "title": "No FEAR Act Data"
   },
   {
     "column": "bottom_rail",


### PR DESCRIPTION
# Description

**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/29528

This PR updates the footer links in the following ways:

1. Move the "VA performance dashboard" link out of the sub-footer (2 rows at very bottom) up to the main footer under the "Get VA updates" column. Place this option as the last option in the column.
2. Add a "Civil Rights" link (destination https://www.va.gov/resources/your-civil-rights-and-how-to-file-a-discrimination-complaint/) to the sub-footer. Place it after the "Accessibility" option.
3. Move the "Freedom of Information Act (FOIA)" to be after the new "Civil Rights" link so it is in proper alpha order with the other links in those 2 lines.

## Screenshots

![image](https://user-images.githubusercontent.com/12773166/132565524-182050bb-c1d5-4d44-a830-c2d08ed80c72.png)

## Acceptance Criteria

1. Move the "VA performance dashboard" link out of the sub-footer (2 rows at very bottom) up to the main footer under the "Get VA updates" column. Place this option as the last option in the column.
2. Add a "Civil Rights" link (destination https://www.va.gov/resources/your-civil-rights-and-how-to-file-a-discrimination-complaint/) to the sub-footer. Place it after the "Accessibility" option.
3. Move the "Freedom of Information Act (FOIA)" to be after the new "Civil Rights" link so it is in proper alpha order with the other links in those 2 lines.