### PR TITLE
Github Actions (DD) -- concurrency prod group

### DIFF
--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -13,6 +13,11 @@ on:
         default: ''
   schedule:
     - cron: 0 18 * * 1-5
+  push:
+
+concurrency:
+  group: prod
+  cancel-in-progress: false
 
 # TODO: Change to correct channel_id when ready
 env:

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -13,7 +13,6 @@ on:
         default: ''
   schedule:
     - cron: 0 18 * * 1-5
-  push:
 
 concurrency:
   group: prod


### PR DESCRIPTION
## Description

See [slack](https://dsva.slack.com/archives/CU1E4CX9U/p1635785187070000?thread_ts=1635542163.067700&cid=CU1E4CX9U) for more details

With a `concurrency` set in place for [content-release](https://github.com/department-of-veterans-affairs/content-build/blob/master/.github/workflows/content-release.yml#L19), we want to ensure that `prod` gets queued accordingly how it is in Jenkins.

This PR adds the following:

Adds daily deploy to `prod` concurrency group to ensure no overlap to content-release `prod` group

Does not conflict with `dev` and `staging`

## Testing done

![image](https://user-images.githubusercontent.com/10648480/139711155-3971a7bb-42e7-4987-af9b-f0f162afaaf0.png)


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
