### PR TITLE
31523: Remove MHV Account Validation in Registry

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -125,15 +125,6 @@
     }
   },
   {
-    "appName": "My Health Account Validation",
-    "entryName": "my-health-account-validation",
-    "rootUrl": "/health-care/my-health-account-validation",
-    "template": {
-      "title": "My Health Account Validation",
-      "layout": "page-react.html"
-    }
-  },
-  {
     "appName": "10-10CG",
     "entryName": "1010cg-application-caregiver-assistance",
     "rootUrl": "/family-member-benefits/apply-for-caregiver-assistance-form-10-10cg",


### PR DESCRIPTION
## Description
MHV Account validation app is being removed from `vets-website`
Removing from the application registry here as well

## Testing done


## Screenshots


## Acceptance criteria
- [ ] MHV Account Validation registry entry removed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
