### PR TITLE
Add back breadcrumbs to nodeEvent graphql

### DIFF
--- a/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
@@ -72,6 +72,7 @@ const buildQuery = () => {
   ${vamcOperatingStatusAndAlerts.fragment}
   ${newsStoryPage.fragment}
   ${nodeEvent.fragment}
+  ${nodeEvent.fragmentWithoutBreadcrumbs}
   ${nodeOffice.fragment}
   ${bioPage.fragment}
   ${vaFormPage.fragment}

--- a/src/site/stages/build/drupal/graphql/GetLatestPageById.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetLatestPageById.graphql.js
@@ -58,6 +58,7 @@ module.exports = `
   ${storyListingPage.fragment}
   ${newsStoryPage.fragment}
   ${nodeEvent.fragment}
+  ${nodeEvent.fragmentWithoutBreadcrumbs}
   ${nodeEventListing.fragment}
   ${bioPage.fragment}
   ${vaFormPage.fragment}

--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionEvents.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionEvents.node.graphql.js
@@ -4,7 +4,7 @@
 
 const EVENTS_RESULTS = `
   entities {
-    ... nodeEvent
+    ... nodeEventWithoutBreadcrumbs
   }
 `;
 

--- a/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
@@ -86,7 +86,7 @@ const nodeHealthCareRegionPage = `
         ... on NodeEventListing {
           reverseFieldListingNode(sort: {field: "field_datetime_range_timezone", direction: ASC }, limit: 1, filter: {conditions: [{field: "type", value: "event"}, {field: "status", value: "1"}, { field: "field_datetime_range_timezone", value: [$today], operator: GREATER_THAN}]}) {
             entities {
-              ... nodeEvent
+              ... nodeEventWithoutBreadcrumbs
             }
           }
         }
@@ -97,7 +97,7 @@ const nodeHealthCareRegionPage = `
         ... on NodeEventListing {
           reverseFieldListingNode(limit: 5000, filter: {conditions: [{field: "type", value: "event"}, {field: "status", value: "1"}, {field: "field_featured", value: "1"}, { field: "field_datetime_range_timezone", value: [$today], operator: GREATER_THAN}]}) {
             entities {
-              ... nodeEvent
+              ... nodeEventWithoutBreadcrumbs
             }
           }
         }
@@ -143,7 +143,7 @@ function getNodeHealthCareRegionPageSlice(operationName, offset, limit) {
   return `
     ${fragments.linkTeaser}
     ${fragments.listOfLinkTeasers}
-    ${nodeEvent.fragment}
+    ${nodeEvent.fragmentWithoutBreadcrumbs}
     ${nodeHealthCareRegionPage}
 
     query ${operationName}($today: String!, $onlyPublishedContent: Boolean!) {

--- a/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
@@ -39,7 +39,7 @@ const nodeCampaignLandingPage = `
     fieldClpEventsPanel
     fieldClpEventsReferences {
       entity {
-        ... nodeEvent
+        ... nodeEventWithoutBreadcrumbs
       }
     }
     fieldClpFaqCta {
@@ -306,7 +306,7 @@ const GetCampaignLandingPages = `
   ${fragments.listOfLinkTeasers}
   ${fragments.linkTeaser}
   ${fragments.alert}
-  ${nodeEvent.fragment}
+  ${nodeEvent.fragmentWithoutBreadcrumbs}
   ${landingPageFragment}
   ${nodeCampaignLandingPage}
 

--- a/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
@@ -14,7 +14,16 @@ const nodeEvent = `
       value
     }
     entityUrl {
-      path
+      ... on EntityCanonicalUrl {
+        breadcrumb {
+          url {
+            path
+            routed
+          }
+          text
+        }
+        path
+      }
     }
     title
     vid

--- a/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
@@ -161,6 +161,156 @@ const nodeEvent = `
   }
 `;
 
+const nodeEventWithoutBreadcrumbs = `
+  fragment nodeEventWithoutBreadcrumbs on NodeEvent {
+    changed
+    entityBundle
+    entityId
+    entityPublished
+    entityMetatags {
+      __typename
+      key
+      value
+    }
+    entityUrl {
+      path
+    }
+    title
+    vid
+    fieldAdditionalInformationAbo {
+      value
+      format
+      processed
+    }
+    fieldAddress {
+      additionalName
+      addressLine1
+      addressLine2
+      administrativeArea
+      countryCode
+      dependentLocality
+      familyName
+      givenName
+      langcode
+      locality
+      organization
+      postalCode
+      sortingCode
+    }
+    fieldBody {
+      format
+      processed
+      value
+    }
+    fieldDatetimeRangeTimezone {
+      duration
+      endTime
+      endValue
+      rrule
+      rruleIndex
+      startTime
+      timezone
+      value
+    }
+    fieldDescription
+    fieldEventCost
+    fieldEventCta
+    fieldEventRegistrationrequired
+    fieldFacilityLocation {
+      entity {
+        entityBundle
+        entityId
+        entityType
+        ... on NodeHealthCareLocalFacility {
+          entityUrl {
+            path
+          }
+          fieldFacilityLocatorApiId
+          title
+        }
+      }
+    }
+    fieldFeatured
+    fieldLink {
+      uri
+      url {
+        path
+      }
+      title
+    }
+    fieldListing {
+      entity {
+        entityBundle
+        entityId
+        entityType
+        ... on NodeEventListing {
+          fieldDescription
+          fieldIntroText
+          fieldOffice {
+            entity {
+              entityType
+              entityBundle
+              entityId
+              ... on NodeOffice {
+                fieldBody {
+                  value
+                  format
+                  processed
+                }
+                fieldDescription
+                fieldMetaTags
+              }
+            }
+          }
+        }
+      }
+    }
+    fieldLocationHumanreadable
+    fieldLocationType
+    fieldMedia {
+      entity {
+        entityBundle
+        entityId
+        entityType
+        ... on MediaImage {
+          image {
+            alt
+            title
+            derivative(style: _72MEDIUMTHUMBNAIL) {
+              height
+              url
+              width
+            }
+          }
+          thumbnail {
+            alt
+            height
+            targetId
+            title
+            url
+            width
+          }
+        }
+      }
+    }
+    fieldMetaTags
+    fieldOrder
+    fieldUrlOfAnOnlineEvent {
+      uri
+      title
+    }
+    uid {
+      targetId
+      ... on FieldNodeUid {
+        entity {
+          name
+          timezone
+        }
+      }
+    }
+  }
+`;
+
 function getNodeEventSlice(operationName, offset, limit = 100) {
   return `
     ${nodeEvent}
@@ -195,5 +345,6 @@ function getNodeEventQueries(entityCounts) {
 
 module.exports = {
   fragment: nodeEvent,
+  fragmentWithoutBreadcrumbs: nodeEventWithoutBreadcrumbs,
   getNodeEventQueries,
 };

--- a/src/site/stages/build/drupal/graphql/nodeEventListing.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeEventListing.graphql.js
@@ -13,12 +13,12 @@ const nodeEventListing = `
     entityId
     pastEvents: reverseFieldListingNode(limit: 5000, filter: { conditions: [{ field: "status", value: "1", operator: EQUAL, enabled: $onlyPublishedContent }, { field: "moderation_state", value: "archived", operator: NOT_EQUAL }, { field: "type", value: "event" }, { field: "field_datetime_range_timezone", value: [$today], operator: SMALLER_THAN }]}, sort: {field: "changed", direction: DESC}) {
       entities {
-        ... nodeEvent
+        ... nodeEventWithoutBreadcrumbs
       }
     }
     reverseFieldListingNode(limit: 5000, filter: { conditions: [{ field: "status", value: "1", operator: EQUAL, enabled: $onlyPublishedContent }, { field: "moderation_state", value: "archived", operator: NOT_EQUAL }, { field: "type", value: "event" }]}, sort: {field: "changed", direction: DESC}) {
       entities {
-        ... nodeEvent
+        ... nodeEventWithoutBreadcrumbs
       }
     }
     fieldOffice {
@@ -33,7 +33,7 @@ const nodeEventListing = `
 
 function getNodeEventListingPageSlice(operationName, offset, limit) {
   return `
-  ${nodeEvent.fragment}
+  ${nodeEvent.fragmentWithoutBreadcrumbs}
   ${nodeEventListing}
 
   query ${operationName}($today: String!,$onlyPublishedContent: Boolean!) {

--- a/src/site/stages/build/drupal/graphql/nodeOffice.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeOffice.graphql.js
@@ -12,14 +12,14 @@ const nodeOffice = `
     fieldBody { processed }
     reverseFieldOfficeNode {
       entities {
-        ... nodeEvent
+        ... nodeEventWithoutBreadcrumbs
       }
     }
   }
 `;
 
 const GetNodeOffices = `
-  ${nodeEvent.fragment}
+  ${nodeEvent.fragmentWithoutBreadcrumbs}
   ${nodeOffice}
 
   query GetNodeOffices($onlyPublishedContent: Boolean!) {


### PR DESCRIPTION
## Description

I thought we could get away with not adding in breadcrumbs to NodeEvent graphql queries, but I was wrong 😭 

PR that removed breadcrumbs from NodeEvents originally: https://github.com/department-of-veterans-affairs/content-build/pull/864/files

## Testing done


## Screenshots
![image](https://user-images.githubusercontent.com/12773166/147769921-4d2ca44a-8220-40f4-8e87-61b7849a16c3.png)


## Acceptance criteria
- [x] Add back NodeEvent graphql queries

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
