### PR TITLE
Add ask-va widget to message us nav

### DIFF
--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -77,12 +77,7 @@
               <section>
                 <h4>Message us</h4>
                 <ul class="va-nav-linkslist-list social">
-                  <li>
-                    <a href="https://iris.custhelp.va.gov/app/ask"
-                      onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Ask questions' });">
-                      Ask a question online
-                    </a>
-                  </li>
+                  <li data-widget-type="ask-va"></li>
                 </ul>
               </section>
 


### PR DESCRIPTION
# Description

**Issues:**
https://github.com/department-of-veterans-affairs/va.gov-team/issues/31960
https://github.com/department-of-veterans-affairs/va.gov-team/issues/31350

This PR implements the `ask-va` react widget on the message us nav.

## Screenshots

![image](https://user-images.githubusercontent.com/12773166/138895632-00707ec0-71ce-4c76-93fb-2a5de488cfa4.png)

