### PR TITLE
Fix Cypress accessibility Slack notifications

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -58,16 +58,16 @@ jobs:
           persist-credentials: false
           path: ./.github/actions/vsp-github-actions
 
-      - name: Notify Slack
-        if: ${{ always() }}
-        uses: ./.github/actions/vsp-github-actions/slack-socket
-        env:
-          SSL_CERT_DIR: /etc/ssl/certs
-        with:
-          slack_app_token: ${{ env.SLACK_APP_TOKEN }}
-          slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
-          attachments: '[{"mrkdwn_in": ["text"], "color": "good", "text": "Starting the daily Cypress accessibility scan of `content-build`, with run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}]'
-          channel_id: ${{ env.CHANNEL_ID }}
+      # - name: Notify Slack
+      #   if: ${{ always() }}
+      #   uses: ./.github/actions/vsp-github-actions/slack-socket
+      #   env:
+      #     SSL_CERT_DIR: /etc/ssl/certs
+      #   with:
+      #     slack_app_token: ${{ env.SLACK_APP_TOKEN }}
+      #     slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
+      #     attachments: '[{"mrkdwn_in": ["text"], "color": "good", "text": "Starting the daily Cypress accessibility scan of `content-build`, with run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}]'
+      #     channel_id: ${{ env.CHANNEL_ID }}
 
       - name: Checkout vagov-content
         uses: actions/checkout@v2
@@ -210,7 +210,7 @@ jobs:
     steps:
       - name: Test
         run: |
-          echo ${{ needs.build.result }}
+          echo "$JOB_CONTEXT"
 
       - name: Checkout content-build
         uses: actions/checkout@v2

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -211,8 +211,6 @@ jobs:
         env:
           JOB_CONTEXT: ${{ toJSON(job) }}
         run: echo "$JOB_CONTEXT"
-      - name: Dump steps context
-
 
       - name: Checkout content-build
         uses: actions/checkout@v2

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -1,9 +1,9 @@
 name: Accessibility Tests
 
-on: [push]
-  # workflow_dispatch:
-  # schedule:
-  #   - cron: '0 10 * * 1-5'
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 10 * * 1-5'
 
 env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
@@ -103,7 +103,7 @@ jobs:
         with:
           command: rm -rf content-build/node_modules && cd content-build && yarn install --frozen-lockfile --prefer-offline --production=false --network-concurrency 1
           max_attempts: 3
-          timeout_minutes: 1
+          timeout_minutes: 5
         env:
           YARN_CACHE_FOLDER: .cache/yarn
 

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -207,10 +207,12 @@ jobs:
       run:
         working-directory: content-build
 
-    steps:
-      - name: Test
-        run: |
-          echo "$JOB_CONTEXT"
+      - name: Dump job context
+        env:
+          JOB_CONTEXT: ${{ toJSON(job) }}
+        run: echo "$JOB_CONTEXT"
+      - name: Dump steps context
+
 
       - name: Checkout content-build
         uses: actions/checkout@v2

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -1,7 +1,7 @@
 name: Accessibility Tests
 
-on:
-  workflow_dispatch: [push]
+on: [push]
+  # workflow_dispatch:
   # schedule:
   #   - cron: '0 10 * * 1-5'
 

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -58,16 +58,16 @@ jobs:
           persist-credentials: false
           path: ./.github/actions/vsp-github-actions
 
-      # - name: Notify Slack
-      #   if: ${{ always() }}
-      #   uses: ./.github/actions/vsp-github-actions/slack-socket
-      #   env:
-      #     SSL_CERT_DIR: /etc/ssl/certs
-      #   with:
-      #     slack_app_token: ${{ env.SLACK_APP_TOKEN }}
-      #     slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
-      #     attachments: '[{"mrkdwn_in": ["text"], "color": "good", "text": "Starting the daily Cypress accessibility scan of `content-build`, with run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}]'
-      #     channel_id: ${{ env.CHANNEL_ID }}
+      - name: Notify Slack
+        if: ${{ always() }}
+        uses: ./.github/actions/vsp-github-actions/slack-socket
+        env:
+          SSL_CERT_DIR: /etc/ssl/certs
+        with:
+          slack_app_token: ${{ env.SLACK_APP_TOKEN }}
+          slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
+          attachments: '[{"mrkdwn_in": ["text"], "color": "good", "text": "Starting the daily Cypress accessibility scan of `content-build`, with run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}]'
+          channel_id: ${{ env.CHANNEL_ID }}
 
       - name: Checkout vagov-content
         uses: actions/checkout@v2
