### PR TITLE
Updating Lovell FHCC to match standardized plain language system name.

### DIFF
--- a/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
+++ b/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
@@ -87,7 +87,7 @@ const FACILITY_MENU_NAMES = [
   'va-northern-indiana-health-care',
   'va-saginaw-health-care',
   // VISN 12
-  'lovell-fhcc-health care',
+  'va-lovell-federal-health care',
   'va-chicago-health-care',
   'va-hines-health-care',
   'va-illiana-health-care',


### PR DESCRIPTION
## Description

Lovell FHCC has standardized around "VA Lovell Federal health care"

It is not yet in dual state, so changing this will not affect va.gov. 

Menu in CMS is being updated in https://github.com/department-of-veterans-affairs/va.gov-cms/issues/6512

## Testing done

None.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
