### PR TITLE
Github Actions (CR) -- Fix release commit

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -348,10 +348,11 @@ jobs:
       - name: Create release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.bump-tag-version.outputs.v_patch }}
           release_name: content-build/${{ steps.bump-tag-version.outputs.v_patch }}
+          commitish: ${{ needs.set-env.outputs.REF }}
 
   deploy:
     name: Deploy


### PR DESCRIPTION
## Description

It was observed that content-release despite tagging the correct commit, the actual release commit associated was latest of master. This PR ensures we are passing the commit associated to the run, in this case being the last successful commit from daily deploy, into the release


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
