### PR TITLE
Use slackapi action

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -198,7 +198,7 @@ jobs:
         uses: ./.github/workflows/slack-notify
         continue-on-error: true
         with:
-          attachments: '[{"mrkdwn_in": ["text"], "color": "good", "text": "Stand by, content release for content-build coming up. <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"}]'
+          attachments: '{"attachments": [{"color": "good","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "Stand by, content release for content-build coming up. <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"}}]}]}'
           channel_id: ${{ env.CHANNEL_ID }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -392,16 +392,15 @@ jobs:
         run: aws s3 cp ./logs/${{ needs.set-env.outputs.BUILDTYPE }}-broken-links.json s3://vetsgov-website-builds-s3-upload/broken-link-reports/${{ needs.set-env.outputs.BUILDTYPE }}-broken-links.json --acl public-read --region us-gov-west-1
 
       - name: Notify Slack about broken links
-        uses: department-of-veterans-affairs/vsp-github-actions/slack-socket@v1.1.0
+        uses: slackapi/slack-github-action@v1.16.0
         if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
         continue-on-error: true
         env:
           SSL_CERT_DIR: /etc/ssl/certs
+          SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
         with:
-          slack_app_token: ${{ env.SLACK_APP_TOKEN }}
-          slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
-          attachments: ${{ steps.get-broken-link-info.outputs.SLACK_ATTACHMENTS }}
-          channel_id: ${{ env.CHANNEL_ID }}
+          payload: ${{ steps.get-broken-link-info.outputs.SLACK_ATTACHMENTS }}
+          channel-id: ${{ env.CHANNEL_ID }}
 
       - name: Export build end time
         id: export-build-end-time
@@ -611,7 +610,7 @@ jobs:
         uses: ./.github/workflows/slack-notify
         continue-on-error: true
         with:
-          attachments: '[{"mrkdwn_in": ["text"], "color": "danger", "text": "<!here> Content release for content-build has failed!: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"}]'
+          attachments: '{"attachments": [{"color": "danger","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "<!here> Content release for content-build has failed!: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"}}]}]}'
           channel_id: ${{ env.CHANNEL_ID }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -333,7 +333,7 @@ jobs:
         uses: ./.github/workflows/slack-notify
         continue-on-error: true
         with:
-          attachments: '{"attachments": [{"color": "#000", "blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": "New Paid Time Off request from <example.com|Fred Enriquez>\n\n<https://example.com|View request>"}}]}]}'
+          attachments: '{"attachments": [{"color": "#f2c744", "blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": "Hello, Assistant to the Regional Manager Dwight! *Michael Scott* wants to know where you'd like to take the Paper Company investors to dinner tonight.\n\n *Please select a restaurant:*"}}]}]}'
           channel_id: C02AG8UF95M
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -304,7 +304,6 @@ jobs:
         with:
           payload: '{"attachments": [{"color": "warning","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "At least one build step in `content-build` has failed, run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}}]}]}'
           channel-id: C02AG8UF95M # gha-build-status
-          slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
 
       # ----------------
       # | End Notify Slack |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -329,6 +329,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Notify Slack
+        uses: ./.github/workflows/slack-notify
+        continue-on-error: true
+        with:
+          attachments: '[{"mrkdwn_in": ["text"], "color": "danger", "text": "content-build master branch CI failed!: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"}]'
+          channel_id: C02AG8UF95M
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
       - name: Install dependencies
         uses: ./.github/workflows/install
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -315,11 +315,10 @@ jobs:
         continue-on-error: true
         env:
           SSL_CERT_DIR: /etc/ssl/certs
+          SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
         with:
-          slack_app_token: ${{ env.SLACK_APP_TOKEN }}
-          slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
-          attachments: ${{ steps.get-broken-link-info.outputs.SLACK_ATTACHMENTS }}
-          channel_id: ${{ env.PLATFORM_BUILD_CHANNEL_ID }}
+          payload: ${{ steps.get-broken-link-info.outputs.SLACK_ATTACHMENTS }}
+          channel-id: ${{ env.CHANNEL_ID }}
 
   unit-tests:
     name: Unit Tests

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -333,7 +333,7 @@ jobs:
         uses: ./.github/workflows/slack-notify
         continue-on-error: true
         with:
-          attachments: '[{"mrkdwn_in": ["text"], "color": "danger", "text": "content-build master branch CI failed!: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"}]'
+          attachments: '{"attachments": [{"color": "#000", "blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": "New Paid Time Off request from <example.com|Fred Enriquez>\n\n<https://example.com|View request>"}}]}]}'
           channel_id: C02AG8UF95M
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -310,7 +310,7 @@ jobs:
       # ----------------
 
       - name: Notify Slack about broken links
-        uses: department-of-veterans-affairs/vsp-github-actions/slack-socket@v1.1.0
+        uses: slackapi/slack-github-action@v1.16.0
         if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
         continue-on-error: true
         env:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -333,7 +333,7 @@ jobs:
         uses: ./.github/workflows/slack-notify
         continue-on-error: true
         with:
-          attachments: '{"attachments": [{"color": "#f2c744", "blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": "Hello, Assistant to the Regional Manager Dwight! *Michael Scott* wants to know where you'd like to take the Paper Company investors to dinner tonight.\n\n *Please select a restaurant:*"}}]}]}'
+          attachments: '{"attachments": [{"color": "#f2c744","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "Hello, Assistant to the Regional Manager Dwight! *Michael Scott* wants to know where you'd like to take the Paper Company investors to dinner tonight.\n\n *Please seleddddct a restaurant:*"}}]}]}'
           channel_id: C02AG8UF95M
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -296,14 +296,14 @@ jobs:
 
       - name: Notify Slack about build failures
         if: ${{ failure() }}
-        uses: department-of-veterans-affairs/vsp-github-actions/slack-socket@v1.1.0
+        uses: slackapi/slack-github-action@v1.16.0
         continue-on-error: true
         env:
           SSL_CERT_DIR: /etc/ssl/certs
+          SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
         with:
-          attachments: '[{"mrkdwn_in": ["text"], "color": "warning", "text": "At least one build step in `content-build` has failed, run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}]'
-          channel_id: C02AG8UF95M # gha-build-status
-          slack_app_token: ${{ env.SLACK_APP_TOKEN }}
+          payload: '{"attachments": [{"color": "warning","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "At least one build step in `content-build` has failed, run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}}]}]}'
+          channel-id: C02AG8UF95M # gha-build-status
           slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
 
       # ----------------
@@ -328,15 +328,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Notify Slack
-        uses: ./.github/workflows/slack-notify
-        continue-on-error: true
-        with:
-          attachments: '{"attachments": [{"color": "#f2c744","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "Hello, Assistant to the Regional Manager Dwight! *Michael Scott* wants to know where you'd like to take the Paper Company investors to dinner tonight.\n\n *Please seleddddct a restaurant:*"}}]}]}'
-          channel_id: C02AG8UF95M
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Install dependencies
         uses: ./.github/workflows/install
@@ -516,7 +507,7 @@ jobs:
         env:
           SSL_CERT_DIR: /etc/ssl/certs
         with:
-          attachments: '[{"mrkdwn_in": ["text"], "color": "danger", "text": "<!here> E2E tests in `content-build` have failed on the `master` branch, run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}]'
+          attachments: '{"attachments": [{"color": "danger","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "<!here> E2E tests in `content-build` have failed on the `master` branch, run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}}]}]}'
           channel_id: C026PD47Z19
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -962,7 +953,7 @@ jobs:
         uses: ./.github/workflows/slack-notify
         continue-on-error: true
         with:
-          attachments: '[{"mrkdwn_in": ["text"], "color": "danger", "text": "content-build master branch CI failed!: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"}]'
+          attachments: '{"attachments": [{"color": "danger","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "content-build master branch CI failed!: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"}}]}]}'
           channel_id: ${{ env.DEVOPS_CHANNEL_ID }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/slack-notify/action.yml
+++ b/.github/workflows/slack-notify/action.yml
@@ -43,4 +43,4 @@ runs:
         SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
       with:
         payload: ${{ inputs.attachments }}
-        channel_id: ${{ inputs.channel_id }}
+        channel-id: ${{ inputs.channel_id }}

--- a/.github/workflows/slack-notify/action.yml
+++ b/.github/workflows/slack-notify/action.yml
@@ -25,11 +25,11 @@ runs:
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
         aws-region: us-gov-west-1
 
-    - name: Get Slack app token
-      uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-      with:
-        ssm_parameter: /devops/github_actions_slack_socket_token
-        env_variable_name: SLACK_APP_TOKEN
+    # - name: Get Slack app token
+    #   uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+    #   with:
+    #     ssm_parameter: /devops/github_actions_slack_socket_token
+    #     env_variable_name: SLACK_APP_TOKEN
 
     - name: Get Slack bot token
       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
@@ -38,9 +38,9 @@ runs:
         env_variable_name: SLACK_BOT_TOKEN
 
     - name: Notify Slack
-      uses: department-of-veterans-affairs/vsp-github-actions/slack-socket@v1.1.0
+      uses: slackapi/slack-github-action@v1.16.0
+      env:
+        SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
       with:
-        slack_app_token: ${{ env.SLACK_APP_TOKEN }}
-        slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
-        attachments: ${{ inputs.attachments }}
+        payload: ${{ inputs.attachments }}
         channel_id: ${{ inputs.channel_id }}

--- a/script/github-actions/check-broken-links.js
+++ b/script/github-actions/check-broken-links.js
@@ -21,10 +21,9 @@ if (fs.existsSync(reportPath)) {
   const color = shouldFail ? 'danger' : 'warning';
   const summary = brokenLinks.summary;
   const heading = `<!subteam^S010U41C30V|cms-helpdesk> ${brokenLinks.brokenLinksCount} broken links found in ${envName} \\n\\n <${SERVER_URL}> \\n`;
-  const slackAttachments = `[{"mrkdwn_in": ["text"], "color": "${color}", "text": "${heading}\\n${summary
+  const slackAttachments = `{"attachments": [{"color": "${color}","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "${heading}\\n${summary
     .replace(/\n/g, '\\n')
-    .replace(/"/g, '\\"')}" }]`; // format summary according to slack api
-
+    .replace(/"/g, '\\"')}"}}]}]}`; // format summary according to slack api
   console.log(
     `${brokenLinks.brokenLinksCount} broken links found. \n ${brokenLinks.summary}`,
   );


### PR DESCRIPTION
## Description

Due to the issue recently arisen from slack notification, we want to move away to depend on downloading the certs required. This PR uses native slackapi action (currently used in daily-accessbiity)

## Testing done

Latest Run and [successful](https://github.com/department-of-veterans-affairs/content-build/runs/4741313901?check_suite_focus=true) notification

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
