### PR TITLE
Followup to followup to build paramaterization: expand array contains call to multiple equality checks

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -105,7 +105,7 @@ jobs:
         uses: andymckay/cancel-action@0.2
 
       - name: Validate deploy_environment
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_environment != "prod" && github.event.inputs.deploy_environment != "staging" && github.event.inputs.deploy_environment != "dev" }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_environment != 'prod' && github.event.inputs.deploy_environment != 'staging' && github.event.inputs.deploy_environment != 'dev' }}
         run: echo "prod, staging, and dev are the only supported environments" && exit 1
 
       # TODO: Remove this when ready for PROD


### PR DESCRIPTION
Github doesn't like manually defined arrays like we tried to use. https://github.com/department-of-veterans-affairs/content-build/actions/runs/1383180089

Expanding to the more verbose method of doing the same thing.