### PR TITLE
VACMS-1317: Update logic to use order field instead of featured field.

### DIFF
--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -31,16 +31,14 @@
               {% endif %}
 
               {% assign featuredEventUrl = null %}
-              {% assign featuredItemSet = false %}
-              {% assign upcomingEvents = reverseFieldListingNode.entities | filterUpcomingEvents  %}
+              {% assign upcomingEvents = reverseFieldListingNode.entities | filterUpcomingEvents | sort: "fieldOrder" %}
 
               {% for featuredEvent in upcomingEvents %}
-                {% if featuredEvent.fieldFeatured == true %}
+                {% if featuredEvent.fieldOrder != null %}
                   {% unless entityUrl.path contains 'past-events' %}
-                    {% if featuredItemSet == false %}
                       {% assign featuredEventUrl = featuredEvent.entityUrl.path %}
                       <div class="usa-width-two-thirds">
-                        <div class="usa-grid usa-grid-full vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4 vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-border-left--7px vads-u-border-color--primary-alt-lightest" id="featured-content">
+                        <div class="usa-grid usa-grid-full vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4 vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-border-left--7px vads-u-border-color--primary-alt-lightest featured-content">
                           <div class="usa-width-full vads-u-padding-left--2">
                             <div class="vads-u-margin-bottom--2">
                               <strong>In the spotlight at
@@ -50,9 +48,7 @@
                           </div>
                         </div>
                       </div>
-                    {% endif %}
                   {% endunless %}
-                  {% assign featuredItemSet = true %}
                 {% endif %}
               {% endfor %}
 
@@ -70,7 +66,7 @@
 
               {% for event in pagedItems %}
                 {% comment %} Don't render the featured event again {% endcomment %}
-                {% if featuredEventUrl != event.entityUrl.path %}
+                {% if event.fieldOrder == null %}
                   <div class="clearfix-text">
                     {% include "src/site/teasers/event.drupal.liquid" with node = event %}
                   </div>
@@ -87,7 +83,7 @@
             </div>
           </div>
               <!-- Last updated & feedback button-->
-          {% include "src/site/includes/above-footer-elements.drupal.liquid" %}  
+          {% include "src/site/includes/above-footer-elements.drupal.liquid" %}
         </article>
       </div>
     </div>

--- a/src/site/layouts/news_stories_page.drupal.liquid
+++ b/src/site/layouts/news_stories_page.drupal.liquid
@@ -72,7 +72,7 @@ Example data:
           {% endfor %}
           {% endif %}
           {% for story in pagedItems %}
-            {% if story.fieldFeatured == false %}
+            {% if story.fieldOrder == null %}
               {% include "src/site/teasers/news_story_page.drupal.liquid" with node = story %}
             {% endif %}
           {% endfor %}

--- a/src/site/layouts/story_listing.drupal.liquid
+++ b/src/site/layouts/story_listing.drupal.liquid
@@ -18,22 +18,20 @@
                 {% endif %}
               </div>
           {% assign stories = reverseFieldListingNode.entities %}
-          {% assign featuredStories = reverseFieldListingNode.entities | filterBy: 'fieldFeatured', true %}
+          {% assign featuredStories = reverseFieldListingNode.entities | sort: 'fieldOrder' %}
           {% assign isFirstPage = isPreview or paginator | isFirstPage %}
           {% if isPreview %}
             {% assign pagingResult = debug | paginatePages: stories, 'story' %}
             {% assign pagedItems = pagingResult.pagedItems%}
             {% assign paginator = pagingResult.paginator%}
           {% endif %}
-          {% if isFirstPage and featuredStories %}
             {% for storyFeature in featuredStories limit:2 %}
+            {% if storyFeature.fieldOrder != null and isFirstPage %}
                 {% include "src/site/teasers/news_story_page_feature.drupal.liquid" with node = storyFeature %}
-            {% endfor %}
-          {% endif %}
-          {% for story in pagedItems %}
-            {% if story.fieldFeatured == false %}
-              {% include "src/site/teasers/news_story_page.drupal.liquid" with node = story %}
             {% endif %}
+            {% endfor %}
+          {% for story in pagedItems %}
+              {% include "src/site/teasers/news_story_page.drupal.liquid" with node = story %}
           {% endfor %}
           {% if stories.length == 0 %}
             <div class="clearfix-text">No stories at this time.</div>

--- a/src/site/layouts/vet_center.drupal.liquid
+++ b/src/site/layouts/vet_center.drupal.liquid
@@ -11,7 +11,7 @@
           {% if title != empty %}
             <h1 aria-describedby="vet-center-title">{{ title }}</h1>
             {% if fieldOfficialName and title != fieldOfficialName %}
-              <p id="vet-center-title" class="field-official-name vads-u-line-height--4 vads-u-font-family--sans vads-u-font-size--lg 
+              <p id="vet-center-title" class="field-official-name vads-u-line-height--4 vads-u-font-family--sans vads-u-font-size--lg
               vads-u-font-weight--bold vads-u-padding-bottom--0p5">
                 Also called the {{fieldOfficialName}}
               </p>
@@ -19,7 +19,7 @@
           {% elsif fieldOfficialName != empty %}
             <h1>{{ fieldOfficialName}}</h1>
           {% endif %}
-          
+
           {% if fieldIntroText != empty %}
             <div class="va-introtext">
               <p>{{ fieldIntroText }}</p>
@@ -162,8 +162,8 @@
 
           {% if fieldCcVetCenterFaqs.fetched %}
             <div class="vads-u-margin-bottom--3" id="field-vet-center-faqs">
