### PR TITLE
Github Actions -- Decouple concurrency group for content-release and daily-deploy

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -18,7 +18,7 @@ on:
     - cron: "45 18 * * 1-5"
 
 concurrency:
-  group: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_environment || 'prod' }}
+  group: content-release-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_environment || 'prod' }}
   cancel-in-progress: ${{ github.event.inputs.deploy_environment != 'prod' }}
 
 env:
@@ -133,6 +133,29 @@ jobs:
           echo "DEPLOY_BUCKET=content.www.va.gov" >> $GITHUB_ENV
           echo "DRUPAL_ADDRESS=http://internal-dsva-vagov-prod-cms-2000800896.us-gov-west-1.elb.amazonaws.com" >> $GITHUB_ENV
 
+  wait-for-current-workflow:
+    name: Wait For Current Workflow
+    runs-on: ubuntu-latest
+    needs: set-env
+    if: always() && needs.set-env.result == 'success'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        uses: ./.github/workflows/install
+        with:
+          key: ${{ hashFiles('yarn.lock') }}
+          yarn_cache_folder: ~/.cache/yarn
+          path: |
+            ~/.cache/yarn
+            node_modules
+
+      - name: Wait for current workflow
+        run: node ./script/github-actions/wait-for-current-workflow-to-complete.js content-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   validate-build-status:
     name: Validate Build Status
     runs-on: ubuntu-latest
@@ -178,12 +201,14 @@ jobs:
   build:
     name: Build
     runs-on: ${{ needs.start-runner.outputs.label }}
-    needs: [set-env, validate-build-status, start-runner]
+    needs: [set-env, validate-build-status, start-runner, wait-for-current-workflow]
     if: |
       always() &&
       needs.set-env.result == 'success' &&
       needs.validate-build-status.result == 'success' &&
       needs.start-runner.result == 'success'
+      needs.wait-for-current-workflow.result == 'success'
+
     defaults:
       run:
         working-directory: content-build

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -133,8 +133,8 @@ jobs:
           echo "DEPLOY_BUCKET=content.www.va.gov" >> $GITHUB_ENV
           echo "DRUPAL_ADDRESS=http://internal-dsva-vagov-prod-cms-2000800896.us-gov-west-1.elb.amazonaws.com" >> $GITHUB_ENV
 
-  wait-for-current-workflow:
-    name: Wait For Current Workflow
+  wait-for-current-workflow-to-complete:
+    name: Wait for current workflow to complete
     runs-on: ubuntu-latest
     needs: set-env
     if: always() && needs.set-env.result == 'success'
@@ -151,7 +151,7 @@ jobs:
             ~/.cache/yarn
             node_modules
 
-      - name: Wait for current workflow
+      - name: Wait for current workflow to complete
         run: node ./script/github-actions/wait-for-current-workflow-to-complete.js content-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -201,13 +201,13 @@ jobs:
   build:
     name: Build
     runs-on: ${{ needs.start-runner.outputs.label }}
-    needs: [set-env, validate-build-status, start-runner, wait-for-current-workflow]
+    needs: [set-env, validate-build-status, start-runner, wait-for-current-workflow-to-complete]
     if: |
       always() &&
       needs.set-env.result == 'success' &&
       needs.validate-build-status.result == 'success' &&
       needs.start-runner.result == 'success'
-      needs.wait-for-current-workflow.result == 'success'
+      needs.wait-for-current-workflow-to-complete.result == 'success'
 
     defaults:
       run:

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -118,8 +118,8 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.commit_sha != '' }}
         run: echo 'COMMIT_SHA=${{ github.event.inputs.commit_sha }}' >> $GITHUB_ENV
 
-  wait-for-current-workflow:
-    name: Wait For Current Workflow
+  wait-for-current-workflow-to-complete:
+    name: Wait for current workflow to complete
     runs-on: ubuntu-latest
     needs: set-env
     if: always() && needs.set-env.result == 'success'
@@ -136,7 +136,7 @@ jobs:
             ~/.cache/yarn
             node_modules
 
-      - name: Wait for current workflow
+      - name: Wait for current workflow to complete
         run: node ./script/github-actions/wait-for-current-workflow-to-complete.js daily-deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -184,7 +184,7 @@ jobs:
   build:
     name: Build
     runs-on: ${{ needs.start-runner.outputs.label }}
-    needs: [set-env, notify-start, validate-build-status, start-runner, wait-for-current-workflow]
+    needs: [set-env, notify-start, validate-build-status, start-runner, wait-for-current-workflow-to-complete]
     defaults:
       run:
         working-directory: content-build

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -14,7 +14,7 @@ on:
     - cron: 0 19 * * 1-5
 
 concurrency:
-  group: prod
+  group: daily-deploy-prod
   cancel-in-progress: false
 
 env:
@@ -118,6 +118,29 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.commit_sha != '' }}
         run: echo 'COMMIT_SHA=${{ github.event.inputs.commit_sha }}' >> $GITHUB_ENV
 
+  wait-for-current-workflow:
+    name: Wait For Current Workflow
+    runs-on: ubuntu-latest
+    needs: set-env
+    if: always() && needs.set-env.result == 'success'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        uses: ./.github/workflows/install
+        with:
+          key: ${{ hashFiles('yarn.lock') }}
+          yarn_cache_folder: ~/.cache/yarn
+          path: |
+            ~/.cache/yarn
+            node_modules
+
+      - name: Wait for current workflow
+        run: node ./script/github-actions/wait-for-current-workflow-to-complete.js daily-deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   validate-build-status:
     name: Validate Build Status
     runs-on: ubuntu-latest
@@ -161,7 +184,7 @@ jobs:
   build:
     name: Build
     runs-on: ${{ needs.start-runner.outputs.label }}
-    needs: [set-env, notify-start, validate-build-status, start-runner]
+    needs: [set-env, notify-start, validate-build-status, start-runner, wait-for-current-workflow]
     defaults:
       run:
         working-directory: content-build


### PR DESCRIPTION
## Description

[Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/32936) related

Part 2 of [PR](#770) and [PR](#768)

The flows are in their own concurrency group and decoupled. The following flow is modified:

Prior to starting the `build` step, it will run `wait-for-current-workflow`. This will allow `content-release` and `daily-deploy` to not be in a race-condition

## Testing done

Local testing. See #768 for more details

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
