### PR TITLE
Hardens "Care we provide" header in VAMC template (#22115).

### DIFF
--- a/src/site/facilities/health_service.drupal.liquid
+++ b/src/site/facilities/health_service.drupal.liquid
@@ -46,6 +46,10 @@
                 {% endif %}
 
                 {% if healthService.fieldBody.processed %}
+                    {% assign isSetFeatureCareWeProvide = '' | featureCareWeProvide %}
+                    {% if isSetFeatureCareWeProvide %}
+                        <h3>Care we provide at {{ fieldOffice.entity.entityLabel }}</h3>
+                    {% endif %}
                     <description>{{ healthService.fieldBody.processed | phoneLinks }}</description>
                 {% endif %}
             </div>

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1456,4 +1456,8 @@ module.exports = function registerFilters() {
     }
     return name;
   };
+
+  liquid.filters.featureCareWeProvide = () => {
+    return cmsFeatureFlags?.FEATURE_CARE_WE_PROVIDE;
+  };
 };


### PR DESCRIPTION
## Description
Hardcodes `h3` "Care we provide at `[VAMC System]`".

## Screenshots
### BEFORE
![image](https://user-images.githubusercontent.com/6863534/150566123-847815b9-6f20-439e-9b57-d7aed354bfcf.png)
### AFTER
![image](https://user-images.githubusercontent.com/6863534/150566564-34f7cbd8-0517-4f7c-a2d2-4158cdff789c.png)

## Acceptance criteria
- [ ] Once feature flag is toggled in CMS, display should be as in "AFTER" screenshot above.
