### PR TITLE
Github Actions (CR) -- Change cancel-in-progress semantic

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -17,7 +17,7 @@ on:
 
 concurrency:
   group: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_environment || 'prod' }}
-  cancel-in-progress: ${{ github.event.inputs.deploy_environment != 'prod' && true || false }}
+  cancel-in-progress: ${{ github.event.inputs.deploy_environment != 'prod' }}
 
 env:
   CHANNEL_ID: C0MQ281DJ # vfs-platform-builds


### PR DESCRIPTION
## Description

I suspect the semantic of the flow being triggered by `va-cms-bot` might somehow be translated to a string. Removing extra layer of complexity and letting the output be determined by GHA, similar to how it is in our CI


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
