### PR TITLE
Github Actions -- Add callback to daily deploy and content-release

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -268,6 +268,13 @@ jobs:
         env:
           YARN_CACHE_FOLDER: .cache/yarn
 
+      - name: Get buildtime
+        id: buildtime
+        run: |
+          BUILDTIME=$(date +%s)
+          echo ::set-output name=buildtime::$BUILDTIME
+          echo "${{ needs.set-env.outputs.BUILDTYPE }}_buildtime=$BUILDTIME" >> $GITHUB_ENV
+
       - name: Build
         run: yarn build --buildtype=${{ needs.set-env.outputs.BUILDTYPE }} --asset-source=local --drupal-address=${{ needs.set-env.outputs.DRUPAL_ADDRESS }} --pull-drupal --drupal-max-parallel-requests=15 --no-drupal-proxy --verbose
         timeout-minutes: 30
@@ -277,13 +284,6 @@ jobs:
       - name: Check broken links
         id: get-broken-link-info
         run: node ./script/github-actions/check-broken-links.js ${{ needs.set-env.outputs.BUILDTYPE }}
-
-      - name: Get buildtime
-        id: buildtime
-        run: |
-          BUILDTIME=$(date +%s)
-          echo ::set-output name=buildtime::$BUILDTIME
-          echo "${{ needs.set-env.outputs.BUILDTYPE }}_buildtime=$BUILDTIME" >> $GITHUB_ENV
 
       - name: Generate build details
         run: |

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -220,6 +220,9 @@ jobs:
       run:
         working-directory: content-build
 
+    outputs:
+      vagovprod_buildtime: ${{ env.vagovprod_buildtime }}
+
     env:
       NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
       CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
@@ -275,6 +278,13 @@ jobs:
         id: get-broken-link-info
         run: node ./script/github-actions/check-broken-links.js ${{ needs.set-env.outputs.BUILDTYPE }}
 
+      - name: Get buildtime
+        id: buildtime
+        run: |
+          BUILDTIME=$(date +%s)
+          echo ::set-output name=buildtime::$BUILDTIME
+          echo "${{ needs.set-env.outputs.BUILDTYPE }}_buildtime=$BUILDTIME" >> $GITHUB_ENV
+
       - name: Generate build details
         run: |
           cat > build/${{ needs.set-env.outputs.BUILDTYPE }}/BUILD.txt << EOF
@@ -285,7 +295,7 @@ jobs:
           RUN_ID=${{ github.run_id }}
           RUN_NUMBER=${{ github.run_number }}
           REF=${{ needs.set-env.outputs.REF }}
-          BUILDTIME=$(date +%s)
+          BUILDTIME=${{ steps.buildtime.outputs.buildtime }}
           EOF
 
       - name: Prearchive
@@ -457,8 +467,11 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    needs: [set-env, create-release]
-    if: ${{ always() && needs.create-release.result == 'success' }}
+    needs: [set-env, build, create-release]
+    if: |
+      always() &&
+      needs.build.result == 'success'
+      needs.create-release.result == 'success'
 
     steps:
       - name: Checkout
@@ -477,6 +490,12 @@ jobs:
           ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_PROD_ROLE
           env_variable_name: AWS_FRONTEND_PROD_ROLE
 
+      - name: Get Drupal token from Parameter Store
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /dsva-vagov/vets-website/prod/drupal-password
+          env_variable_name: CALLBACK_TOKEN
+
       - name: Configure AWS Credentials (2)
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -492,6 +511,15 @@ jobs:
         env:
           SRC: s3://vetsgov-website-builds-s3-upload/content-build/${{needs.set-env.outputs.REF}}/${{needs.set-env.outputs.BUILDTYPE}}.tar.bz2
           DEST: s3://${{ needs.set-env.outputs.DEPLOY_BUCKET }}
+
+      - name: CMS GovDelivery callback
+        uses: fjogeleit/http-request-action@master
+        continue-on-error: true
+        with:
+          url: https://prod.cms.va.gov/api/govdelivery_bulletins/queue?EndTime=${{ needs.build.outputs.vagovprod_buildtime }}
+          method: POST
+          username: api
+          password: ${{ env.CALLBACK_TOKEN }}
 
   notify-failure:
     name: Notify Failure

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -168,6 +168,13 @@ jobs:
         if: ${{ github.ref == 'refs/heads/master' }}
         run: echo "DRUPAL_ADDRESS=${{ matrix.drupal-address }}" >> $GITHUB_ENV
 
+      - name: Get buildtime
+        id: buildtime
+        run: |
+          BUILDTIME=$(date +%s)
+          echo ::set-output name=buildtime::$BUILDTIME
+          echo "${{ matrix.buildtype }}_buildtime=$BUILDTIME" >> $GITHUB_ENV
+
       - name: Build
         run: yarn build --buildtype=${{ matrix.buildtype }} --asset-source=local --drupal-address=${{ env.DRUPAL_ADDRESS }} --pull-drupal --drupal-max-parallel-requests=15 --no-drupal-proxy --verbose
         env:
