### PR TITLE
remove always from wait-for-current-workflow in daily deploy

### DIFF
--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -118,7 +118,7 @@ jobs:
     name: Wait for current workflow to complete
     runs-on: ubuntu-latest
     needs: set-env
-    if: always() && needs.set-env.result == 'success'
+    if: needs.set-env.result == 'success'
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -119,6 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: set-env
     if: needs.set-env.result == 'success'
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
## Description

To not hault the daily deploy, removing `always`.

Was previously needed when `content-release` and `daily-deploy` were coupled

Added timeout for additional layer

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
