### PR TITLE
Github Actions (CI) -- Channel Notification

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,7 +9,8 @@ on:
 
 env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
-  CHANNEL_ID: C37M86Y8G #devops-deploys
+  DEVOPS_CHANNEL_ID: C37M86Y8G #devops-deploys
+  PLATFORM_BUILD_CHANNEL_ID: C0MQ281DJ #vfs-platform-support
   NEXUS_REGISTRY: https://devops.va.gov/dots-nexus/repository/platform-npm-group-nocache/
 
 concurrency:
@@ -300,7 +301,7 @@ jobs:
           slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
           attachments: ${{ steps.get-broken-link-info.outputs.SLACK_ATTACHMENTS }}
           blocks: ${{ steps.get-broken-link-info.outputs.SLACK_BLOCKS }}
-          channel_id: ${{ env.CHANNEL_ID}}
+          channel_id: ${{ env.PLATFORM_BUILD_CHANNEL_ID}}
 
   unit-tests:
     name: Unit Tests
@@ -1035,4 +1036,4 @@ jobs:
           slack_app_token: ${{ env.SLACK_APP_TOKEN }}
           slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
           attachments: '[{"mrkdwn_in": ["text"], "color": "danger", "text": "content-build master branch CI failed!: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"}]'
-          channel_id: ${{ env.CHANNEL_ID }}
+          channel_id: ${{ env.DEVOPS_CHANNEL_ID }}


### PR DESCRIPTION
## Description

Broken link information was being sent to #devops-deploy, which is fine, but Jenkins sends them to #vfs-platform-build

This PR addresses that


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
