### PR TITLE
Add timeout to the Cypress steps in the daily accessibility scan

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -106,6 +106,7 @@ jobs:
   a11y:
     name: Accessibility Tests
     needs: build
+    timeout-minutes: 120
     runs-on: [self-hosted, asg]
     container:
       image: public.ecr.aws/cypress-io/cypress/browsers:node14.16.0-chrome89-ff77


### PR DESCRIPTION
## Description
This PR adds a two hour timeout to the Cypress job in the daily accessibility scan in order to handle situations when one or more of the parallel steps hang.