### PR TITLE
Github Actions -- Fix upload same tag/release while waiting

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -88,7 +88,6 @@ jobs:
     name: Set Env Variables
     runs-on: ubuntu-latest
     outputs:
-      LATEST_TAG_VERSION: ${{ steps.get-latest-tag.outputs.LATEST_TAG_VERSION }}
       RELEASE_WAIT: ${{ env.RELEASE_WAIT }}
       REF: ${{ steps.get-latest-release.outputs.target_commitish }}
       BUILDTYPE: ${{ env.BUILDTYPE }}
@@ -109,10 +108,6 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ needs.set-env.outputs.REF }}
-
-      - name: Get latest tag
-        id: get-latest-tag
-        run: echo ::set-output name=LATEST_TAG_VERSION::$(git fetch --all --tags > /dev/null && git tag -l | sort -V --reverse | head -n 1)
 
       - name: Get latest release
         id: get-latest-release
@@ -416,9 +411,13 @@ jobs:
           ref: ${{ needs.set-env.outputs.REF }}
           token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
 
+      - name: Get latest tag
+        id: get-latest-tag
+        run: echo ::set-output name=LATEST_TAG_VERSION::$(git fetch --all --tags > /dev/null && git tag -l | sort -V --reverse | head -n 1)
+
       - name: Waiting to release
         run: |
-          echo "Waiting to release: https://github.com/${{github.repository}}/compare/${{needs.set-env.outputs.LATEST_TAG_VERSION}}...${{needs.set-env.outputs.REF}}"
+          echo "Waiting to release: https://github.com/${{github.repository}}/compare/${{steps.get-latest-tag.outputs.LATEST_TAG_VERSION}}...${{needs.set-env.outputs.REF}}"
 
       - name: Sleep for ${{ needs.set-env.outputs.RELEASE_WAIT }} minutes
         uses: whatnick/wait-action@master
@@ -429,7 +428,7 @@ jobs:
         id: bump-tag-version
         uses: WyriHaximus/github-action-next-semvers@v1
         with:
-          version: ${{ needs.set-env.outputs.LATEST_TAG_VERSION }}
+          version: ${{ steps.get-latest-tag.outputs.LATEST_TAG_VERSION }}
 
       - name: Create tag
         run: git tag ${{ steps.bump-tag-version.outputs.v_patch }} ${{ needs.set-env.outputs.REF }} && git push origin ${{ steps.bump-tag-version.outputs.v_patch }}

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -84,7 +84,6 @@ jobs:
     name: Set Env Variables
     runs-on: ubuntu-latest
     outputs:
-      LATEST_TAG_VERSION: ${{ steps.get-latest-tag.outputs.LATEST_TAG_VERSION }}
       RELEASE_WAIT: ${{ env.RELEASE_WAIT }}
       COMMIT_SHA: ${{ env.COMMIT_SHA }}
 
@@ -97,10 +96,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-
-      - name: Get latest tag
-        id: get-latest-tag
-        run: echo ::set-output name=LATEST_TAG_VERSION::$(git fetch --all --tags > /dev/null && git tag -l | sort -V --reverse | head -n 1)
 
       - name: Get release wait time (scheduled release)
         if: ${{ github.event.schedule != '' }}
@@ -166,17 +161,23 @@ jobs:
   notify-start:
     name: Notify Start
     runs-on: ubuntu-latest
-    needs: set-env
+    needs: [set-env, wait-for-current-workflow-to-complete]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Get latest tag
+        id: get-latest-tag
+        run: echo ::set-output name=LATEST_TAG_VERSION::$(git fetch --all --tags > /dev/null && git tag -l | sort -V --reverse | head -n 1)
 
       - name: Notify Slack
         uses: ./.github/workflows/slack-notify
         continue-on-error: true
         with:
-          attachments: '[{"mrkdwn_in": ["text"], "color": "good", "text": "Stand by, production deploy for content-build coming up in ${{ needs.set-env.outputs.RELEASE_WAIT }} minutes. View what coming here: <https://github.com/${{ github.repository }}/compare/content-build/${{ needs.set-env.outputs.LATEST_TAG_VERSION }}...${{ needs.set-env.outputs.COMMIT_SHA }}>"}]'
+          attachments: '[{"mrkdwn_in": ["text"], "color": "good", "text": "Stand by, production deploy for content-build coming up in ${{ needs.set-env.outputs.RELEASE_WAIT }} minutes. View what coming here: <https://github.com/${{ github.repository }}/compare/content-build/${{ steps.get-latest-tag.outputs.LATEST_TAG_VERSION }}...${{ needs.set-env.outputs.COMMIT_SHA }}>"}]'
           channel_id: ${{ env.CHANNEL_ID }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -184,7 +185,14 @@ jobs:
   build:
     name: Build
     runs-on: ${{ needs.start-runner.outputs.label }}
-    needs: [set-env, notify-start, validate-build-status, start-runner, wait-for-current-workflow-to-complete]
+    needs:
+      [
+        set-env,
+        notify-start,
+        validate-build-status,
+        start-runner,
+        wait-for-current-workflow-to-complete,
+      ]
     defaults:
       run:
         working-directory: content-build
@@ -393,9 +401,13 @@ jobs:
           ref: ${{ needs.set-env.outputs.COMMIT_SHA }}
           token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
 
+      - name: Get latest tag
+        id: get-latest-tag
+        run: echo ::set-output name=LATEST_TAG_VERSION::$(git fetch --all --tags > /dev/null && git tag -l | sort -V --reverse | head -n 1)
+
       - name: Waiting to release
         run: |
-          echo 'Waiting to release: https://github.com/${{ github.repository }}/compare/${{ needs.set-env.outputs.LATEST_TAG_VERSION }}...${{ needs.set-env.outputs.COMMIT_SHA }}'
+          echo 'Waiting to release: https://github.com/${{ github.repository }}/compare/${{steps.get-latest-tag.outputs.LATEST_TAG_VERSION}}...${{ needs.set-env.outputs.COMMIT_SHA }}'
 
       - name: Sleep for ${{ needs.set-env.outputs.RELEASE_WAIT }} minutes
         uses: whatnick/wait-action@master
@@ -406,7 +418,7 @@ jobs:
         id: bump-tag-version
         uses: WyriHaximus/github-action-next-semvers@v1
         with:
-          version: ${{ needs.set-env.outputs.LATEST_TAG_VERSION }}
+          version: ${{ steps.get-latest-tag.outputs.LATEST_TAG_VERSION }}
 
       - name: Create tag
         run: git tag ${{ steps.bump-tag-version.outputs.v_patch }} ${{ needs.set-env.outputs.COMMIT_SHA }} && git push origin ${{ steps.bump-tag-version.outputs.v_patch }}

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -407,7 +407,7 @@ jobs:
 
       - name: Waiting to release
         run: |
-          echo 'Waiting to release: https://github.com/${{ github.repository }}/compare/${{steps.get-latest-tag.outputs.LATEST_TAG_VERSION}}...${{ needs.set-env.outputs.COMMIT_SHA }}'
+          echo 'Waiting to release: https://github.com/${{ github.repository }}/compare/${{ steps.get-latest-tag.outputs.LATEST_TAG_VERSION }}...${{ needs.set-env.outputs.COMMIT_SHA }}'
 
       - name: Sleep for ${{ needs.set-env.outputs.RELEASE_WAIT }} minutes
         uses: whatnick/wait-action@master


### PR DESCRIPTION
## Description

With the latest wait-workflow, since we get the latest tag at the beginning, if a workflow is waiting, it has an outdated tag. This PR changes workflow to get latest workflow prior to uploading new tag from workflow


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
