### PR TITLE
Github Actions (CR) -- fix slack notifications

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -167,7 +167,7 @@ jobs:
         uses: ./.github/workflows/slack-notify
         continue-on-error: true
         with:
-          attachments: '[{"mrkdwn_in": ["text"], "color": "good", "text": "Stand by, content release for vagovprod content-build coming up. <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"}]'
+          attachments: '[{"mrkdwn_in": ["text"], "color": "good", "text": "Stand by, content release for content-build coming up. <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"}]'
           channel_id: ${{ env.CHANNEL_ID }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/script/github-actions/check-broken-links.js
+++ b/script/github-actions/check-broken-links.js
@@ -20,7 +20,7 @@ if (fs.existsSync(reportPath)) {
     brokenLinks.brokenLinksCount > maxBrokenLinks;
   const color = shouldFail ? 'danger' : 'warning';
   const summary = brokenLinks.summary;
-  const heading = `<!cms-helpdesk> ${brokenLinks.brokenLinksCount} broken links found in ${envName} \\n\\n <${SERVER_URL}> \\n`;
+  const heading = `<@cms-helpdesk> ${brokenLinks.brokenLinksCount} broken links found in ${envName} \\n\\n <${SERVER_URL}> \\n`;
   const slackAttachments = `[{"mrkdwn_in": ["text"], "color": "${color}", "text": "${heading}\\n${summary
     .replace(/\n/g, '\\n')
     .replace(/"/g, '\\"')}" }]`; // format summary according to slack api


### PR DESCRIPTION
## Description

It was noticed that when broken links are detected, they are not notifying cms-helpdesk properly. This PR addresses that issue.


## Testing done

[Via stackoverflow forum](https://stackoverflow.com/a/69709495)

## Screenshots

![image](https://user-images.githubusercontent.com/10648480/141143731-0fabfb8d-2709-4c7e-acfe-105362a94b00.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
