### PR TITLE
Add empty links to header link teasers

### DIFF
--- a/src/site/paragraphs/list_of_link_teasers.drupal.liquid
+++ b/src/site/paragraphs/list_of_link_teasers.drupal.liquid
@@ -7,24 +7,29 @@
 {% endcomment %}
 {% assign header = "h2" %}
 {% if parentFieldName === "field_spokes" %}
-    {% assign headerClass = "hub-page-link-list__title" %}
-    {% assign ulClass = "hub-page-link-list" %}
+  {% assign headerClass = "hub-page-link-list__title" %}
+  {% assign ulClass = "hub-page-link-list" %}
 {% else %}
-    {% assign headerClass = "va-nav-linkslist-heading" %}
-    {% assign ulClass = "va-nav-linkslist-list" %}
+  {% assign headerClass = "va-nav-linkslist-heading" %}
+  {% assign ulClass = "va-nav-linkslist-list" %}
 {% endif %}
 <section data-template="paragraphs/list_of_link_teasers" data-entity-id="{{ entity.entityId }}" class="{{ entity.parentFieldName }}">
-    {% if entity.fieldTitle != empty %}
-      <{{ header }}
-          id="{{ entity.fieldTitle | hashReference }}"
-          class="{{ headerClass }}">
-          {{ entity.fieldTitle }}
-      </{{ header }}>
-    {% endif %}
-    <ul class="{{ ulClass }}">
-        {% assign section_header = entity.fieldTitle %}
-        {% for linkTeaser in entity.fieldVaParagraphs %}
-            {% include "src/site/paragraphs/linkTeaser.drupal.liquid" linkTeaser = linkTeaser.entity parentFieldName = parentFieldName boldTitle = boldTitle section_header = section_header %}
-        {% endfor %}
-    </ul>
+  {% if entity.fieldTitle != empty %}
+    <{{header}} class="{{ headerClass }}">
+      <a
+        name="{{ entity.fieldTitle | hashReference }}"
+        class="va-u-outline--none"
+        id="{{ entity.fieldTitle | hashReference }}"
+        tabindex="-1"
+        href="#{{ entity.fieldTitle | hashReference }}"
+      ></a>
+      {{ entity.fieldTitle }}
+    </{{header}}>
+  {% endif %}
+  <ul class="{{ ulClass }}">
+    {% assign section_header = entity.fieldTitle %}
+    {% for linkTeaser in entity.fieldVaParagraphs %}
+      {% include "src/site/paragraphs/linkTeaser.drupal.liquid" linkTeaser = linkTeaser.entity parentFieldName = parentFieldName boldTitle = boldTitle section_header = section_header %}
+    {% endfor %}
+  </ul>
 </section>

--- a/src/site/stages/build/plugins/modify-dom/add-id-to-subheadings.js
+++ b/src/site/stages/build/plugins/modify-dom/add-id-to-subheadings.js
@@ -34,6 +34,17 @@ function createUniqueId(headingEl, headingOptions) {
   return anchor;
 }
 
