### PR TITLE
Github Actions -- POC input options

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: test
+
+on: push
+
+jobs:
+  test:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Get latest release
+      id: get-latest-release
+      with:
+        action: thebritican/fetch-latest-release@v2.0.0
+
+    - name: Test output
+      run: 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,16 +1,26 @@
-name: test
+name: Mixed inputs
 
-on: push
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        type: choice
+        description: Who to greet
+        options: 
+        - monalisa
+        - cschleiden
+      message:
+        required: true
+      use-emoji:
+        type: boolean
+        description: Include 🎉🤣 emojis
+      environment:
+        type: environment
 
 jobs:
-  test:
-    - name: Checkout
-      uses: actions/checkout@v2
+  greet:
+    runs-on: ubuntu-latest
 
-    - name: Get latest release
-      id: get-latest-release
-      with:
-        action: thebritican/fetch-latest-release@v2.0.0
-
-    - name: Test output
-      run: 
+    steps:
+    - name: Send greeting
+      run: echo "${{ github.event.inputs.message }} ${{ fromJSON('["", "🥳"]')[github.event.inputs.use-emoji == 'true'] }} ${{ github.event.inputs.name }}"


### PR DESCRIPTION
## Description

Copied demo from [github](https://github.blog/changelog/2021-11-10-github-actions-input-types-for-manual-workflows/) to see outputs. Most seem straight forward, but I am curious on what `environment` looks like 👀 

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
