### PR TITLE
Corrects Central Western Massachusetts facility sidebar name.

### DIFF
--- a/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
+++ b/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
@@ -10,7 +10,7 @@ const FACILITY_MENU_NAMES = [
   // VISN 1
   'va-bedford-health-care',
   'va-boston-health-care',
-  'va-central-western-massachusetts-health-care',
+  'va-central-western-massachusetts',
   'va-connecticut-health-care',
   'va-maine-health-care',
   'va-manchester-health-care',


### PR DESCRIPTION
## Description
The name specified here was too long -- Drupal machine names have a length limit to avoid transgressing DB length limits, etc.

## Testing done


## Screenshots
<img width="833" alt="Screen Shot 2021-09-09 at 7 40 48 AM" src="https://user-images.githubusercontent.com/1318579/132679385-1fdc2e5b-a120-4c29-896c-f75e3c538bad.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
