### PR TITLE
Fix errors in recent build

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -310,7 +310,7 @@ jobs:
 
       - name: Export gql page count
         id: export-gql-page-count
-        run: echo ::set-output name=GQL_PAGE_COUNT::$(cat build-output.txt | | grep -oP 'with \d+ pages' | grep -oP '\d+')
+        run: echo ::set-output name=GQL_PAGE_COUNT::$(cat build-output.txt | grep -oP 'with \d+ pages' | grep -oP '\d+')
 
       - name: Check broken links
         id: get-broken-link-info

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -694,6 +694,13 @@ jobs:
           jq '.series[].tags[2] = "status:${{needs.deploy.result}}"' | \
           jq '.series[].tags[3] = "trigger:${{env.BUILD_TRIGGER}}"' > metrics.json
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
       - name: Get datadog token from ssm
         uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
         with:


### PR DESCRIPTION
## Description
Fixes https://github.com/department-of-veterans-affairs/content-build/runs/4401966715?check_suite_focus=true

Gotta auth to aws before we can get ssm secrets.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
