### PR TITLE
VACMS-6950: Remove "Page last built" field from 3 content types

### DIFF
--- a/src/site/stages/build/drupal/graphql/landingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/landingPage.graphql.js
@@ -58,9 +58,6 @@ const landingPageFragment = `
       value
       date
     }
-    fieldPageLastBuilt {
-      date
-    }
     fieldTeaserText
     fieldRelatedOffice {
       entity {

--- a/src/site/stages/build/drupal/graphql/page.graphql.js
+++ b/src/site/stages/build/drupal/graphql/page.graphql.js
@@ -54,9 +54,6 @@ const pageFragment = `
         }
       }
     }
-    fieldPageLastBuilt {
-      date
-    }
     changed
   }
 `;


### PR DESCRIPTION
- Updated "LandingPage" and "page" GraphQL files and removed references to "fieldPageLastBuilt" field.

## Description

closes #[6950](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/6950)

## Testing done
Successful build

## Screenshots


## Acceptance criteria
- [ ] Passing build

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
