### PR TITLE
Add skipLinkFocus function for in-page links

### DIFF
--- a/src/site/assets/js/skip-link-focus.js
+++ b/src/site/assets/js/skip-link-focus.js
@@ -1,0 +1,24 @@
+(function() {
+  var isIe = /(trident|msie)/i.test(navigator.userAgent);
+
+  if (isIe && document.getElementById && window.addEventListener) {
+    window.addEventListener('hashchange', function skipLinkFocus() {
+      var id = location.hash.substring(1);
+      var element;
+
+      if (!/^[A-z0-9_-]+$/.test(id)) {
+        return;
+      }
+
+      element = document.getElementById(id);
+
+      if (element) {
+        if (!/^(?:a|select|input|button|textarea)$/i.test(element.tagName)) {
+          element.tabIndex = -1;
+        }
+
+        element.focus();
+      }
+    });
+  }
+})();

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -127,3 +127,7 @@
       checkBrowserCompatibility();
     })();
   </script>
+
+  <script nonce="**CSP_NONCE**">
+    {% include "src/site/assets/js/skip-link-focus.js" %}
+  </script>

--- a/src/site/paragraphs/list_of_link_teasers.drupal.liquid
+++ b/src/site/paragraphs/list_of_link_teasers.drupal.liquid
@@ -7,24 +7,26 @@
 {% endcomment %}
 {% assign header = "h2" %}
 {% if parentFieldName === "field_spokes" %}
-    {% assign headerClass = "hub-page-link-list__title" %}
-    {% assign ulClass = "hub-page-link-list" %}
+  {% assign headerClass = "hub-page-link-list__title" %}
+  {% assign ulClass = "hub-page-link-list" %}
 {% else %}
-    {% assign headerClass = "va-nav-linkslist-heading" %}
-    {% assign ulClass = "va-nav-linkslist-list" %}
+  {% assign headerClass = "va-nav-linkslist-heading" %}
+  {% assign ulClass = "va-nav-linkslist-list" %}
 {% endif %}
 <section data-template="paragraphs/list_of_link_teasers" data-entity-id="{{ entity.entityId }}" class="{{ entity.parentFieldName }}">
-    {% if entity.fieldTitle != empty %}
-      <{{ header }}
-          id="{{ entity.fieldTitle | hashReference }}"
-          class="{{ headerClass }}">
-          {{ entity.fieldTitle }}
-      </{{ header }}>
-    {% endif %}
-    <ul class="{{ ulClass }}">
-        {% assign section_header = entity.fieldTitle %}
-        {% for linkTeaser in entity.fieldVaParagraphs %}
-            {% include "src/site/paragraphs/linkTeaser.drupal.liquid" linkTeaser = linkTeaser.entity parentFieldName = parentFieldName boldTitle = boldTitle section_header = section_header %}
-        {% endfor %}
-    </ul>
+  {% if entity.fieldTitle != empty %}
+    <{{ header }}
+      id="{{ entity.fieldTitle | hashReference }}"
+      class="{{ headerClass }}"
+      tabindex="-1"
+    >
+      {{ entity.fieldTitle }}
+    </{{ header }}>
+  {% endif %}
+  <ul class="{{ ulClass }}">
+    {% assign section_header = entity.fieldTitle %}
+    {% for linkTeaser in entity.fieldVaParagraphs %}
+      {% include "src/site/paragraphs/linkTeaser.drupal.liquid" linkTeaser = linkTeaser.entity parentFieldName = parentFieldName boldTitle = boldTitle section_header = section_header %}
+    {% endfor %}
+  </ul>
 </section>


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/15244
Ensure focus moves to the anchor location for in page links

Companion pr to remove `cursor: default` from the nbsp in the link: https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/690

## Testing done
local, unit

## Screenshots

https://user-images.githubusercontent.com/3144003/134232170-430ef9ad-5ac0-4a1c-a0c0-1c29ecea3a20.mov


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
