### PR TITLE
My Education Benefits: Change root Url to approved path

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1133,8 +1133,8 @@
   },
   {
     "appName": "My Education Benefits",
-    "entryName": "my-education-benefits",
-    "rootUrl": "/my-education-benefits",
+    "entryName": "1990ez-edu-benefits",
+    "rootUrl": "/education/apply-for-benefits-form-22-1990",
     "template": {
       "vagovprod": false,
       "layout": "page-react.html"


### PR DESCRIPTION
## Description
- We've received approval for My Education Benefits app's root url. This change makes it /education/apply-for-benefits-form-22-1990

When this change makes it in, we'll make the corresponding manifest.json change in vets-website on PR https://github.com/department-of-veterans-affairs/vets-website/pull/18889

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
