### PR TITLE
Add stdized red color to VCL

### DIFF
--- a/src/site/includes/top-nav.html
+++ b/src/site/includes/top-nav.html
@@ -11,8 +11,12 @@
     <div class="va-notice--banner-inner">
       {% include "src/site/includes/usa-website-header.html" %}
     </div>
-    <div class="va-crisis-line-container">
-      <button onclick="recordEvent({ event: 'nav-crisis-header' })" data-show="#modal-crisisline" class="va-crisis-line va-overlay-trigger">
+    <div class="va-crisis-line-container vads-u-background-color--secondary-darkest">
+      <button
+        class="va-crisis-line va-overlay-trigger vads-u-background-color--secondary-darkest"
+        data-show="#modal-crisisline"
+        onclick="recordEvent({ event: 'nav-crisis-header' })"
+      >
         <div class="va-crisis-line-inner">
           <span class="va-crisis-line-icon" aria-hidden="true"></span>
           <span class="va-crisis-line-text" onClick="recordEvent({ event: 'nav-jumplink-click' });">Talk to the <strong>Veterans Crisis Line</strong> now</span>


### PR DESCRIPTION
## Description
**Ticket:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/32672

This PR updates the VCL red background color to match header v2's VCL background color.

## Testing done
Locally

## Screenshots
<img width="467" alt="Screen Shot 2021-11-10 at 10 45 01 AM" src="https://user-images.githubusercontent.com/12773166/141167050-e84091eb-ce18-4667-921a-a1e04f77eed7.png">
<img width="841" alt="Screen Shot 2021-11-10 at 10 45 09 AM" src="https://user-images.githubusercontent.com/12773166/141167051-0da8dc35-d9d6-44d3-af60-97e685d6f577.png">
<img width="560" alt="Screen Shot 2021-11-10 at 10 45 18 AM" src="https://user-images.githubusercontent.com/12773166/141167056-85123657-4235-4fd7-9775-cfa5a398d7b0.png">

## Acceptance criteria
- [x] Update VCL bg color to be secondary-darkest

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
