### PR TITLE
Disable content-release Workflow

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -7,9 +7,9 @@ on:
         description: "Minutes to wait before creating release"
         required: false
         default: 5
-  schedule:
-    - cron: "0 13-16,20-21 * * 1-5"
-    - cron: "45 17 * * 1-5"
+  # schedule:
+  #   - cron: "0 13-16,20-21 * * 1-5"
+  #   - cron: "45 17 * * 1-5"
 
 # TODO: Change to correct channel_id when ready
 env:


### PR DESCRIPTION
## Description
Temporarily disabling to stop from archiving to prod. Long term fix will be modifying the archive step to point to dev instead of prod.