### PR TITLE
Update testing reports workflow to new data repo structure

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -558,7 +558,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: cypress-mochawesome-test-results
-          path: testing-tools-team-dashboard-data/src/mochawesome/data
+          path: testing-tools-team-dashboard-data/src/testing-reports/data
 
       - name: Get BigQuery service credentials
         uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
@@ -597,7 +597,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: cypress-video-artifacts
-          path: testing-tools-team-dashboard-data/cypress-reports/videos/${{ env.UUID }}
+          path: testing-tools-team-dashboard-data/testing-reports/videos/${{ env.UUID }}
 
       - name: Get AWS IAM role
         uses: marvinpinto/action-inject-ssm-secrets@v1.2.1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -534,7 +534,6 @@ jobs:
           repository: department-of-veterans-affairs/testing-tools-team-dashboard-data
           token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
           path: testing-tools-team-dashboard-data
-          ref: Cbonade/refactor-classes
 
       # TODO: Set .nvmrc in testing-tools-team-dashboard-data.
       # - name: Get Node version

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -534,6 +534,7 @@ jobs:
           repository: department-of-veterans-affairs/testing-tools-team-dashboard-data
           token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
           path: testing-tools-team-dashboard-data
+          ref: Cbonade/refactor-classes
 
       # TODO: Set .nvmrc in testing-tools-team-dashboard-data.
       # - name: Get Node version


### PR DESCRIPTION
## Description
This PR will redirect the artifact downloads to the new directories that we created when we restructured the dashboard data repo.

Associated restructure: https://github.com/department-of-veterans-affairs/testing-tools-team-dashboard-data/pull/86

## Testing done
Workflow passed when targeting feature branch.

