### PR TITLE
Added VA health connect phone number

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1286,4 +1286,12 @@ module.exports = function registerFilters() {
       return `/health-care/${path}`;
     }
   };
+
+  liquid.filters.isVisn8 = visn => {
+    return visn.split('|')[0].trim() === 'VISN 8';
+  };
+
+  liquid.filters.featureAddVaHealthConnectNumber = () => {
+    return cmsFeatureFlags.FEATURE_HEALTH_CONNECT_NUMBER;
+  };
 };

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1292,6 +1292,6 @@ module.exports = function registerFilters() {
   };
 
   liquid.filters.featureAddVaHealthConnectNumber = () => {
-    return cmsFeatureFlags.FEATURE_HEALTH_CONNECT_NUMBER;
+    return cmsFeatureFlags?.FEATURE_HEALTH_CONNECT_NUMBER;
   };
 };

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1288,6 +1288,7 @@ module.exports = function registerFilters() {
   };
 
   liquid.filters.isVisn8 = visn => {
+    if (!visn) return null;
     return visn.split('|')[0].trim() === 'VISN 8';
   };
 

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -1953,3 +1953,33 @@ describe('sliceArray', () => {
     expect(liquid.filters.sliceArray(testArray, 2)).to.deep.eq(expected);
   });
 });
+
+describe('isVisn8', () => {
+  it('returns null if data is null', () => {
+    expect(liquid.filters.isVisn8(null)).to.be.null;
+  });
+
+  it('returns true if string = "VISN 8"', () => {
+    expect(liquid.filters.isVisn8('VISN 8 | more text')).to.be.true;
+  });
+
+  it('returns true if string = "VISN 8"', () => {
+    expect(liquid.filters.isVisn8('VISN 8 |')).to.be.true;
+  });
+
+  it('returns false if string does NOT equal "VISN 8"', () => {
+    expect(liquid.filters.isVisn8('VISN 9 | more text')).to.be.false;
+  });
+
+  it('returns false if string does NOT equal "VISN 8"', () => {
+    expect(liquid.filters.isVisn8('VISN 9 more text')).to.be.false;
+  });
+
+  it('returns false if string does NOT equal "VISN 8"', () => {
+    expect(liquid.filters.isVisn8('VISN 8 more text')).to.be.false;
+  });
+
+  it('returns false if string does NOT equal "VISN 8"', () => {
+    expect(liquid.filters.isVisn8('| VISN 8 |')).to.be.false;
+  });
+});

--- a/src/site/includes/facilityListing.drupal.liquid
+++ b/src/site/includes/facilityListing.drupal.liquid
@@ -34,13 +34,15 @@
           <a href="tel:{{ entity.fieldPhoneNumber }}">{{ entity.fieldPhoneNumber }}</a>
         </div>
       {% endif %}
-      {% assign shouldAddVaHealthConnectNumber = "" | featureAddVaHealthConnectNumber %}
-      {% assign isVisn8 = facilitySidebar.description | isVisn8 %}
-      {% if shouldAddVaHealthConnectNumber == true and isVisn8 == true %}
-        <div class="vads-u-margin-bottom--1">
-          <strong>VA health connect:</strong>
-          <a href="tel:877-741-3400">877-741-3400</a>
-        </div>
+      {% if facilitySidebar.description %}
+        {% assign shouldAddVaHealthConnectNumber = ''| featureAddVaHealthConnectNumber %}
+        {% assign isVisn8 = facilitySidebar.description | isVisn8 %}
+        {% if shouldAddVaHealthConnectNumber == true and isVisn8 == true %}
+          <div class="vads-u-margin-bottom--1">
+            <strong>VA health connect:</strong>
+            <a href="tel:877-741-3400">877-741-3400</a>
+          </div>
+        {% endif %}  
       {% endif %}
       {% if entity.fieldMentalHealthPhone %}
         <div class="mental-health-clinic-phone">

--- a/src/site/includes/facilityListing.drupal.liquid
+++ b/src/site/includes/facilityListing.drupal.liquid
@@ -39,7 +39,7 @@
       {% if shouldAddVaHealthConnectNumber == true and isVisn8 == true %}
         <div class="vads-u-margin-bottom--1">
           <strong>VA health connect:</strong>
-          <a href="tel:1-877-741-3400">1-877-741-3400</a>
+          <a href="tel:877-741-3400">877-741-3400</a>
         </div>
       {% endif %}
       {% if entity.fieldMentalHealthPhone %}

--- a/src/site/includes/facilityListing.drupal.liquid
+++ b/src/site/includes/facilityListing.drupal.liquid
@@ -34,6 +34,14 @@
           <a href="tel:{{ entity.fieldPhoneNumber }}">{{ entity.fieldPhoneNumber }}</a>
         </div>
       {% endif %}
