### PR TITLE
Github Actions -- rename content-release flow to unblock

### DIFF
--- a/.github/workflows/content-release-v2.yml
+++ b/.github/workflows/content-release-v2.yml
@@ -1,4 +1,4 @@
-name: Content Release
+name: Content Release v2
 
 on:
   workflow_dispatch:
@@ -18,9 +18,10 @@ on:
     - cron: '45 18 * * 1-5'
 
 concurrency:
-  group: content-release-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_environment || 'prod' }}
+  group: content-release-v2-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_environment || 'prod' }}
   cancel-in-progress: ${{ github.event.inputs.deploy_environment != 'prod' }}
 
+timeout-minutes: 60
 env:
   CHANNEL_ID: C0MQ281DJ # vfs-platform-builds
   DSVA_SCHEDULE_ENABLED: true
@@ -210,7 +211,6 @@ jobs:
       ]
     timeout-minutes: 30
     if: |
-      always() &&
       needs.set-env.result == 'success' &&
       needs.validate-build-status.result == 'success' &&
       needs.start-runner.result == 'success' &&

--- a/script/github-actions/wait-for-current-workflow-to-complete.js
+++ b/script/github-actions/wait-for-current-workflow-to-complete.js
@@ -18,6 +18,7 @@ const dailyDeployParams = {
   status: 'in_progress',
 };
 
+// TODO: Rename back to content-release when resolved
 const contentReleaseParams = {
   owner,
   repo,

--- a/script/github-actions/wait-for-current-workflow-to-complete.js
+++ b/script/github-actions/wait-for-current-workflow-to-complete.js
@@ -21,7 +21,7 @@ const dailyDeployParams = {
 const contentReleaseParams = {
   owner,
   repo,
-  workflow_id: 'content-release.yml',
+  workflow_id: 'content-release-v2.yml',
   status: 'in_progress',
 };
 


### PR DESCRIPTION
## Description

Renaming filename and creating new `group` to unblock content-release

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
