### PR TITLE
Update startsAt + endsAt to use timezone

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1408,10 +1408,12 @@ module.exports = function registerFilters() {
     const timezone = fieldDatetimeRangeTimezone?.timezone;
 
     // Derive starts at and ends at.
-    const formattedStartsAt = moment(startsAtUnix * 1000).format(
-      'ddd MMM D, YYYY, h:mm a',
-    );
-    const formattedEndsAt = moment(endsAtUnix * 1000).format('h:mm a');
+    const formattedStartsAt = moment
+      .tz(startsAtUnix * 1000, timezone)
+      .format('ddd MMM D, YYYY, h:mm a');
+    const formattedEndsAt = moment
+      .tz(endsAtUnix * 1000, timezone)
+      .format('h:mm a');
     const endsAtTimezone = moment.tz(endsAtUnix * 1000, timezone).format('z');
 
     return `${formattedStartsAt} - ${formattedEndsAt} ${endsAtTimezone}`;

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -2251,7 +2251,7 @@ describe('healthCareRegionNonClinicalServiceLocationsByType', () => {
   const facilitiesInSystem =
     healthCareRegionNonClinicalServicesData.reverseFieldRegionPageNode.entities;
 
-  const billingAndInsuraceServicesFacilities = [
+  const billingAndInsuranceServicesFacilities = [
     {
       entityLabel: 'Anchorage VA Medical Center',
       fieldAddress: {
@@ -2308,20 +2308,20 @@ describe('healthCareRegionNonClinicalServiceLocationsByType', () => {
     // dig into this one to ensure labels and addresses match
     expect(facilitiesOfferingBillingAndInsurance.length).to.equal(2);
     expect(facilitiesOfferingBillingAndInsurance[0].entityLabel).to.equal(
-      billingAndInsuraceServicesFacilities[0].entityLabel,
+      billingAndInsuranceServicesFacilities[0].entityLabel,
     );
     expect(
       facilitiesOfferingBillingAndInsurance[0].fieldAddress.addressLine1,
     ).to.equal(
-      billingAndInsuraceServicesFacilities[0].fieldAddress.addressLine1,
+      billingAndInsuranceServicesFacilities[0].fieldAddress.addressLine1,
     );
     expect(facilitiesOfferingBillingAndInsurance[1].entityLabel).to.equal(
-      billingAndInsuraceServicesFacilities[1].entityLabel,
+      billingAndInsuranceServicesFacilities[1].entityLabel,
     );
     expect(
       facilitiesOfferingBillingAndInsurance[1].fieldAddress.addressLine1,
     ).to.equal(
-      billingAndInsuraceServicesFacilities[1].fieldAddress.addressLine1,
+      billingAndInsuranceServicesFacilities[1].fieldAddress.addressLine1,
     );
 
     const facilitiesOfferingMedicalRecords = liquid.filters.healthCareRegionNonClinicalServiceLocationsByType(
@@ -2341,5 +2341,26 @@ describe('healthCareRegionNonClinicalServiceLocationsByType', () => {
       'Dummy',
     );
     expect(facilitiesOfferingDummy.length).to.equal(0);
+  });
+});
+
+describe('deriveFormattedTimestamp', () => {
+  it('returns what we expect', () => {
+    // Set up.
+    const fieldDatetimeRangeTimezone = {
+      duration: 60,
+      endTime: null,
+      endValue: 1641409200,
+      rrule: null,
+      rruleIndex: null,
+      startTime: null,
+      timezone: 'America/New_York',
+      value: 1641405600,
+    };
+
+    // Assertions.
+    expect(
+      liquid.filters.deriveFormattedTimestamp(fieldDatetimeRangeTimezone),
+    ).to.equal('Wed Jan. 5, 2022, 1:00 p.m. - 2:00 p.m. EST');
   });
 });


### PR DESCRIPTION
## Description

This PR standardizes the timestamp shown for events v2 across event listing pages + event detail pages.

## Screenshots

### Before where all timestamps were showing different values

![image](https://user-images.githubusercontent.com/12773166/147858218-31779699-2d99-4074-9afe-2ef4f0b05426.png)
![image](https://user-images.githubusercontent.com/12773166/147858222-ce983abb-1b8a-4d03-b829-f1924bd4abc1.png)
![image](https://user-images.githubusercontent.com/12773166/147858228-cdba4cc2-6441-434c-9311-1e8ef8efc74e.png)

### Now all values are `Wednesday, Jan 5, 2022, 1:00 p.m. – 2:00 p.m. EST` for this example

## Acceptance criteria
- [x] Standardize event timestamps

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
