### PR TITLE
Fix fieldLink.url.path from previous refactor

### DIFF
--- a/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
@@ -74,6 +74,9 @@ const nodeEvent = `
     fieldFeatured
     fieldLink {
       uri
+      url {
+        path
+      }
       title
     }
     fieldListing {


### PR DESCRIPTION
# Description

This PR fixes a broken link issue with the previous GraphQL refactor for NodeEvents.

![image](https://user-images.githubusercontent.com/12773166/147712567-26e1ba56-5190-4a12-9658-07a87690fe4d.png)
