### PR TITLE
Github Actions -- change flow to prevent race condition during daily deploy for content-release

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -134,7 +134,6 @@ jobs:
   wait-for-current-workflow-to-complete:
     name: Wait for current workflow to complete
     runs-on: ubuntu-latest
-    needs: set-env
     if: |
       always() &&
       ((github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_environment == 'prod') || github.event_name == 'schedule')

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -14,8 +14,8 @@ on:
         options:
           - prod
   schedule:
-    - cron: "0 14-17,21-22 * * 1-5"
-    - cron: "45 18 * * 1-5"
+    - cron: '0 14-17,21-22 * * 1-5'
+    - cron: '45 18 * * 1-5'
 
 concurrency:
   group: content-release-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_environment || 'prod' }}
@@ -88,6 +88,8 @@ jobs:
   set-env:
     name: Set Env Variables
     runs-on: ubuntu-latest
+    if: always() && needs.wait-for-current-workflow-to-complete.result == 'success'
+    needs: wait-for-current-workflow-to-complete
     outputs:
       RELEASE_WAIT: ${{ env.RELEASE_WAIT }}
       REF: ${{ steps.get-latest-release.outputs.target_commitish }}
@@ -133,7 +135,9 @@ jobs:
     name: Wait for current workflow to complete
     runs-on: ubuntu-latest
     needs: set-env
-    if: always() && needs.set-env.result == 'success'
+    if: |
+      always() &&
+      ((github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_environment == 'prod') || github.event_name == 'schedule')
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -155,6 +159,7 @@ jobs:
   validate-build-status:
     name: Validate Build Status
     runs-on: ubuntu-latest
+    if: always() && needs.set-env.result == 'success'
     needs: set-env
 
     steps:
@@ -179,7 +184,7 @@ jobs:
     name: Notify Start
     runs-on: ubuntu-latest
     needs: set-env
-    if: ${{ needs.set-env.outputs.BUILDTYPE == 'vagovprod' }}
+    if: ${{ always() && needs.set-env.outputs.BUILDTYPE == 'vagovprod' }}
 
     steps:
       - name: Checkout
@@ -197,7 +202,13 @@ jobs:
   build:
     name: Build
     runs-on: ${{ needs.start-runner.outputs.label }}
-    needs: [set-env, validate-build-status, start-runner, wait-for-current-workflow-to-complete]
+    needs:
+      [
+        set-env,
+        validate-build-status,
+        start-runner,
+        wait-for-current-workflow-to-complete,
+      ]
     if: |
       always() &&
       needs.set-env.result == 'success' &&


### PR DESCRIPTION
## Description

This PR addresses adds additonal layer to prevent race condition seen today (11/23):

- If content-release is waiting, wait until daily deploy finishes before grabbing latest release
- Daily deploy bases it off latest commit rather than release, so no modification needed for that workflow


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
