### PR TITLE
Remove unnecessary side navs

### DIFF
--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -7,11 +7,9 @@
 <div class="interior" id="content" data-template="event.drupal.liquid">
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">
-      {% if entityUrl.path contains "/outreach-and-events" %}
-        {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = outreachSidebar %}
-      {% else %}
+      {% unless entityUrl.path contains "/outreach-and-events" %}
         {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
-      {% endif %}
+      {% endunless %}
 
       <div class="usa-width-three-fourths">
         <article aria-labelledby="article-heading" class="usa-content" role="region">

--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -9,11 +9,10 @@
 <div class="interior vads-u-padding-bottom--3" id="content" data-template="event_listing.drupal.liquid">
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">
-      {% if entityUrl.breadcrumb.1.text == "Outreach and events" %}
-        {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = outreachSidebar %}
-      {% else %}
+      {% if entityUrl.breadcrumb.1.text != "Outreach and events" %}
         {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar%}
       {% endif %}
+
       <div class="usa-width-three-fourths">
         <article aria-labelledby="article-heading" class="vads-l-grid-container--full" role="region">
           <div class="vads-l-grid-container--full">

--- a/src/site/layouts/publication_listing.drupal.liquid
+++ b/src/site/layouts/publication_listing.drupal.liquid
@@ -6,7 +6,6 @@
 <div class="interior" id="content" data-template="publication_listing.drupal.liquid">
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">
-      {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = outreachSidebar %}
       <div class="usa-width-three-fourths">
 
         <article aria-labelledby="article-heading" role="region" class="usa-content vads-l-grid-container--full">


### PR DESCRIPTION
# Description

**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/33451

This PR removes unnecessary side navs from events templates.

## Screenshots

Remove side nav from Events Materials sub page.
![Screen Shot 2021-12-01 at 12 18 35 PM](https://user-images.githubusercontent.com/70410912/144299306-aec6b7bf-ac51-4146-9cb4-7900015e5b8f.png)

Remove the side nav from the Events sub page. 
![Screen Shot 2021-12-01 at 12 18 42 PM](https://user-images.githubusercontent.com/70410912/144299415-8af7e11c-a0d4-4329-9e2b-90380be070f4.png)

Remove side nave from Events Details Page.
![image](https://user-images.githubusercontent.com/12773166/144461305-69744ce8-5ece-4bc1-a63f-c0cc21dfc48b.png)

## AC

- [x] Remove unnecessary side navs from related events pages.

