### PR TITLE
Add pastEvents and allEventTeasers to window

### DIFF
--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -92,5 +92,11 @@
     </div>
   </main>
 </div>
+
+<script nonce="**CSP_NONCE**" type="text/javascript">
+  window.allEventTeasers = {{ allEventTeasers | json }};
+  window.pastEvents = {{ pastEvents | json }};
+</script>
+
 {% include "src/site/includes/footer.html" %}
 {% include "src/site/includes/debug.drupal.liquid" %}


### PR DESCRIPTION
# Description

**Issue:** https://github.com/department-of-veterans-affairs/vets-website/pull/19389

This PR adds the events data to window to be used by the events v2 react app.

## Acceptance Criteria

- [x] Add events cms data to window to be used by the events v2 react app.