### PR TITLE
Limit number of link teasers

### DIFF
--- a/src/site/components/browse-by-audience.drupal.liquid
+++ b/src/site/components/browse-by-audience.drupal.liquid
@@ -21,7 +21,7 @@
       <div class="form-expanding-group additional-info-container vads-u-margin-y--2p5">
         <div class="additional-info-title">Show more</div>
 
-        {% assign remainingAudienceTags = audienceTags | sliceArrayFromStart: pageSize %}
+        {% assign remainingAudienceTags = audienceTags | sliceArray: pageSize %}
 
         <span>
           <div class="additional-info-content">

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1286,8 +1286,4 @@ module.exports = function registerFilters() {
       return `/health-care/${path}`;
     }
   };
-
-  // liquid.filters.sliceArray = (arr, startIndex, endIndex) => {
-  //   return _.slice(arr, startIndex, endIndex);
-  // };
 };

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1285,4 +1285,8 @@ module.exports = function registerFilters() {
       return `/health-care/${path}`;
     }
   };
+
+  liquid.filters.sliceArray = (arr, startIndex, endIndex) => {
+    return _.slice(arr, startIndex, endIndex);
+  };
 };

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -249,8 +249,9 @@ module.exports = function registerFilters() {
   };
 
   //  liquid slice filter only works on strings
-  liquid.filters.sliceArrayFromStart = (arr, startIndex) => {
-    return _.slice(arr, startIndex);
+  liquid.filters.sliceArray = (arr, startIndex, endIndex) => {
+    if (!arr) return null;
+    return _.slice(arr, startIndex, endIndex);
   };
 
   liquid.filters.benefitTerms = data => {
@@ -1286,7 +1287,7 @@ module.exports = function registerFilters() {
     }
   };
 
-  liquid.filters.sliceArray = (arr, startIndex, endIndex) => {
-    return _.slice(arr, startIndex, endIndex);
-  };
+  // liquid.filters.sliceArray = (arr, startIndex, endIndex) => {
+  //   return _.slice(arr, startIndex, endIndex);
+  // };
 };

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -1933,3 +1933,23 @@ describe('filterSidebarData', () => {
     expect(filteredData.links[0].links[0].links[1].links).to.deep.equal([]);
   });
 });
+
+describe('sliceArray', () => {
+  it('returns null if array is null', () => {
+    expect(liquid.filters.sliceArray(null, 0, 5)).to.be.null;
+  });
+
+  it('returns first 5 elements - startIndex = 0, endIndex = 5', () => {
+    const testArray = [1, 2, 3, 4, 5, 6];
+    const expected = [1, 2, 3, 4, 5];
+
+    expect(liquid.filters.sliceArray(testArray, 0, 5)).to.deep.eq(expected);
+  });
+
+  it('returns elements from startIndex = 2 and on, if an endIndex is not passed in', () => {
+    const testArray = [1, 2, 3, 4, 5, 6];
+    const expected = [3, 4, 5, 6];
+
+    expect(liquid.filters.sliceArray(testArray, 2)).to.deep.eq(expected);
+  });
+});

--- a/src/site/layouts/media_list_images.drupal.liquid
+++ b/src/site/layouts/media_list_images.drupal.liquid
@@ -48,7 +48,7 @@
             <dl class="media-list-images usa-unstyled-list" role="list">
               {% if fieldMediaListImages.entity.fieldImages.size != 0 %}
                 {% assign pageSize = 10 %}
-                {% assign remainingImages = fieldMediaListImages.entity.fieldImages | sliceArrayFromStart: pageSize, fieldMediaListImages.entity.fieldImages.size %}
+                {% assign remainingImages = fieldMediaListImages.entity.fieldImages | sliceArray: pageSize, fieldMediaListImages.entity.fieldImages.size %}
 
                 {% for mediaImage in fieldMediaListImages.entity.fieldImages %}
                   {% assign recordsCount = recordsCount | plus: 1 %}

