### PR TITLE
Github Action -- production queue script

### DIFF
--- a/script/github-actions/validate-content-release-status.js
+++ b/script/github-actions/validate-content-release-status.js
@@ -25,6 +25,10 @@ const contentReleaseParams = {
   status: 'in_progress',
 };
 
+/**
+ * uses octokit request for github action to get workflow with status in_progress
+ * @param {object} params
+ */
 function getLatestInProgressWorkflow(params) {
   return octokit.rest.actions
     .listWorkflowRuns(params)
@@ -41,6 +45,11 @@ function getLatestInProgressWorkflow(params) {
     });
 }
 
+/**
+ * Returns workflow that has priority
+ * @param {object} ddWorkflow
+ * @param {object} crWorkflow
+ */
 function getPriorityWorkflow(ddWorkflow, crWorkflow) {
   if (ddWorkflow === null) return 'content-release';
   if (crWorkflow === null) return 'daily-deploy';

--- a/script/github-actions/validate-content-release-status.js
+++ b/script/github-actions/validate-content-release-status.js
@@ -1,0 +1,88 @@
+/* eslint-disable no-console */
+/* eslint-disable camelcase */
+const { Octokit } = require('@octokit/rest');
+const { sleep } = require('../../script/utils');
+
+const { GITHUB_TOKEN: auth } = process.env; // GITHUB_REPOSITORY
+const timeout = 2; // minutes
+const [owner, repo] = 'department-of-veterans-affairs/content-build'.split('/'); // GITHUB_REPOSITORY.split('/');
+
+const octokit = new Octokit({ auth });
+const currentWorkflow = 'content-release';
+
+const dailyDeployParams = {
+  owner,
+  repo,
+  workflow_id: 'daily-deploy-production.yml',
+  status: 'in_progress',
+};
+
+const contentReleaseParams = {
+  owner,
+  repo,
+  workflow_id: 'content-release.yml',
+  status: 'in_progress',
+};
+
+function getLatestWorkflow(params) {
+  return octokit.rest.actions
+    .listWorkflowRuns(params)
+    .then(response => {
+      if (response.status !== 200) {
+        throw new Error(
+          `Response ${response.status} from ${response.url}. Aborting.`,
+        );
+      }
+      return response.data;
+    })
+    .then(({ workflow_runs }) => {
+      return workflow_runs.length === 0 ? null : workflow_runs[0];
+    });
+}
+
+function queueWorkflows(dailyDeployWorkflow, contentReleaseWorkflow) {
+  if (dailyDeployWorkflow === null) return 'content-release';
+  if (contentReleaseWorkflow === null) return 'daily-deploy';
+
+  const [dailyDeployTimestamp, contentReleaseTimestamp] = [
+    Date.parse(dailyDeployWorkflow.created_at),
+    Date.parse(contentReleaseWorkflow.created_at),
+  ];
+
+  if (dailyDeployTimestamp < contentReleaseTimestamp) {
+    return 'daily-deploy';
+  } else if (contentReleaseTimestamp < dailyDeployTimestamp) {
+    return 'content-release';
+  }
+
+  throw new Error(
+    'Both workflows created at exact same time. Trigger manually',
+  );
+}
+
+/**
+ * Checks Github Actions url. Loops recursively until error is thrown.
+ */
+async function main() {
+  try {
+    const ddWorkflow = await getLatestWorkflow(dailyDeployParams);
+    const crWorkflow = await getLatestWorkflow(contentReleaseParams);
+    const flow = await queueWorkflows(ddWorkflow, crWorkflow);
+
+    if (currentWorkflow !== flow) {
+      console.log(
+        `${flow} is currently running. Sleeping ${currentWorkflow} for ${timeout} minutes`,
+      );
+      await sleep(timeout * 60 * 1000);
+      await main();
+      return;
+    } else {
+      console.log(`${currentWorkflow} can continue!`);
+    }
+  } catch (e) {
+    console.error(e);
+    process.exit(1);
+  }
+}
+
+main();

--- a/script/github-actions/validate-content-release-status.js
+++ b/script/github-actions/validate-content-release-status.js
@@ -3,12 +3,13 @@
 const { Octokit } = require('@octokit/rest');
 const { sleep } = require('../../script/utils');
 
-const { GITHUB_TOKEN: auth } = process.env; // GITHUB_REPOSITORY
+const { GITHUB_TOKEN: auth, GITHUB_REPOSITORY } = process.env;
+const args = process.argv.slice(2);
 const timeout = 2; // minutes
-const [owner, repo] = 'department-of-veterans-affairs/content-build'.split('/'); // GITHUB_REPOSITORY.split('/');
+const [owner, repo] = GITHUB_REPOSITORY.split('/');
 
 const octokit = new Octokit({ auth });
-const currentWorkflow = 'content-release';
+const currentWorkflow = args[0];
 
 const dailyDeployParams = {
   owner,


### PR DESCRIPTION
## Description

[Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/32936) related

Due to daily deploy and content-release being in the same concurrency group, there have been a few instances where one can cancel the flow of the other (primarily, content-release cancelling daily-deploy mid run).

In an effort to reduce the cancellation of these flows, we will be separating them into their own groups. We still need to ensure no race-condition occur, that this PR addresses that.

This is part 1 of 2. Part 2 requires this PR to be merged, wait until this script is included in release (the following day when merged), the we can create a PR to modify flow of content-release and daily-deploy to use this script.

## Testing done

Local. See screenshot below

## Screenshots

Local testing done while [daily deploy](https://github.com/department-of-veterans-affairs/content-build/actions/runs/1473210282) was running
![image](https://user-images.githubusercontent.com/10648480/142289786-aae07a80-9a1b-4bb3-a6e3-eca75b5f2f5c.png)