-              {% include "src/site/includes/centralized-content.drupal.liquid" 
-                entity = fieldCcVetCenterFaqs.fetched 
+              {% include "src/site/includes/centralized-content.drupal.liquid"
+                entity = fieldCcVetCenterFaqs.fetched
                 contentType = fieldCcVetCenterFaqs.fetchedBundle
                 level = 3
               %}
@@ -171,7 +171,7 @@
           {% endif %}
           <va-back-to-top></va-back-to-top>
     <!-- Last updated & feedback button -->
-          {% include "src/site/includes/above-footer-elements.drupal.liquid" %}          
+          {% include "src/site/includes/above-footer-elements.drupal.liquid" %}
         </article>
       </div>
     </div>

--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionEvents.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionEvents.node.graphql.js
@@ -17,7 +17,7 @@ function queryFilter(isAll) {
     ${
       isAll
         ? ''
-        : '{ field: "field_featured" value: "1"}, { field: "field_datetime_range_timezone", value: [$today], operator: GREATER_THAN}'
+        : '{ field: "field_order" value: ["0", "1"]}, { field: "field_datetime_range_timezone", value: [$today], operator: GREATER_THAN}'
     }
   ]} sort: [{field: "field_order", direction: ASC }, {field: "field_datetime_range_timezone", direction: ASC }] limit: ${
     isAll ? '5000' : '2'

--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionNewsStories.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionNewsStories.node.graphql.js
@@ -7,7 +7,7 @@ const NEWS_STORIES_RESULTS = `
     entityId
     ... on NodeNewsStory {
       title
-      fieldFeatured
+      fieldOrder
       fieldIntroText
       fieldMedia {
         entity {
@@ -37,7 +37,7 @@ function queryFilter(isAll) {
       conditions: [
         { field: "type", value: "news_story"}
         { field: "status", value: "1"}
-        ${isAll ? '' : '{ field: "field_featured" value: "1"}'}
+        ${isAll ? '' : '{ field: "field_order" value: ["0", "1"]}'}
       ]} sort: {field: "created", direction: DESC }, limit:${
         isAll ? '500' : '2'
       })

--- a/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
@@ -95,7 +95,7 @@ const nodeHealthCareRegionPage = `
     eventTeasersFeatured: reverseFieldOfficeNode(limit: 1000, filter: {conditions: [{field: "type", value: "event_listing"}]}) {
       entities {
         ... on NodeEventListing {
-          reverseFieldListingNode(limit: 5000, filter: {conditions: [{field: "type", value: "event"}, {field: "status", value: "1"}, {field: "field_featured", value: "1"}, { field: "field_datetime_range_timezone", value: [$today], operator: GREATER_THAN}]}) {
+          reverseFieldListingNode(limit: 5000, filter: {conditions: [{field: "type", value: "event"}, {field: "status", value: "1"}, {field: "field_order", value: ["0", "1"]}, { field: "field_datetime_range_timezone", value: [$today], operator: GREATER_THAN}]}) {
             entities {
               ... nodeEventWithoutBreadcrumbs
             }
@@ -106,11 +106,11 @@ const nodeHealthCareRegionPage = `
     newsStoryTeasersFeatured: reverseFieldOfficeNode(limit: 1000, filter: {conditions: [{field: "type", value: "story_listing"}]}) {
       entities {
         ... on NodeStoryListing {
-          reverseFieldListingNode(limit: 1000, filter: {conditions: [{field: "type", value: "news_story"}, {field: "status", value: "1"}, {field: "field_featured", value: "1"}]}) {
+          reverseFieldListingNode(limit: 1000, filter: {conditions: [{field: "type", value: "news_story"}, {field: "status", value: "1"}, {field: "field_order", value: ["0", "1"]}]}) {
             entities {
               ... on NodeNewsStory {
                 title
-                fieldFeatured
+                fieldOrder
                 fieldIntroText
                 fieldMedia {
                   entity {

--- a/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
@@ -80,7 +80,6 @@ const nodeEvent = `
         }
       }
     }
-    fieldFeatured
     fieldLink {
       uri
       url {
@@ -230,7 +229,6 @@ const nodeEventWithoutBreadcrumbs = `
         }
       }
     }
-    fieldFeatured
     fieldLink {
       uri
       url {

--- a/src/site/stages/build/drupal/graphql/storyListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/storyListingPage.graphql.js
@@ -13,7 +13,7 @@ const storyListingPage = `
         ... on NodeNewsStory {
           entityId
           title
-          fieldFeatured
+          fieldOrder
           entityUrl {
             path
           }


### PR DESCRIPTION
## Description
See https://github.com/department-of-veterans-affairs/va.gov-cms/issues/1317
Featured boolean is being removed from cms content model, and fieldOrder (existing) is going to be used instead. Field order will place stories & events in featured position at top of listing page, sorted by weight. Multiple #1's and #2's may appear. These updates also account for system page story and events feature items.
After this work is deployed to prod, cms content model change to remove fieldFeatured will be completed.

## Testing done
Visual / build

## Screenshots
### Events listing page (Butler - features will not appear on past events pages, and will fall from feature slot when current date is greater than event date)
![image](https://user-images.githubusercontent.com/2404547/138535273-04f68949-5c51-41f5-8c4a-40419ea32a79.png)

### Stories page (Butler)
![image](https://user-images.githubusercontent.com/2404547/138535276-a4ae4f2d-8473-4202-a4b0-f7ceba3b8128.png)

### System page (Butler)
![image](https://user-images.githubusercontent.com/2404547/138535371-d0051e1f-fdb9-4e93-b70c-5d1e58099107.png)

## Acceptance criteria
- [ ] Passing build, and featured events and listing appear on associated system list pages, as well as on system page in featured slots