--- a/src/site/layouts/tests/vamc/fixtures/health_care_region_page.json
+++ b/src/site/layouts/tests/vamc/fixtures/health_care_region_page.json
@@ -233,6 +233,19 @@
             },
             "fieldLinkSummary": null
           }
+        },
+        {
+          "entity": {
+            "entityId": "1234",
+            "fieldLink": {
+              "url": {
+                "path": "https://www.publichealth.va.gov/n-coronavirus/index.asp"
+              },
+              "title": "9th link teaser",
+              "options": []
+            },
+            "fieldLinkSummary": null
+          }
         }
       ]
     }

--- a/src/site/layouts/tests/vamc/template/health_care_region_page.unit.spec.js
+++ b/src/site/layouts/tests/vamc/template/health_care_region_page.unit.spec.js
@@ -125,4 +125,8 @@ describe('intro', () => {
       '/health-care/view-test-and-lab-results/',
     ]);
   });
+
+  it('Should display at most 8 link teasers', async () => {
+    expect(container.querySelectorAll('.link-teaser').length).to.eq(8);
+  });
 });

--- a/src/site/paragraphs/facilities/list_of_link_teasers_facility.drupal.liquid
+++ b/src/site/paragraphs/facilities/list_of_link_teasers_facility.drupal.liquid
@@ -13,18 +13,26 @@
 
     <div class="va-c-list-link-teasers">
       <div class="usa-grid usa-grid-full vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row">
+        {% assign linkTeasers = paragraph.fieldVaParagraphs %}
+        {% comment %}
+            Max number of links allowed = 8
+        {% endcomment %}
+        {% if linkTeasers.length > 8 %}
+          {% assign linkTeasers = linkTeasers | sliceArray: 0, 8 %}
+        {% endif %}
+        
         {% comment %}
             If there are less than or exactly 6 links, 3 items per column
             If there are more than 6 links, 4 items per column
         {% endcomment %}
-        {% if paragraph.fieldVaParagraphs.length > 6 %}
+        {% if linkTeasers.length > 6 %}
           {% assign linkWrapperStartIndex = 5 %}
           {% assign linkWrapperEndIndex = 4 %}
         {%  else %}
           {% assign linkWrapperStartIndex = 4 %}
           {% assign linkWrapperEndIndex = 3 %}
         {% endif %}
-        {% for linkTeaser in paragraph.fieldVaParagraphs %}
+        {% for linkTeaser in linkTeasers %}
           {% assign link = linkTeaser.entity.fieldLink %}
 
           {% assign everyStartItem = forloop.index | genericModulo: linkWrapperStartIndex %}

--- a/src/site/paragraphs/facilities/list_of_link_teasers_facility.drupal.liquid
+++ b/src/site/paragraphs/facilities/list_of_link_teasers_facility.drupal.liquid
@@ -41,7 +41,7 @@
             <div class="usa-width-one-half vads-u-display--flex vads-u-flex-direction--column">
             {% endif %}
             <a onclick="recordEvent({ event: 'nav-featured-content-link-click', 'featured-content-header': '{{ paragraph.fieldTitle }}', 'featured-content-click-label': '{{ link.title }}' });" 
-                class="vads-u-margin-bottom--2"
+                class="link-teaser vads-u-margin-bottom--2"
                 href="{{ link.url.path }}"
             >
               {{ link.title }}


### PR DESCRIPTION
## Description
Resolves - https://github.com/department-of-veterans-affairs/va.gov-team/issues/32451

Per Dave, there should be only 2 columns with 8 links max.
See slack thread: https://dsva.slack.com/archives/C0FQSS30V/p1636040104227200
![Screen Shot 2021-11-04 at 10 03 34 PM](https://user-images.githubusercontent.com/84030819/140445989-3f0a0298-190a-494d-bbe9-b26f04245fff.png)

Limiting number of link to show the first 8. 

To test use this tugboat instance (it has a total of 9 links but only displays the first 8) - https://web-xzcrb121xmxquzas9jcd9p86dgwpkuam.demo.cms.va.gov/detroit-health-care/