### PR TITLE
Add sidebar to past events page

### DIFF
--- a/src/site/facilities/health_care_region_detail_content.drupal.liquid
+++ b/src/site/facilities/health_care_region_detail_content.drupal.liquid
@@ -1,4 +1,4 @@
-<article aria-labelledby="article-heading" role="region" class="usa-content">
+<article aria-labelledby="article-heading" role="region" class="usa-content" data-template="health_care_region_detail_content.drupal.liquid">
   <h1 id="article-heading">{{ title }}</h1>
   <div class="va-introtext">
     <p>{{ fieldIntroText }}</p>

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -4,7 +4,7 @@
 
 {% include "src/site/includes/date.drupal.liquid" %}
 
-<div class="interior" id="content">
+<div class="interior" id="content" data-template="event.drupal.liquid">
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">
       {% if entityUrl.path contains "/outreach-and-events" %}

--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -2,7 +2,7 @@
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
 
-<div class="interior vads-u-padding-bottom--3" id="content">
+<div class="interior vads-u-padding-bottom--3" id="content" data-template="event_listing.drupal.liquid">
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">
       {% if entityUrl.breadcrumb.1.text == "Outreach and events" %}

--- a/src/site/layouts/news_stories_page.drupal.liquid
+++ b/src/site/layouts/news_stories_page.drupal.liquid
@@ -49,7 +49,7 @@ Example data:
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
 
-<div id="content" class="interior">
+<div id="content" class="interior" data-template="news_stories_page.drupal.liquid">
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}

--- a/src/site/layouts/office.drupal.liquid
+++ b/src/site/layouts/office.drupal.liquid
@@ -2,7 +2,7 @@
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" %}
 
-<div class="interior" id="content">
+<div class="interior" id="content" data-template="office.drupal.liquid">
   <main class="va-l-detail-page">
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = outreachSidebar %}

--- a/src/site/layouts/press_releases_listing.drupal.liquid
+++ b/src/site/layouts/press_releases_listing.drupal.liquid
@@ -50,7 +50,7 @@ larger space in the Fayette Plaza at 627 Pittsburgh Road, Suite 2, Uniontown,
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
 
-<div id="content" class="interior">
+<div id="content" class="interior" data-template="press_releases_listing.drupal.liquid">
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">
 

--- a/src/site/layouts/publication_listing.drupal.liquid
+++ b/src/site/layouts/publication_listing.drupal.liquid
@@ -3,7 +3,7 @@
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
 
-<div class="interior" id="content">
+<div class="interior" id="content" data-template="publication_listing.drupal.liquid">
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = outreachSidebar %}

--- a/src/site/layouts/story_listing.drupal.liquid
+++ b/src/site/layouts/story_listing.drupal.liquid
@@ -2,7 +2,7 @@
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
 
-<div id="content" class="interior">
+<div id="content" class="interior" data-template="story_listing.drupal.liquid">
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}

--- a/src/site/layouts/vamc_system_policies_page.drupal.liquid
+++ b/src/site/layouts/vamc_system_policies_page.drupal.liquid
@@ -1,7 +1,8 @@
 {% include "src/site/includes/header.html" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
-<div class="interior" id="content">
+
+<div class="interior" id="content" data-template="vamc_system_policies_page.drupal.liquid">
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -48,18 +48,21 @@ function createPastEventListPages(page, drupalPagePath, files) {
     ['desc'],
   );
 
-  // Past Events listing page
-  const pastEventsEntityUrl = createEntityUrlObj(drupalPagePath);
+  // Derive the path + breadcrumbs for past events.
+  const pastEventsEntityURL = createEntityUrlObj(drupalPagePath);
 
+  // Derive the data that the event_listing template receives.
   const pastEventsObj = {
-    allEventTeasers: pastEventTeasers,
-    eventTeasers: pastEventTeasers,
-    fieldIntroText: page.fieldIntroText,
-    facilitySidebar: sidebar,
-    entityUrl: pastEventsEntityUrl,
-    title: page.title,
     alert: page.alert,
+    allEventTeasers: pastEventTeasers,
+    entityUrl: pastEventsEntityURL,
+    eventTeasers: pastEventTeasers,
+    facilitySidebar: sidebar,
+    fieldIntroText: page.fieldIntroText,
+    outreachSidebar: page.outreachSidebar,
+    title: page.title,
   };
+
   const pastEventsPage = updateEntityUrlObj(
     pastEventsObj,
     drupalPagePath,


### PR DESCRIPTION
# Description

**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/30238

This PR makes it so the left nav doesn't disappear on the Past Events page.

**Unresolved issues:**
https://github.com/department-of-veterans-affairs/va.gov-team/issues/30240
https://github.com/department-of-veterans-affairs/va.gov-team/issues/30239

The above issues aren't clear in what needs to be done to resolve them, but this PR could hypothetically include changes that resolve them if desired ^

## Testing

Locally

## Screenshots

![localhost_3002_outreach-and-events_events_past-events_](https://user-images.githubusercontent.com/12773166/134614034-8bbd6b2c-69a1-40bf-9dc8-cdce0e8540ca.png)

## Acceptance Criteria

- [x] Past events shows left nav