### PR TITLE
Update hashReference filter

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -303,13 +303,16 @@ module.exports = function registerFilters() {
     return output;
   };
 
-  liquid.filters.hashReference = str => {
+  liquid.filters.hashReference = (str, length = 100) => {
     if (!str) return null;
     return str
       .toString()
       .toLowerCase()
+      .normalize('NFD') // normalize diacritics
+      .replace(/[^-a-zA-Z0-9 ]/g, '')
       .trim()
-      .replace(/\s+/g, '-');
+      .replace(/\s+/g, '-')
+      .substring(0, length);
   };
 
   // We might not need this filter, refactor

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -531,6 +531,32 @@ describe('hashReference', () => {
       'testing-one-two-three',
     );
   });
+
+  it('returns hyphenated string in all lowercase', () => {
+    expect(liquid.filters.hashReference('Lorem IPSUM dolor SIT amet')).to.eq(
+      'lorem-ipsum-dolor-sit-amet',
+    );
+  });
+  it('returns hyphenated string without punctuation', () => {
+    expect(liquid.filters.hashReference('lorem, ipsum. dolor; sit amet')).to.eq(
+      'lorem-ipsum-dolor-sit-amet',
+    );
+  });
+  it('returns hyphenated string at a set length', () => {
+    expect(
+      liquid.filters.hashReference('lorem ipsum dolor sit amet', 20),
+    ).to.eq('lorem-ipsum-dolor-si');
+  });
+  it('returns hyphenated string with normalized & stripped out diacritics', () => {
+    // normalize diacritics:
+    // \u00e9 = é (single character e with acute accent)
+    // e\u0301 = é (e + combining acute accent)
+    // \u00f1 = ñ (single character n with tilde)
+    // n\u0303 = ñ (n + combining tilde)
+    expect(
+      liquid.filters.hashReference('a \u00e9 e\u0301 \u00f1 n\u0303'),
+    ).to.eq('a-e-e-n-n');
+  });
 });
 
 describe('fileSize', () => {

--- a/src/site/paragraphs/collapsible_panel.drupal.liquid
+++ b/src/site/paragraphs/collapsible_panel.drupal.liquid
@@ -35,7 +35,10 @@
         {% for accordionItem in entity.fieldVaParagraphs %}
             {% assign item = accordionItem.entity %}
             {% assign id = item.entityId %}
-            <va-accordion-item header="{{ item.fieldTitle | encode }}">
+            <va-accordion-item
+              header="{{ item.fieldTitle | encode }}"
+              id="{{item.fieldTitle | hashReference: 30 }}-{{id}}"
+            >
                 <div
                     id={{id}}
                     data-template="paragraphs/collapsible_panel__panel"


### PR DESCRIPTION
## Description

We need a truncated unique ID applied to accordions so that we can expand them if they have a matching hash.

This PR updates the `hashReference` liquid filter:
- Normalizes diacritics, so we can support multiple languages
- Removes non-alphanumeric characters
- Truncates the string to a specified length, 30 characters for the accordion, 100 (arbitrary value for all IDs using this filter)

Lastly, the accordion item ID now mimics the ID added to the previous component that used a partial header text + ID as a suffix.

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/28658
- https://github.com/department-of-veterans-affairs/content-build/pull/743 (reverted because IDs were not unique)

## Testing done

Updated `hashReference` unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Update `hashReference` to provide a normalized alphanumeric truncated ID

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
