### PR TITLE
Github Actions (DD) -- Fix daily deploy missing commit_sha

### DIFF
--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -84,6 +84,7 @@ jobs:
     outputs:
       LATEST_TAG_VERSION: ${{ steps.get-latest-tag.outputs.LATEST_TAG_VERSION }}
       RELEASE_WAIT: ${{ env.RELEASE_WAIT }}
+      COMMIT_SHA: ${{ env.COMMIT_SHA }}
 
     steps:
       - name: Cancel workflow due to DSVA schedule


### PR DESCRIPTION
## Description

It looks like we missed the `commit_sha` being passed. It is being called, but no reference being made. This PR adds the reference globally to access it


## Testing done

N/A. Will be observed via Slack channel
