### PR TITLE
Github Actions (MD) -- Enhance manual deployment

### DIFF
--- a/.github/workflows/manual-deploy-dev-staging.yml
+++ b/.github/workflows/manual-deploy-dev-staging.yml
@@ -46,14 +46,14 @@ jobs:
           role-session-name: vsp-frontendteam-githubaction
 
       - name: Deploy Dev
-        if: ${{ github.event.inputs.commit_sha == 'dev' || github.event.inputs.commit_sha == 'both' }}
+        if: ${{ github.event.inputs.deploy_environment == 'dev' || github.event.inputs.deploy_environment == 'both' }}
         run: ./script/github-actions/deploy.sh -s $SRC -d $DEST -v
         env:
           SRC: s3://vetsgov-website-builds-s3-upload/content-build/${{ github.event.inputs.commit_sha }}/vagovdev.tar.bz2
           DEST: s3://content.dev.va.gov
         
       - name: Deploy Staging
-        if: ${{ github.event.inputs.commit_sha == 'staging' || github.event.inputs.commit_sha == 'both' }}
+        if: ${{ github.event.inputs.deploy_environment == 'staging' || github.event.inputs.deploy_environment == 'both' }}
         run: ./script/github-actions/deploy.sh -s $SRC -d $DEST -v
         env:
           SRC: s3://vetsgov-website-builds-s3-upload/content-build/${{ github.event.inputs.commit_sha }}/vagovstaging.tar.bz2


### PR DESCRIPTION
## Description

During yesterdays debugging, it was pointed out that in Jenkins it only does for one environment rather than both.

This PR mimics that ability, but also grants the ability if we want both to be deployed, the `both` flag will trigger it

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
