### PR TITLE
Upgrade Cypress GitHub Actions report generator to latest version

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -463,7 +463,7 @@ jobs:
 
       - name: Publish test results
         if: ${{ always() }}
-        uses: mikepenz/action-junit-report@v2.4.2
+        uses: mikepenz/action-junit-report@v2.6.0
         with:
           check_name: 'Cypress Tests Summary'
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
This PR upgrades the `mikepenz/action-junit-report` action used in Cypress tests on GitHub Actions to the latest version.

## Acceptance criteria
- [ ] CI passes.
- [ ] Cypress test reports are generated without issues on GitHub Actions.