### PR TITLE
Field related links section fix

### DIFF
--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -161,7 +161,7 @@
 
           <!-- List of links section -->
           {% if fieldRegionPage.entity.fieldRelatedLinks != empty %}
-            {% include "src/site/paragraphs/facilities/list_of_link_teasers_facility.drupal.liquid" with paragraph = fieldRegionPage.entity.fieldRelatedLinks.entity %}
+            {% include "src/site/paragraphs/facilities/list_of_link_teasers_facility.drupal.liquid" with paragraph = fieldRegionPage.entity.fieldRelatedLinks.0.entity %}
           {% endif %}
 
           <!-- Local Health Services -->

--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -125,7 +125,7 @@
 
           <!-- List of links section -->
           <div class="vads-u-margin-top--5">
-            {% include "src/site/paragraphs/facilities/list_of_link_teasers_facility.drupal.liquid" with paragraph = fieldRelatedLinks.entity %}
+            {% include "src/site/paragraphs/facilities/list_of_link_teasers_facility.drupal.liquid" with paragraph = fieldRelatedLinks.0.entity %}
           </div>
 
           {% assign header = "h3" %}

--- a/src/site/layouts/tests/vamc/fixtures/health_care_region_page.json
+++ b/src/site/layouts/tests/vamc/fixtures/health_care_region_page.json
@@ -124,7 +124,7 @@
   "fieldGovdeliveryIdEmerg": "USVHA_396",
   "fieldGovdeliveryIdNews": "USVHA_94",
   "fieldIntroText": "At VA Pittsburgh Healthcare System, our health care teams are deeply experienced and guided by the needs of Veterans, their families, and caregivers. Find a health facility near you, and manage your health online. Sign up for community events and updates.",
-  "fieldRelatedLinks": {
+  "fieldRelatedLinks": [{
     "entity": {
       "parentFieldName": "field_related_links",
       "fieldTitle": "In the spotlight at VA Pittsburgh health care",
@@ -249,7 +249,7 @@
         }
       ]
     }
-  },
+  }],
   "fieldOperatingStatus": {
     "url": {
       "path": "/pittsburgh-health-care/operating-status"


### PR DESCRIPTION
## Description
Fixes issue with field related links section not rendering on VAMC pages.

<details>
<summary>field related links section</summary>

![Screen Shot 2021-11-29 at 2 22 05 PM](https://user-images.githubusercontent.com/84030819/143929511-29e30bf8-ae84-4791-85ba-df7a012e32b5.png)

</details>

See thread: https://dsva.slack.com/archives/CT4GZBM8F/p1637794126229100 

