### PR TITLE
Github Actions -- Add timeout to prevent content-release or daily deploy getting stuck

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -198,6 +198,7 @@ jobs:
     name: Build
     runs-on: ${{ needs.start-runner.outputs.label }}
     needs: [set-env, validate-build-status, start-runner, wait-for-current-workflow-to-complete]
+    timeout-minutes: 30
     if: |
       always() &&
       needs.set-env.result == 'success' &&

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -186,6 +186,7 @@ jobs:
   build:
     name: Build
     runs-on: ${{ needs.start-runner.outputs.label }}
+    timeout-minutes: 30
     needs:
       [
         set-env,


### PR DESCRIPTION
## Description

Given what occurred today, adding a timeout to build in the event it gets stuck

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
