### PR TITLE
Github Actions (CI) -- Fix SHA in archive

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -695,7 +695,7 @@ jobs:
           role-session-name: vsp-frontendteam-githubaction
 
       - name: Upload build
-        run: aws s3 cp ${{ matrix.buildtype }}.tar.bz2 s3://vetsgov-website-builds-s3-upload/content-build/$GITHUB_SHA/${{ matrix.buildtype }}.tar.bz2 --acl public-read --region us-gov-west-1
+        run: aws s3 cp ${{ matrix.buildtype }}.tar.bz2 s3://vetsgov-website-builds-s3-upload/content-build/${{ github.sha }}/${{ matrix.buildtype }}.tar.bz2 --acl public-read --region us-gov-west-1
 
   deploy:
     name: Deploy


### PR DESCRIPTION
## Description

The url is coming as `s3://vetsgov-website-builds-s3-upload/content-build/$GITHUB_SHA/vagovdev.tar.bz2` where $GITHUB_SHA is not being coverted to commit_ref. This PR fixes syntax