+      {% assign shouldAddVaHealthConnectNumber = "" | featureAddVaHealthConnectNumber %}
+      {% assign isVisn8 = facilitySidebar.description | isVisn8 %}
+      {% if shouldAddVaHealthConnectNumber == true and isVisn8 == true %}
+        <div class="vads-u-margin-bottom--1">
+          <strong>VA health connect:</strong>
+          <a href="tel:1-877-741-3400">1-877-741-3400</a>
+        </div>
+      {% endif %}
       {% if entity.fieldMentalHealthPhone %}
         <div class="mental-health-clinic-phone">
           <strong>Mental health clinic:</strong>

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -72,6 +72,14 @@
                               href="tel:{{ fieldPhoneNumber }}">{{ fieldPhoneNumber }}</a>
                         </div>
                       {% endif %}
+                      {% assign shouldAddVaHealthConnectNumber = "" | featureAddVaHealthConnectNumber %}
+                      {% assign isVisn8 = facilitySidebar.description | isVisn8 %}
+                      {% if shouldAddVaHealthConnectNumber == true and isVisn8 == true %}
+                        <div class="vads-u-margin-bottom--1">
+                          <strong>VA health connect:</strong>
+                          <a href="tel:1-877-741-3400">1-877-741-3400</a>
+                        </div>
+                      {% endif %}
                       {% if fieldMentalHealthPhone %}
                         <div class="mental-health-clinic-phone"><strong>Mental
                             health clinic:

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -72,13 +72,15 @@
                               href="tel:{{ fieldPhoneNumber }}">{{ fieldPhoneNumber }}</a>
                         </div>
                       {% endif %}
-                      {% assign shouldAddVaHealthConnectNumber = "" | featureAddVaHealthConnectNumber %}
-                      {% assign isVisn8 = facilitySidebar.description | isVisn8 %}
-                      {% if shouldAddVaHealthConnectNumber == true and isVisn8 == true %}
-                        <div class="vads-u-margin-bottom--1">
-                          <strong>VA health connect:</strong>
-                          <a href="tel:877-741-3400">877-741-3400</a>
-                        </div>
+                      {% if facilitySidebar.description %}
+                        {% assign shouldAddVaHealthConnectNumber = ''| featureAddVaHealthConnectNumber %}
+                        {% assign isVisn8 = facilitySidebar.description | isVisn8 %}
+                        {% if shouldAddVaHealthConnectNumber == true and isVisn8 == true %}
+                          <div class="vads-u-margin-bottom--1">
+                            <strong>VA health connect:</strong>
+                            <a href="tel:877-741-3400">877-741-3400</a>
+                          </div>
+                        {% endif %}
                       {% endif %}
                       {% if fieldMentalHealthPhone %}
                         <div class="mental-health-clinic-phone"><strong>Mental

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -77,7 +77,7 @@
                       {% if shouldAddVaHealthConnectNumber == true and isVisn8 == true %}
                         <div class="vads-u-margin-bottom--1">
                           <strong>VA health connect:</strong>
-                          <a href="tel:1-877-741-3400">1-877-741-3400</a>
+                          <a href="tel:877-741-3400">877-741-3400</a>
                         </div>
                       {% endif %}
                       {% if fieldMentalHealthPhone %}


### PR DESCRIPTION
## Description
Resolves - https://github.com/department-of-veterans-affairs/va.gov-team/issues/32561

Per Michelle, the phone number is: **877-741-3400**

## Screenshots

VA health connect phone number should only be displayed if cms feature toggle is on and if VISN 8 system

VA health connect phone number is displayed in the following places (using North Florida health care (visn 8) as an example): 

<details>
<summary>north-florida-health-care/</summary>

![Screen Shot 2021-11-09 at 9 50 21 AM](https://user-images.githubusercontent.com/84030819/140947080-045ca235-be3c-4fa4-ab2b-f8f63ee043e3.png)

</details>

<details>
<summary>north-florida-health-care/locations</summary>

![Screen Shot 2021-11-09 at 9 57 37 AM](https://user-images.githubusercontent.com/84030819/140948117-0959faaa-d6a5-43d8-89ea-d2fce065f41c.png)

</details>

And all the facility pages attached to that visn
For example:

<details>
<summary>north-florida-health-care/locations/gainesville-ninety-eighth-street-va-clinic/</summary>

![Screen Shot 2021-11-09 at 10 03 50 AM](https://user-images.githubusercontent.com/84030819/140949159-39ad8408-d5af-4ab7-86d1-e034f818cf52.png)

</details>

## Testing

Tugboat instance (phone # displays here)- https://web-khwba2p3ozkcd3sjcsfi9wyyxbltjjze.demo.cms.va.gov/miami-health-care/

Check `/pittsburgh-health-care` as well, it is NOT visn8 and health connect phone number should not display


