### PR TITLE
Github Actions (CR) -- Notify failure only on non-successful prod deploys

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -398,7 +398,9 @@ jobs:
   notify-failure:
     name: Notify Failure
     runs-on: ubuntu-latest
-    if: ${{ (failure() || cancelled()) && needs.set-env.outputs.BUILDTYPE == 'vagovprod' }}
+    if: |
+      needs.set-env.outputs.BUILDTYPE == 'vagovprod' &&
+      ((failure() || cancelled()) && needs.deploy.result != 'success')
     needs: [set-env, deploy]
 
     steps:


### PR DESCRIPTION
## Description

Given our current queue system, despite if successful, flow will be marked as `cancelled` and notify user as failure. This PR is tightening the conditional statement.

If a deploy is successful despite it being cancelled (while we investigate queueing in more depth), do not notify via slack as failure

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
