### PR TITLE
VACMS-7163: Add lovell-federal-health-care menu to VISN 12  facilitySidebar

### DIFF
--- a/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
+++ b/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
@@ -87,6 +87,7 @@ const FACILITY_MENU_NAMES = [
   'va-northern-indiana-health-care',
   'va-saginaw-health-care',
   // VISN 12
+  'lovell-federal-health-care',
   'va-lovell-federal-health-care',
   'va-chicago-health-care',
   'va-hines-health-care',


### PR DESCRIPTION
- Updated "facilitySidebar.nav.graphql.js", added the new "lovell-federal-health-care" menu machine name to the VISN 12 section.

## Description

related to #7163

## Testing done

All test passes.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
