### PR TITLE
Fix unit test reporting on GitHub Actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -344,6 +344,7 @@ jobs:
         run: node script/app-coverage-report.js > test-results/coverage_report.txt
 
       - name: Get code coverage
+        if: ${{ always() }}
         id: code-coverage
         run: echo ::set-output name=MARKDOWN::$(node ./script/github-actions/code-coverage-format-report.js)
 


### PR DESCRIPTION
## Description
The `Get code coverage` step in the unit test job does not run when unit test fail, causing an undefined environment variable to be passed into the step that follows this.

## Acceptance criteria
- [ ] CI passes.