### PR TITLE
Add ID to common va-accordion-item

### DIFF
--- a/src/site/paragraphs/collapsible_panel.drupal.liquid
+++ b/src/site/paragraphs/collapsible_panel.drupal.liquid
@@ -35,7 +35,7 @@
         {% for accordionItem in entity.fieldVaParagraphs %}
             {% assign item = accordionItem.entity %}
             {% assign id = item.entityId %}
-            <va-accordion-item header="{{ item.fieldTitle | encode }}">
+            <va-accordion-item header="{{ item.fieldTitle | encode }}" id={{id}}>
                 <div
                     id={{id}}
                     data-template="paragraphs/collapsible_panel__panel"


### PR DESCRIPTION
## Description

Include entity ID on `va-accordion-item`, which will be used to target and expand the accordion when the url hash matches the ID. See https://github.com/department-of-veterans-affairs/va.gov-team/issues/28658

Specifically, we need to be able to target & expand the accordion on this page - https://staging.va.gov/decision-reviews/higher-level-review/

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [x] Add entity ID to `va-accordion-item`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
