### PR TITLE
Add a continuous content-build mode

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -13,6 +13,11 @@ on:
         required: true
         options:
           - prod
+
+  repository_dispatch:
+    types:
+      - "Content Release"
+
   schedule:
     - cron: '0 14-17,21-22 * * 1-5'
     - cron: '45 18 * * 1-5'
@@ -24,6 +29,7 @@ concurrency:
 env:
   CHANNEL_ID: C0MQ281DJ # vfs-platform-builds
   DSVA_SCHEDULE_ENABLED: true
+  RUN_CONTINUOUSLY_ENABLED: false
 
 jobs:
   start-runner:
@@ -103,8 +109,21 @@ jobs:
         id: export-approx-workflow-start-time
         run: echo ::set-output name=APPROX_WORKFLOW_START_TIME::$(date +"%s")
 
+      - name: Determine if we're within scheduled hours
+        id: scheduled-hours
+        run: |
+          if [ $(date +%H) -gt 13 ] && [ $(date +%H) -lt 23 ]; then
+            echo ::set-output name=WITHIN_SCHEDULED_HOURS::true
+          else
+            echo ::set-output name=WITHIN_SCHEDULED_HOURS::false
+          fi
+
       - name: Cancel workflow due to DSVA schedule
-        if: ${{ env.DSVA_SCHEDULE_ENABLED != 'true' }}
+        if: ${{ env.DSVA_SCHEDULE_ENABLED != 'true' && env.RUN_CONTINUOUSLY_ENABLED != 'true' }}
+        uses: andymckay/cancel-action@0.2
+
+      - name: Cancel manual workflows during scheduled hours if continuous mode is enabled
+        if: ${{ env.RUN_CONTINUOUSLY_ENABLED == 'true' && github.event_name == 'workflow_dispatch' && steps.scheduled-hours.outputs.WITHIN_SCHEDULED_HOURS == 'true' }}
         uses: andymckay/cancel-action@0.2
 
       - name: Validate workflow_dispatch deploy_environment
@@ -121,8 +140,8 @@ jobs:
         id: get-latest-release
         uses: thebritican/fetch-latest-release@v2.0.0
 
-      - name: Get release wait time (scheduled release)
-        if: ${{ github.event_name == 'schedule' }}
+      - name: Get release wait time (automatic release)
+        if: ${{ github.event_name == 'schedule' || github.event_name == "repository_dispatch" }}
         run: echo "RELEASE_WAIT=0" >> $GITHUB_ENV
 
       - name: Get release wait time (workflow_dispatch)
@@ -130,7 +149,7 @@ jobs:
         run: echo "RELEASE_WAIT=${{ github.event.inputs.release_wait }}" >> $GITHUB_ENV
 
       - name: Set environment details for vagovprod
-        if: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_environment == 'prod') || github.event_name == 'schedule' }}
+        if: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_environment == 'prod') || github.event_name == 'schedule' || github.event_name == "repository_dispatch" }}
         run: |
           echo "BUILDTYPE=vagovprod" >> $GITHUB_ENV
           echo "DEPLOY_BUCKET=content.www.va.gov" >> $GITHUB_ENV
@@ -141,7 +160,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       always() &&
-      ((github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_environment == 'prod') || github.event_name == 'schedule')
+      ((github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_environment == 'prod') || github.event_name == 'schedule' || github.event_name == "repository_dispatch")
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -603,11 +622,9 @@ jobs:
 
     steps:
       - name: Checkout
-        if: ${{ env.DSVA_SCHEDULE_ENABLED == 'true' }}
         uses: actions/checkout@v2
 
       - name: Notify Slack
-        if: ${{ env.DSVA_SCHEDULE_ENABLED == 'true' }}
         uses: ./.github/workflows/slack-notify
         continue-on-error: true
         with:
@@ -663,7 +680,7 @@ jobs:
         run: echo "NOW=$(date +"%s")" >> $GITHUB_ENV
 
       - name: Set vars for scheduled runs
-        if: ${{ github.event_name == 'schedule' }}
+        if: ${{ github.event_name == 'schedule' || github.event_name == "repository_dispatch" }}
         run: |
           echo "DEPLOY_ENV=prod" >> $GITHUB_ENV
           echo "BUILD_TRIGGER=scheduled" >> $GITHUB_ENV
@@ -729,3 +746,31 @@ jobs:
           -H "Content-Type: text/json" \
           -H "DD-API-KEY: ${{ env.VAGOV_CMS_DATADOG_API_KEY }}" \
           -d @- < metrics.json
+
+  run-again:
+    name: Run the workflow again
+    needs: [deploy]
+    runs-on: ubuntu-latest
+    if: ${{ env.RUN_CONTINUOUSLY == 'true' && DSVA_SCHEDULE_ENABLED == 'false' }}
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}
+
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Get bot token from Parameter Store
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+
+      - name: Run another content build
+        run: |
+          curl -X POST -H "Authorization: Bearer ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/department-of-veterans-affairs/content-build/dispatches -d '{"event_type": "Content Release"}'
+

