### PR TITLE
Fix react breadcrumbs

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -39,10 +39,6 @@
           "name": "Pension benefits"
         },
         {
-          "path": "pension/how-to-apply/",
-          "name": "How to apply"
-        },
-        {
           "path": "pension/application/527EZ",
           "name": "Apply for Veterans Pension"
         }
@@ -218,10 +214,6 @@
         {
           "path": "health-care/",
           "name": "Health Care"
-        },
-        {
-          "path": "health-care/how-to-apply/",
-          "name": "How to apply"
         },
         {
           "path": "health-care/apply/application",
@@ -526,12 +518,16 @@
       "includeBreadcrumbs": true,
       "breadcrumbs_override": [
         {
-          "name": "Education",
+          "name": "Education and training",
           "path": "education/"
         },
         {
-          "name": "Apply for education benefits",
-          "path": "education/how-to-apply/"
+          "name": "Change your GI Bill school or program",
+          "path": "education/change-gi-bill-benefits/"
+        },
+        {
+          "name": "Change your dependent benefits VA Form 22-5495",
+          "path": "education/apply-for-education-benefits/application/5495/"
         }
       ]
     }
@@ -750,16 +746,20 @@
       "includeBreadcrumbs": true,
       "breadcrumbs_override": [
         {
-          "path": "records/",
-          "name": "Records"
+          "name": "Records",
+          "path": "records/"
         },
         {
-          "path": "records/get-veteran-id-cards/",
-          "name": "Types of Veteran ID cards"
+          "name": "Types of Veteran ID cards",
+          "path": "records/get-veteran-id-cards/"
         },
         {
-          "path": "records/get-veteran-id-cards/apply/",
-          "name": "Apply for an ID Card"
+          "name": "How to apply for a Veteran ID Card",
+          "path": "records/get-veteran-id-cards/vic/"
+        },
+        {
+          "name": "Request a printed Veteran ID Card",
+          "path": "records/get-veteran-id-cards/apply/"
         }
       ]
     }

--- a/src/site/includes/breadcrumbs.html
+++ b/src/site/includes/breadcrumbs.html
@@ -1,46 +1,56 @@
-{% if gatePage === true %} {% assign gatePageClassName = 'va-nav-breadcrumbs--gate' %} {% endif %}
+{% if gatePage === true %}
+  {% assign gatePageClassName = 'va-nav-breadcrumbs--gate' %}
+{% endif %}
 
 <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs {{gatePageClassName}} {% if newGrid %}new-grid{% endif %}" id="va-breadcrumbs">
   <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
     <li>
-      <a href="/" onClick="recordEvent({ event: 'nav-breadcrumb', 'nav-breadcrumb-section': 'home' });">Home</a>
+      <a href="/" onClick="recordEvent({ event: 'nav-breadcrumb', 'nav-breadcrumb-section': 'home' });">
+        Home
+      </a>
     </li>
+
     {% assign crumbs = breadcrumb_path %}
 
     {% if breadcrumbs_override %}
-    {% assign crumbs = breadcrumbs_override %}
+      {% assign crumbs = breadcrumbs_override %}
     {% endif %}
 
     {% assign current_page = crumbs | last %}
 
     {% for crumb in crumbs %}
+      <!-- Adding back in the last link as aria-current="page" -->
+      {% comment %}
+        Each breadcrumb item has a child object.
+        One of the properties of that object is `file` which loads the front matter metadata from the corresponding Markdown input file.
+        Below, we’ve assigned that object to a variable named 'crumb_child_meta'.
+        If these templates are still using tinyliquid, you can dump the properties of this object using {{ crumb | keys }}.
+      {% endcomment %}
+      {% assign crumb_child_meta = crumb.children.0.file %}
 
-    <!-- Adding back in the last link as aria-current="page" -->
-    {% comment %} Each breadcrumb item has a child object. One of the properties of that object is `file` which loads the front matter metadata from the corresponding Markdown input file. Below, we’ve assigned that object to a variable named 'crumb_child_meta'. If these templates are still using tinyliquid, you can dump the properties of this object using {{ crumb | keys }}. {% endcomment %}
-    {% assign crumb_child_meta = crumb.children.0.file %}
-    <li>
-      {% if current_page.name != crumb.name %}
-      <a href="/{{ crumb.path }}">
-        {% if crumb_child_meta.display_title %}
-          {{ crumb_child_meta.display_title }}
-        {% elsif crumb_child_meta.title %}
-          {{ crumb_child_meta.title }}
+      <li>
+        {% if current_page.name != crumb.name %}
+          <a href="/{{ crumb.path }}">
+            {% if crumb_child_meta.display_title %}
+              {{ crumb_child_meta.display_title }}
+            {% elsif crumb_child_meta.title %}
+              {{ crumb_child_meta.title }}
+            {% else %}
+              {{ crumb.name | replace: '-', ' ' | capitalize }}
+            {% endif %}
+          </a>
         {% else %}
-          {{ crumb.name | replace: '-', ' ' | capitalize }}
+          <a aria-current="page" href="/{{ crumb.path }}">
+            {% if crumb_child_meta.display_title %}
+              {{ crumb_child_meta.display_title }}
+            {% elsif crumb_child_meta.title %}
+              {{ crumb_child_meta.title }}
+            {% else %}
+              {{ crumb.name | replace: '-', ' ' | capitalize }}
+            {% endif %}
+          </a>
         {% endif %}
-      </a>
-      {% else %}
-      <a aria-current="page" href="/{{ crumb.path }}">
-        {% if crumb_child_meta.display_title %}
-          {{ crumb_child_meta.display_title }}
-        {% elsif crumb_child_meta.title %}
-          {{ crumb_child_meta.title }}
-        {% else %}
-          {{ crumb.name | replace: '-', ' ' | capitalize }}
-        {% endif %}
-      </a>
-      {% endif %}
-    </li>
+      </li>
     {% endfor %}
   </ul>
 </nav>


### PR DESCRIPTION
# Description

**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/6582

This PR fixes the following breadcrumbs for react apps:

1. https://staging.va.gov/education/apply-for-education-benefits/application/5495 <br> **This one should be changed to** [Home](https://www.va.gov) > [Education and training](https://www.va.gov/education/) > [Change your GI Bill school or program](https://www.va.gov/education/change-gi-bill-benefits/) > Change your dependent benefits VA Form 22-5495
1. https://staging.va.gov/health-care/apply/application <br>**This one should be changed** remove "How to apply" from path
1. https://staging.va.gov/pension/application/527EZ <br>**This one should be changed** remove "How to apply" from path
1. https://staging.va.gov/records/get-veteran-id-cards/apply <br> **This one should be changed to**  [Home](https://www.va.gov/) > [Records](https://www.va.gov/records/) > [Types of Veteran ID cards](https://www.va.gov/records/get-veteran-id-cards/) > [How to apply for a Veteran ID Card](https://www.va.gov/records/get-veteran-id-cards/vic/) > Request a printed Veteran ID Card

## Screenshots

![image](https://user-images.githubusercontent.com/12773166/136064878-8b2d8916-cd3e-422e-abd2-8d0ee9360776.png)

![image](https://user-images.githubusercontent.com/12773166/136064907-7dbd3ddb-1365-4a7b-a9db-3fef6f822472.png)

![image](https://user-images.githubusercontent.com/12773166/136064942-badd2832-bc45-4538-b281-6425e6d72533.png)

## Acceptance Criteria

- [x] Fix react breadcrumb overrides according to IA guidance
