### PR TITLE
Github Actions (daily-deploy) -- Add schedule on/off for daily deploy

### DIFF
--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -17,6 +17,7 @@ on:
 # TODO: Change to correct channel_id when ready
 env:
   CHANNEL_ID: C024DUC9S1K # -test-tim-accessibility-gha
+  DSVA_SCHEDULE_ENABLED: true
 
 jobs:
   start-runner:
@@ -85,6 +86,10 @@ jobs:
       RELEASE_WAIT: ${{ env.RELEASE_WAIT }}
 
     steps:
+      - name: Cancel workflow due to DSVA schedule
+        if: ${{ env.DSVA_SCHEDULE_ENABLED != 'true' }}
+        uses: andymckay/cancel-action@0.2
+
       - name: Checkout
         uses: actions/checkout@v2
         with:
@@ -398,6 +403,7 @@ jobs:
 
     steps:
     - name: Configure AWS credentials
+      if: ${{ env.DSVA_SCHEDULE_ENABLED == 'true' }}
       uses: aws-actions/configure-aws-credentials@v1
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -405,24 +411,28 @@ jobs:
         aws-region: us-gov-west-1
 
     - name: Get Slack app token
+      if: ${{ env.DSVA_SCHEDULE_ENABLED == 'true' }}
       uses: marvinpinto/action-inject-ssm-secrets@v1.1.1
       with:
         ssm_parameter: /devops/github_actions_slack_socket_token
         env_variable_name: SLACK_APP_TOKEN
 
     - name: Get Slack bot token
+      if: ${{ env.DSVA_SCHEDULE_ENABLED == 'true' }}
       uses: marvinpinto/action-inject-ssm-secrets@v1.1.1
       with:
         ssm_parameter: /devops/github_actions_slack_bot_user_token
         env_variable_name: SLACK_BOT_TOKEN
         
     - name: Get va-vsp-bot token
+      if: ${{ env.DSVA_SCHEDULE_ENABLED == 'true' }}
       uses: marvinpinto/action-inject-ssm-secrets@v1.1.1
       with:
         ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
         env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
 
     - name: Checkout VSP actions
+      if: ${{ env.DSVA_SCHEDULE_ENABLED == 'true' }}
       uses: actions/checkout@v2
       with:
         repository: department-of-veterans-affairs/vsp-github-actions
@@ -432,6 +442,7 @@ jobs:
         path: ./.github/actions/vsp-github-actions
 
     - name: Notify Slack
+      if: ${{ env.DSVA_SCHEDULE_ENABLED == 'true' }}
       uses: ./.github/actions/vsp-github-actions/slack-socket
       with:
         slack_app_token: ${{ env.SLACK_APP_TOKEN }}


### PR DESCRIPTION
## Description

It was overlook in `daily-deploy` workflow to have on/off schedule. It is in `content-release` as well in `daily-deploy` for `vets-website`.

This PR adding that minor detail


## Testing done

N/A -- already implemented and in-effect

