### PR TITLE
Remove Cypress caching from GitHub Actions jobs

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -73,7 +73,6 @@ jobs:
         with:
           path: |
             .cache/yarn
-            /github/home/.cache/Cypress
             **/node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-cypress-${{ hashFiles('**/yarn.lock') }}
           restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-cypress-
@@ -265,7 +264,6 @@ jobs:
         with:
           path: |
             .cache/yarn
-            /github/home/.cache/Cypress
             **/node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-cypress-${{ hashFiles('**/yarn.lock') }}
           restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-cypress-


### PR DESCRIPTION
## Description
Quick PR to remove caching of the Cypress binary from two jobs in the daily accessibility scan that do not use the binary.