### PR TITLE
Add fixture tests for block alert template

### DIFF
--- a/src/site/blocks/alert.drupal.liquid
+++ b/src/site/blocks/alert.drupal.liquid
@@ -1,27 +1,3 @@
-{% comment %}
-    Example data:
-    {
-        "entityBundle": "alert",
-        "fieldAlertType": "warning",
-        "fieldAlertTitle": "How do I talk to someone right now?",
-        "fieldReusability": "reusable",
-        "fieldAlertContent": {
-            "entity": {
-                "entityId": "932",
-                "entityBundle": "expandable_text"
-                "fieldWysiwyg": {
-                    "processed": "..."
-                },
-                "fieldTextExpander": "Find out how to get support anytime day or night."
-            }
-        }
-    }
-{% endcomment %}
-
-{% if alert.fieldAlertContent %}
-  {% assign expander = alert.fieldAlertContent.entity %}
-{% endif %}
-
 {% assign alertType = alert.fieldAlertType %}
 
 {% if alertType = "information" %}
@@ -35,23 +11,22 @@
         {{ alert.fieldAlertTitle }}
       </h2>
 
-      {% if expander.fieldTextExpander == empty %}
-          {{ expander.fieldWysiwyg.processed }}
+      {% if alert.fieldAlertContent.entity.fieldTextExpander == empty %}
+        {{ alert.fieldAlertContent.entity.fieldWysiwyg.processed }}
       {% endif %}
 
-      {% if expander.fieldTextExpander %}
+      {% if alert.fieldAlertContent.entity.fieldTextExpander %}
         {% comment %}
           NOTE: .additional-info-container is a class utilized by
           createAdditionalInfoWidget.js to add toggle functionality to info alerts
         {% endcomment %}
-
-        <div data-alert-box-title="{{ alert.fieldAlertTitle }}" data-label="{{ expander.fieldTextExpander }}" class="form-expanding-group borderless-alert additional-info-container">
+        <div data-alert-box-title="{{ alert.fieldAlertTitle }}" data-label="{{ alert.fieldAlertContent.entity.fieldTextExpander }}" class="form-expanding-group borderless-alert additional-info-container">
           <div class="additional-info-title">
-            {{ expander.fieldTextExpander }}
+            {{ alert.fieldAlertContent.entity.fieldTextExpander }}
           </div>
 
-          {% if expander.fieldWysiwyg %}
-            <div class="additional-info-content usa-alert-text" hidden>{{ expander.fieldWysiwyg.processed }}</div>
+          {% if alert.fieldAlertContent.entity.fieldWysiwyg %}
+            <div class="additional-info-content usa-alert-text" hidden>{{ alert.fieldAlertContent.entity.fieldWysiwyg.processed }}</div>
           {% endif %}
         </div>
       {% endif %}

--- a/src/site/blocks/tests/alert/alert.unit.spec.js
+++ b/src/site/blocks/tests/alert/alert.unit.spec.js
@@ -1,0 +1,40 @@
+// Node modules.
+import { beforeEach } from 'mocha';
+import { expect } from 'chai';
+// Relative imports.
+import axeCheck from '~/site/tests/support/axe';
+import { parseFixture, renderHTML } from '~/site/tests/support';
+
+// Derive the layout path.
+const layoutPath = 'src/site/blocks/alert.drupal.liquid';
+
+describe('blocks/alert.drupal.liquid', () => {
+  let container;
+  const data = parseFixture(
+    'src/site/blocks/tests/alert/fixtures/alert-data.json',
+  );
+
+  beforeEach(async () => {
+    container = await renderHTML(layoutPath, data);
+  });
+
+  it('reports no axe violations', async () => {
+    const violations = await axeCheck(container);
+    expect(violations.length).to.equal(0);
+  });
+
+  it('has a h2 header for the alert', () => {
+    const title = container.querySelector('h2');
+    expect(title.innerHTML.trim()).to.equal(data.alert.fieldAlertTitle);
+  });
+
+  it('has the correct alert type class', () => {
+    const alert = container.querySelector('.usa-alert');
+    const alertType =
+      data.alert.fieldAlertType === 'information'
+        ? 'info'
+        : data.alert.fieldAlertTitle;
+
+    expect(alert.classList.contains(`usa-alert-${alertType}`)).to.be.true;
+  });
+});

--- a/src/site/blocks/tests/alert/fixtures/alert-data.json
+++ b/src/site/blocks/tests/alert/fixtures/alert-data.json
@@ -1,0 +1,21 @@
+{
+  "alert": {
+    "id": 41,
+    "entityPublished": true,
+    "fieldAlertDismissable": false,
+    "fieldAlertFrequency": "always",
+    "fieldNodeReference": [
+      {
+        "targetId": 5090
+      }
+    ],
+    "fieldIsThisAHeaderAlert": "in_page_alert",
+    "fieldAlertType": "information",
+    "fieldAlertTitle": "You can choose to receive improved pension benefits",
+    "fieldAlertContent": {
+      "entity": {
+        "entityRendered": "  <div class=\"paragraph paragraph--type--expandable-text paragraph--view-mode--full\">\n    <div class=\"paragraph--metadata\">\n            \n    </div>\n          <div class=\"field field--name-field-text-expander field--type-string field--label-above\">\n  <div class=\"field__label\">Text Expander</div>\n                <div class=\"field__item\">\n          <span class=\"additional-info-title\">Learn more about changing your pension benefits program</span>\n        </div>\n          </div>\n\n  <div class=\"clearfix text-formatted field field--name-field-wysiwyg field--type-text-long field--label-above\">\n    <div class=\"field__label\">Full Text</div>\n              <div class=\"field__item\"><p><strong>If you're currently receiving payments from a Section 306 or old law pension,</strong> you can elect to change your benefits to begin receiving payments through the current, improved VA pension program. If you have questions about your benefits, please call us at <a href=\"tel:+18772946380\">877-294-6380</a>.</p>\n\n<p>View the current rates for improved pension programs:<br /><a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"94caf7db-5c43-45ee-a98f-b0d05831328b\" href=\"/pension/veterans-pension-rates\" title=\"2021 VA pension rates for Veterans\">Veterans Pension rates</a><br /><a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"aa96d639-fcea-4cb6-b3c8-1002dbec0ac5\" href=\"/pension/survivors-pension-rates\" title=\"2021 VA Survivors Pension benefit rates\">Survivors Pension rates</a></p>\n\n<p><strong>If you've lost entitlement to your Section 306 or old law pension,</strong> you can't apply again for these benefits. But you can apply for an improved <a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"17ab63a7-1b97-4587-8e54-6fae907af781\" href=\"/pension/how-to-apply\" title=\"How to apply for a VA pension as a Veteran\">Veterans Pension</a> or <a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"ef05c64c-5825-4a68-bb8b-b42475185ce0\" href=\"/pension/survivors-pension\" title=\"VA Survivors Pension\">Survivors Pension</a>.</p></div>\n          </div>\n\n      </div>\n"
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Description

This PR adds fixture tests for the block alert liquid template.

## Ticket

https://github.com/department-of-veterans-affairs/va.gov-team/issues/30547

## Screenshots

![image](https://user-images.githubusercontent.com/12773166/135478430-7d72258f-8757-47f9-a034-beee8df353d8.png)

## Acceptance Criteria

- [x] Create tests for block alert template.
