### PR TITLE
Add edge case for support service link with no phone number

### DIFF
--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -104,6 +104,11 @@
                       >
                         <span>{{ service.title }}</span><br>
                       </a>
+                    {% elsif service.fieldLink.url.path %}
+                      <a href="{{ service.fieldLink.url.path }}"
+                        onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Ask questions' });">
+                        <span>{{ service.title }}</span><br>
+                      </a>
                     {% else %}
                       {{ service.title }}
                     {% endif %}


### PR DESCRIPTION
# Description

**Issue:** 

**Slack:** https://dsva.slack.com/archives/C52CL1PKQ/p1635260135116400

This PR adds support for support services that 1) have a link but 2) do not have a phone number to be displayed as a link instead of just raw text.
