### PR TITLE
VACMS-7009: Video link text label is not making it to the FE

### DIFF
--- a/src/site/paragraphs/downloadable_file.drupal.liquid
+++ b/src/site/paragraphs/downloadable_file.drupal.liquid
@@ -52,7 +52,7 @@
     {% if entity.fieldMedia.entity.entityBundle == 'video' %}
         <a class="video-link" target="_blank"
            href="{{entity.fieldMedia.entity.fieldMediaVideoEmbedField}}">
-            <i class="fas fa-play-circle vads-u-margin--0p5" aria-hidden="true" role="img"></i>Go to video
+            <i class="fas fa-play-circle vads-u-margin--0p5" aria-hidden="true" role="img"></i>{{entity.fieldMedia.fieldTitle}}
         </a>
     {% endif %}
 </div>

--- a/src/site/paragraphs/downloadable_file.drupal.liquid
+++ b/src/site/paragraphs/downloadable_file.drupal.liquid
@@ -52,7 +52,7 @@
     {% if entity.fieldMedia.entity.entityBundle == 'video' %}
         <a class="video-link" target="_blank"
            href="{{entity.fieldMedia.entity.fieldMediaVideoEmbedField}}">
-            <i class="fas fa-play-circle vads-u-margin--0p5" aria-hidden="true" role="img"></i>{{entity.fieldMedia.fieldTitle}}
+            <i class="fas fa-play-circle vads-u-margin--0p5" aria-hidden="true" role="img"></i>{{entity.fieldTitle}}
         </a>
     {% endif %}
 </div>


### PR DESCRIPTION
- Updated video link text in FE paragraph twig template.
- Adjusted video link text variable to "`{{entity.fieldTitle}}`".

## Description
Relates to https://github.com/department-of-veterans-affairs/va.gov-cms/issues/7009

and unites https://github.com/department-of-veterans-affairs/va.gov-cms/pull/7125

## QA steps

As user editor
- [ ] Go to `/houston-health-care/work-with-us/internships-and-fellowships/pharmacy-residencies/` (node 23174) to verify and confirm that the link text for the video is "**Find out more about Pharmacy Residency programs at VA Houston.**" and not "**Go to video**".

## Screenshots
![VACMS-7009-video-link-text-fixed](https://user-images.githubusercontent.com/846871/144632086-ccbcff0b-20bf-4ea6-a04c-c861e398cf78.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
