### PR TITLE
Update slack mention from cmshelpdesk to cms-helpdesk

### DIFF
--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -157,7 +157,7 @@ def checkForBrokenLinks(String buildLogPath, String envName, Boolean contentOnly
       color = 'danger'
     }
 
-    def heading = "@cmshelpdesk ${brokenLinks.brokenLinksCount} broken links found in the `${envName}` build in `${source}`\n\n${env.RUN_DISPLAY_URL}\n\n"
+    def heading = "@cms-helpdesk ${brokenLinks.brokenLinksCount} broken links found in the `${envName}` build in `${source}`\n\n${env.RUN_DISPLAY_URL}\n\n"
     def message = "${heading}\n${brokenLinks.summary}".stripMargin()
 
     echo "${brokenLinks.brokenLinksCount} broken links found"

--- a/script/github-actions/check-broken-links.js
+++ b/script/github-actions/check-broken-links.js
@@ -20,7 +20,7 @@ if (fs.existsSync(reportPath)) {
     brokenLinks.brokenLinksCount > maxBrokenLinks;
   const color = shouldFail ? '#D33834' : '#FFCC00'; // danger or warning, needs to be in hex
   const summary = brokenLinks.summary;
-  const heading = `${brokenLinks.brokenLinksCount} broken links found in ${envName} \\n\\n <${SERVER_URL}>`; // TODO: Add @cmshelpdesk when prod ready
+  const heading = `${brokenLinks.brokenLinksCount} broken links found in ${envName} \\n\\n <${SERVER_URL}>`; // TODO: Add @cms-helpdesk when prod ready
   const slackBlocks = `[{"type": "section","text": {"type": "mrkdwn","text": "${heading}"}}]`;
   const slackAttachments = `[{"mrkdwn_in": ["text"], "color": "${color}", "text": "${summary
     .replace(/\n/g, '\\n')


### PR DESCRIPTION
## Description

Update slack mention from cmshelpdesk to cms-helpdesk.  The slack group was renamed.  See https://dsva.slack.com/archives/CT4GZBM8F/p1633100486175200 for background.

