### PR TITLE
VAVFS-6800-FE-displays-in-progress-events-as-past

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -873,7 +873,9 @@ module.exports = function registerFilters() {
     if (!data) return null;
     const currentTimestamp = new Date().getTime();
     return data.filter(event => {
-      return event.fieldDatetimeRangeTimezone.value * 1000 < currentTimestamp;
+      return (
+        event.fieldDatetimeRangeTimezone.endValue * 1000 < currentTimestamp
+      );
     });
   };
 
@@ -881,7 +883,9 @@ module.exports = function registerFilters() {
     if (!data) return null;
     const currentTimestamp = new Date().getTime();
     return data.filter(event => {
-      return event.fieldDatetimeRangeTimezone.value * 1000 >= currentTimestamp;
+      return (
+        event.fieldDatetimeRangeTimezone.endValue * 1000 >= currentTimestamp
+      );
     });
   };
 

--- a/src/site/stages/build/drupal/graphql/eventListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/eventListingPage.graphql.js
@@ -16,7 +16,7 @@ const eventListingPage = `
         {field: "status", value: "1", operator: EQUAL, enabled: $onlyPublishedContent}, 
         {field: "moderation_state", value: "archived", operator: NOT_EQUAL}, 
         {field: "type", value: "event"},
-        {field: "field_datetime_range_timezone", value: [$today], operator: SMALLER_THAN}]},
+        {field: "field_datetime_range_timezone.endValue", value: [$today], operator: SMALLER_THAN}]},
       sort: {field: "changed", direction: DESC}) {
           entities {
             ... on NodeEvent {


### PR DESCRIPTION
## Description
VAVFS-6800-FE-displays-in-progress-events-as-past

## Testing done
local testing is done

## Screenshots
<img width="1317" alt="Screen Shot 2021-10-27 at 12 27 53 PM" src="https://user-images.githubusercontent.com/90930782/139116180-84f47020-82dd-46c5-ba40-c306688b9bba.png">
<img width="1317" alt="Screen Shot 2021-10-27 at 12 28 06 PM" src="https://user-images.githubusercontent.com/90930782/139116183-4ee3c7af-03b7-4f51-a178-56481c26ee94.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
