### PR TITLE
Github Action - Build always executes

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -179,6 +179,11 @@ jobs:
     name: Build
     runs-on: ${{ needs.start-runner.outputs.label }}
     needs: [set-env, validate-build-status, start-runner]
+    if: |
+      always() &&
+      needs.set-env.result == 'success' &&
+      needs.validate-build-status.result == 'success' &&
+      needs.start-runner.result == 'success'
     defaults:
       run:
         working-directory: content-build


### PR DESCRIPTION
## Description

As build is the longest job in the workflow, we want to ensure that if it is being checked against, to finish the workflow


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