@@ -89,23 +89,23 @@ jobs:
         with:
           node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 
-      # - name: Cache dependencies
-      #   id: cache-dependencies
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: |
-      #       ~/.cache/yarn
-      #       node_modules
-      #     key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
+      - name: Cache dependencies
+        id: cache-dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/yarn
+            node_modules
+          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
-      # - name: Install dependencies
-      #   uses: nick-invision/retry@v2
-      #   with:
-      #     command: rm -rf content-build/node_modules && cd content-build && yarn install --frozen-lockfile --prefer-offline --production=false --network-concurrency 1
-      #     max_attempts: 3
-      #     timeout_minutes: 1
-      #   env:
-      #     YARN_CACHE_FOLDER: .cache/yarn
+      - name: Install dependencies
+        uses: nick-invision/retry@v2
+        with:
+          command: rm -rf content-build/node_modules && cd content-build && yarn install --frozen-lockfile --prefer-offline --production=false --network-concurrency 1
+          max_attempts: 3
+          timeout_minutes: 1
+        env:
+          YARN_CACHE_FOLDER: .cache/yarn
 
       - name: Set Drupal address
         run: echo "DRUPAL_ADDRESS=http://internal-dsva-vagov-prod-cms-2000800896.us-gov-west-1.elb.amazonaws.com" >> $GITHUB_ENV
@@ -197,7 +197,7 @@ jobs:
   slack:
     name: Notify Slack and upload Mochawesome report
     runs-on: ubuntu-latest
-    needs: a11y
+    needs: [build, a11y]
     if: ${{ always() }}
 
     env:
@@ -207,11 +207,7 @@ jobs:
       run:
         working-directory: content-build
 
-      - name: Dump job context
-        env:
-          JOB_CONTEXT: ${{ toJSON(job) }}
-        run: echo "$JOB_CONTEXT"
-
+    steps:
       - name: Checkout content-build
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -89,23 +89,23 @@ jobs:
         with:
           node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 
-      - name: Cache dependencies
-        id: cache-dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cache/yarn
-            node_modules
-          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
+      # - name: Cache dependencies
+      #   id: cache-dependencies
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: |
+      #       ~/.cache/yarn
+      #       node_modules
+      #     key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
-      - name: Install dependencies
-        uses: nick-invision/retry@v2
-        with:
-          command: rm -rf content-build/node_modules && cd content-build && yarn install --frozen-lockfile --prefer-offline --production=false --network-concurrency 1
-          max_attempts: 3
-          timeout_minutes: 1
-        env:
-          YARN_CACHE_FOLDER: .cache/yarn
+      # - name: Install dependencies
+      #   uses: nick-invision/retry@v2
+      #   with:
+      #     command: rm -rf content-build/node_modules && cd content-build && yarn install --frozen-lockfile --prefer-offline --production=false --network-concurrency 1
+      #     max_attempts: 3
+      #     timeout_minutes: 1
+      #   env:
+      #     YARN_CACHE_FOLDER: .cache/yarn
 
       - name: Set Drupal address
         run: echo "DRUPAL_ADDRESS=http://internal-dsva-vagov-prod-cms-2000800896.us-gov-west-1.elb.amazonaws.com" >> $GITHUB_ENV

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -1,9 +1,9 @@
 name: Accessibility Tests
 
 on:
-  workflow_dispatch:
-  schedule:
-    - cron: '0 10 * * 1-5'
+  workflow_dispatch: [push]
+  # schedule:
+  #   - cron: '0 10 * * 1-5'
 
 env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
@@ -103,7 +103,7 @@ jobs:
         with:
           command: rm -rf content-build/node_modules && cd content-build && yarn install --frozen-lockfile --prefer-offline --production=false --network-concurrency 1
           max_attempts: 3
-          timeout_minutes: 5
+          timeout_minutes: 1
         env:
           YARN_CACHE_FOLDER: .cache/yarn
 
@@ -208,6 +208,10 @@ jobs:
         working-directory: content-build
 
     steps:
+      - name: Test
+        run: |
+          echo ${{ needs.build.result }}
+
       - name: Checkout content-build
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
## Description
The `slack` job was missing the `build` job in the `needs` configuration, which meant that `needs.build.result` was undefined. Due to this issue the Slack failure notification would not be triggered when the `build` job failed.