### PR TITLE
Update list of buttons to ul + li tags

### DIFF
--- a/src/site/layouts/basic_landing_page.drupal.liquid
+++ b/src/site/layouts/basic_landing_page.drupal.liquid
@@ -21,11 +21,13 @@
 
           <!-- Buttons -->
           {% if fieldButtons != empty %}
-            <div class="vads-u-margin-y--3">
+            <ul class="vads-u-margin-y--3 usa-unstyled-list">
               {% for fieldButton in fieldButtons %}
-                {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+                <li class="vads-u-margin-bottom--2">
+                  {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+                </li>
               {% endfor %}
-            </div>
+            </ul>
           {% endif %}
 
           <!-- TOC -->
@@ -60,11 +62,13 @@
       <div class="usa-width-three-fourths">
         <!-- Repeated buttons -->
         {% if fieldButtonsRepeat %}
-          <div class="vads-u-margin-top--3">
+          <ul class="vads-u-margin-top--3 usa-unstyled-list">
             {% for fieldButton in fieldButtons %}
-              {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+              <li class="vads-u-margin-bottom--2">
+                {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+              </li>
             {% endfor %}
-          </div>
+          </ul>
         {% endif %}
       </div>
 

--- a/src/site/layouts/checklist.drupal.liquid
+++ b/src/site/layouts/checklist.drupal.liquid
@@ -28,11 +28,13 @@
             {% endif %}
 
             <!-- Buttons -->
-            <div class="vads-u-margin-y--3">
+            <ul class="vads-u-margin-y--3 usa-unstyled-list">
               {% for fieldButton in fieldButtons %}
-                {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+                <li class="vads-u-margin-bottom--2">
+                  {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+                </li>
               {% endfor %}
-            </div>
+            </ul>
 
             <!-- Checklist sections -->
             {% assign checklistSectionIndex = 0 %}
@@ -73,11 +75,13 @@
 
             <!-- Buttons -->
             {% if fieldButtonsRepeat %}
-              <div class="vads-u-margin-top--3">
+              <ul class="vads-u-margin-top--3 usa-unstyled-list">
                 {% for fieldButton in fieldButtons %}
-                  {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+                  <li class="vads-u-margin-bottom--2">
+                    {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+                  </li>
                 {% endfor %}
-              </div>
+              </ul>
             {% endif %}
           </article>
 

--- a/src/site/layouts/faq_multiple_q_a.drupal.liquid
+++ b/src/site/layouts/faq_multiple_q_a.drupal.liquid
@@ -28,11 +28,13 @@
             {% endif %}
 
             <!-- Buttons -->
-            <div class="vads-u-margin-y--3">
-              {% for fieldButton in fieldButtons  %}
-                {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+            <ul class="vads-u-margin-y--3 usa-unstyled-list">
+              {% for fieldButton in fieldButtons %}
+                <li class="vads-u-margin-bottom--2">
+                  {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+                </li>
               {% endfor %}
-            </div>
+            </ul>
 
             <!-- TOC -->
             {% if fieldTableOfContentsBoolean %}
@@ -91,11 +93,13 @@
 
             <!-- Repeated buttons -->
             {% if fieldButtonsRepeat %}
-              <div class="vads-u-margin-top--3">
-                {% for fieldButton in fieldButtons  %}
-                  {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+              <ul class="vads-u-margin-top--3 usa-unstyled-list">
+                {% for fieldButton in fieldButtons %}
+                  <li class="vads-u-margin-bottom--2">
+                    {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+                  </li>
                 {% endfor %}
-              </div>
+              </ul>
             {% endif %}
           </article>
 

--- a/src/site/layouts/media_list_images.drupal.liquid
+++ b/src/site/layouts/media_list_images.drupal.liquid
@@ -26,11 +26,13 @@
             {% endif %}
 
             <!-- Buttons -->
-            <div class="vads-u-margin-y--3">
+            <ul class="vads-u-margin-y--3 usa-unstyled-list">
               {% for fieldButton in fieldButtons %}
-                {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+                <li class="vads-u-margin-bottom--2">
+                  {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+                </li>
               {% endfor %}
-            </div>
+            </ul>
 
             <!-- Section Header -->
             {% if fieldMediaListImages.entity.fieldSectionHeader %}
@@ -158,11 +160,13 @@
 
             <!-- Repeated buttons -->
             {% if fieldButtonsRepeat %}
-              <div class="vads-u-margin-top--3">
+              <ul class="vads-u-margin-top--3 usa-unstyled-list">
                 {% for fieldButton in fieldButtons %}
-                  {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+                  <li class="vads-u-margin-bottom--2">
+                    {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+                  </li>
                 {% endfor %}
-              </div>
+              </ul>
             {% endif %}
           </article>
           <!-- ================ -->

--- a/src/site/layouts/media_list_videos.drupal.liquid
+++ b/src/site/layouts/media_list_videos.drupal.liquid
@@ -26,11 +26,13 @@
             {% endif %}
 
             <!-- Buttons -->
-            <div class="vads-u-margin-y--3">
+            <ul class="vads-u-margin-y--3 usa-unstyled-list">
               {% for fieldButton in fieldButtons %}
-                {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+                <li class="vads-u-margin-bottom--2">
+                  {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+                </li>
               {% endfor %}
-            </div>
+            </ul>
 
             <!-- Videos List -->
             <h2>{{ fieldMediaListVideos.entity.fieldSectionHeader | default: 'Videos' }}</h2>
@@ -76,11 +78,13 @@
 
             <!-- Repeated buttons -->
             {% if fieldButtonsRepeat %}
-              <div class="vads-u-margin-top--3">
+              <ul class="vads-u-margin-top--3 usa-unstyled-list">
                 {% for fieldButton in fieldButtons %}
-                  {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+                  <li class="vads-u-margin-bottom--2">
+                    {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+                  </li>
                 {% endfor %}
-              </div>
+              </ul>
             {% endif %}
           </article>
 

--- a/src/site/layouts/q_a.drupal.liquid
+++ b/src/site/layouts/q_a.drupal.liquid
@@ -29,11 +29,13 @@
             {% endif %}
 
             <!-- Buttons -->
-            <div class="vads-u-margin-top--3">
-              {% for fieldButton in fieldButtons  %}
-                {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+            <ul class="vads-u-margin-top--3 usa-unstyled-list">
+              {% for fieldButton in fieldButtons %}
+                <li class="vads-u-margin-bottom--2">
+                  {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+                </li>
               {% endfor %}
-            </div>
+            </ul>
           </article>
 
           <!-- Tags -->

--- a/src/site/layouts/step_by_step.drupal.liquid
+++ b/src/site/layouts/step_by_step.drupal.liquid
@@ -26,11 +26,13 @@
             {% endif %}
 
             <!-- Buttons -->
-            <div class="vads-u-margin-top--3 vads-u-display--flex vads-u-justify-content--center medium-screen:vads-u-display--block">
-              {% for fieldButton in fieldButtons  %}
-                {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+            <ul class="vads-u-margin-top--3 usa-unstyled-list vads-u-display--flex vads-u-justify-content--center medium-screen:vads-u-display--block">
+              {% for fieldButton in fieldButtons %}
+                <li class="vads-u-margin-bottom--2">
+                  {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+                </li>
               {% endfor %}
-            </div>
+            </ul>
 
             <!-- Steps -->
             {% for fieldStepsItem in fieldSteps %}
@@ -87,11 +89,13 @@
 
             <!-- Repeated buttons -->
             {% if fieldButtonsRepeat %}
-              <div class="vads-u-margin-top--3 vads-u-display--flex vads-u-justify-content--center medium-screen:vads-u-display--block">
-                {% for fieldButton in fieldButtons  %}
-                  {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+              <ul class="vads-u-margin-top--3 usa-unstyled-list vads-u-display--flex vads-u-justify-content--center medium-screen:vads-u-display--block">
+                {% for fieldButton in fieldButtons %}
+                  <li class="vads-u-margin-bottom--2">
+                    {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+                  </li>
                 {% endfor %}
-              </div>
+              </ul>
             {% endif %}
           </article>
 

--- a/src/site/layouts/support_resources_detail_page.drupal.liquid
+++ b/src/site/layouts/support_resources_detail_page.drupal.liquid
@@ -26,11 +26,13 @@
             {% endif %}
 
             <!-- Buttons -->
-            <div class="vads-u-margin-y--3">
+            <ul class="vads-u-margin-y--3 usa-unstyled-list">
               {% for fieldButton in fieldButtons %}
-                {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+                <li class="vads-u-margin-bottom--2">
+                  {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+                </li>
               {% endfor %}
-            </div>
+            </ul>
 
             <!-- TOC -->
             {% if fieldTableOfContentsBoolean %}
@@ -49,11 +51,13 @@
 
             <!-- Repeated buttons -->
             {% if fieldButtonsRepeat %}
-              <div class="vads-u-margin-top--3">
+              <ul class="vads-u-margin-top--3 usa-unstyled-list">
                 {% for fieldButton in fieldButtons %}
-                  {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+                  <li class="vads-u-margin-bottom--2">
+                    {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+                  </li>
                 {% endfor %}
-              </div>
+              </ul>
             {% endif %}
           </article>
 


### PR DESCRIPTION
# Description

This PR changes the list of buttons from a wrapping div to `ul` + `li` tags.

## Related ticket
Incoming...

## Screenshots

#### Before

![image](https://user-images.githubusercontent.com/12773166/133475169-08c22eed-64c6-40af-a785-0ebf92f656bf.png)

#### After

![image](https://user-images.githubusercontent.com/12773166/133475108-a30f4c08-2042-47c4-a3be-d707866ddd8e.png)

## Acceptance Criteria

- [x] List the buttons on R&S pages.