### PR TITLE
VACMS-7723: shift scheduled content release times 6 minutes earlier.

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -14,7 +14,7 @@ on:
         options:
           - prod
   schedule:
-    - cron: '0 14-17,21-22 * * 1-5'
+    - cron: '54 13-16,20-21 * * 1-5'
     - cron: '45 18 * * 1-5'
 
 concurrency:


### PR DESCRIPTION
## Description
See https://github.com/department-of-veterans-affairs/va.gov-cms/issues/7723

## Acceptance criteria
- [ ] Scheduled Content releases previously at the top of the hour are moved 6 minutes earlier.

## Definition of done
- [ ] Scheduled Content releases previously at the top of the hour are moved 6 minutes earlier.

