### PR TITLE
raw cert change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN aws --version # Verify AWS CLI installation.
 ENV AWS_CA_BUNDLE /etc/ssl/certs/ca-certificates.crt
 
 # Add VA Root CA to Docker Certificate Authority (CA) Store so that NODE can use it for requests.
-ADD http://crl.pki.va.gov/PKI/AIA/VA/VA-Internal-S2-RCA1-v1.cer /usr/local/share/ca-certificates/
+ADD https://raw.githubusercontent.com/department-of-veterans-affairs/platform-va-ca-certificate/main/VA-Internal-S2-RCA1-v1.cer /usr/local/share/ca-certificates/
 RUN openssl x509 -inform DER -in /usr/local/share/ca-certificates/VA-Internal-S2-RCA1-v1.cer -out /usr/local/share/ca-certificates/VA-Internal-S2-RCA1-v1.crt
 RUN update-ca-certificates
 


### PR DESCRIPTION
## Description
Cert update to point to the newly created public cert repo. This change is expected to address the failing jenkins jobs:
http://jenkins.vfs.va.gov/job/builds/job/content-build-content-only-vagovprod and others

department-of-veterans-affairs/va.gov-team#34841

## Testing done
Tested locally with the docker build

## Screenshots


## Acceptance criteria
- [ ] to address the failed jenkins builds

## Definition of done
- [X] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
