### PR TITLE
Use new Datadog API key name specifically for content-build (not CMS)

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -474,7 +474,7 @@ jobs:
       CREATE_RELEASE_END_TIME: ${{ steps.export-create-release-end-time.outputs.CREATE_RELEASE_END_TIME }}
 
     steps:
-      - name: Configure AWS Credentials
+      - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -624,8 +624,8 @@ jobs:
       - name: Get Datadog token from Parameter Store
         uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
         with:
-          ssm_parameter: /cms/common/datadog/api_key
-          env_variable_name: VAGOV_CMS_DATADOG_API_KEY
+          ssm_parameter: /dsva-vagov/content-build/GHA_CONTENT_BUILD_DATADOG_API_KEY
+          env_variable_name: GHA_CONTENT_BUILD_DATADOG_API_KEY
 
       - name: Build JSON object
         run: |
@@ -646,7 +646,7 @@ jobs:
         run: |
           curl -X POST "https://api.datadoghq.com/api/v1/events" \
           -H "Content-Type: text/json" \
-          -H "DD-API-KEY: ${{ env.VAGOV_CMS_DATADOG_API_KEY }}" \
+          -H "DD-API-KEY: ${{ env.GHA_CONTENT_BUILD_DATADOG_API_KEY }}" \
           -d @- < event.json
 
   stop-runner:
@@ -743,7 +743,7 @@ jobs:
           jq '.series[].tags[2] = "status:${{needs.deploy.result}}"' | \
           jq '.series[].tags[3] = "trigger:${{env.BUILD_TRIGGER}}"' > metrics.json
 
-      - name: Configure AWS Credentials
+      - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -753,12 +753,12 @@ jobs:
       - name: Get Datadog token from Parameter Store
         uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
         with:
-          ssm_parameter: /cms/common/datadog/api_key
-          env_variable_name: VAGOV_CMS_DATADOG_API_KEY
+          ssm_parameter: /dsva-vagov/content-build/GHA_CONTENT_BUILD_DATADOG_API_KEY
+          env_variable_name: GHA_CONTENT_BUILD_DATADOG_API_KEY
 
       - name: Send metrics to Datadog
         run: |
           curl -X POST "https://api.datadoghq.com/api/v1/series" \
           -H "Content-Type: text/json" \
-          -H "DD-API-KEY: ${{ env.VAGOV_CMS_DATADOG_API_KEY }}" \
+          -H "DD-API-KEY: ${{ env.GHA_CONTENT_BUILD_DATADOG_API_KEY }}" \
           -d @- < metrics.json


### PR DESCRIPTION
## Description
See https://github.com/department-of-veterans-affairs/va.gov-cms/issues/7213

Key has been created in Datadog and added to Parameter Store here `/dsva-vagov/content-build/GHA_CONTENT_BUILD_DATADOG_API_KEY` and this should "just work" once merged. 


## Testing done


## Screenshots
![image](https://user-images.githubusercontent.com/1504756/151466931-8ba0f1b1-a04c-4b12-9580-6ddf28e5b1f5.png)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
