### PR TITLE
Github Actions (CR) -- Adding ref to checkout for create-release

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -106,6 +106,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          ref: ${{ needs.set-env.outputs.REF }}
 
       - name: Get latest tag
         id: get-latest-tag
@@ -310,6 +311,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          ref: ${{ needs.set-env.outputs.REF }}
 
       - name: Waiting to release
         run: |


### PR DESCRIPTION
## Description

Suspect create-release portion for content-release is failing due to ref. It is unable to push a commit it is not on. This PR checks out that ref to attempt to push correct tag associated with it


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
