### PR TITLE
Github Actions (CI) -- Persist only tar rather than builds for archive step

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -297,7 +297,7 @@ jobs:
       - name: Restore vagovprod build
         run: |
           mv /tmp/${{ github.run_id }}/vagovprod.tar.bz2 .
-          df
+          df -h
 
       - name: Configure AWS credentials (1)
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -279,29 +279,25 @@ jobs:
       - name: Prearchive
         run: node ./script/prearchive.js --buildtype=${{ env.BUILDTYPE }}
 
+      - name: Compress build
+        run: tar -C build/${{ env.BUILDTYPE }} -cf ${{ env.BUILDTYPE }}.tar.bz2 .
+
       - name: Persist prearchived build
         run: |
           mkdir -p /tmp/${{ github.run_id }}
           rm -rf /tmp/${{ github.run_id }}/${{ env.BUILDTYPE }}
-          mv build/${{ env.BUILDTYPE }} /tmp/${{ github.run_id }}
+          mv ${{ env.BUILDTYPE }}.tar.bz2 /tmp/${{ github.run_id }}
 
   archive:
     name: Archive
     runs-on: ${{ needs.start-runner.outputs.label }}
     needs: [set-env, build, start-runner]
 
-    env:
-      BUILDTYPE: vagovprod
-
     steps:
       - name: Restore vagovprod build
         run: |
-          mkdir -p build
-          cp -R /tmp/${{ github.run_id }}/${{ env.BUILDTYPE }} build/${{ env.BUILDTYPE }}
-          du -h build/${{ env.BUILDTYPE }}
-
-      - name: Compress ${{ env.BUILDTYPE }} build
-        run: tar -cvf ${{ env.BUILDTYPE }}.tar.bz2 build/${{ env.BUILDTYPE }}
+          mv /tmp/${{ github.run_id }}/vagovprod.tar.bz2 .
+          df
 
       - name: Configure AWS credentials (1)
         uses: aws-actions/configure-aws-credentials@v1
@@ -327,7 +323,7 @@ jobs:
           role-session-name: vsp-frontendteam-githubaction
 
       - name: Upload build
-        run: aws s3 cp ${{ env.BUILDTYPE }}.tar.bz2 s3://vetsgov-website-builds-s3-upload/content-build/${{needs.set-env.outputs.REF}}/${{env.BUILDTYPE}}.tar.bz2 --acl public-read --region us-gov-west-1
+        run: aws s3 cp vagovprod.tar.bz2 s3://vetsgov-website-builds-s3-upload/content-build/${{needs.set-env.outputs.REF}}/vagovprod.tar.bz2 --acl public-read --region us-gov-west-1
 
   create-release:
     name: Create Release

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -298,6 +298,7 @@ jobs:
         run: |
           mv /tmp/${{ github.run_id }}/vagovprod.tar.bz2 .
           df -h
+          du -h vagovprod.tar.bz2
 
       - name: Configure AWS credentials (1)
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -204,11 +204,14 @@ jobs:
       - name: Prearchive
         run: node ./script/prearchive.js --buildtype=${{ matrix.buildtype }}
 
+      - name: Compress build
+        run: tar -C build/${{ matrix.buildtype }} -cf ${{ matrix.buildtype }}.tar.bz2 .
+
       - name: Persist prearchived build
         run: |
           mkdir -p /tmp/${{ github.run_id }}
           rm -rf /tmp/${{ github.run_id }}/${{ matrix.buildtype }}
-          mv build/${{ matrix.buildtype }} /tmp/${{ github.run_id }}
+          mv ${{ matrix.buildtype }}.tar.bz2 /tmp/${{ github.run_id }}
 
       - name: Get Slack app token
         uses: marvinpinto/action-inject-ssm-secrets@v1.1.1
@@ -722,9 +725,6 @@ jobs:
           mkdir -p build
           cp -R /tmp/${{ github.run_id }}/${{ matrix.buildtype }} build/${{ matrix.buildtype }}
           du -h build/${{ matrix.buildtype }}
-
-      - name: Compress build
-        run: tar -C build/${{ matrix.buildtype }} -cf ${{ matrix.buildtype }}.tar.bz2 .
 
       - name: Configure AWS credentials (1)
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -723,7 +723,7 @@ jobs:
       - name: Restore ${{ matrix.buildtype }} build
         run: |
           mv /tmp/${{ github.run_id }}/${{ matrix.buildtype }}.tar.bz2 .
-          df
+          df -h
 
       - name: Configure AWS credentials (1)
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -724,6 +724,7 @@ jobs:
         run: |
           mv /tmp/${{ github.run_id }}/${{ matrix.buildtype }}.tar.bz2 .
           df -h
