### PR TITLE
Github Actions (CI) -- Optimize archive compression

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -670,7 +670,7 @@ jobs:
           du -h build/${{ matrix.buildtype }}
 
       - name: Compress build
-        run: tar -C build/${{ matrix.buildtype }} -cjf ${{ matrix.buildtype }}.tar.bz2 .
+        run: tar -C build/${{ matrix.buildtype }} -cf ${{ matrix.buildtype }}.tar.bz2 .
 
       - name: Configure AWS credentials (1)
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -210,6 +210,7 @@ jobs:
         run: |
           cat > build/${{ matrix.buildtype }}/BUILD.txt << EOF
           BUILDTYPE=${{ matrix.buildtype }}
+          NODE_ENV=production
           BRANCH_NAME=$(echo "${GITHUB_REF#refs/heads/}")
           CHANGE_TARGET=null
           RUN_ID=${{ github.run_id }}


### PR DESCRIPTION
## Description

Related [ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/28585#issuecomment-902232486)

With the current compression the time takes roughly `15 mins`. This new method should drastically shave time and also affect the `deploy` step as well.