### PR TITLE
Github Actions (CR) -- Checkout specific commit for create-release

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -308,6 +308,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.set-env.outputs.REF }}
 
       - name: Waiting to release
         run: |


### PR DESCRIPTION
## Description

Create release is failing to find specific commit associated to release due to `checkout`

This PR specifies that specific checkout in order to package and create release accordingly

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
