### PR TITLE
adds graphql query and liquid filters for non-clinical services

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -610,6 +610,14 @@ module.exports = function registerFilters() {
       // Recreate the embedded youtube.com URL so we know it's formatted correctly.
       const urlInstance = new URL(url);
       const pathname = urlInstance?.pathname?.replace('/embed', '');
+
+      // Edge case for https://www.youtube.com/watch?v=HlkZeAYmw94.
+      if (urlInstance.searchParams?.get?.('v')) {
+        return `https://www.youtube.com/embed/${urlInstance.searchParams?.get?.(
+          'v',
+        )}`;
+      }
+
       return `https://www.youtube.com/embed${pathname}`;
     } catch (error) {
       return url;
@@ -1323,6 +1331,7 @@ module.exports = function registerFilters() {
       .map(facility => ({
         entityLabel: facility.entityLabel,
         fieldAddress: facility.fieldAddress,
+        fieldFacilityHours: facility.fieldFacilityHours,
         locations: liquid.filters.serviceLocationsAtFacilityByServiceType(
           facility.reverseFieldFacilityLocationNode.entities,
           serviceType,

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1298,4 +1298,36 @@ module.exports = function registerFilters() {
   liquid.filters.featureAddVaHealthConnectNumber = () => {
     return cmsFeatureFlags?.FEATURE_HEALTH_CONNECT_NUMBER;
   };
+
+  liquid.filters.serviceLocationsAtFacilityByServiceType = (
+    allServicesAtFacility,
+    serviceType,
+  ) => {
+    return allServicesAtFacility.reduce((acc, service) => {
+      if (
+        serviceType === service?.fieldServiceNameAndDescripti?.entity?.name &&
+        service?.fieldServiceLocation
+      ) {
+        return [...acc, ...service.fieldServiceLocation];
+      }
+
+      return acc;
+    }, []);
+  };
+
+  liquid.filters.healthcareSystemNonClinicalServiceLocationsByType = (
+    facilitiesInSystem,
+    serviceType,
+  ) => {
+    return facilitiesInSystem
+      .map(facility => ({
+        entityLabel: facility.entityLabel,
+        fieldAddress: facility.fieldAddress,
+        locations: liquid.filters.serviceLocationsAtFacilityByServiceType(
+          facility.reverseFieldFacilityLocationNode.entities,
+          serviceType,
+        ),
+      }))
+      .filter(facility => facility.locations.length > 0);
+  };
 };

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1318,7 +1318,6 @@ module.exports = function registerFilters() {
       ) {
         return [...acc, ...service.fieldServiceLocation];
       }
-
       return acc;
     }, []);
   };

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -7,6 +7,7 @@ import featuredContentData from '../layouts/tests/vet_center/template/fixtures/f
 import eventListingMockData from '../layouts/tests/vamc/fixtures/eventListingMockData.json';
 import pressReleasesMockData from '../layouts/tests/vamc/fixtures/pressReleasesMockData.json';
 import sidebarData from './fixtures/sidebarData.json';
+import hcSysNonClinicalSvcLocByType from '../layouts/tests/vamc/fixtures/healthcareSystemNonClinicalServiceLocationsByTypeMockData.json';
 
 const _ = require('lodash');
 
@@ -2007,5 +2008,158 @@ describe('isVisn8', () => {
 
   it('returns false if string does NOT equal "VISN 8"', () => {
     expect(liquid.filters.isVisn8('| VISN 8 |')).to.be.false;
+  });
+});
+
+describe('serviceLocationsAtFacilityByServiceType', () => {
+  const allServicesAtFacility =
+    hcSysNonClinicalSvcLocByType.entities[0].fieldOffice.entity
+      .reverseFieldRegionPageNode.entities[0].reverseFieldFacilityLocationNode
+      .entities;
+
+  const expected = {
+    entityId: '41817',
+    fieldServiceNameAndDescripti: {
+      entity: {
+        entityId: '1027',
+        entityLabel: 'Billing and insurance',
+        name: 'Billing and insurance',
+      },
+      targetId: 1027,
+    },
+    fieldServiceLocation: [
+      {
+        entity: {
+          status: true,
+          fieldAdditionalHoursInfo: null,
+          fieldEmailContacts: [],
+          fieldFacilityServiceHours: {
+            value: [
+              ['Mon', '9:00 a.m. to 5:00 p.m. ET'],
+              ['Tue', '9:00 a.m. to 5:00 p.m. ET'],
+              ['Wed', '9:00 a.m. to 5:00 p.m. ET'],
+              ['Thu', '9:00 a.m. to 5:00 p.m. ET'],
+              ['Fri', '9:00 a.m. to 5:00 p.m. ET'],
+              ['Sat', 'Closed'],
+              ['Sun', 'Closed'],
+            ],
+          },
+          fieldHours: '2',
+          fieldPhone: [],
+          fieldUseMainFacilityPhone: true,
+          fieldServiceLocationAddress: {
+            entity: {
+              fieldUseFacilityAddress: true,
+              fieldBuildingNameNumber: 'Building 1',
+              fieldClinicName: 'Anchorage A',
+              fieldWingFloorOrRoomNumber: 'Floor 3',
+              fieldAddress: {
+                addressLine1: '',
+                addressLine2: '',
+                postalCode: '',
+                locality: '',
+                administrativeArea: '',
+              },
+            },
+          },
+        },
+      },
+    ],
+  };
+  it('does not return facilities data for the "Billing and insurance" service type', () => {
+    const serviceType = 'Medical Records';
+    const facilityLocationsByType = liquid.filters.serviceLocationsAtFacilityByServiceType(
+      allServicesAtFacility,
+      serviceType,
+    );
+    expect(facilityLocationsByType[0]).to.not.equal(
+      expected.fieldServiceLocation[0],
+    );
+  });
+
+  it('returns facilities data for the "Billing and insurance" service type only', () => {
+    const serviceType = 'Billing and insurance';
+    const facilityLocationsByType = liquid.filters.serviceLocationsAtFacilityByServiceType(
+      allServicesAtFacility,
+      serviceType,
+    );
+    expect(facilityLocationsByType[0]).to.deep.equal(
+      expected.fieldServiceLocation[0],
+    );
+  });
+  it('returns and empty array if serviceType argument is not passed', () => {
+    const facilityLocationsByType = liquid.filters.serviceLocationsAtFacilityByServiceType(
+      allServicesAtFacility,
+    );
+    expect(facilityLocationsByType).to.eql([]);
+  });
+});
+
+describe('healthcareSystemNonClinicalServiceLocationsByType', () => {
+  const billingAndInsuraceServicesFacilities = [
+    {
+      entityLabel: 'Anchorage VA Medical Center',
+      fieldAddress: {
+        addressLine1: '1201 North Muldoon Road',
+        addressLine2: null,
+        postalCode: '99504-6104',
+        locality: 'Anchorage',
+        administrativeArea: 'AK',
+      },
+    },
+    {
+      entityLabel: 'Fairbanks VA Clinic',
+      fieldAddress: {
+        addressLine1: '4076 Neeley Road, Room 1J-101',
+        addressLine2: null,
+        postalCode: '99703-1110',
+        locality: 'Fort Wainwright',
+        administrativeArea: 'AK',
+      },
+    },
+  ];
+
+  const facilitiesInSystem =
+    hcSysNonClinicalSvcLocByType.entities[0].fieldOffice.entity
+      .reverseFieldRegionPageNode.entities;
+
+  const serviceType = 'Billing and insurance';
+  it('returns count of facility locations which provide "Billing and insurance" service', () => {
+    const serviceLocations = liquid.filters.healthcareSystemNonClinicalServiceLocationsByType(
+      facilitiesInSystem,
+      serviceType,
+    );
+    expect(serviceLocations.length).to.eql(2);
+  });
+
+  it('returns facility entityLabel information', () => {
+    const serviceLocations = liquid.filters.healthcareSystemNonClinicalServiceLocationsByType(
+      facilitiesInSystem,
+      serviceType,
+    );
+    expect(serviceLocations[0].entityLabel).to.eql(
+      billingAndInsuraceServicesFacilities[0].entityLabel,
+    );
+  });
+
+  it('returns facility fieldAddress addressLine1  information', () => {
+    const serviceLocations = liquid.filters.healthcareSystemNonClinicalServiceLocationsByType(
+      facilitiesInSystem,
+      serviceType,
+    );
+    expect(serviceLocations[0].fieldAddress.addressLine1).to.eql(
+      billingAndInsuraceServicesFacilities[0].fieldAddress.addressLine1,
+    );
+  });
+
+  it('does not return facilities data for the "Billing and insurance" service type', () => {
+    const serviceTypeMedical = 'Medical Records';
+    const facilityLocationsByType = liquid.filters.healthcareSystemNonClinicalServiceLocationsByType(
+      facilitiesInSystem,
+      serviceTypeMedical,
+    );
+    expect(facilityLocationsByType[0]).to.not.equal(
+      billingAndInsuraceServicesFacilities[0].entityLabel,
+    );
   });
 });

--- a/src/site/layouts/tests/vamc/fixtures/healthcareSystemNonClinicalServiceLocationsByTypeMockData.json
+++ b/src/site/layouts/tests/vamc/fixtures/healthcareSystemNonClinicalServiceLocationsByTypeMockData.json
@@ -1,0 +1,1003 @@
+{
+    "entities": [
+        {
+            "title": "Billing and insurance",
+            "status": true,
+            "changed": 1638901234,
+            "entityBundle": "vamc_system_billing_insurance",
+            "entityUrl": {
+                "path": "/alaska-health-care/billing-and-insurance-0"
+            },
+            "fieldCcTopOfPageContent": {
+                "fetched": {
+                    "fieldWysiwyg": [
+                        {
+                            "value": "<p>Please note that you won’t need to pay any copays for X-rays, lab tests, preventive tests, and services like health screenings or immunizations.</p>\r\n\r\n<h2 id=\"pay-online-by-phoneor-mail\">Pay online, by phone,&nbsp;or mail</h2>\r\n\r\n<p>Find out how to make a payment—and what to do if you're having trouble making payments or you disagree with your bill.</p>\r\n\r\n<p><a class=\"usa-button\" href=\"https://www.va.gov/health-care/pay-copay-bill/\" hreflang=\"en\">Pay online, by phone, or by mail</a></p>\r\n\r\n<h2 id=\"pay-in-person\">Pay in person</h2>\r\n\r\n<p>To pay your copay bill in person, visit the agent cashier's office.</p>\r\n\r\n<p>Please bring your payment stub, along with a check or money order made payable to \"VA.\" Be sure to include your VA account number on the check or money order.</p>\r\n",
+                            "format": "rich_text",
+                            "processed": "<p>Please note that you won’t need to pay any copays for X-rays, lab tests, preventive tests, and services like health screenings or immunizations.</p>\n\n<h2 id=\"pay-online-by-phoneor-mail\">Pay online, by phone, or mail</h2>\n\n<p>Find out how to make a payment—and what to do if you're having trouble making payments or you disagree with your bill.</p>\n\n<p><a class=\"usa-button\" href=\"https://www.va.gov/health-care/pay-copay-bill/\" hreflang=\"en\">Pay online, by phone, or by mail</a></p>\n\n<h2 id=\"pay-in-person\">Pay in person</h2>\n\n<p>To pay your copay bill in person, visit the agent cashier's office.</p>\n\n<p>Please bring your payment stub, along with a check or money order made payable to \"VA.\" Be sure to include your VA account number on the check or money order.</p>"
+                        }
+                    ]
+                },
+                "fetchedBundle": "wysiwyg"
+            },
+            "fieldCcBottomOfPageContent": {
+                "fetched": {
+                    "fieldWysiwyg": [
+                        {
+                            "value": "<h2 id=\"private-and-other-health-insur\">Private and other health insurance</h2>\r\n\r\n<p dir=\"ltr\">If you have another form of health coverage—like Medicare, Medicaid, TRICARE, or a private insurance plan through your&nbsp;spouse’s employer—please bring your insurance card with you to your health care appointment.</p>\r\n\r\n<p><a href=\"https://www.va.gov/health-care/about-va-health-benefits/va-health-care-and-other-insurance/\" hreflang=\"en\">Learn how VA health care works with other health insurance</a></p>\r\n",
+                            "format": "rich_text",
+                            "processed": "<h2 id=\"private-and-other-health-insur\">Private and other health insurance</h2>\n\n<p dir=\"ltr\">If you have another form of health coverage—like Medicare, Medicaid, TRICARE, or a private insurance plan through your spouse’s employer—please bring your insurance card with you to your health care appointment.</p>\n\n<p><a href=\"https://www.va.gov/health-care/about-va-health-benefits/va-health-care-and-other-insurance/\" hreflang=\"en\">Learn how VA health care works with other health insurance</a></p>"
+                        }
+                    ]
+                },
+                "fetchedBundle": "wysiwyg"
+            },
+            "fieldCcRelatedLinks": {
+                "fetched": {
+                    "fieldTitle": [
+                        {
+                            "value": "More information"
+                        }
+                    ],
+                    "fieldVaParagraphs": [
+                        {
+                            "entity": {
+                                "targetId": "82297",
+                                "targetRevisionId": "418175",
+                                "entityType": "paragraph",
+                                "entityBundle": "link_teaser",
+                                "pid": "82297",
+                                "label": "VAMC System - \"Billing and insurance\" page content > Content > Link teasers",
+                                "status": true,
+                                "langcode": "en",
+                                "fieldLink": [
+                                    {
+                                        "uri": "entity:node/703",
+                                        "title": "VA health care copay rates",
+                                        "options": [],
+                                        "url": {
+                                            "path": "/health-care/copay-rates"
+                                        }
+                                    }
+                                ],
+                                "fieldLinkSummary": [
+                                    {
+                                        "value": "Review copay rates for outpatient care, hospital stays, medications, and other health services."
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "entity": {
+                                "targetId": "82298",
+                                "targetRevisionId": "418176",
+                                "entityType": "paragraph",
+                                "entityBundle": "link_teaser",
+                                "pid": "82298",
+                                "label": "VAMC System - \"Billing and insurance\" page content > Content > Link teasers",
+                                "status": true,
+                                "langcode": "en",
+                                "fieldLink": [
+                                    {
+                                        "uri": "entity:node/706",
+                                        "title": "VA financial hardship assistance",
+                                        "options": [],
+                                        "url": {
+                                            "path": "/health-care/pay-copay-bill/financial-hardship"
+                                        }
+                                    }
+                                ],
+                                "fieldLinkSummary": [
+                                    {
+                                        "value": "If you’re struggling to pay your copays, learn how to request a repayment plan, debt relief, or copay exemption."
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "entity": {
+                                "targetId": "82299",
+                                "targetRevisionId": "418177",
+                                "entityType": "paragraph",
+                                "entityBundle": "link_teaser",
+                                "pid": "82299",
+                                "label": "VAMC System - \"Billing and insurance\" page content > Content > Link teasers",
+                                "status": true,
+                                "langcode": "en",
+                                "fieldLink": [
+                                    {
+                                        "uri": "entity:node/705",
+                                        "title": "Dispute your VA copay charges",
+                                        "options": [],
+                                        "url": {
+                                            "path": "/health-care/pay-copay-bill/dispute-charges"
+                                        }
+                                    }
+                                ],
+                                "fieldLinkSummary": [
+                                    {
+                                        "value": "Find out how to file a dispute If you disagree with the charges or amounts on your bill."
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "entity": {
+                                "targetId": "82300",
+                                "targetRevisionId": "418178",
+                                "entityType": "paragraph",
+                                "entityBundle": "link_teaser",
+                                "pid": "82300",
+                                "label": "VAMC System - \"Billing and insurance\" page content > Content > Link teasers",
+                                "status": true,
+                                "langcode": "en",
+                                "fieldLink": [
+                                    {
+                                        "uri": "entity:node/8473",
+                                        "title": "Change your address on file with VA",
+                                        "options": [],
+                                        "url": {
+                                            "path": "/resources/change-your-address-on-file-with-va"
+                                        }
+                                    }
+                                ],
+                                "fieldLinkSummary": [
+                                    {
+                                        "value": "Update your address and other information in your VA.gov profile. This will update your information across several VA benefits and services."
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "fetchedBundle": "list_of_link_teasers"
+            },
+            "fieldOffice": {
+                "entity": {
+                    "entityId": "15032",
+                    "entityLabel": "VA Alaska health care",
+                    "reverseFieldRegionPageNode": {
+                        "entities": [
+                            {
+                                "entityLabel": "Anchorage VA Medical Center",
+                                "fieldFacilityHours": {
+                                    "value": [
+                                        [
+                                            "Mon",
+                                            "730AM-430PM"
+                                        ],
+                                        [
+                                            "Tue",
+                                            "730AM-430PM"
+                                        ],
+                                        [
+                                            "Wed",
+                                            "730AM-430PM"
+                                        ],
+                                        [
+                                            "Thu",
+                                            "730AM-430PM"
+                                        ],
+                                        [
+                                            "Fri",
+                                            "730AM-430PM"
+                                        ],
+                                        [
+                                            "Sat",
+                                            "Closed"
+                                        ],
+                                        [
+                                            "Sun",
+                                            "Closed"
+                                        ]
+                                    ]
+                                },
+                                "fieldAddress": {
+                                    "addressLine1": "1201 North Muldoon Road",
+                                    "addressLine2": null,
+                                    "postalCode": "99504-6104",
+                                    "locality": "Anchorage",
+                                    "administrativeArea": "AK"
+                                },
+                                "reverseFieldFacilityLocationNode": {
+                                    "entities": [
+                                        {
+                                            "entityId": "41814",
+                                            "fieldServiceNameAndDescripti": {
+                                                "entity": {
+                                                    "entityId": "1026",
+                                                    "entityLabel": "Medical records",
+                                                    "name": "Medical records"
+                                                },
+                                                "targetId": 1026
+                                            },
+                                            "fieldServiceLocation": [
+                                                {
+                                                    "entity": {
+                                                        "status": true,
+                                                        "fieldAdditionalHoursInfo": null,
+                                                        "fieldEmailContacts": [],
+                                                        "fieldFacilityServiceHours": {
+                                                            "value": [
+                                                                [
+                                                                    "Mon",
+                                                                    ""
+                                                                ],
+                                                                [
+                                                                    "Tue",
+                                                                    ""
+                                                                ],
+                                                                [
+                                                                    "Wed",
+                                                                    ""
+                                                                ],
+                                                                [
+                                                                    "Thu",
+                                                                    ""
+                                                                ],
+                                                                [
+                                                                    "Fri",
+                                                                    ""
+                                                                ],
+                                                                [
+                                                                    "Sat",
+                                                                    ""
+                                                                ],
+                                                                [
+                                                                    "Sun",
+                                                                    ""
+                                                                ]
+                                                            ]
+                                                        },
+                                                        "fieldHours": "0",
+                                                        "fieldPhone": [],
+                                                        "fieldUseMainFacilityPhone": true,
+                                                        "fieldServiceLocationAddress": {
+                                                            "entity": {
+                                                                "fieldUseFacilityAddress": true,
+                                                                "fieldBuildingNameNumber": null,
+                                                                "fieldClinicName": null,
+                                                                "fieldWingFloorOrRoomNumber": null,
+                                                                "fieldAddress": {
+                                                                    "addressLine1": "",
+                                                                    "addressLine2": "",
+                                                                    "postalCode": "",
+                                                                    "locality": "",
+                                                                    "administrativeArea": ""
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "entityId": "41817",
+                                            "fieldServiceNameAndDescripti": {
+                                                "entity": {
+                                                    "entityId": "1027",
+                                                    "entityLabel": "Billing and insurance",
+                                                    "name": "Billing and insurance"
+                                                },
+                                                "targetId": 1027
+                                            },
+                                            "fieldServiceLocation": [
+                                                {
+                                                    "entity": {
+                                                        "status": true,
+                                                        "fieldAdditionalHoursInfo": null,
+                                                        "fieldEmailContacts": [],
+                                                        "fieldFacilityServiceHours": {
+                                                            "value": [
+                                                                [
+                                                                    "Mon",
+                                                                    "9:00 a.m. to 5:00 p.m. ET"
+                                                                ],
+                                                                [
+                                                                    "Tue",
+                                                                    "9:00 a.m. to 5:00 p.m. ET"
+                                                                ],
+                                                                [
+                                                                    "Wed",
+                                                                    "9:00 a.m. to 5:00 p.m. ET"
+                                                                ],
+                                                                [
+                                                                    "Thu",
+                                                                    "9:00 a.m. to 5:00 p.m. ET"
+                                                                ],
+                                                                [
+                                                                    "Fri",
+                                                                    "9:00 a.m. to 5:00 p.m. ET"
+                                                                ],
+                                                                [
+                                                                    "Sat",
+                                                                    "Closed"
+                                                                ],
+                                                                [
+                                                                    "Sun",
+                                                                    "Closed"
+                                                                ]
+                                                            ]
+                                                        },
+                                                        "fieldHours": "2",
+                                                        "fieldPhone": [],
+                                                        "fieldUseMainFacilityPhone": true,
+                                                        "fieldServiceLocationAddress": {
+                                                            "entity": {
+                                                                "fieldUseFacilityAddress": true,
+                                                                "fieldBuildingNameNumber": "Building 1",
+                                                                "fieldClinicName": "Anchorage A",
+                                                                "fieldWingFloorOrRoomNumber": "Floor 3",
+                                                                "fieldAddress": {
+                                                                    "addressLine1": "",
+                                                                    "addressLine2": "",
+                                                                    "postalCode": "",
+                                                                    "locality": "",
+                                                                    "administrativeArea": ""
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "entityId": "41820",
+                                            "fieldServiceNameAndDescripti": {
+                                                "entity": {
+                                                    "entityId": "1025",
+                                                    "entityLabel": "Register for care",
+                                                    "name": "Register for care"
+                                                },
+                                                "targetId": 1025
+                                            },
+                                            "fieldServiceLocation": [
+                                                {
+                                                    "entity": {
+                                                        "status": true,
+                                                        "fieldAdditionalHoursInfo": "Appointments may be available outside these hours, please call",
+                                                        "fieldEmailContacts": [
+                                                            {
+                                                                "entity": {
+                                                                    "fieldEmailLabel": "Register for care test Aman",
+                                                                    "fieldEmailAddress": "amantest@registerforcare.com"
+                                                                }
+                                                            }
+                                                        ],
+                                                        "fieldFacilityServiceHours": {
+                                                            "value": [
+                                                                [
+                                                                    "Mon",
+                                                                    "24/7"
+                                                                ],
+                                                                [
+                                                                    "Tue",
+                                                                    "24/7"
+                                                                ],
+                                                                [
+                                                                    "Wed",
+                                                                    "24/7"
+                                                                ],
+                                                                [
+                                                                    "Thu",
+                                                                    "24/7"
+                                                                ],
+                                                                [
+                                                                    "Fri",
+                                                                    "24/7"
+                                                                ],
+                                                                [
+                                                                    "Sat",
+                                                                    ""
+                                                                ],
+                                                                [
+                                                                    "Sun",
+                                                                    ""
+                                                                ]
+                                                            ]
+                                                        },
+                                                        "fieldHours": "2",
+                                                        "fieldPhone": [
+                                                            {
+                                                                "entity": {
+                                                                    "fieldPhoneLabel": "Homer Office Number",
+                                                                    "fieldPhoneNumber": "123-456-7890",
+                                                                    "fieldPhoneExtension": null,
+                                                                    "fieldPhoneNumberType": "tel"
+                                                                }
+                                                            },
+                                                            {
+                                                                "entity": {
+                                                                    "fieldPhoneLabel": "Home office number 2",
+                                                                    "fieldPhoneNumber": "123-456-7777",
+                                                                    "fieldPhoneExtension": null,
+                                                                    "fieldPhoneNumberType": "tel"
+                                                                }
+                                                            }
+                                                        ],
+                                                        "fieldUseMainFacilityPhone": false,
+                                                        "fieldServiceLocationAddress": {
+                                                            "entity": {
+                                                                "fieldUseFacilityAddress": true,
+                                                                "fieldBuildingNameNumber": null,
+                                                                "fieldClinicName": null,
+                                                                "fieldWingFloorOrRoomNumber": null,
+                                                                "fieldAddress": {
+                                                                    "addressLine1": "",
+                                                                    "addressLine2": "",
+                                                                    "postalCode": "",
+                                                                    "locality": "",
+                                                                    "administrativeArea": ""
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "entityLabel": "Fairbanks VA Clinic",
+                                "fieldFacilityHours": {
+                                    "value": [
+                                        [
+                                            "Mon",
+                                            "730AM-400PM"
+                                        ],
+                                        [
+                                            "Tue",
+                                            "730AM-400PM"
+                                        ],
+                                        [
+                                            "Wed",
+                                            "730AM-400PM"
+                                        ],
+                                        [
+                                            "Thu",
+                                            "730AM-400PM"
+                                        ],
+                                        [
+                                            "Fri",
+                                            "730AM-400PM"
+                                        ],
+                                        [
+                                            "Sat",
+                                            "Closed"
+                                        ],
+                                        [
+                                            "Sun",
+                                            "Closed"
+                                        ]
+                                    ]
+                                },
+                                "fieldAddress": {
+                                    "addressLine1": "4076 Neeley Road, Room 1J-101",
+                                    "addressLine2": null,
+                                    "postalCode": "99703-1110",
+                                    "locality": "Fort Wainwright",
+                                    "administrativeArea": "AK"
+                                },
+                                "reverseFieldFacilityLocationNode": {
+                                    "entities": [
+                                        {
+                                            "entityId": "41815",
+                                            "fieldServiceNameAndDescripti": {
+                                                "entity": {
+                                                    "entityId": "1026",
+                                                    "entityLabel": "Medical records",
+                                                    "name": "Medical records"
+                                                },
+                                                "targetId": 1026
+                                            },
+                                            "fieldServiceLocation": [
+                                                {
+                                                    "entity": {
+                                                        "status": true,
+                                                        "fieldAdditionalHoursInfo": "Aman test:Appointments may be available outside these hours, please call",
+                                                        "fieldEmailContacts": [
+                                                            {
+                                                                "entity": {
+                                                                    "fieldEmailLabel": "Email for Anchorage office",
+                                                                    "fieldEmailAddress": "test@test.com"
+                                                                }
+                                                            }
+                                                        ],
+                                                        "fieldFacilityServiceHours": {
+                                                            "value": [
+                                                                [
+                                                                    "Mon",
+                                                                    "24/7"
+                                                                ],
+                                                                [
+                                                                    "Tue",
+                                                                    "24/7"
+                                                                ],
+                                                                [
+                                                                    "Wed",
+                                                                    "8:00 a.m. to 5:30 p.m. ET"
+                                                                ],
+                                                                [
+                                                                    "Thu",
+                                                                    "9:00 a.m. to 5:30 p.m. ET"
+                                                                ],
+                                                                [
+                                                                    "Fri",
+                                                                    "24/7"
+                                                                ],
+                                                                [
+                                                                    "Sat",
+                                                                    ""
+                                                                ],
+                                                                [
+                                                                    "Sun",
+                                                                    ""
+                                                                ]
+                                                            ]
+                                                        },
+                                                        "fieldHours": "2",
+                                                        "fieldPhone": [
+                                                            {
+                                                                "entity": {
+                                                                    "fieldPhoneLabel": "Anchorage Office",
+                                                                    "fieldPhoneNumber": "111-111-1111",
+                                                                    "fieldPhoneExtension": null,
+                                                                    "fieldPhoneNumberType": "tel"
+                                                                }
+                                                            },
+                                                            {
+                                                                "entity": {
+                                                                    "fieldPhoneLabel": "Anchorage Office",
+                                                                    "fieldPhoneNumber": "222-222-2222",
+                                                                    "fieldPhoneExtension": null,
+                                                                    "fieldPhoneNumberType": "tel"
+                                                                }
+                                                            }
+                                                        ],
+                                                        "fieldUseMainFacilityPhone": false,
+                                                        "fieldServiceLocationAddress": {
+                                                            "entity": {
+                                                                "fieldUseFacilityAddress": false,
+                                                                "fieldBuildingNameNumber": "Building 11",
+                                                                "fieldClinicName": "Fraibank VA (Aman) A",
+                                                                "fieldWingFloorOrRoomNumber": "Floor 12, Room Number 1002",
+                                                                "fieldAddress": {
+                                                                    "addressLine1": "1234 Main St",
+                                                                    "addressLine2": "Aman test",
+                                                                    "postalCode": "99501",
+                                                                    "locality": "Anchorage",
+                                                                    "administrativeArea": "AK"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "entity": {
+                                                        "status": true,
+                                                        "fieldAdditionalHoursInfo": "Testing using facility hours",
+                                                        "fieldEmailContacts": [
+                                                            {
+                                                                "entity": {
+                                                                    "fieldEmailLabel": "testing ",
+                                                                    "fieldEmailAddress": "amantest@test.com"
+                                                                }
+                                                            }
+                                                        ],
+                                                        "fieldFacilityServiceHours": {
+                                                            "value": [
+                                                                [
+                                                                    "Mon",
+                                                                    ""
+                                                                ],
+                                                                [
+                                                                    "Tue",
+                                                                    ""
+                                                                ],
+                                                                [
+                                                                    "Wed",
+                                                                    ""
+                                                                ],
+                                                                [
+                                                                    "Thu",
+                                                                    ""
+                                                                ],
+                                                                [
+                                                                    "Fri",
+                                                                    ""
+                                                                ],
+                                                                [
+                                                                    "Sat",
+                                                                    ""
+                                                                ],
+                                                                [
+                                                                    "Sun",
+                                                                    ""
+                                                                ]
+                                                            ]
+                                                        },
+                                                        "fieldHours": "0",
+                                                        "fieldPhone": [],
+                                                        "fieldUseMainFacilityPhone": true,
+                                                        "fieldServiceLocationAddress": {
+                                                            "entity": {
+                                                                "fieldUseFacilityAddress": true,
+                                                                "fieldBuildingNameNumber": null,
+                                                                "fieldClinicName": null,
+                                                                "fieldWingFloorOrRoomNumber": null,
+                                                                "fieldAddress": {
+                                                                    "addressLine1": "",
+                                                                    "addressLine2": "",
+                                                                    "postalCode": "",
+                                                                    "locality": "",
+                                                                    "administrativeArea": ""
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "entityId": "41818",
+                                            "fieldServiceNameAndDescripti": {
+                                                "entity": {
+                                                    "entityId": "1027",
+                                                    "entityLabel": "Billing and insurance",
+                                                    "name": "Billing and insurance"
+                                                },
+                                                "targetId": 1027
+                                            },
+                                            "fieldServiceLocation": [
+                                                {
+                                                    "entity": {
+                                                        "status": true,
+                                                        "fieldAdditionalHoursInfo": null,
+                                                        "fieldEmailContacts": [],
+                                                        "fieldFacilityServiceHours": {
+                                                            "value": [
+                                                                [
+                                                                    "Mon",
+                                                                    "24/7"
+                                                                ],
+                                                                [
+                                                                    "Tue",
+                                                                    "8:00 a.m. to 5:30 p.m. ET"
+                                                                ],
+                                                                [
+                                                                    "Wed",
+                                                                    "24/7"
+                                                                ],
+                                                                [
+                                                                    "Thu",
+                                                                    "8:00 a.m. to 5:30 p.m. ET"
+                                                                ],
+                                                                [
+                                                                    "Fri",
+                                                                    "24/7"
+                                                                ],
+                                                                [
+                                                                    "Sat",
+                                                                    ""
+                                                                ],
+                                                                [
+                                                                    "Sun",
+                                                                    ""
+                                                                ]
+                                                            ]
+                                                        },
+                                                        "fieldHours": "2",
+                                                        "fieldPhone": [],
+                                                        "fieldUseMainFacilityPhone": false,
+                                                        "fieldServiceLocationAddress": {
+                                                            "entity": {
+                                                                "fieldUseFacilityAddress": false,
+                                                                "fieldBuildingNameNumber": "Building 100",
+                                                                "fieldClinicName": "Fairbanks A",
+                                                                "fieldWingFloorOrRoomNumber": "Room 301",
+                                                                "fieldAddress": {
+                                                                    "addressLine1": "1234 Street A",
+                                                                    "addressLine2": "",
+                                                                    "postalCode": "99703",
+                                                                    "locality": "Fairbanks",
+                                                                    "administrativeArea": "AK"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "entity": {
+                                                        "status": true,
+                                                        "fieldAdditionalHoursInfo": null,
+                                                        "fieldEmailContacts": [],
+                                                        "fieldFacilityServiceHours": {
+                                                            "value": [
+                                                                [
+                                                                    "Mon",
+                                                                    ""
+                                                                ],
+                                                                [
+                                                                    "Tue",
+                                                                    ""
+                                                                ],
+                                                                [
+                                                                    "Wed",
+                                                                    ""
+                                                                ],
+                                                                [
+                                                                    "Thu",
+                                                                    ""
+                                                                ],
+                                                                [
+                                                                    "Fri",
+                                                                    ""
+                                                                ],
+                                                                [
+                                                                    "Sat",
+                                                                    ""
+                                                                ],
+                                                                [
+                                                                    "Sun",
+                                                                    ""
+                                                                ]
+                                                            ]
+                                                        },
+                                                        "fieldHours": "0",
+                                                        "fieldPhone": [],
+                                                        "fieldUseMainFacilityPhone": true,
+                                                        "fieldServiceLocationAddress": {
+                                                            "entity": {
+                                                                "fieldUseFacilityAddress": true,
+                                                                "fieldBuildingNameNumber": "Building 200",
+                                                                "fieldClinicName": "Fairbanks B",
+                                                                "fieldWingFloorOrRoomNumber": "Room 402",
+                                                                "fieldAddress": {
+                                                                    "addressLine1": "",
+                                                                    "addressLine2": "",
+                                                                    "postalCode": "",
+                                                                    "locality": "",
+                                                                    "administrativeArea": ""
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "entityLabel": "Kenai VA Clinic",
+                                "fieldFacilityHours": {
+                                    "value": [
+                                        [
+                                            "Mon",
+                                            "730AM-400PM"
+                                        ],
+                                        [
+                                            "Tue",
+                                            "730AM-400PM"
+                                        ],
+                                        [
+                                            "Wed",
+                                            "730AM-400PM"
+                                        ],
+                                        [
+                                            "Thu",
+                                            "730AM-400PM"
+                                        ],
+                                        [
+                                            "Fri",
+                                            "730AM-400PM"
+                                        ],
+                                        [
+                                            "Sat",
+                                            "Closed"
+                                        ],
+                                        [
+                                            "Sun",
+                                            "Closed"
+                                        ]
+                                    ]
+                                },
+                                "fieldAddress": {
+                                    "addressLine1": "240 Hospital Place, Central Peninsula Hospital, Suite 105",
+                                    "addressLine2": null,
+                                    "postalCode": "99669-7559",
+                                    "locality": "Soldotna",
+                                    "administrativeArea": "AK"
+                                },
+                                "reverseFieldFacilityLocationNode": {
+                                    "entities": []
+                                }
+                            },
+                            {
+                                "entityLabel": "Homer VA Clinic",
+                                "fieldFacilityHours": {
+                                    "value": [
+                                        [
+                                            "Mon",
+                                            "800AM-400PM"
+                                        ],
+                                        [
+                                            "Tue",
+                                            "800AM-400PM"
+                                        ],
+                                        [
+                                            "Wed",
+                                            "800AM-400PM"
+                                        ],
+                                        [
+                                            "Thu",
+                                            "Closed"
+                                        ],
+                                        [
+                                            "Fri",
+                                            "Closed"
+                                        ],
+                                        [
+                                            "Sat",
+                                            "Closed"
+                                        ],
+                                        [
+                                            "Sun",
+                                            "Closed"
+                                        ]
+                                    ]
+                                },
+                                "fieldAddress": {
+                                    "addressLine1": "4141 Pennock Street",
+                                    "addressLine2": null,
+                                    "postalCode": "99603-7223",
+                                    "locality": "Homer",
+                                    "administrativeArea": "AK"
+                                },
+                                "reverseFieldFacilityLocationNode": {
+                                    "entities": []
+                                }
+                            },
+                            {
+                                "entityLabel": "Juneau VA Clinic",
+                                "fieldFacilityHours": {
+                                    "value": [
+                                        [
+                                            "Mon",
+                                            "730AM-400PM"
+                                        ],
+                                        [
+                                            "Tue",
+                                            "730AM-400PM"
+                                        ],
+                                        [
+                                            "Wed",
+                                            "730AM-400PM"
+                                        ],
+                                        [
+                                            "Thu",
+                                            "730AM-400PM"
+                                        ],
+                                        [
+                                            "Fri",
+                                            "730AM-400PM"
+                                        ],
+                                        [
+                                            "Sat",
+                                            "Closed"
+                                        ],
+                                        [
+                                            "Sun",
+                                            "Closed"
+                                        ]
+                                    ]
+                                },
+                                "fieldAddress": {
+                                    "addressLine1": "709 West 9th Street, Federal Building, Suite 150",
+                                    "addressLine2": null,
+                                    "postalCode": "99801-1807",
+                                    "locality": "Juneau",
+                                    "administrativeArea": "AK"
+                                },
+                                "reverseFieldFacilityLocationNode": {
+                                    "entities": []
+                                }
+                            },
+                            {
+                                "entityLabel": "Mat-Su VA Clinic",
+                                "fieldFacilityHours": {
+                                    "value": [
+                                        [
+                                            "Mon",
+                                            "730AM-400PM"
+                                        ],
+                                        [
+                                            "Tue",
+                                            "730AM-400PM"
+                                        ],
+                                        [
+                                            "Wed",
+                                            "730AM-400PM"
+                                        ],
+                                        [
+                                            "Thu",
+                                            "730AM-400PM"
+                                        ],
+                                        [
+                                            "Fri",
+                                            "730AM-400PM"
+                                        ],
+                                        [
+                                            "Sat",
+                                            "Closed"
+                                        ],
+                                        [
+                                            "Sun",
+                                            "Closed"
+                                        ]
+                                    ]
+                                },
+                                "fieldAddress": {
+                                    "addressLine1": "865 North Seward Meridian Parkway, Suite 105",
+                                    "addressLine2": null,
+                                    "postalCode": "99654-7241",
+                                    "locality": "Wasilla",
+                                    "administrativeArea": "AK"
+                                },
+                                "reverseFieldFacilityLocationNode": {
+                                    "entities": []
+                                }
+                            },
+                            {
+                                "entityLabel": "Elmendorf-Richardson VA Clinic",
+                                "fieldFacilityHours": {
+                                    "value": [
+                                        [
+                                            "Mon",
+                                            "800AM-430PM"
+                                        ],
+                                        [
+                                            "Tue",
+                                            "800AM-430PM"
+                                        ],
+                                        [
+                                            "Wed",
+                                            "800AM-430PM"
+                                        ],
+                                        [
+                                            "Thu",
+                                            "800AM-430PM"
+                                        ],
+                                        [
+                                            "Fri",
+                                            "800AM-430PM"
+                                        ],
+                                        [
+                                            "Sat",
+                                            "Closed"
+                                        ],
+                                        [
+                                            "Sun",
+                                            "Closed"
+                                        ]
+                                    ]
+                                },
+                                "fieldAddress": {
+                                    "addressLine1": "5955 Zeamer Avenue, 673rd Medical Group, Building 673",
+                                    "addressLine2": null,
+                                    "postalCode": "99506-3702",
+                                    "locality": "Joint Base Elmendorf-Richardson",
+                                    "administrativeArea": "AK"
+                                },
+                                "reverseFieldFacilityLocationNode": {
+                                    "entities": []
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionNonClinicialServices.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionNonClinicialServices.node.graphql.js
@@ -1,0 +1,92 @@
+/**
+ * Non-clincial services at all facilities within a health care system
+ */
+const FIELD_ADDRESS = `
+  fieldAddress {
+    addressLine1
+    addressLine2
+    postalCode
+    locality
+    administrativeArea
+  }
+`;
+
+module.exports = `
+  entity {
+    entityId
+    entityLabel
+    reverseFieldRegionPageNode(limit: 50, filter: {conditions: [{field: "type", value: ["health_care_local_facility"]}]}) {
+      entities {
+        ... on NodeHealthCareLocalFacility {
+          entityLabel
+          ${FIELD_ADDRESS}
+          reverseFieldFacilityLocationNode(limit: 50, filter: {
+            conditions: [
+              {
+                field: "type", value: ["vha_facility_nonclinical_service"]
+              }
+            ]
+          }) {
+            entities {
+              ... on NodeVhaFacilityNonclinicalService {
+                entityId
+                fieldServiceNameAndDescripti {
+                  entity {
+                    entityId
+                    entityLabel
+                    name
+                  }
+                  targetId
+                }
+                fieldServiceLocation {
+                  entity {
+                    status
+                  ... on ParagraphServiceLocation {
+                    fieldAdditionalHoursInfo
+                    fieldEmailContacts {
+                      entity {
+                        ... on ParagraphEmailContact {
+                        	fieldEmailLabel
+                          fieldEmailAddress
+                        }
+                      }
+                    }
+                    fieldFacilityServiceHours {
+                      tableValue
+                      value
+                    }
+                    fieldHours
+                    fieldPhone {
+                      entity {
+                        ... on ParagraphPhoneNumber {
+                          fieldPhoneLabel
+                          fieldPhoneNumber
+                          fieldPhoneExtension
+                          fieldPhoneNumberType
+                        }
+                      }
+                    }
+                    fieldUseMainFacilityPhone
+                      fieldServiceLocationAddress {
+                        entity {
+                          ... on ParagraphServiceLocationAddress {
+                            fieldUseFacilityAddress
+                            fieldBuildingNameNumber
+                            fieldClinicName
+                            fieldUseFacilityAddress
+                            fieldWingFloorOrRoomNumber
+                            ${FIELD_ADDRESS}
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;

--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionNonClinicialServices.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionNonClinicialServices.node.graphql.js
@@ -19,6 +19,9 @@ module.exports = `
       entities {
         ... on NodeHealthCareLocalFacility {
           entityLabel
+          fieldFacilityHours {
+            value
+          }
           ${FIELD_ADDRESS}
           reverseFieldFacilityLocationNode(limit: 50, filter: {
             conditions: [
@@ -52,7 +55,6 @@ module.exports = `
                       }
                     }
                     fieldFacilityServiceHours {
-                      tableValue
                       value
                     }
                     fieldHours


### PR DESCRIPTION
## Description
- Adds GraphQL fragment (`facilities-fragments/healthCareRegionNonClinicialServices.node.graphql.js`) that can be shared between top-task pages.
- Adds filter in `liquid.js` to pare down result from the query mentioned above.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
