### PR TITLE
Fix Cypress accessibility reporting on GitHub Actions

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -205,7 +205,7 @@ jobs:
         if: ${{ always() }}
         with:
           name: cypress-mochawesome-test-results
-          path: content-build/mochawesome-report
+          path: mochawesome-report
           retention-days: 1
 
   slack:


### PR DESCRIPTION
## Description
This PR updates the path to archive Cypress a11y test results on GitHub Actions. This change is needed due to a change in the working directory from a recent PR.