### PR TITLE
Pipe drupal data into react pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,6 +185,7 @@
     "node-fetch": "^2.6.1",
     "nyc": "^15.1.0",
     "prettier": "^1.14.3",
+    "proxyquire": "^2.1.3",
     "recursive-readdir": "^2.2.2",
     "saucelabs": "^1.4.0",
     "selenium-server": "^3.141.59",

--- a/src/site/components/fullwidth_banner_alerts.drupal.liquid
+++ b/src/site/components/fullwidth_banner_alerts.drupal.liquid
@@ -6,8 +6,10 @@
     {% assign alertType = "info" %}
   {% endif %}
 
-  {% assign region = entityUrl.path | regionBasePath | prepend: "/" %}
-  {% assign lastArg = entityUrl.path | split: "/" | last | prepend: "/" %}
+  {% if entityUrl.path %}
+    {% assign region = entityUrl.path | regionBasePath | prepend: "/" %}
+    {% assign lastArg = entityUrl.path | split: "/" | last | prepend: "/" %}
+  {% endif %}
 
   {% assign outputStatus = false %}
   {% assign emailUpdates = "" %}

--- a/src/site/layouts/page-react.html
+++ b/src/site/layouts/page-react.html
@@ -10,3 +10,4 @@
   </main>
 </div>
 {% include "src/site/includes/footer.html" %}
+{% include "src/site/includes/debug.drupal.liquid" %}

--- a/src/site/stages/build/add-debug-info.js
+++ b/src/site/stages/build/add-debug-info.js
@@ -35,13 +35,9 @@ function writeFile(fileName, fileObject, buildtype) {
     const oldString = 'window.contentData = null;';
     const debugInfo = _.omit(fileObject, KEYS_TO_IGNORE);
 
-    try {
-      const newString = `window.contentData = ${JSON.stringify(debugInfo)};`;
-      const newContents = contents.toString().replace(oldString, newString);
-      fs.writeFileSync(filePath, newContents, { overwrite: true });
-    } catch (err) {
-      console.error(err);
-    }
+    const newString = `window.contentData = ${JSON.stringify(debugInfo)};`;
+    const newContents = contents.toString().replace(oldString, newString);
+    fs.writeFileSync(filePath, newContents, { overwrite: true });
 
     resolve();
   });

--- a/src/site/stages/build/add-debug-info.js
+++ b/src/site/stages/build/add-debug-info.js
@@ -20,6 +20,7 @@ const KEYS_TO_IGNORE = [
   'nav_path',
   'path',
   'private',
+  'next',
 ];
 
 function writeFile(fileName, fileObject, buildtype) {
@@ -32,10 +33,14 @@ function writeFile(fileName, fileObject, buildtype) {
     // We want to replace all instances of that with the debug object.
     const oldString = 'window.contentData = null;';
     const debugInfo = _.omit(fileObject, KEYS_TO_IGNORE);
-    const newString = `window.contentData = ${JSON.stringify(debugInfo)};`;
-    const newContents = contents.toString().replace(oldString, newString);
 
-    fs.writeFileSync(filePath, newContents, { overwrite: true });
+    try {
+      const newString = `window.contentData = ${JSON.stringify(debugInfo)};`;
+      const newContents = contents.toString().replace(oldString, newString);
+      fs.writeFileSync(filePath, newContents, { overwrite: true });
+    } catch (err) {
+      console.error(err);
+    }
 
     resolve();
   });

