### PR TITLE
Github Actions (CI) -- Add concurrency to content-release based off environment

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -15,6 +15,10 @@ on:
   #   - cron: "0 13-16,20-21 * * 1-5"
   #   - cron: "45 17 * * 1-5"
 
+concurrency:
+  group: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_environment || 'prod' }}
+  cancel-in-progress: false
+
 # TODO: Change to correct channel_id when ready
 env:
   CHANNEL_ID: C024DUC9S1K # -test-tim-accessibility-gha

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -17,7 +17,7 @@ on:
 
 concurrency:
   group: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_environment || 'prod' }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event.inputs.deploy_environment != 'prod' && true || false }}
 
 # TODO: Change to correct channel_id when ready
 env:


### PR DESCRIPTION
## Description

As discussed in [slack](https://dsva.slack.com/archives/C01512KN35G/p1635533884032500?thread_ts=1635529221.019000&cid=C01512KN35G) thread, CR workflow now queued based off of their environment

## Testing done

N/A, will need to merge first and test dispatch. Important thing to notice is 

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