+function createTOCListItem(id, text) {
+  return `
+    <li class="vads-u-margin-bottom--2">
+      <a
+        href="#${id}"
+        onClick="recordEvent({ event: 'nav-jumplink-click', heading: '${id}' });"
+        class="vads-u-display--flex vads-u-text-decoration--none"
+      ><i class="fas fa-arrow-down va-c-font-size--xs vads-u-margin-top--1 vads-u-margin-right--1" aria-hidden="true"></i>${text}</a>
+    </li>`;
+}
+
 module.exports = {
   modifyFile(fileName, file) {
     let idAdded = false;
@@ -76,10 +87,17 @@ module.exports = {
         const isInAccordionButton = parent.hasClass('usa-accordion-button');
         const isInAccordion = parent.hasClass('usa-accordion-content');
         const isInAlert = parent.hasClass('usa-alert-body');
+        const emptyLinkId = heading.find('a').attr('id');
 
         // skip heading if it already has an id
         // skip heading if it's in an accordion button or an alert
-        if (!heading.attr('id') && !isInAccordionButton && !isInAlert) {
+        // skip heading if it contains an empty link with an id
+        if (
+          !heading.attr('id') &&
+          !isInAccordionButton &&
+          !isInAlert &&
+          !emptyLinkId
+        ) {
           const headingID = createUniqueId(heading, headingOptions);
           heading.attr('id', headingID);
           idAdded = true;
@@ -89,21 +107,17 @@ module.exports = {
         if (
           el.tagName.toLowerCase() === 'h2' &&
           tableOfContentsList &&
-          heading.attr('id') &&
+          (heading.attr('id') || emptyLinkId) &&
           heading.text().toLowerCase() !== 'on this page' &&
           !isInAccordionButton &&
           !isInAccordion &&
           !isInAlert
         ) {
           tableOfContentsList.append(
-            `<li class="vads-u-margin-bottom--2"><a href="#${heading.attr(
-              'id',
-            )}" onClick="recordEvent({ event: 'nav-jumplink-click', heading: '${heading.attr(
-              'id',
-            )}' });"
-              class="vads-u-display--flex vads-u-text-decoration--none">
-              <i class="fas fa-arrow-down va-c-font-size--xs vads-u-margin-top--1 vads-u-margin-right--1" aria-hidden="true">
-              </i>${heading.text()}</a></li>`,
+            createTOCListItem(
+              heading.attr('id') || emptyLinkId,
+              heading.text(),
+            ),
           );
           idAdded = true;
           hasTOCLinks = true;

--- a/src/site/stages/build/plugins/modify-dom/add-id-to-subheadings.js
+++ b/src/site/stages/build/plugins/modify-dom/add-id-to-subheadings.js
@@ -87,7 +87,7 @@ module.exports = {
         const isInAccordionButton = parent.hasClass('usa-accordion-button');
         const isInAccordion = parent.hasClass('usa-accordion-content');
         const isInAlert = parent.hasClass('usa-alert-body');
-        const emptyLinkId = heading.find('a').attr('id');
+        const emptyLinkId = heading.find('a')?.attr('id');
 
         // skip heading if it already has an id
         // skip heading if it's in an accordion button or an alert

--- a/src/site/stages/build/plugins/modify-dom/tests/add-id-to-subheadings.spec.js
+++ b/src/site/stages/build/plugins/modify-dom/tests/add-id-to-subheadings.spec.js
@@ -15,7 +15,7 @@ describe('addIdToSubheadings', () => {
         expect(
           document
             .querySelector('#table-of-contents li a[href="#test-h2"]')
-            .text.replaceAll(/\W+/g, ' ')
+            .text.replaceAll(/\s+/g, ' ')
             .trim(),
         ).to.equal('Test h2');
         expect(
@@ -57,6 +57,28 @@ describe('addIdToSubheadings', () => {
       },
       document => {
         expect(document.querySelector('#table-of-contents')).to.eq(null);
+        done();
+      },
+    );
+  });
+
+  it('does not add an id to an h2 if it contains an empty link with an id', done => {
+    testMetalsmithPlugin(
+      {
+        fileName: 'testSubheadings.html',
+        fixturesPath:
+          './src/site/stages/build/plugins/modify-dom/tests/fixtures/',
+        plugins: [addSubheadingsIds],
+      },
+      document => {
+        expect(
+          document
+            .querySelector('#table-of-contents li a[href="#test-empty-link"]')
+            .text.replaceAll(/\s+/g, ' ')
+            .trim(),
+        ).to.equal('Test h2 with empty link');
+        expect(document.querySelector('h2#test-empty-link')).to.eq(null);
+
         done();
       },
     );

--- a/src/site/stages/build/plugins/modify-dom/tests/fixtures/testSubheadings.html
+++ b/src/site/stages/build/plugins/modify-dom/tests/fixtures/testSubheadings.html
@@ -1,10 +1,19 @@
 <body>
   <div>
-    <h2 id="test-h2">Test h2</h2>
+    <h2>Test h2</h2>
     <h3 id="test-h3">Test h3</h3>
     <div class="usa-alert-body">
       <h2 id="test-alert-h2">Test Alert h2</h2>
     </div>
+    <h2>
+      <a
+        name="test-empty-link"
+        id="test-empty-link"
+        tabindex="-1"
+        href="#test-empty-link"
+      ></a>
+      Test h2 with empty link
+    </h2>
   </div>
   <div id="table-of-contents">
     <ul></ul>


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/15244
In IE11 when using the in page links via keyboard navigation focus does not move with the page position. This adds empty links that do not display focus to the anchors for those inpage links. This keeps display unchanged while telling IE11 (and the browsers that already understood what to do) where to send focus.

## Testing done
local, unit

## Screenshots
https://user-images.githubusercontent.com/3144003/132901108-f318d591-ce19-4397-8f5d-46624631f056.mov


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
