### PR TITLE
Github Actions -- Update callback URL

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -516,7 +516,7 @@ jobs:
         uses: fjogeleit/http-request-action@master
         continue-on-error: true
         with:
-          url: https://prod.cms.va.gov/api/govdelivery_bulletins/queue?EndTime=${{ needs.build.outputs.vagovprod_buildtime }}
+          url: http://internal-dsva-vagov-prod-cms-2000800896.us-gov-west-1.elb.amazonaws.com/api/govdelivery_bulletins/queue?EndTime=${{ needs.build.outputs.vagovprod_buildtime }}
           method: POST
           username: api
           password: ${{ env.CALLBACK_TOKEN }}


### PR DESCRIPTION
## Description

See [slack](https://dsva.slack.com/archives/C0MQ281DJ/p1638206769368300?thread_ts=1638194569.356200&cid=C0MQ281DJ) for more details
No error or access denied displayed, but callback not working as intended. Updating URL

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
