### PR TITLE
Updating GIBCT url to being with /education

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -691,7 +691,7 @@
   {
     "appName": "GI Bill Comparison Tool",
     "entryName": "gi",
-    "rootUrl": "/gi-bill-comparison-tool",
+    "rootUrl": "/education/gi-bill-comparison-tool",
     "template": {
       "title": "GI Bill Comparison Tool",
       "display_title": "GI Bill school comparison",
@@ -705,7 +705,7 @@
   {
     "appName": "CT Redesign Sandbox",
     "entryName": "gi-sandbox",
-    "rootUrl": "/gi-bill-comparison-tool-sandbox",
+    "rootUrl": "/education/gi-bill-comparison-tool-sandbox",
     "template": {
       "vagovprod": false,
       "title": "CT Redesign Sandbox",

--- a/src/site/includes/common-and-popular.html
+++ b/src/site/includes/common-and-popular.html
@@ -20,7 +20,7 @@
         <a href="/find-locations/">Find nearby VA locations</a>
       </li>
       <li>
-        <a href="/gi-bill-comparison-tool">View education benefits available by school</a>
+        <a href="/education/gi-bill-comparison-tool">View education benefits available by school</a>
       </li>
       <li>
         <a target="_blank" href="https://www.veteranscrisisline.net/" rel="noopener noreferrer" class="external no-external-icon">Contact the Veterans Crisis Line</a>


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/33883

## Testing done
Visited http://localhost:3002/education/gi-bill-comparison-tool-sandbox/ and http://localhost:3002/education/gi-bill-comparison-tool/ and validated they worked.

Made sure http://localhost:3002/gi-bill-comparison-tool-sandbox/ and http://localhost:3002/education/gi-bill-comparison-tool/ do not work.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
