### PR TITLE
Remove special case for apostrophe in encode filter

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -817,11 +817,8 @@ module.exports = function registerFilters() {
       return '';
     }
 
-    // Replace single quotes.
-    const stringWithoutSingleQuotes = string.replace("'", '&apos;');
-
     // Encode the string.
-    return he.encode(stringWithoutSingleQuotes, { useNamedReferences: true });
+    return he.encode(string, { useNamedReferences: true });
   };
 
   // fieldCcVetCenterFeaturedCon data structure is different

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -1059,7 +1059,7 @@ describe('rejectBy', () => {
 describe('encode', () => {
   it('encodes strings', () => {
     expect(liquid.filters.encode("foo © bar ≠ baz 𝌆 qux''")).to.equal(
-      'foo &copy; bar &ne; baz &#x1D306; qux&amp;apos;&apos;',
+      'foo &copy; bar &ne; baz &#x1D306; qux&apos;&apos;',
     );
   });
 


### PR DESCRIPTION
Fixes issues with apostrophe's rendering as `&quot` in accordion headers.

See [Slack thread](https://dsva.slack.com/archives/CDHBKAL9W/p1635796452030800)