### PR TITLE
Added cerner redirect for Central Ohio health system scheduling link

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1226,8 +1226,12 @@ module.exports = function registerFilters() {
     return languages[language][whichNode];
   };
 
-  liquid.filters.topTaskUrl = (flag, path) => {
-    if (flag === 'cerner') {
+  liquid.filters.topTaskUrl = (flag, path, systemName) => {
+    if (
+      flag === 'cerner' ||
+      (systemName === 'VA Central Ohio health care' &&
+        path === 'schedule-view-va-appointments/')
+    ) {
       return 'https://patientportal.myhealth.va.gov';
     } else {
       return `/health-care/${path}`;

--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -75,7 +75,7 @@
                 <div
                   class="vads-facility-hub-cta vads-u-border-color--primary-alt-light medium-screen:vads-u-border-bottom--1px">
                   <a onClick="recordEvent({ event: 'cta-hub-link-click' });"
-                    href="{{ fieldVamcEhrSystem | topTaskUrl: "schedule-view-va-appointments/" }}"
+                    href="{{ fieldVamcEhrSystem | topTaskUrl: "schedule-view-va-appointments/", title }}"
                     class="top-task-link vads-u-height--full vads-u-width--full">
                     <i
                       class="far fa-calendar-check vads-facility-hub-cta-circle">&nbsp;</i>


### PR DESCRIPTION
## Description
Resolves - https://github.com/department-of-veterans-affairs/va.gov-team/issues/31487
Per Michelle, the redirect should happen with Central Ohio health system NOT Columbus facility. You can find more info on this in the comments of the original issue.

If the health system = Central Ohio and the top task link = schedule and manage health appointments
then we redirect to cerner (patientportal.myhealth.va.gov)

<img width="816" alt="Screen Shot 2021-11-02 at 6 09 55 PM" src="https://user-images.githubusercontent.com/84030819/139958794-b17709ed-3e8c-457f-8923-8585275d556d.png">
