### PR TITLE
Add empty alt value

### DIFF
--- a/src/site/includes/top-nav.html
+++ b/src/site/includes/top-nav.html
@@ -20,7 +20,7 @@
         <div class="va-crisis-line-inner">
           <span class="va-crisis-line-icon" aria-hidden="true"></span>
           <span class="va-crisis-line-text" onClick="recordEvent({ event: 'nav-jumplink-click' });">Talk to the <strong>Veterans Crisis Line</strong> now</span>
-          <img class="va-crisis-line-arrow" src="/img/arrow-right-white.svg" aria-hidden="true"></img>
+          <img alt="" aria-hidden="true" class="va-crisis-line-arrow" src="/img/arrow-right-white.svg"></img>
         </div>
       </button>
     </div>


### PR DESCRIPTION
# Description

**Issue:** 
https://github.com/department-of-veterans-affairs/va.gov-team/issues/33650

**Slack:** https://dsva.slack.com/archives/C8E985R32/p1638568029035700?thread_ts=1638566761.034300&cid=C8E985R32

This PR adds an empty `alt=""` value for the arrow in VCL.
