### PR TITLE
VACMS-6176: Remove alert block fields from graphql that are being removed from CMS

### DIFF
--- a/src/site/stages/build/drupal/graphql/alerts.graphql.js
+++ b/src/site/stages/build/drupal/graphql/alerts.graphql.js
@@ -10,12 +10,6 @@ const partialQuery = `
       ... on BlockContentAlert {
         id
         entityPublished
-        fieldAlertDismissable
-        fieldAlertFrequency
-        fieldNodeReference {
-          targetId
-        }
-        fieldIsThisAHeaderAlert
         fieldAlertType
         fieldAlertTitle
         fieldAlertContent {

--- a/src/site/stages/build/drupal/graphql/block-fragments/alert.block.graphql.js
+++ b/src/site/stages/build/drupal/graphql/block-fragments/alert.block.graphql.js
@@ -19,7 +19,6 @@ const alert = `
 fragment alert on BlockContentAlert {
   entityId
   entityPublished
-  fieldAlertDismissable
   fieldAlertType
   fieldAlertTitle
   fieldReusability


### PR DESCRIPTION
## Description
Removes four legacy fields from alert blocks that are no longer in use and being removed from cms.
See: https://github.com/department-of-veterans-affairs/va.gov-cms/pull/6419

## Testing done
Build

## Screenshots
```
Error with GetAlerts. Scroll up for the GraphQL query that has errors:
      │ 
      │ [
      │   {
      │     "message": "Cannot query field \"fieldAlertDismissable\" on type \"BlockContentAlert\". Did you mean \"fieldAlertTitle\" or \"fieldAlertType\"?",
      │     "category": "graphql",
      │     "locations": [
      │       {
      │         "line": 11,
      │         "column": 9
      │       }
      │     ]
      │   },
      │   {
      │     "message": "Cannot query field \"fieldAlertFrequency\" on type \"BlockContentAlert\". Did you mean \"fieldAlertContent\", \"fieldAlertTitle\", or \"fieldAlertType\"?",
      │     "category": "graphql",
      │     "locations": [
      │       {
      │         "line": 12,
      │         "column": 9
      │       }
      │     ]
      │   },
      │   {
      │     "message": "Cannot query field \"fieldNodeReference\" on type \"BlockContentAlert\".",
      │     "category": "graphql",
      │     "locations": [
      │       {
      │         "line": 13,
      │         "column": 9
      │       }
      │     ]
      │   },
      │   {
      │     "message": "Cannot query field \"fieldIsThisAHeaderAlert\" on type \"BlockContentAlert\".",
      │     "category": "graphql",
      │     "locations": [
      │       {
      │         "line": 16,
      │         "column": 9
      │       }
      │     ]
      │   }
      │ ]
```

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
