### PR TITLE
Github Actions (CI, content-release & daily-deploy) -- Fix caching

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -238,8 +238,8 @@ jobs:
         with:
           path: |
             .cache/yarn
-            node_modules
-          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
+            **/node_modules
+          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-${{ hashFiles('**/yarn.lock') }}
           restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-
 
       - name: Install dependencies

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -237,10 +237,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ~/.cache/yarn
+            .cache/yarn
             node_modules
-          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
-          restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-
+          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline --network-concurrency 1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -539,6 +539,9 @@ jobs:
         with:
           node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 
+      - name: pwd
+        run: pwd
+
       - name: Cache dependencies
         id: cache-dependencies
         uses: actions/cache@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -153,8 +153,8 @@ jobs:
           path: |
             /usr/local/share/.cache/yarn
             node_modules
-          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
-          restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-
+          key: v2-${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: v2-${{ steps.get-node-version.outputs.NODE_VERSION }}-
 
       - name: ls
         run: ls -la

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -461,13 +461,11 @@ jobs:
         with:
           path: |
             .cache/yarn
-            /github/home/.cache/Cypress
+            /root/.cache/Cypress
             **/node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-cypress-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-cypress-
-            ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-
-            ${{ steps.get-node-version.outputs.NODE_VERSION }}-
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline --production=false

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Get yarn cache directory path
         run: yarn cache dir
       
-      - name: pwd 
+      - name: pwd
         run: pwd
 
       - name: Install dependencies

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -140,21 +140,6 @@ jobs:
         with:
           node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 
-      - name: ls
-        run: ls -la
-
-      - name: Get yarn cache directory path
-        run: yarn cache dir
-
-      - name: pwd
-        run: pwd
-
-      - name: hash string
-        run: echo ${{ hashFiles('**/yarn.lock') }}
-
-      - name: cat yarn.lock
-        run: cat yarn.lock
-
       - name: Cache dependencies
         id: cache-dependencies
         uses: actions/cache@v2
@@ -163,9 +148,6 @@ jobs:
             .cache/yarn
             **/node_modules
           key: v4-${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
-
-      - name: ls
-        run: ls -la
 
       - name: Get yarn cache directory path
         run: yarn cache dir
@@ -491,10 +473,9 @@ jobs:
         with:
           path: |
             .cache/yarn
-            /github/home/.cache/Cypress
-            node_modules
-          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
-          restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-
+            /root/.cache/Cypress
+            **/node_modules
+          key: v5-${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline --production=false

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -120,11 +120,11 @@ jobs:
             drupal-address: http://internal-dsva-vagov-prod-cms-2000800896.us-gov-west-1.elb.amazonaws.com
 
     steps:
-      - name: Checkout vagov-content
-        uses: actions/checkout@v2
-        with:
-          repository: department-of-veterans-affairs/vagov-content
-          path: vagov-content
+      # - name: Checkout vagov-content
+      #   uses: actions/checkout@v2
+      #   with:
+      #     repository: department-of-veterans-affairs/vagov-content
+      #     path: vagov-content
 
       - name: Checkout content-build
         uses: actions/checkout@v2
@@ -146,6 +146,9 @@ jobs:
       - name: Get yarn cache directory path
         run: yarn cache dir
 
+      - name: pwd
+        run: pwd
+
       - name: Cache dependencies
         id: cache-dependencies
         uses: actions/cache@v2
@@ -160,6 +163,9 @@ jobs:
 
       - name: Get yarn cache directory path
         run: yarn cache dir
+      
+      - name: pwd
+        run: pwd
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline --network-concurrency 1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -148,8 +148,7 @@ jobs:
             .cache/yarn
             **/node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-
+          restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline --network-concurrency 1
@@ -460,8 +459,7 @@ jobs:
             /github/home/.cache/Cypress
             **/node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-cypress-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-cypress-
+          restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-cypress-
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline --production=false
@@ -531,8 +529,7 @@ jobs:
             .cache/yarn
             node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-
+          restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -154,7 +154,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            /usr/local/share/.cache/yarn
+            .cache/yarn
             node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
           restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -152,12 +152,6 @@ jobs:
             ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-
             ${{ steps.get-node-version.outputs.NODE_VERSION }}-
 
-      - name: Get yarn cache directory path
-        run: yarn cache dir
-      
-      - name: pwd
-        run: pwd
-
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline --network-concurrency 1
         env:
@@ -300,19 +294,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            /usr/local/share/.cache/yarn
+            .cache/yarn
             node_modules
-          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
-          # restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-
-
-      - name: ls
-        run: ls -la
-
-      - name: Get yarn cache directory path
-        run: yarn cache dir
-
-      - name: pwd
-        run: pwd
+          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline
@@ -476,7 +461,7 @@ jobs:
         with:
           path: |
             .cache/yarn
-            /root/.cache/Cypress
+            /github/home/.cache/Cypress
             **/node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-cypress-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
@@ -543,9 +528,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
-
-      - name: pwd
-        run: pwd
 
       - name: Cache dependencies
         id: cache-dependencies

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -307,9 +307,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            .cache/yarn
+            /usr/local/share/.cache/yarn
             node_modules
-          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
+          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
           restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-
 
       - name: ls

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -147,9 +147,6 @@ jobs:
         id: yarn-cache-dir-path
         run: yarn cache dir
 
-      - name: log cache dir
-        run: ls .cache
-
       - name: Cache dependencies
         id: cache-dependencies
         uses: actions/cache@v2
@@ -159,6 +156,13 @@ jobs:
             node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
           restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-
+
+      - name: ls
+        run: ls -la
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: yarn cache dir
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline --network-concurrency 1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -162,8 +162,7 @@ jobs:
           path: |
             .cache/yarn
             **/node_modules
-          key: v3-${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: v3-${{ steps.get-node-version.outputs.NODE_VERSION }}-
+          key: v4-${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
 
       - name: ls
         run: ls -la

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -147,7 +147,8 @@ jobs:
           path: |
             .cache/yarn
             **/node_modules
-          key: v4-${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-
 
       - name: Get yarn cache directory path
         run: yarn cache dir
@@ -475,7 +476,8 @@ jobs:
             .cache/yarn
             /root/.cache/Cypress
             **/node_modules
-          key: v5-${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-cypress-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-cypress-
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline --production=false
@@ -543,9 +545,9 @@ jobs:
         with:
           path: |
             .cache/yarn
-            node_modules
-          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
-          restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-
+            **/node_modules
+          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -461,7 +461,7 @@ jobs:
         with:
           path: |
             .cache/yarn
-            /root/.cache/Cypress
+            /github/home/.cache/Cypress
             **/node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-cypress-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -148,7 +148,9 @@ jobs:
             .cache/yarn
             **/node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-
+          restore-keys: |
+            ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-
+            ${{ steps.get-node-version.outputs.NODE_VERSION }}-
 
       - name: Get yarn cache directory path
         run: yarn cache dir
@@ -477,7 +479,10 @@ jobs:
             /root/.cache/Cypress
             **/node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-cypress-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-cypress-
+          restore-keys: |
+            ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-cypress-
+            ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-
+            ${{ steps.get-node-version.outputs.NODE_VERSION }}-
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline --production=false
@@ -548,9 +553,11 @@ jobs:
         with:
           path: |
             .cache/yarn
-            **/node_modules
-          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-
+            node_modules
+          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-
+            ${{ steps.get-node-version.outputs.NODE_VERSION }}-
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -170,7 +170,7 @@ jobs:
       - name: Get yarn cache directory path
         run: yarn cache dir
       
-      - name: pwd
+      - name: pwd 
         run: pwd
 
       - name: Install dependencies

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -151,7 +151,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            .cache/yarn
+            /usr/local/share/.cache/yarn
             node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
           restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -140,6 +140,16 @@ jobs:
         with:
           node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 
+      - name: ls
+        run: ls -la
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: yarn cache dir
+
+      - name: log cache dir
+        run: ls .cache
+
       - name: Cache dependencies
         id: cache-dependencies
         uses: actions/cache@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -162,8 +162,8 @@ jobs:
           path: |
             /usr/local/share/.cache/yarn
             **/node_modules
-          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-
+          key: v3-${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: v3-${{ steps.get-node-version.outputs.NODE_VERSION }}-
 
       - name: ls
         run: ls -la

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -150,7 +150,7 @@ jobs:
         run: pwd
 
       - name: hash string
-        run: echo ${{ hashFiles('./yarn.lock') }}
+        run: echo ${{ hashFiles('**/yarn.lock') }}
 
       - name: cat yarn.lock
         run: cat yarn.lock
@@ -162,7 +162,7 @@ jobs:
           path: |
             .cache/yarn
             node_modules
-          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
+          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
           restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-
 
       - name: ls

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -529,7 +529,7 @@ jobs:
             .cache/yarn
             node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-
+          restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -156,7 +156,8 @@ jobs:
           path: |
             /usr/local/share/.cache/yarn
             node_modules
-          key: v2-${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
+          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-
 
       - name: ls
         run: ls -la

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -144,7 +144,6 @@ jobs:
         run: ls -la
 
       - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
         run: yarn cache dir
 
       - name: Cache dependencies
@@ -161,7 +160,6 @@ jobs:
         run: ls -la
 
       - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
         run: yarn cache dir
 
       - name: Install dependencies

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -302,6 +302,9 @@ jobs:
         with:
           node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 
+      - name: hash string
+        run: echo ${{ hashFiles('./yarn.lock') }}
+
       - name: Cache dependencies
         id: cache-dependencies
         uses: actions/cache@v2
@@ -310,7 +313,7 @@ jobs:
             /usr/local/share/.cache/yarn
             node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-
+          # restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-
 
       - name: ls
         run: ls -la

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -154,7 +154,6 @@ jobs:
             /usr/local/share/.cache/yarn
             node_modules
           key: v2-${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
-          restore-keys: v2-${{ steps.get-node-version.outputs.NODE_VERSION }}-
 
       - name: ls
         run: ls -la

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -160,7 +160,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            /usr/local/share/.cache/yarn
+            .cache/yarn
             **/node_modules
           key: v3-${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
           restore-keys: v3-${{ steps.get-node-version.outputs.NODE_VERSION }}-

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -160,8 +160,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            .cache/yarn
-            node_modules
+            /usr/local/share/.cache/yarn
+            **/node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
           restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -120,11 +120,11 @@ jobs:
             drupal-address: http://internal-dsva-vagov-prod-cms-2000800896.us-gov-west-1.elb.amazonaws.com
 
     steps:
-      # - name: Checkout vagov-content
-      #   uses: actions/checkout@v2
-      #   with:
-      #     repository: department-of-veterans-affairs/vagov-content
-      #     path: vagov-content
+      - name: Checkout vagov-content
+        uses: actions/checkout@v2
+        with:
+          repository: department-of-veterans-affairs/vagov-content
+          path: vagov-content
 
       - name: Checkout content-build
         uses: actions/checkout@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -312,6 +312,15 @@ jobs:
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
           restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-
 
+      - name: ls
+        run: ls -la
+
+      - name: Get yarn cache directory path
+        run: yarn cache dir
+
+      - name: pwd
+        run: pwd
+
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline
         env:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -150,7 +150,6 @@ jobs:
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-
-            ${{ steps.get-node-version.outputs.NODE_VERSION }}-
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline --network-concurrency 1
@@ -534,7 +533,6 @@ jobs:
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-
-            ${{ steps.get-node-version.outputs.NODE_VERSION }}-
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -286,9 +286,6 @@ jobs:
         with:
           node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 
-      - name: hash string
-        run: echo ${{ hashFiles('./yarn.lock') }}
-
       - name: Cache dependencies
         id: cache-dependencies
         uses: actions/cache@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -149,6 +149,12 @@ jobs:
       - name: pwd
         run: pwd
 
+      - name: hash string
+        run: echo ${{ hashFiles('./yarn.lock') }}
+
+      - name: cat yarn.lock
+        run: cat yarn.lock
+
       - name: Cache dependencies
         id: cache-dependencies
         uses: actions/cache@v2

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -120,10 +120,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ~/.cache/yarn
-            node_modules
-          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
-          restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-
+            .cache/yarn
+            **/node_modules
+          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline --network-concurrency 1


### PR DESCRIPTION
## Description

This PR addresses the [following](https://github.com/department-of-veterans-affairs/va.gov-team/issues/28585#issuecomment-907288548)

Since we have changed to the on-demand runners, caching was not working as intended as the pathing has changed. This PR fixes by adding news keys specific to on-demand runners

## Testing done

[Yesterdays Run](https://github.com/department-of-veterans-affairs/content-build/actions/runs/1219436708)
Current run