### PR TITLE
Github Action (CR) -- disable cron for content-release

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -11,9 +11,9 @@ on:
         description: The environment to deploy content to prod
         required: true
         default: prod
-  schedule:
-    - cron: "0 14-17,21-22 * * 1-5"
-    - cron: "45 18 * * 1-5"
+  # schedule:
+  #   - cron: "0 14-17,21-22 * * 1-5"
+  #   - cron: "45 18 * * 1-5"
 
 concurrency:
   group: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_environment || 'prod' }}


### PR DESCRIPTION
## Description

11/11 is a holiday. Removing cron


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
