### PR TITLE
Fix Mochawesome report generation in Cypress accessibility tests

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -183,6 +183,7 @@ jobs:
         run: CYPRESS_CONTENT_BUILD_PORT=3002 yarn cy:run --browser chrome --headless --port 3001 --config baseUrl=http://localhost:3002,video=false,testFiles=**/tests/**/*.a11y.spec.js --reporter mochawesome --reporter-options "configFile=config/cypress-reporters.json" --spec "src/platform/site-wide/tests/sitemap/sitemap-${{ matrix.ci_node_index }}.a11y.spec.js"
 
       - name: Rename Mochawesome JSON file
+        if: ${{ always() }}
         run: mv mochawesome-report/mochawesome.json mochawesome-report/mochawesome-${{ matrix.ci_node_index }}.json 
 
       - name: Archive Mochawesome test results


### PR DESCRIPTION
## Description
The Mochawesome report file generated in the parallel steps of the Cypress accessibility workflow was not being renamed when an accessibility failure was detected, causing reports to be overwritten. This PR fixes this issue.