+          du -h ${{ matrix.buildtype }}.tar.bz2
 
       - name: Configure AWS credentials (1)
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -723,6 +723,7 @@ jobs:
       - name: Restore ${{ matrix.buildtype }} build
         run: |
           mv /tmp/${{ github.run_id }}/${{ matrix.buildtype }}.tar.bz2 .
+          df
 
       - name: Configure AWS credentials (1)
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -720,11 +720,9 @@ jobs:
         buildtype: [vagovdev]
 
     steps:
-      - name: Restore ${{ matrix.buildtype }} build
+      - name: Restore ${{ matrix.buildtype }} compressed
         run: |
-          mkdir -p build
-          cp -R /tmp/${{ github.run_id }}/${{ matrix.buildtype }} build/${{ matrix.buildtype }}
-          du -h build/${{ matrix.buildtype }}
+          mv ${{ matrix.buildtype }}.tar.bz2 .
 
       - name: Configure AWS credentials (1)
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -720,9 +720,9 @@ jobs:
         buildtype: [vagovdev]
 
     steps:
-      - name: Restore ${{ matrix.buildtype }} compressed
+      - name: Restore ${{ matrix.buildtype }} build
         run: |
-          mv ${{ matrix.buildtype }}.tar.bz2 .
+          mv /tmp/${{ github.run_id }}/${{ matrix.buildtype }}.tar.bz2 .
 
       - name: Configure AWS credentials (1)
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -303,7 +303,7 @@ jobs:
       - name: Restore vagovprod build
         run: |
           mv /tmp/${{ github.run_id }}/vagovprod.tar.bz2 .
-          df
+          df -h
 
       - name: Configure AWS credentials (1)
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -304,6 +304,7 @@ jobs:
         run: |
           mv /tmp/${{ github.run_id }}/vagovprod.tar.bz2 .
           df -h
+          du -h vagovprod.tar.bz2
 
       - name: Configure AWS credentials (1)
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -284,29 +284,25 @@ jobs:
       - name: Prearchive
         run: node ./script/prearchive.js --buildtype=${{ env.BUILDTYPE }}
 
+      - name: Compress build
+        run: tar -C build/${{ env.BUILDTYPE }} -cf ${{ env.BUILDTYPE }}.tar.bz2 .
+
       - name: Persist prearchived build
         run: |
           mkdir -p /tmp/${{ github.run_id }}
           rm -rf /tmp/${{ github.run_id }}/${{ env.BUILDTYPE }}
-          mv build/${{ env.BUILDTYPE }} /tmp/${{ github.run_id }}
+          mv ${{ env.BUILDTYPE }}.tar.bz2 /tmp/${{ github.run_id }}
 
   archive:
     name: Archive
     runs-on: ${{ needs.start-runner.outputs.label }}
     needs: [set-env, build, start-runner]
 
-    env:
-      BUILDTYPE: vagovprod
-
     steps:
       - name: Restore vagovprod build
         run: |
-          mkdir -p build
-          cp -R /tmp/${{ github.run_id }}/${{ env.BUILDTYPE }} build/${{ env.BUILDTYPE }}
-          du -h build/${{ env.BUILDTYPE }}
-
-      - name: Compress ${{ env.BUILDTYPE }} build
-        run: tar -cvf ${{ env.BUILDTYPE }}.tar.bz2 build/${{ env.BUILDTYPE }}
+          mv /tmp/${{ github.run_id }}/vagovprod.tar.bz2 .
+          df
 
       - name: Configure AWS credentials (1)
         uses: aws-actions/configure-aws-credentials@v1
@@ -332,7 +328,7 @@ jobs:
           role-session-name: vsp-frontendteam-githubaction
 
       - name: Upload build
-        run: aws s3 cp ${{ env.BUILDTYPE }}.tar.bz2 s3://vetsgov-website-builds-s3-upload/content-build/${{ needs.set-env.outputs.COMMIT_SHA }}/${{ env.BUILDTYPE }}.tar.bz2 --acl public-read --region us-gov-west-1
+        run: aws s3 cp vagovprod.tar.bz2 s3://vetsgov-website-builds-s3-upload/content-build/${{ needs.set-env.outputs.COMMIT_SHA }}/vagovprod.tar.bz2 --acl public-read --region us-gov-west-1
 
   create-release:
     name: Create Release


### PR DESCRIPTION
## Description

This PR refers to this [ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/31189)

It was noticed that CI workflow was failing due to disk space running out. Despite the disk space size increased, we want to reduce space used as we will add `vagovstaging` and `vagovprod`

Code cleanup up bit in `content-release` and `daily-deploy` as well

## Testing done

Latest Run
