### PR TITLE
Github Actions (CI) -- add continue-on-error

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -292,6 +292,7 @@ jobs:
       - name: Notify Slack about broken links
         uses: ./.github/actions/vsp-github-actions/slack-socket
         if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
+        continue-on-error: true
         env:
           SSL_CERT_DIR: /etc/ssl/certs
         with:


### PR DESCRIPTION
## Description

It was noticed that `continue-on-error` flag was missed. This PR addresses in the event it fails.