### PR TITLE
Remove VLC with display none

### DIFF
--- a/src/site/includes/top-nav.html
+++ b/src/site/includes/top-nav.html
@@ -11,7 +11,7 @@
     <div class="va-notice--banner-inner">
       {% include "src/site/includes/usa-website-header.html" %}
     </div>
-    <div class="va-crisis-line-container">
+    <div class="va-crisis-line-container vads-u-display--none">
       <button onclick="recordEvent({ event: 'nav-crisis-header' })" data-show="#modal-crisisline" class="va-crisis-line va-overlay-trigger">
         <div class="va-crisis-line-inner">
           <span class="va-crisis-line-icon" aria-hidden="true"></span>


### PR DESCRIPTION
## Description
**Slack:** https://dsva.slack.com/archives/C52CL1PKQ/p1634741429397500

Microsoft is having issues with online chat.
We want to remove this online chat option in the modal (that's triggered from the header) until Microsoft fixes it.

## Testing done


## Screenshots
![image](https://user-images.githubusercontent.com/12773166/138120377-39ced1fe-962c-4569-b5ab-64d19ed06677.png)

## Acceptance criteria
- [x] Remove VLC for now

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
