### PR TITLE
Run Cypress test report job on GitHub Actions only after tests run

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -570,7 +570,7 @@ jobs:
     name: Testing Reports
     runs-on: ubuntu-latest
     needs: [cypress-tests]
-    if: ${{ always() }}
+    if: ${{ needs.cypress-tests.result == 'failure' || needs.cypress-tests.result == 'success' }}
     continue-on-error: true
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
## Description
This PR modifies the Cypress workflow in GitHub Actions CI so that the Cypress test report job runs only if the Cypress test suite has completed.

## Acceptance criteria
- [ ] CI passes.