### PR TITLE
Update `README` with GitHub Actions build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# VA.gov Content Build [![Build Status](https://dev.vets.gov/jenkins/buildStatus/icon?job=testing/content-build/master)](http://jenkins.vetsgov-internal/job/testing/job/content-build/job/master/)
+# VA.gov Content Build ![Build Status](https://github.com/department-of-veterans-affairs/content-build/actions/workflows/continuous-integration.yml/badge.svg?branch=master)
 
 ## What is this?
 


### PR DESCRIPTION
## Description
PR to add a GitHub Actions build status badge to the `README` now that GitHub Actions is the primary CI pipeline.

## Acceptance criteria
- [ ] `README` shows correct build status for the `master` branch.