### PR TITLE
Wait for the CMS to be ready before running graphql queries

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -283,6 +283,9 @@ jobs:
         env:
           YARN_CACHE_FOLDER: .cache/yarn
 
+      - name: Wait for the CMS to be ready
+        uses: ./.github/workflows/wait-for-cms-ready
+
       - name: Export content build start time
         id: export-content-build-start-time
         run: echo ::set-output name=CONTENT_BUILD_START_TIME::$(date +"%s")

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -284,7 +284,7 @@ jobs:
           YARN_CACHE_FOLDER: .cache/yarn
 
       - name: Wait for the CMS to be ready
-        uses: ./.github/workflows/wait-for-cms-ready
+        uses: ./content-build/.github/workflows/wait-for-cms-ready
 
       - name: Export content build start time
         id: export-content-build-start-time

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -176,7 +176,7 @@ jobs:
           echo "${{ matrix.buildtype }}_buildtime=$BUILDTIME" >> $GITHUB_ENV
 
       - name: Wait for the CMS to be ready
-        uses: ./.github/workflows/wait-for-cms-ready
+        uses: ./content-build/.github/workflows/wait-for-cms-ready
         with:
           base_url: ${{ matrix.drupal-address }}
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -175,6 +175,11 @@ jobs:
           echo ::set-output name=buildtime::$BUILDTIME
           echo "${{ matrix.buildtype }}_buildtime=$BUILDTIME" >> $GITHUB_ENV
 
+      - name: Wait for the CMS to be ready
+        uses: ./.github/workflows/wait-for-cms-ready
+        with:
+          base_url: ${{ matrix.drupal-address }}
+
       - name: Build
         run: yarn build --buildtype=${{ matrix.buildtype }} --asset-source=local --drupal-address=${{ env.DRUPAL_ADDRESS }} --pull-drupal --drupal-max-parallel-requests=15 --no-drupal-proxy --verbose
         env:

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -257,6 +257,9 @@ jobs:
           echo ::set-output name=buildtime::$BUILDTIME
           echo "${{ env.BUILDTYPE }}_buildtime=$BUILDTIME" >> $GITHUB_ENV
 
+      - name: Wait for the CMS to be ready
+        uses: ./.github/workflows/wait-for-cms-ready
+
       - name: Build
         run: yarn build --buildtype=${{ env.BUILDTYPE }} --drupal-address='${{ env.DRUPAL_ADDRESS }}' --no-drupal-proxy
         timeout-minutes: 30

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -258,7 +258,7 @@ jobs:
           echo "${{ env.BUILDTYPE }}_buildtime=$BUILDTIME" >> $GITHUB_ENV
 
       - name: Wait for the CMS to be ready
-        uses: ./.github/workflows/wait-for-cms-ready
+        uses: ./content-build/.github/workflows/wait-for-cms-ready
 
       - name: Build
         run: yarn build --buildtype=${{ env.BUILDTYPE }} --drupal-address='${{ env.DRUPAL_ADDRESS }}' --no-drupal-proxy

--- a/.github/workflows/wait-for-cms-ready/action.yml
+++ b/.github/workflows/wait-for-cms-ready/action.yml
@@ -1,5 +1,3 @@
-# TODO: Consider moving the govdelivery callback into this action.
-# See https://github.com/department-of-veterans-affairs/content-build/pull/832#pullrequestreview-827896343
 name: Wait for CMS to be ready
 description: Pause until we know that the CMS is online and ready to go
 


### PR DESCRIPTION
## Description

Follow-up to #832. There was a failure today resulting from the CMS being mid-deploy when the graphql queries were attempted. This PR should reduce the chances of that happening.

(There is still a potential failure mode where the CMS is ready before the graphql queries start, but the CMS goes down _during_ the graphql queries. There's not much that can be done about that at this point.)

Related ticket: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/7242

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
