### PR TITLE
Fix Cypress modal failures

### DIFF
--- a/src/site/layouts/tests/vamc/e2e/location_detail.cypress.spec.js
+++ b/src/site/layouts/tests/vamc/e2e/location_detail.cypress.spec.js
@@ -6,13 +6,14 @@ const phoneRegex = /\d{3}-\d{3}-\d{4}/;
 
 Cypress.Commands.add('checkElements', (page, isMobile) => {
   cy.visit(page);
-  cy.get('#modal-announcement-title').should('exist');
-  cy.get('button')
-    .contains('Continue to the website')
-    .click()
-    .then(() => {
-      cy.get('#modal-announcement-title').should('not.exist');
-    });
+  // TODO: Determine if this can be removed.
+  // cy.get('#modal-announcement-title').should('exist');
+  // cy.get('button')
+  //   .contains('Continue to the website')
+  //   .click()
+  //   .then(() => {
+  //     cy.get('#modal-announcement-title').should('not.exist');
+  //   });
   cy.get('.va-introtext').should('exist');
   cy.get('a.usa-button').contains('Make an appointment');
   cy.get('a.usa-button').contains('Register for care');

--- a/src/site/layouts/tests/vamc/e2e/location_home.cypress.spec.js
+++ b/src/site/layouts/tests/vamc/e2e/location_home.cypress.spec.js
@@ -4,13 +4,14 @@ import './commands.cypress';
 
 Cypress.Commands.add('checkElements', (page, isMobile) => {
   cy.visit(page);
-  cy.get('#modal-announcement-title').should('exist');
-  cy.get('button')
-    .contains('Continue to the website')
-    .click()
-    .then(() => {
-      cy.get('#modal-announcement-title').should('not.exist');
-    });
+  // TODO: Determine if this can be removed.
+  // cy.get('#modal-announcement-title').should('exist');
+  // cy.get('button')
+  //   .contains('Continue to the website')
+  //   .click()
+  //   .then(() => {
+  //     cy.get('#modal-announcement-title').should('not.exist');
+  //   });
   cy.get('a.usa-button').contains('Make an appointment');
   cy.get('a.usa-button').contains('View all health services');
   cy.get('a.usa-button').contains('Register for care');

--- a/src/site/layouts/tests/vamc/e2e/system_home.cypress.spec.js
+++ b/src/site/layouts/tests/vamc/e2e/system_home.cypress.spec.js
@@ -2,13 +2,14 @@ const phoneRegex = /\d{3}-\d{3}-\d{4}/;
 
 Cypress.Commands.add('checkElements', (page, isMobile) => {
   cy.visit(page);
-  cy.get('#modal-announcement-title').should('exist');
-  cy.get('button')
-    .contains('Continue to the website')
-    .click()
-    .then(() => {
-      cy.get('#modal-announcement-title').should('not.exist');
-    });
+  // TODO: Determine if this can be removed.
+  // cy.get('#modal-announcement-title').should('exist');
+  // cy.get('button')
+  //   .contains('Continue to the website')
+  //   .click()
+  //   .then(() => {
+  //     cy.get('#modal-announcement-title').should('not.exist');
+  //   });
   cy.get('.va-introtext').should('exist');
   cy.get('a.usa-button').contains('Make an appointment');
   cy.get('a.usa-button').contains('View all health services');


### PR DESCRIPTION
## Description
This PR removes Cypress interactions with a modal that no longer appears on the pages being tested, which is causing failures on CI.

## Acceptance criteria
- [ ] CI passes.