### PR TITLE
Creates new React app for Office Directory.

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1205,5 +1205,14 @@
       "vagovprod": false,
       "layout": "page-react.html"
     }
+  },
+  {
+    "appName": "All VA offices",
+    "entryName": "office-directory",
+    "rootUrl": "/office-directory",
+    "template": {
+      "vagovprod": false,
+      "layout": "page-react.html"
+    }
   }
 ]


### PR DESCRIPTION
## Description
See: https://github.com/department-of-veterans-affairs/vets-website/pull/20023

Together with the linked PR above, a new React app is added.  Most of the code for the new app will live in `vets-website`, but a new React app needs an entry in the `content-build` registry as well.  This PR captures that entry.

Note: this will not show in production, due to the `vagovprod` flag being set to false:
```
  {
    "appName": "All VA offices",
    "entryName": "office-directory",
    "rootUrl": "/office-directory",
    "template": {
      "vagovprod": false,
      "layout": "page-react.html"
    }
  }