### PR TITLE
Add temp entry point to old url for GI Bill.

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -688,6 +688,20 @@
       "loadingMessage": "Please wait while we log you in."
     }
   },
+    {
+      "appName": "GI Bill Comparison Tool",
+      "entryName": "gi",
+      "rootUrl": "/gi-bill-comparison-tool",
+      "template": {
+        "title": "GI Bill Comparison Tool",
+        "display_title": "GI Bill school comparison",
+        "description": "Use our GI Bill Comparison Tool to help you decide which education program and school is best for you. Find out which benefits you’ll get at your chosen school.",
+        "layout": "page-react.html",
+        "collection": "education",
+        "spoke": "More resources",
+        "order": 1
+      }
+    },
   {
     "appName": "GI Bill Comparison Tool",
     "entryName": "gi",


### PR DESCRIPTION
## Description
content-build is breaking due to broken links on a URL change PR. Per convo with #platform-support, suggestion was to add a temporary entrypoint with old URL.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
