### PR TITLE
Use graceful-fs to prevent EMFILE errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "find-root": "^1.1.0",
     "fs-extra": "^7.0.0",
     "glob": "^7.1.7",
+    "graceful-fs": "^4.2.8",
     "http-server": "^0.12.3",
     "husky": ">=6",
     "isomorphic-fetch": "^2.2.1",

--- a/src/site/stages/build/index.js
+++ b/src/site/stages/build/index.js
@@ -38,6 +38,13 @@ const rewriteDrupalPages = require('./plugins/rewrite-drupal-pages');
 const rewriteVaDomains = require('./plugins/rewrite-va-domains');
 const updateRobots = require('./plugins/update-robots');
 
+// Replace fs with graceful-fs to retry on EMFILE errors. Metalsmith can
+// attempt to open too many files simultaneously, so we need to handle it.
+const realFs = require('fs');
+const gracefulFs = require('graceful-fs');
+
+gracefulFs.gracefulify(realFs);
+
 function build(BUILD_OPTIONS) {
   const smith = silverSmith();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5540,7 +5540,7 @@ gonzales-pe-sl@^4.2.3:
   dependencies:
     minimist "1.1.x"
 
-graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.3, graceful-fs@^4.2.4, graceful-fs@^4.2.6:
+graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.3, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.8:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==


### PR DESCRIPTION
## Description
The content build has [recently failed](http://jenkins.vfs.va.gov/job/builds/job/content-build-content-only-vagovprod/1582/console) a couple times with `Error: EMFILE: too many open files, uv_resident_set_memory`. The failure occurs after the final step in the build process, when metalsmith writes all the files to disk. Metalsmith sometimes attempts to open too many files simultaneously, hitting the limit on file descriptors. I think that's the problem in this case.

This PR should resolve the issue by replacing `fs` with `graceful-fs` before the build process starts. When an EMFILE error occurs, graceful-fs will automatically retry. This way we are protected against EMFILE errors throughout the build process.

## Testing done
- Run diff on builds with and without graceful-fs (no differences)
- Compare local and CI build times with and without graceful-fs (no time penalty)
- Successful local and CI builds

## Acceptance criteria
- [x] Metalsmith is forced to use `graceful-fs` instead of `fs`
- [x] Build process succeeds with no regressions

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
