### PR TITLE
Fix environment variable name for content release

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -329,7 +329,7 @@ jobs:
           role-session-name: vsp-frontendteam-githubaction
 
       - name: Upload build
-        run: aws s3 cp ${{ needs.set-env.outputs.BUILDTYPE }}.tar.bz2 s3://vetsgov-website-builds-s3-upload/content-build/${{needs.set-env.outputs.REF}}/${{ needs.set-env.outputs.BUILDTYPE }}.tar.bz2 --acl public-read --region us-gov-west-1
+        run: aws s3 cp ${{ needs.set-env.outputs.BUILDTYPE }}.tar.bz2 s3://vetsgov-website-builds-s3-upload/content-build/${{needs.set-env.outputs.REF}}/${{ needs.set-env.outputs.DEPLOY_ARCHIVE }}.tar.bz2 --acl public-read --region us-gov-west-1
 
   create-release:
     name: Create Release


### PR DESCRIPTION
`BUILDTYPE` was from an old version of the build. This PR should fix the problem we had on https://github.com/department-of-veterans-affairs/content-build/actions/runs/1386453154
