### PR TITLE
VAVFS-6724: [Fixed] staff title missing

### DIFF
--- a/src/site/paragraphs/staff_profile.drupal.liquid
+++ b/src/site/paragraphs/staff_profile.drupal.liquid
@@ -31,7 +31,7 @@
             {{ bio.fieldNameFirst }} {{ bio.fieldLastName }} {{ bio.fieldSuffix }}
           {% endif %}
         </p>
-      {% if bio.fieldCompleteBiographyCreate %}
+      {% if bio.fieldDescription %}
         <p class="
         vads-u-font-weight--normal
         vads-u-font-size--base


### PR DESCRIPTION
## Description


## Testing done
local unit tests passed

## Screenshots
<img width="973" alt="Local Unit tests passed" src="https://user-images.githubusercontent.com/90930782/138130796-e5686ce4-e5fa-4d2a-bd89-36176be592a1.png">
<img width="1187" alt="Title and Names now appear" src="https://user-images.githubusercontent.com/90930782/138130799-ac6630cf-3622-49b8-9e5a-33b4ad705421.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/6724
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
