### PR TITLE
Remove if check for in_page_alert

### DIFF
--- a/src/site/blocks/alert.drupal.liquid
+++ b/src/site/blocks/alert.drupal.liquid
@@ -28,36 +28,33 @@
   {% assign alertType = "info" %}
 {% endif %}
 
-{% comment %} Only show `in_page_alert` alerts. {% endcomment %}
-{% if alert.fieldIsThisAHeaderAlert == 'in_page_alert' %}
-  {% if isPreview or alert.entityPublished %}
-    <div data-template="blocks/alert" data-entity-id="{{ alert.entityId }}" class="usa-alert usa-alert-{{ alertType }}" role="alert">
-      <div class="usa-alert-body">
-        <h2 class="usa-alert-heading vads-u-font-size--h3">
-          {{ alert.fieldAlertTitle }}
-        </h2>
+{% if isPreview or alert.entityPublished %}
+  <div data-template="blocks/alert" data-entity-id="{{ alert.entityId }}" class="usa-alert usa-alert-{{ alertType }}" role="alert">
+    <div class="usa-alert-body">
+      <h2 class="usa-alert-heading vads-u-font-size--h3">
+        {{ alert.fieldAlertTitle }}
+      </h2>
 
-        {% if expander.fieldTextExpander == empty %}
-            {{ expander.fieldWysiwyg.processed }}
-        {% endif %}
+      {% if expander.fieldTextExpander == empty %}
+          {{ expander.fieldWysiwyg.processed }}
+      {% endif %}
 
-        {% if expander.fieldTextExpander %}
-          {% comment %}
-            NOTE: .additional-info-container is a class utilized by
-            createAdditionalInfoWidget.js to add toggle functionality to info alerts
-          {% endcomment %}
+      {% if expander.fieldTextExpander %}
+        {% comment %}
+          NOTE: .additional-info-container is a class utilized by
+          createAdditionalInfoWidget.js to add toggle functionality to info alerts
+        {% endcomment %}
 
-          <div data-alert-box-title="{{ alert.fieldAlertTitle }}" data-label="{{ expander.fieldTextExpander }}" class="form-expanding-group borderless-alert additional-info-container">
-            <div class="additional-info-title">
-              {{ expander.fieldTextExpander }}
-            </div>
-
-            {% if expander.fieldWysiwyg %}
-              <div class="additional-info-content usa-alert-text" hidden>{{ expander.fieldWysiwyg.processed }}</div>
-            {% endif %}
+        <div data-alert-box-title="{{ alert.fieldAlertTitle }}" data-label="{{ expander.fieldTextExpander }}" class="form-expanding-group borderless-alert additional-info-container">
+          <div class="additional-info-title">
+            {{ expander.fieldTextExpander }}
           </div>
-        {% endif %}
-      </div>
+
+          {% if expander.fieldWysiwyg %}
+            <div class="additional-info-content usa-alert-text" hidden>{{ expander.fieldWysiwyg.processed }}</div>
+          {% endif %}
+        </div>
+      {% endif %}
     </div>
-  {% endif %}
+  </div>
 {% endif %}


### PR DESCRIPTION
# Description

**Slack:** https://dsva.slack.com/archives/CBU0KDSB1/p1632491843104300

This PR removes a 1 line `if` statement where we check for alerts to be `in_page_alert`, which isn't necessary. This if statement was causing in-page alerts not to appear on benefit hubs.

## Testing

Locally

## Screenshots

### Before

![www va gov_housing-assistance_home-loans_trouble-making-payments_](https://user-images.githubusercontent.com/12773166/134692447-b54ffe09-59a3-4721-ba05-71a6d2f398ae.png)

### After

![localhost_3002_education_about-gi-bill-benefits_how-to-use-benefits_vettec-high-tech-program_ (1)](https://user-images.githubusercontent.com/12773166/134692706-b5a830d3-9c59-4ad7-b9f4-3c2ab7fa92c9.png)