### PR TITLE
Remove Jenkins broken link notification

### DIFF
--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -178,7 +178,7 @@ def checkForBrokenLinks(String buildLogPath, String envName, Boolean contentOnly
     // cannot be serialized by default.
     brokenLinks = null
 
-    uploadBrokenLinksFile(brokenLinksFile, envName)
+    // uploadBrokenLinksFile(brokenLinksFile, envName)
 
     // slackSend(
     //   message: message,

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -180,12 +180,12 @@ def checkForBrokenLinks(String buildLogPath, String envName, Boolean contentOnly
 
     uploadBrokenLinksFile(brokenLinksFile, envName)
 
-    slackSend(
-      message: message,
-      color: color,
-      failOnError: true,
-      channel: 'vfs-platform-builds'
-    )
+    // slackSend(
+    //   message: message,
+    //   color: color,
+    //   failOnError: true,
+    //   channel: 'vfs-platform-builds'
+    // )
 
     if (color == 'danger') {
       throw new Exception('Broken links found')


### PR DESCRIPTION
## Description

Build channel still getting Jenkins notification when it should not. This PR removes slack notification being sent from Jenkins

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
