### PR TITLE
Don't alert slack when the build is cancelled

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -595,7 +595,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       needs.set-env.outputs.BUILDTYPE == 'vagovprod' &&
-      ((failure() || cancelled()) && needs.deploy.result != 'success')
+      (failure() && needs.deploy.result != 'success')
     needs: [set-env, deploy]
 
     steps:


### PR DESCRIPTION
## Description

Related ticket: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/7363

Sending alerts when a build is cancelled creates a lot of noise. There's nothing that can/should be done about a cancelled build, so let's not send it.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
