### PR TITLE
Github Actions -- Increase wait timer between daily deploy and content-build

### DIFF
--- a/script/github-actions/wait-for-current-workflow-to-complete.js
+++ b/script/github-actions/wait-for-current-workflow-to-complete.js
@@ -5,7 +5,7 @@ const { sleep } = require('../utils');
 
 const { GITHUB_TOKEN: auth, GITHUB_REPOSITORY } = process.env;
 const args = process.argv.slice(2);
-const timeout = 2; // minutes
+const timeout = 3; // minutes
 const [owner, repo] = GITHUB_REPOSITORY.split('/');
 
 const octokit = new Octokit({ auth });


### PR DESCRIPTION
## Description

There have been a couple of instances where Github Actions workflow gets "stopped" in order to prepare for next step. Because of it, API sometimes treats as no workflow running, and therefore can signal counterpart to continue with their process.

Increasing the timer to prevent this edge case

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
