### PR TITLE
Wait for the CMS to be ready before triggering govdelivery

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -569,6 +569,9 @@ jobs:
           SRC: s3://vetsgov-website-builds-s3-upload/content-build/${{needs.set-env.outputs.REF}}/${{needs.set-env.outputs.BUILDTYPE}}.tar.bz2
           DEST: s3://${{ needs.set-env.outputs.DEPLOY_BUCKET }}
 
+      - name: Wait for the CMS to be ready
+        uses: ./.github/workflows/wait-for-cms-ready
+
       - name: CMS GovDelivery callback
         uses: fjogeleit/http-request-action@master
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -845,6 +845,11 @@ jobs:
           SRC: s3://vetsgov-website-builds-s3-upload/content-build/${{ github.sha }}/${{ matrix.environment }}.tar.bz2
           DEST: s3://${{ matrix.bucket }}
 
+      - name: Wait for the CMS to be ready
+        uses: ./.github/workflows/wait-for-cms-ready
+        with:
+          base_url: https://staging.cms.va.gov
+
       - name: CMS GovDelivery callback
         if: ${{ matrix.environment == 'vagovstaging' }}
         uses: fjogeleit/http-request-action@master

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -492,6 +492,9 @@ jobs:
           SRC: s3://vetsgov-website-builds-s3-upload/content-build/${{ needs.set-env.outputs.COMMIT_SHA }}/${{ env.ENVIRONMENT }}.tar.bz2
           DEST: s3://${{ env.BUCKET }}
 
+      - name: Wait for the CMS to be ready
+        uses: ./.github/workflows/wait-for-cms-ready
+
       - name: CMS GovDelivery callback
         uses: fjogeleit/http-request-action@master
         with:

--- a/.github/workflows/wait-for-cms-ready/action.yml
+++ b/.github/workflows/wait-for-cms-ready/action.yml
@@ -1,3 +1,5 @@
+# TODO: Consider moving the govdelivery callback into this action.
+# See https://github.com/department-of-veterans-affairs/content-build/pull/832#pullrequestreview-827896343
 name: Wait for CMS to be ready
 description: Pause until we know that the CMS is online and ready to go
 

--- a/.github/workflows/wait-for-cms-ready/action.yml
+++ b/.github/workflows/wait-for-cms-ready/action.yml
@@ -11,9 +11,9 @@ inputs:
     required: false
     default: '15'
   timeout:
-    description: how long should we wait for the cms to be ready (in minutes)
+    description: how long should we wait for the cms to be ready (in seconds)
     required: false
-    default: '30'
+    default: '1800'
 
 runs:
   using: composite

--- a/.github/workflows/wait-for-cms-ready/action.yml
+++ b/.github/workflows/wait-for-cms-ready/action.yml
@@ -3,7 +3,7 @@ description: Pause until we know that the CMS is online and ready to go
 
 inputs:
   base_url:
-    description: base url for the cms environment to wait for
+    description: Base url for the cms environment to wait for
     required: false
     default: 'https://prod.cms.va.gov'
   interval:

--- a/.github/workflows/wait-for-cms-ready/action.yml
+++ b/.github/workflows/wait-for-cms-ready/action.yml
@@ -11,7 +11,7 @@ inputs:
     required: false
     default: '15'
   timeout:
-    description: how long should we wait for the cms to be ready (in seconds)
+    description: How long should we wait for the cms to be ready (in seconds)
     required: false
     default: '1800'
 

--- a/.github/workflows/wait-for-cms-ready/action.yml
+++ b/.github/workflows/wait-for-cms-ready/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: false
     default: 'https://prod.cms.va.gov'
   interval:
-    description: how often to poll the environment for status (in seconds)
+    description: How often to poll the environment for status (in seconds)
     required: false
     default: '15'
   timeout:

--- a/.github/workflows/wait-for-cms-ready/action.yml
+++ b/.github/workflows/wait-for-cms-ready/action.yml
@@ -1,0 +1,41 @@
+name: Wait for CMS to be ready
+description: Pause until we know that the CMS is online and ready to go
+
+inputs:
+  base_url:
+    description: base url for the cms environment to wait for
+    required: false
+    default: 'https://prod.cms.va.gov'
+  interval:
+    description: how often to poll the environment for status (in seconds)
+    required: false
+    default: '15'
+  timeout:
+    description: how long should we wait for the cms to be ready (in minutes)
+    required: false
+    default: '30'
+
+runs:
+  using: composite
+  steps:
+    - name: Wait for CMS to be ready
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      run: |
+        timer=0
+
+        while true
+        do
+          if [ $timer -gt ${{ inputs.timeout }} ]; then
+            echo "Timeout exceeded."
+            exit 1
+          fi
+
+          if [[ "$(curl -s -o /dev/null -w '%{http_code}' ${{ inputs.base_url }})" != "200" ]]; then
+            sleep ${{ inputs.interval }}
+            timer=$(($timer + ${{ inputs.interval }}))
+          else
+            echo "Ready!"
+            break
+          fi
+        done


### PR DESCRIPTION
## Description

In the past few days, there have been a number of content release failures related to trying to do stuff while the CMS is deploying.

Here are a couple of examples:

* https://github.com/department-of-veterans-affairs/content-build/actions/runs/1555528870
* https://github.com/department-of-veterans-affairs/content-build/actions/runs/1532069013

Instead of just sending the request, let's wait for the CMS to be ready and _then_ send the request. This needs some testing, which I will do in a separate PR so as not to pollute the Git history.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
