### PR TITLE
Remove class that changes h2 to h3 styling

### DIFF
--- a/src/site/paragraphs/q_a.drupal.liquid
+++ b/src/site/paragraphs/q_a.drupal.liquid
@@ -1,7 +1,7 @@
 <div data-template="paragraphs/q_a" data-entity-id="{{ entity.entityId }}" data-analytics-faq-section="{{ sectionHeader | escape }}" data-analytics-faq-text="{{ entity.fieldQuestion | escape }}">
   <div itemscope itemprop="mainEntity" itemtype="https://schema.org/Question" id="{{ entity.entityId }}">
     <div class="vads-u-display--flex">
-      <h2 class="vads-u-font-size--h3" itemprop="name">
+      <h2 itemprop="name">
         {{ entity.fieldQuestion }}
       </h2>
     </div>


### PR DESCRIPTION
# Description

**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/34362

This PR removes the class that styles h2 to h3 tags.

