### PR TITLE
Add route for covid vaccination trials app

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -855,6 +855,26 @@
     }
   },
   {
+    "appName": "Coronavirus Research - Volunteer - V2",
+    "entryName": "coronavirus-research-v2",
+    "rootUrl": "/coronavirus-research/volunteer/v2",
+    "template": {
+      "vagovprod": false,
+      "layout": "page-react.html",
+      "includeBreadcrumbs": true,
+      "breadcrumbs_override": [
+        {
+          "path": "coronavirus-research/",
+          "name": "Participating in coronavirus research at VA"
+        },
+        {
+          "path": "coronavirus-research/volunteer/v2",
+          "name": "Sign up to volunteer"
+        }
+      ]
+    }
+  },
+  {
     "appName": "Coronavirus Research - Update",
     "entryName": "coronavirus-research-update",
     "rootUrl": "/coronavirus-research/volunteer/update",


### PR DESCRIPTION
## Description
This PR adds a route for Covid Vaccine Trials application.  This is a temporary route that will be removed when the new version of this form is promoted to production.  The `production` flag for this route is set to `false` and there is a feature toggle that will prevent access to this application.   

related vets-website branch, will create PR tomorrow: https://github.com/department-of-veterans-affairs/vets-website/tree/jm/covid-research-signup-updates 

## Testing done
manual local testing

## Acceptance criteria
- [x] Accessing url like `/coronavirus-research/volunteer/v2/sign-up` navigates to the [new Covid Vaccine Trials sign-up form](https://github.com/department-of-veterans-affairs/vets-website/tree/jm/covid-research-signup-updates/src/applications/coronavirus-research/sign-up-v2)
- [x] Accessing url like `/coronavirus-research/volunteer/sign-up` continues to navigate to the [existing Covid Vaccine Trials sign-up form](https://github.com/department-of-veterans-affairs/vets-website/tree/jm/covid-research-signup-updates/src/applications/coronavirus-research/sign-up)
- [x] Accessing url like `/coronavirus-research/volunteer/update/update-form?id=<UUID>`  navigates to the [Covid Vaccine Trials update form](https://github.com/department-of-veterans-affairs/vets-website/tree/jm/covid-research-signup-updates/src/applications/coronavirus-research/update)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
