### PR TITLE
Remove Chrome installation step from GitHub Actions accessibility workflow

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -170,11 +170,6 @@ jobs:
           mkdir -p build/vagovprod
           tar -C build/vagovprod -xjf /__w/content-build/content-build/test-build.tar.bz2
 
-      - name: Install Chrome
-        uses: browser-actions/setup-chrome@latest
-        with:
-          chrome-version: stable
-
       - name: Start content-build
         run: node src/platform/testing/e2e/test-server.js --buildtype vagovprod --port=3002 &
 


### PR DESCRIPTION
## Description
Chrome comes pre-installed in the Docker container used to run accessibility tests on GitHub Actions, so this step to re-install Chrome can be removed.