--- a/.github/workflows/continuous-content-release-supervisor.yml
+++ b/.github/workflows/continuous-content-release-supervisor.yml
@@ -1,0 +1,97 @@
+# This workflow runs once per hour and kicks off a content build if all of the
+# following conditions are true:
+#
+# * Scheduled builds are disabled
+# * Continuous builds are enabled
+# * There are no WIP content builds
+# * There are no content builds that have completed successfully in the last 30 min
+#
+# This is needed for continuous mode so that a) the continuous builds will start
+# at 9am and b) if anything happens that would prevent the content build from
+# re-queueing itself (a runner crashes or something), it can be re-started without
+# manual intervention.
+
+name: Continuous Content Release Supervisor
+
+on:
+  schedule:
+    - cron: 0 14-22 * * 1-5
+
+jobs:
+  check-content-release:
+    runs-on: ubuntu-latest
+    outputs:
+      needs-kicked: ${{ steps.decision.outputs.needs-kicked }}
+    steps:
+      - name: Check schedule enabled
+        run: |
+          curl https://raw.githubusercontent.com/department-of-veterans-affairs/content-build/master/.github/workflows/content-release.yml | grep 'DSVA_SCHEDULE_ENABLED: true' > /dev/null
+          if [ $? -eq 0 ]; then
+            echo "SCHEDULE_ENABLED=true" >> $GITHUB_ENV
+          else
+            echo "SCHEDULE_ENABLED=false" >> $GITHUB_ENV
+          fi
+
+      - name: Check continuous enabled
+        run: |
+          curl https://raw.githubusercontent.com/department-of-veterans-affairs/content-build/master/.github/workflows/content-release.yml | grep 'RUN_CONTINOUSLY_ENABLED: true' > /dev/null
+          if [ $? -eq 0 ]; then
+            echo "CONTINUOUS_ENABLED=true" >> $GITHUB_ENV
+          else
+            echo "CONTINUOUS_ENABLED=false" >> $GITHUB_ENV
+          fi
+
+      - name: Check for requested, queued, or in progress builds
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/department-of-veterans-affairs/content-build/actions/runs?branch=master" | jq 'isempty(.workflow_runs[] | select(.name == "Content Release" and (.status == "in_progress" or .status == "waiting" or .status == "requested")) | {"name": .name, "status": .status, "conclusion": .conclusion, "created_at": .created_at, "updated_at": .updated_at}) == false or halt_error(1)' 2> /dev/null
+          if [ $? -eq 0 ]; then
+            echo "HAS_WIP_BUILDS=true" >> $GITHUB_ENV
+          else
+            echo "HAS_WIP_BUILDS=false" >> $GITHUB_ENV
+          fi
+
+      - name: Check for recently completed builds
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/department-of-veterans-affairs/content-build/actions/runs?branch=master" | jq '[.workflow_runs[] | select(.name == "Content Release" and .status == "completed" and .conclusion == "success") | {"name": .name, "status": .status, "conclusion": .conclusion, "created_at": .created_at, "updated_at": .updated_at}]' | jq 'isempty(.[] | select(.updated_at | fromdate > (now - 1800))) == false or halt_error(1)' 2> /dev/null
+          if [ $? -eq 0 ]; then
+            echo "HAS_RECENT_BUILDS=true" >> $GITHUB_ENV
+          else
+            echo "HAS_RECENT_BUILDS=false" >> $GITHUB_ENV
+          fi
+
+      - name: Decide whether or not to restart the job
+        id: decision
+        run: |
+          if [[ "$SCHEDULE_ENABLED" == "true" ]]; then
+            echo ::set-output name=needs-kicked::false
+          fi
+
+          if [[ "$CONTINUOUS_ENABLED" == "true" ]] && [[ "$HAS_WIP_BUILDS" == "false" ]] && [[ "$HAS_RECENT_BUILDS" == "false" ]]; then
+            echo ::set-output name=needs-kicked::true
+          fi
+
+  kick-content-release:
+    runs-on: ubuntu-latest
+    needs: check-content-release
+    if: ${{ needs.check-content-release.outputs.needs-kicked == 'true' }}
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Get bot token from Parameter Store
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+
+      - name: Run another content build
+        run: |
+          curl -X POST -H "Authorization: Bearer ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/department-of-veterans-affairs/content-build/dispatches -d '{"event_type": "Content Release"}'


### PR DESCRIPTION
## Description

Right now, the best SLA we can offer to editors around how fast content can get to prod is ~30-90 minutes. If we stop scheduling the build at the top of the hour and instead run it continuously throughout the day, there are several benefits:

* We can guarantee < 60 minutes (and more likely ~30 min) timeframe for content to get to production
* We can stop worrying about the relative priority of scheduled vs manual builds because if we're building continuously, we can ignore manual build requests (manual builds are still processed normally outside of business hours)
* If we can speed up the build by even  a small amount, it has instant benefit to users (right now, if the build is faster, nobody really notices -- we run it at the same time no matter what).

This is just a first pass at the idea, but I'm interested in feedback on this approach!

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
