### PR TITLE
Add skipLinkFocus function for in-page links

### DIFF
--- a/src/site/assets/js/skip-link-focus.js
+++ b/src/site/assets/js/skip-link-focus.js
@@ -1,0 +1,24 @@
+(function() {
+  var isIe = /(trident|msie)/i.test(navigator.userAgent);
+
+  if (isIe && document.getElementById && window.addEventListener) {
+    window.addEventListener('hashchange', function skipLinkFocus() {
+      var id = location.hash.substring(1);
+      var element;
+
+      if (!/^[A-z0-9_-]+$/.test(id)) {
+        return;
+      }
+
+      element = document.getElementById(id);
+
+      if (element) {
+        if (!/^(?:a|select|input|button|textarea)$/i.test(element.tagName)) {
+          element.tabIndex = -1;
+        }
+
+        element.focus();
+      }
+    });
+  }
+})();

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -127,3 +127,7 @@
       checkBrowserCompatibility();
     })();
   </script>
+
+  <script nonce="**CSP_NONCE**">
+    {% include "src/site/assets/js/skip-link-focus.js" %}
+  </script>

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -128,6 +128,6 @@
     })();
   </script>
 
-  <script nonce="**CSP_NONCE**">
+  <script nonce="**CSP_NONCE**" type="text/javascript">
     {% include "src/site/assets/js/skip-link-focus.js" %}
   </script>

--- a/src/site/paragraphs/list_of_link_teasers.drupal.liquid
+++ b/src/site/paragraphs/list_of_link_teasers.drupal.liquid
@@ -7,24 +7,26 @@
 {% endcomment %}
 {% assign header = "h2" %}
 {% if parentFieldName === "field_spokes" %}
-    {% assign headerClass = "hub-page-link-list__title" %}
-    {% assign ulClass = "hub-page-link-list" %}
+  {% assign headerClass = "hub-page-link-list__title" %}
+  {% assign ulClass = "hub-page-link-list" %}
 {% else %}
-    {% assign headerClass = "va-nav-linkslist-heading" %}
-    {% assign ulClass = "va-nav-linkslist-list" %}
+  {% assign headerClass = "va-nav-linkslist-heading" %}
+  {% assign ulClass = "va-nav-linkslist-list" %}
 {% endif %}
 <section data-template="paragraphs/list_of_link_teasers" data-entity-id="{{ entity.entityId }}" class="{{ entity.parentFieldName }}">
-    {% if entity.fieldTitle != empty %}
-      <{{ header }}
-          id="{{ entity.fieldTitle | hashReference }}"
-          class="{{ headerClass }}">
-          {{ entity.fieldTitle }}
-      </{{ header }}>
-    {% endif %}
-    <ul class="{{ ulClass }}">
-        {% assign section_header = entity.fieldTitle %}
-        {% for linkTeaser in entity.fieldVaParagraphs %}
-            {% include "src/site/paragraphs/linkTeaser.drupal.liquid" linkTeaser = linkTeaser.entity parentFieldName = parentFieldName boldTitle = boldTitle section_header = section_header %}
-        {% endfor %}
-    </ul>
+  {% if entity.fieldTitle != empty %}
+    <{{ header }}
+      id="{{ entity.fieldTitle | hashReference }}"
+      class="{{ headerClass }}"
+      tabindex="-1"
+    >
+      {{ entity.fieldTitle }}
+    </{{ header }}>
+  {% endif %}
+  <ul class="{{ ulClass }}">
+    {% assign section_header = entity.fieldTitle %}
+    {% for linkTeaser in entity.fieldVaParagraphs %}
+      {% include "src/site/paragraphs/linkTeaser.drupal.liquid" linkTeaser = linkTeaser.entity parentFieldName = parentFieldName boldTitle = boldTitle section_header = section_header %}
+    {% endfor %}
+  </ul>
 </section>


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/15244

This makes it so in IE11 when using an in-page link, focus moves to the anchor.

Based on suggestions in the issue ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/15244#issuecomment-919094499 and the solution wordpress used to use: https://github.com/Automattic/_s/pull/1424/files#diff-d2325198d8f488786a89d08ce9ba0863a8b6afdf22a9498615dd42e9e96024d4

## Testing done
local

## Screenshots
https://user-images.githubusercontent.com/3144003/134527447-96131393-95fc-4c8c-acd2-4615383bfc73.mov

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
