### PR TITLE
Revert "Updating GIBCT url to being with /education"

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -691,7 +691,7 @@
   {
     "appName": "GI Bill Comparison Tool",
     "entryName": "gi",
-    "rootUrl": "/education/gi-bill-comparison-tool",
+    "rootUrl": "/gi-bill-comparison-tool",
     "template": {
       "title": "GI Bill Comparison Tool",
       "display_title": "GI Bill school comparison",
@@ -705,7 +705,7 @@
   {
     "appName": "CT Redesign Sandbox",
     "entryName": "gi-sandbox",
-    "rootUrl": "/education/gi-bill-comparison-tool-sandbox",
+    "rootUrl": "/gi-bill-comparison-tool-sandbox",
     "template": {
       "vagovprod": false,
       "title": "CT Redesign Sandbox",

--- a/src/site/includes/common-and-popular.html
+++ b/src/site/includes/common-and-popular.html
@@ -20,7 +20,7 @@
         <a href="/find-locations/">Find nearby VA locations</a>
       </li>
       <li>
-        <a href="/education/gi-bill-comparison-tool">View education benefits available by school</a>
+        <a href="/gi-bill-comparison-tool">View education benefits available by school</a>
       </li>
       <li>
         <a target="_blank" href="https://www.veteranscrisisline.net/" rel="noopener noreferrer" class="external no-external-icon">Contact the Veterans Crisis Line</a>


### PR DESCRIPTION
Reverts department-of-veterans-affairs/content-build#862

This is causing content release failures currently.