--- a/src/site/stages/build/add-debug-info.js
+++ b/src/site/stages/build/add-debug-info.js
@@ -14,6 +14,7 @@ const KEYS_TO_IGNORE = [
   'contents',
   'filename',
   'isDrupalPage',
+  'shouldAddDebugInfo',
   'layout',
   'modified',
   'nav_children',
@@ -53,8 +54,9 @@ async function addDebugInfo(files, buildtype) {
     console.log('\nAdding debug info to Drupal pages...\n');
     console.time(timeString);
 
-    const isDrupalPage = fileName => files[fileName].isDrupalPage;
-    const drupalFileNames = Object.keys(files).filter(isDrupalPage);
+    const shouldAddDebugInfo = fileName =>
+      files[fileName].isDrupalPage || files[fileName].shouldAddDebugInfo;
+    const drupalFileNames = Object.keys(files).filter(shouldAddDebugInfo);
 
     while (drupalFileNames.length) {
       const promises = [];

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -17,6 +17,7 @@ const {
   addGetUpdatesFields,
   addPager,
 } = require('./health-care-region');
+const createReactPages = require('../plugins/create-react-pages');
 
 const { addHubIconField } = require('./benefit-hub');
 const { addHomeContent } = require('./home');
@@ -314,6 +315,7 @@ function getDrupalContent(buildOptions) {
 
       await loadCachedDrupalFiles(buildOptions, files);
       pipeDrupalPagesIntoMetalsmith(drupalData, files);
+      await createReactPages(files, drupalData);
       addHomeContent(drupalData, files, metalsmith, buildOptions);
       log('Successfully piped Drupal content into Metalsmith!');
       buildOptions.drupalData = drupalData;

--- a/src/site/stages/build/index.js
+++ b/src/site/stages/build/index.js
@@ -26,7 +26,6 @@ const createDrupalDebugPage = require('./plugins/create-drupal-debug');
 const createEnvironmentFilter = require('./plugins/create-environment-filter');
 const createHeaderFooter = require('./plugins/create-header-footer');
 const createOutreachAssetsData = require('./plugins/create-outreach-assets-data');
-const createReactPages = require('./plugins/create-react-pages');
 const createResourcesAndSupportWebsiteSection = require('./plugins/create-resources-and-support-section');
 const createSitemaps = require('./plugins/create-sitemaps');
 const createSymlink = require('./plugins/create-symlink');
@@ -79,7 +78,6 @@ function build(BUILD_OPTIONS) {
     );
   }
 
-  smith.use(createReactPages(BUILD_OPTIONS), 'Create React pages');
   smith.use(getDrupalContent(BUILD_OPTIONS), 'Get Drupal content');
   smith.use(addDrupalPrefix(BUILD_OPTIONS), 'Add Drupal Prefix');
 

--- a/src/site/stages/build/plugins/create-react-pages.js
+++ b/src/site/stages/build/plugins/create-react-pages.js
@@ -24,7 +24,7 @@ function createReactPages(files, drupalData = { data: {} }, done) {
       files[filePath] = {
         title: appName,
         entryname: entryName,
-        isDrupalPage: true,
+        shouldAddDebugInfo: true,
         debug: null,
         path: trimmedUrl,
         layout: 'page-react.html',

--- a/src/site/stages/build/plugins/create-react-pages.js
+++ b/src/site/stages/build/plugins/create-react-pages.js
@@ -2,31 +2,42 @@
 const path = require('path');
 const appRegistry = require('../../../../applications/registry.json');
 
-function createReactPages() {
-  return (files, metalsmith, done) => {
-    appRegistry.forEach(({ entryName, appName, rootUrl, template }) => {
-      const trimmedUrl = path.join('.', rootUrl);
-      const filePath = path.join(trimmedUrl, 'index.html');
+function createReactPages(files, drupalData = { data: {} }, done) {
+  const {
+    data: {
+      alerts: alertsItem = {},
+      banners,
+      bannerAlerts: bannerAlertsItem = {},
+    },
+  } = drupalData;
+  const alertItems = { alert: alertsItem };
 
-      if (!files[filePath]) {
-        if (global.verbose) {
-          console.log(
-            `Generating HTML template for application ${appName} at ${rootUrl}`,
-          );
-        }
-        files[filePath] = {
-          title: appName,
-          entryname: entryName,
-          path: trimmedUrl,
-          layout: 'page-react.html',
-          contents: Buffer.from('\n<!-- Generated from manifest.json -->\n'),
-          ...template,
-        };
+  appRegistry.forEach(({ entryName, appName, rootUrl, template }) => {
+    const trimmedUrl = path.join('.', rootUrl);
+    const filePath = path.join(trimmedUrl, 'index.html');
+    if (!files[filePath]) {
+      if (global.verbose) {
+        console.log(
+          `Generating HTML template for application ${appName} at ${rootUrl}`,
+        );
       }
-    });
+      files[filePath] = {
+        title: appName,
+        entryname: entryName,
+        isDrupalPage: true,
+        debug: null,
+        path: trimmedUrl,
+        layout: 'page-react.html',
+        contents: Buffer.from('\n<!-- Generated from manifest.json -->\n'),
+        alertItems,
+        ...{ bannerAlert: bannerAlertsItem },
+        ...{ banners },
+        ...template,
+      };
+    }
+  });
 
-    done();
-  };
+  done?.();
 }
 
 module.exports = createReactPages;

--- a/src/site/stages/build/plugins/create-react-pages.js
+++ b/src/site/stages/build/plugins/create-react-pages.js
@@ -29,6 +29,7 @@ function createReactPages(files, drupalData = { data: {} }, done) {
         path: trimmedUrl,
         layout: 'page-react.html',
         contents: Buffer.from('\n<!-- Generated from manifest.json -->\n'),
+        entityUrl: { path: `/${trimmedUrl}` },
         alertItems,
         ...{ bannerAlert: bannerAlertsItem },
         ...{ banners },

--- a/src/site/stages/build/plugins/tests/create-react-pages.spec.js
+++ b/src/site/stages/build/plugins/tests/create-react-pages.spec.js
@@ -28,6 +28,7 @@ describe('createReactPages', () => {
         isDrupalPage: true,
         debug: null,
         layout: 'page-react.html',
+        entityUrl: { path: '/covid19screen' },
         alertItems: { alert: [] },
         bannerAlert: [],
         banners: [],

--- a/src/site/stages/build/plugins/tests/create-react-pages.spec.js
+++ b/src/site/stages/build/plugins/tests/create-react-pages.spec.js
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+import proxyquire from 'proxyquire';
+// relative imports
+import appRegistry from './fixtures/createReactPages.fixture';
+
+const createReactPages = proxyquire.noCallThru()('../create-react-pages.js', {
+  '../../../../applications/registry.json': appRegistry,
+});
+
+beforeEach(() => {});
+
+describe('createReactPages', () => {
+  it('should add <h2> ids to "On this Page" table of contents', done => {
+    const files = {};
+    const testDrupalData = {
+      data: {
+        alerts: [],
+        banners: [],
+        bannerAlerts: [],
+      },
+    };
+
+    createReactPages(files, testDrupalData, () => {
+      expect(files['covid19screen/index.html']).to.deep.include({
+        title: 'COVID-19 screening tool',
+        entryname: 'covid19screen',
+        path: 'covid19screen',
+        isDrupalPage: true,
+        debug: null,
+        layout: 'page-react.html',
+        alertItems: { alert: [] },
+        bannerAlert: [],
+        banners: [],
+      });
+
+      done();
+    });
+  });
+});

--- a/src/site/stages/build/plugins/tests/create-react-pages.spec.js
+++ b/src/site/stages/build/plugins/tests/create-react-pages.spec.js
@@ -25,7 +25,7 @@ describe('createReactPages', () => {
         title: 'COVID-19 screening tool',
         entryname: 'covid19screen',
         path: 'covid19screen',
-        isDrupalPage: true,
+        shouldAddDebugInfo: true,
         debug: null,
         layout: 'page-react.html',
         entityUrl: { path: '/covid19screen' },

--- a/src/site/stages/build/plugins/tests/fixtures/createReactPages.fixture.js
+++ b/src/site/stages/build/plugins/tests/fixtures/createReactPages.fixture.js
@@ -1,0 +1,15 @@
+const appRegistry = [
+  {
+    appName: 'COVID-19 screener',
+    entryName: 'covid19screen',
+    rootUrl: '/covid19screen',
+    template: {
+      title: 'COVID-19 screening tool',
+      layout: 'page-react.html',
+      private: true,
+      vagovprod: true,
+    },
+  },
+];
+
+export default appRegistry;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5272,6 +5272,14 @@ file-uri-to-path@1, file-uri-to-path@1.0.0:
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
   integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
+fill-keys@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/fill-keys/-/fill-keys-1.0.2.tgz#9a8fa36f4e8ad634e3bf6b4f3c8882551452eb20"
+  integrity sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=
+  dependencies:
+    is-object "~1.0.1"
+    merge-descriptors "~1.0.0"
+
 fill-range@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
@@ -6617,6 +6625,11 @@ is-obj@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
   integrity sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==
 
+is-object@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.2.tgz#a56552e1c665c9e950b4a025461da87e72f86fcf"
+  integrity sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==
+
 is-path-cwd@^2.0.0, is-path-cwd@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-2.2.0.tgz#67d43b82664a7b5191fd9119127eb300048a9fdb"
@@ -7763,7 +7776,7 @@ memory-fs@^0.5.0:
     errno "^0.1.3"
     readable-stream "^2.0.1"
 
-merge-descriptors@1.0.1:
+merge-descriptors@1.0.1, merge-descriptors@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
   integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
@@ -8231,6 +8244,11 @@ mocker-api@^2.1.0:
     local-ip-url "1.0.3"
     minimist "^1.2.5"
     path-to-regexp "6.2.0"
+
+module-not-found-error@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/module-not-found-error/-/module-not-found-error-1.0.1.tgz#cf8b4ff4f29640674d6cdd02b0e3bc523c2bbdc0"
+  integrity sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=
 
 moment-timezone@^0.5.31:
   version "0.5.32"
@@ -9352,6 +9370,15 @@ proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
+proxyquire@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/proxyquire/-/proxyquire-2.1.3.tgz#2049a7eefa10a9a953346a18e54aab2b4268df39"
+  integrity sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==
+  dependencies:
+    fill-keys "^1.0.2"
+    module-not-found-error "^1.0.1"
+    resolve "^1.11.1"
 
 prr@~1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/29943

React pages are created independently of fetching drupal content which means they do not get any debug data nor access to globals like `banners` and `alerts` as they should.

## Testing done
local,unit

## Screenshots
<img width="1792" alt="Screen Shot 2021-09-20 at 3 14 14 PM" src="https://user-images.githubusercontent.com/3144003/134060935-0c6e887f-99ff-47fa-980c-601a2f7bd4cc.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
