### PR TITLE
Implement Official Name Display

### DIFF
--- a/src/site/layouts/tests/vet_center/template/fixtures/vet_center_data.json
+++ b/src/site/layouts/tests/vet_center/template/fixtures/vet_center_data.json
@@ -258,6 +258,7 @@
   "entityBundle": "vet_center",
   "entityLabel": "Escanaba Vet Center",
   "fieldOfficialName": "Escanaba Vet Center",
+  "title": "Escanaba Vet Center",
   "fieldIntroText": "We offer confidential help for Veterans, service members, and their families at no cost in a non-medical setting. Our services include counseling for needs such as depression, posttraumatic stress disorder (PTSD), and the psychological effects of military sexual trauma (MST). We can also connect you with more support in VA and your community.",
   "fieldFacilityLocatorApiId": "vc_0434V",
   "fieldMedia": {

--- a/src/site/layouts/tests/vet_center/template/vet_center.drupal.unit.spec.js
+++ b/src/site/layouts/tests/vet_center/template/vet_center.drupal.unit.spec.js
@@ -97,10 +97,42 @@ describe('Vet Center Main Page', () => {
     );
   });
 
-  it('renders header and intro text', () => {
-    expect(container.querySelector('h1').innerHTML).to.equal(
+  it('renders header but no field official name text if title and fieldOfficialName are equal to each other', () => {
+    expect(container.querySelector('h1').innerHTML).to.equal(testData.title);
+
+    expect(container.querySelector('.field-official-name')).to.not.exist;
+  });
+
+  it('renders header AND field official name text if title and fieldOfficialName are NOT equal to each other', async () => {
+    const mockData = _.cloneDeep(data);
+    const newOfficialNameText = 'Testing Field Official Name Vet Center';
+
+    mockData.fieldOfficialName = newOfficialNameText;
+
+    const newContainer = await renderHTML(layoutPath, mockData);
+    expect(container.querySelector('h1').innerHTML).to.equal(testData.title);
+
+    expect(
+      newContainer
+        .querySelector('.field-official-name')
+        .innerHTML.replace(/\s+/g, ' ')
+        .trim(),
+    ).to.equal('Also called the Testing Field Official Name Vet Center');
+  });
+
+  it('uses fieldOfficialName to render vet center title if title = null', async () => {
+    const mockData = _.cloneDeep(data);
+    mockData.title = null;
+
+    const newContainer = await renderHTML(layoutPath, mockData);
+    expect(newContainer.querySelector('h1').innerHTML).to.equal(
       testData.fieldOfficialName,
     );
+
+    expect(newContainer.querySelector('.field-official-name')).to.not.exist;
+  });
+
+  it('renders intro text', () => {
     expect(container.querySelector('div.va-introtext > p').innerHTML).to.equal(
       testData.fieldIntroText,
     );

--- a/src/site/layouts/vet_center.drupal.liquid
+++ b/src/site/layouts/vet_center.drupal.liquid
@@ -8,10 +8,18 @@
     <div class="usa-grid usa-grid-full">
       <div class="usa-width-three-fourths">
         <article class="usa-content va-l-facility-detail vads-u-padding-bottom--0">
-          {% if fieldOfficialName != empty %}
-            <h1>{{ fieldOfficialName }}</h1>
+          {% if title != empty %}
+            <h1>{{ title }}</h1>
+            {% if fieldOfficialName and title != fieldOfficialName %}
+              <p class="field-official-name vads-u-line-height--4 vads-u-font-family--sans vads-u-font-size--lg 
+              vads-u-font-weight--bold vads-u-padding-bottom--0p5">
+                Also called the {{fieldOfficialName}}
+              </p>
+            {% endif %}
+          {% elsif fieldOfficialName != empty %}
+            <h1>{{ fieldOfficialName}}</h1>
           {% endif %}
-
+          
           {% if fieldIntroText != empty %}
             <div class="va-introtext">
               <p>{{ fieldIntroText }}</p>

--- a/src/site/layouts/vet_center.drupal.liquid
+++ b/src/site/layouts/vet_center.drupal.liquid
@@ -9,9 +9,9 @@
       <div class="usa-width-three-fourths">
         <article class="usa-content va-l-facility-detail vads-u-padding-bottom--0">
           {% if title != empty %}
-            <h1>{{ title }}</h1>
+            <h1 aria-describedby="vet-center-title">{{ title }}</h1>
             {% if fieldOfficialName and title != fieldOfficialName %}
-              <p class="field-official-name vads-u-line-height--4 vads-u-font-family--sans vads-u-font-size--lg 
+              <p id="vet-center-title" class="field-official-name vads-u-line-height--4 vads-u-font-family--sans vads-u-font-size--lg 
               vads-u-font-weight--bold vads-u-padding-bottom--0p5">
                 Also called the {{fieldOfficialName}}
               </p>

--- a/src/site/stages/build/drupal/graphql/vetCenter.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vetCenter.graphql.js
@@ -19,6 +19,7 @@ const vetCenterFragment = `
         }
         entityBundle
         entityLabel
+        title
         fieldOfficialName
         fieldIntroText
         fieldFacilityLocatorApiId


### PR DESCRIPTION
## Description
Resolves - https://github.com/department-of-veterans-affairs/va.gov-team/issues/33053

If a vet center has an official name that is different from its title, we display that official name right below the vet center title

To test use this tugboat instance - https://web-khwba2p3ozkcd3sjcsfi9wyyxbltjjze.demo.cms.va.gov/prescott-vet-center/

![Screen Shot 2021-12-07 at 12 47 16 PM](https://user-images.githubusercontent.com/84030819/145080195-78176fa2-4396-4f84-8323-965fa194172b.png)

