### PR TITLE
Add Slack notifications to Cypress tests on GitHub Actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -565,6 +565,57 @@ jobs:
           name: cypress-screenshot-artifacts
           path: cypress/screenshots
 
+      - name: Configure AWS credentials
+        if: ${{ github.ref == 'refs/heads/master' && failure() }}
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Get va-vsp-bot token
+        if: ${{ github.ref == 'refs/heads/master' && failure() }}
+        uses: marvinpinto/action-inject-ssm-secrets@v1.1.1
+        with:
+          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+
+      - name: Checkout VSP actions
+        if: ${{ github.ref == 'refs/heads/master' && failure() }}
+        uses: actions/checkout@v2
+        with:
+          repository: department-of-veterans-affairs/vsp-github-actions
+          ref: refs/heads/main
+          token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
+          persist-credentials: false
+          path: ./.github/actions/vsp-github-actions
+
+      - name: Get Slack app token
+        if: ${{ github.ref == 'refs/heads/master' && failure() }}
+        uses: marvinpinto/action-inject-ssm-secrets@v1.1.1
+        with:
+          ssm_parameter: /devops/github_actions_slack_socket_token
+          env_variable_name: SLACK_APP_TOKEN
+
+      - name: Get Slack bot token
+        if: ${{ github.ref == 'refs/heads/master' && failure() }}
+        uses: marvinpinto/action-inject-ssm-secrets@v1.1.1
+        with:
+          ssm_parameter: /devops/github_actions_slack_bot_user_token
+          env_variable_name: SLACK_BOT_TOKEN
+
+      - name: Notify Slack about Cypress test failures
+        if: ${{ github.ref == 'refs/heads/master' && failure() }}
+        uses: ./.github/actions/vsp-github-actions/slack-socket
+        continue-on-error: true
+        env:
+          SSL_CERT_DIR: /etc/ssl/certs
+        with:
+          slack_app_token: ${{ env.SLACK_APP_TOKEN }}
+          slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
+          attachments: '[{"mrkdwn_in": ["text"], "color": "danger", "text": "<!here> E2E tests in `content-build` have failed on the `master` branch, run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}]'
+          channel_id: C026PD47Z19
+
   nightwatch-tests:
     name: Nightwatch E2E Tests
     runs-on: ${{ needs.start-runner.outputs.vagovprod }}


### PR DESCRIPTION
## Description
This PR modifies the CI workflow on GitHub Actions so that a Slack notification is sent to `#gha-test-status` when Cypress tests fail on `master`.