### PR TITLE
Add events widget to event_listing

### DIFF
--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -2,6 +2,10 @@
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
 
+<!-- Events page v2 -->
+<div data-widget-type="events"></div>
+
+<!-- Events page v1 -->
 <div class="interior vads-u-padding-bottom--3" id="content" data-template="event_listing.drupal.liquid">
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">


### PR DESCRIPTION
# Description

**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/32598

This PR adds the `events` react widget (doesn't currently exist) to the `event_listing` pages.

## Acceptance Criteria

- [x] Add `events` react widget to `event_listing` pages.
