### PR TITLE
Github Actions (CR) -- Fix syntax error

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -13,10 +13,6 @@ on:
         description: The environment to deploy content to (dev, staging, prod)
         required: true
         default: prod
-
-  # TODO: Remove once testing is finished 
-  push:
-
   # schedule:
   #   - cron: "0 13-16,20-21 * * 1-5"
   #   - cron: "45 17 * * 1-5"
@@ -103,7 +99,7 @@ jobs:
         uses: andymckay/cancel-action@0.2
 
       - name: Validate deploy_environment
-        if: ${{ contains(fromJson('["prod", "staging", "dev", ""]'), github.event.inputs.deploy_environment) }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !contains(fromJson('["prod", "staging", "dev"]'), github.event.inputs.deploy_environment) }}
         run: echo "prod, staging, and dev are the only supported environments" && exit 1
 
       # TODO: Remove this when ready for PROD
@@ -130,10 +126,6 @@ jobs:
 
       - name: Get release wait time for scheduled dispatch
         if: ${{ github.event_name == 'schedule' }}
-        run: echo "RELEASE_WAIT=0" >> $GITHUB_ENV
-
-      - name: Get release wait time for push-initiated dispatch
-        if: ${{ github.event_name == 'push' }}
         run: echo "RELEASE_WAIT=0" >> $GITHUB_ENV
 
       - name: Set deploy environment for manual dispatch


### PR DESCRIPTION
## Description

Content-release was failing due to syntax error. Changed syntax to conditionally check array rather than call each explicitly

## Testing done

[Purposely failed run via on_push](https://github.com/department-of-veterans-affairs/content-build/actions/runs/1383208083)
