### PR TITLE
VACMS-7163: Remove "va-lovell-federal-health-care" menu from "facilitySidebar.nav.graphql.js" VISN 12 section

### DIFF
--- a/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
+++ b/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
@@ -88,7 +88,6 @@ const FACILITY_MENU_NAMES = [
   'va-saginaw-health-care',
   // VISN 12
   'lovell-federal-health-care',
-  'va-lovell-federal-health-care',
   'va-chicago-health-care',
   'va-hines-health-care',
   'va-illiana-health-care',


### PR DESCRIPTION
- Removed "va-lovell-federal-health-care" menu from "facilitySidebar.nav.graphql.js" VISN 12 section.

## Description

closes #7163

## Testing done

All tests passes

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
