### PR TITLE
Fix Slack notifications for Cypress accessibility tests when build job fails

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -257,7 +257,7 @@ jobs:
 
       - name: Accessibility Test Failure
         uses: ./.github/actions/vsp-github-actions/slack-socket
-        if: ${{ needs.a11y.result == 'failure' }}
+        if: ${{ needs.a11y.result == 'failure' || needs.build.result == 'failure' }}
         env:
           SSL_CERT_DIR: /etc/ssl/certs
         with:


### PR DESCRIPTION
## Description
This PR modifies the workflow for the daily Cypress accessibility scan so that a failure notification is sent if the `build` job fails.