### PR TITLE
Github Actions -- Notify callback delivery failure

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -565,13 +565,25 @@ jobs:
           DEST: s3://${{ needs.set-env.outputs.DEPLOY_BUCKET }}
 
       - name: CMS GovDelivery callback
+        id: govdelivery-callback
         uses: fjogeleit/http-request-action@master
+        continue-on-error: true
         with:
           url: https://prod.cms.va.gov/api/govdelivery_bulletins/queue?EndTime=${{ needs.build.outputs.vagovprod_buildtime }}&src=gha&runId=${{ github.run_id }}&runNumber=${{ github.run_number }}
           method: GET
           username: api
           password: ${{ env.CALLBACK_TOKEN }}
           timeout: 10000
+
+      - name: Notify GovDelivery callback failure
+        uses: ./.github/workflows/slack-notify
+        if: ${{ steps.govdelivery-callback.status == 'failure' }}
+        continue-on-error: true
+        with:
+          attachments: '[{"mrkdwn_in": ["text"], "color": "warning", "text": "Content release for content-build govdelivery callback failed!: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"}]'
+          channel_id: ${{ env.CHANNEL_ID }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Export deploy end time
         id: export-deploy-end-time

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -846,7 +846,9 @@ jobs:
           DEST: s3://${{ matrix.bucket }}
 
       - name: CMS GovDelivery callback
+        id: govdelivery-callback
         if: ${{ matrix.environment == 'vagovstaging' }}
+        continue-on-error: true
         uses: fjogeleit/http-request-action@master
         with:
           url: https://staging.cms.va.gov/api/govdelivery_bulletins/queue?EndTime=${{ needs.build.outputs.vagovstaging_buildtime }}&src=gha&runId=${{ github.run_id }}&runNumber=${{ github.run_number }}
@@ -854,6 +856,16 @@ jobs:
           username: api
           password: ${{ env.CALLBACK_TOKEN }}
           timeout: 10000
+
+      - name: Notify GovDelivery callback failure
+        uses: ./.github/workflows/slack-notify
+        if: ${{ steps.govdelivery-callback.status == 'failure' }}
+        continue-on-error: true
+        with:
+          attachments: '[{"mrkdwn_in": ["text"], "color": "warning", "text": "content-build govdelivery callback failed!: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"}]'
+          channel_id: ${{ env.DEVOPS_CHANNEL_ID }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   stop-runner:
     name: Stop on-demand-runner

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -493,13 +493,25 @@ jobs:
           DEST: s3://${{ env.BUCKET }}
 
       - name: CMS GovDelivery callback
+        id: govdelivery-callback
         uses: fjogeleit/http-request-action@master
+        continue-on-error: true
         with:
           url: https://prod.cms.va.gov/api/govdelivery_bulletins/queue?EndTime=${{ needs.build.outputs.vagovprod_buildtime }}&src=gha&runId=${{ github.run_id }}&runNumber=${{ github.run_number }}
           method: GET
           username: api
           password: ${{ env.CALLBACK_TOKEN }}
           timeout: 10000
+
+      - name: Notify GovDelivery callback failure
+        uses: ./.github/workflows/slack-notify
+        if: ${{ steps.govdelivery-callback.status == 'failure' }}
+        continue-on-error: true
+        with:
+          attachments: '[{"mrkdwn_in": ["text"], "color": "warning", "text": "Production deploy for content-build govdelivery callback failed!: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"}]'
+          channel_id: ${{ env.CHANNEL_ID }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   notify-failure:
     name: Notify Failure


### PR DESCRIPTION
## Description

We don't workflows to fail if callback step fails. This PR does the following:

- If callback does fail, workflow will not error out due to `continue-on-error`
- Notify channel of callback failure

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
