### PR TITLE
Fix Skip to Content link

### DIFF
--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -84,6 +84,15 @@
     src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=VA" id="_fed_an_ua_tag"></script>
 
   <script nonce="**CSP_NONCE**" type="text/javascript">
+    function focusContent(e) {
+      e.preventDefault();
+      e.target.hidden = true;
+      const contentElement = document.querySelector('#content h1') || document.querySelector('#content');
+      contentElement.setAttribute('tabindex', '-1');
+      window.scrollTo(0, contentElement.offsetTop);
+      contentElement.focus();
+      // TODO - remove negative tabindex from content element on blur
+    }
     window.VetsGov = window.VetsGov || {};
     window.VetsGov.headerFooter = JSON.parse({{ headerFooterData }});
   </script>
@@ -108,7 +117,7 @@
   {% endif %}
 
   {{ google_analytics_noscript }}
-  <a class="show-on-focus" href="#content">Skip to Content</a>
+  <a class="show-on-focus" href="#content" onclick="focusContent(event)">Skip to Content</a>
 
   {% if !noHeader %}
     {% include "src/site/includes/top-nav.html" %}

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -89,6 +89,9 @@
       e.target.hidden = true;
       const contentElement = document.querySelector('#content h1') || document.querySelector('#content');
       contentElement.setAttribute('tabindex', '-1');
+      contentElement.addEventListener('blur', (event) => {
+        event.target.removeAttribute('tabindex');
+      }, true);
       window.scrollTo(0, contentElement.offsetTop);
       contentElement.focus();
     }

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -91,7 +91,6 @@
       contentElement.setAttribute('tabindex', '-1');
       window.scrollTo(0, contentElement.offsetTop);
       contentElement.focus();
-      // TODO - remove negative tabindex from content element on blur
     }
     window.VetsGov = window.VetsGov || {};
     window.VetsGov.headerFooter = JSON.parse({{ headerFooterData }});


### PR DESCRIPTION
Resolves department-of-veterans-affairs/va.gov-team#27445

See also: https://github.com/department-of-veterans-affairs/vets-website/pull/18823

TL:DR - the Skip to Content link currently skips to the breadcrumbs, which is confusing for non-sighted users.
This change makes it skip to the first H1 on the page, if one exists. If not, the current behavior is preserved.
To access the Skip to Content link you must use a screen reader navigator or hit shift-TAB several times.