@@ -177,13 +184,6 @@ jobs:
         id: get-broken-link-info
         if: ${{ matrix.buildtype == 'vagovprod' }}
         run: node ./script/github-actions/check-broken-links.js ${{ matrix.buildtype }}
-
-      - name: Get buildtime
-        id: buildtime
-        run: |
-          BUILDTIME=$(date +%s)
-          echo ::set-output name=buildtime::$BUILDTIME
-          echo "${{ matrix.buildtype }}_buildtime=$BUILDTIME" >> $GITHUB_ENV
 
       - name: Generate build details
         run: |

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -250,6 +250,13 @@ jobs:
         env:
           YARN_CACHE_FOLDER: .cache/yarn
 
+      - name: Get buildtime
+        id: buildtime
+        run: |
+          BUILDTIME=$(date +%s)
+          echo ::set-output name=buildtime::$BUILDTIME
+          echo "{{ env.BUILDTYPE }}_buildtime=$BUILDTIME" >> $GITHUB_ENV
+
       - name: Build
         run: yarn build --buildtype=${{ env.BUILDTYPE }} --drupal-address='${{ env.DRUPAL_ADDRESS }}' --no-drupal-proxy
         timeout-minutes: 30
@@ -259,13 +266,6 @@ jobs:
       - name: Check broken links
         id: get-broken-link-info
         run: node ./script/github-actions/check-broken-links.js {{ env.BUILDTYPE }}
-
-      - name: Get buildtime
-        id: buildtime
-        run: |
-          BUILDTIME=$(date +%s)
-          echo ::set-output name=buildtime::$BUILDTIME
-          echo "{{ env.BUILDTYPE }}_buildtime=$BUILDTIME" >> $GITHUB_ENV
 
       - name: Generate build details
         run: |

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -199,6 +199,9 @@ jobs:
       run:
         working-directory: content-build
 
+    outputs:
+      vagovprod_buildtime: ${{ env.vagovprod_buildtime }}
+
     env:
       NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
       BUILDTYPE: vagovprod
@@ -257,6 +260,13 @@ jobs:
         id: get-broken-link-info
         run: node ./script/github-actions/check-broken-links.js {{ env.BUILDTYPE }}
 
+      - name: Get buildtime
+        id: buildtime
+        run: |
+          BUILDTIME=$(date +%s)
+          echo ::set-output name=buildtime::$BUILDTIME
+          echo "{{ env.BUILDTYPE }}_buildtime=$BUILDTIME" >> $GITHUB_ENV
+
       - name: Generate build details
         run: |
           cat > build/${{ env.BUILDTYPE }}/BUILD.txt << EOF
@@ -267,7 +277,7 @@ jobs:
           RUN_ID=${{ github.run_id }}
           RUN_NUMBER=${{ github.run_number }}
           REF=${{ needs.set-env.outputs.COMMIT_SHA }}
-          BUILDTIME=$(date +%s)
+          BUILDTIME=${{ steps.buildtime.outputs.buildtime }}
           EOF
 
       - name: Prearchive
@@ -436,7 +446,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    needs: [set-env, create-release]
+    needs: [set-env, build, create-release]
 
     env:
       ENVIRONMENT: vagovprod
@@ -459,6 +469,12 @@ jobs:
           ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_PROD_ROLE
           env_variable_name: AWS_FRONTEND_PROD_ROLE
 
+      - name: Get Drupal token from Parameter Store
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /dsva-vagov/vets-website/prod/drupal-password
+          env_variable_name: CALLBACK_TOKEN
+
       - name: Configure AWS Credentials (2)
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -474,6 +490,15 @@ jobs:
         env:
           SRC: s3://vetsgov-website-builds-s3-upload/content-build/${{ needs.set-env.outputs.COMMIT_SHA }}/${{ env.ENVIRONMENT }}.tar.bz2
           DEST: s3://${{ env.BUCKET }}
+
+      - name: CMS GovDelivery callback
+        uses: fjogeleit/http-request-action@master
+        continue-on-error: true
+        with:
+          url: https://prod.cms.va.gov/api/govdelivery_bulletins/queue?EndTime=${{ needs.build.outputs.vagovprod_buildtime }}
+          method: POST
+          username: api
+          password: ${{ env.CALLBACK_TOKEN }}
 
   notify-failure:
     name: Notify Failure


### PR DESCRIPTION
## Description

See [Slack](https://dsva.slack.com/archives/C01512KN35G/p1637785399079500) for more details

It was pointed out that the govcallback should be added to daily deploy and content release as it is an integral part. This PR does the following:

- Grab the buildtime and store accordingly
- Grab token from SSM
- Make call to callback using token

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
