### PR TITLE
VACMS-7262: replace slack failure notification with datadog event.

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -22,7 +22,7 @@ concurrency:
   cancel-in-progress: ${{ github.event.inputs.deploy_environment != 'prod' }}
 
 env:
-  CHANNEL_ID: C0MQ281DJ # vfs-platform-builds
+  CHANNEL_ID: CJT90C0UT # cms-notifications
   DSVA_SCHEDULE_ENABLED: true
 
 jobs:
@@ -601,19 +601,40 @@ jobs:
     needs: [set-env, deploy]
 
     steps:
-      - name: Checkout
-        if: ${{ env.DSVA_SCHEDULE_ENABLED == 'true' }}
-        uses: actions/checkout@v2
-
-      - name: Notify Slack
-        if: ${{ env.DSVA_SCHEDULE_ENABLED == 'true' }}
-        uses: ./.github/workflows/slack-notify
-        continue-on-error: true
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
         with:
-          payload: '{"attachments": [{"color": "#D33834","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "<!here> Content release for content-build has failed!: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"}}]}]}'
-          channel_id: ${{ env.CHANNEL_ID }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Get datadog token from ssm
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /cms/common/datadog/api_key
+          env_variable_name: VAGOV_CMS_DATADOG_API_KEY
+
+      - name: Build JSON object
+        run: |
+          jq --null-input '{}' | \
+          jq '.title = "VA.gov CMS content release has failed"' | \
+          jq '.text = "VA.gov Content release ${{github.run_id}} failed at \(now|strftime("%Y-%m-%d %H:%M:%S"))! https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"' | \
+          jq '.date_happened = now' | \
+          jq '.aggregation_key = "content release ${{github.run_id}}"' | \
+          jq '.tags[0] = "project:vagov"' | \
+          jq '.tags[1] = "repo:content-build"' | \
+          jq '.tags[2] = "workflow:content-release"' | \
+          jq '.tags[3] = "env:${{env.DEPLOY_ENV}}"' | \
+          jq '.tags[5] = "status:${{needs.deploy.result}}"' | \
+          jq '.tags[6] = "trigger:${{env.BUILD_TRIGGER}}"' | \
+          jq '.alert_type = "error"' > event.json
+
+      - name: Send event to Datadog
+        run: |
+          curl -X POST "https://api.datadoghq.com/api/v1/events" \
+          -H "Content-Type: text/json" \
+          -H "DD-API-KEY: ${{ env.VAGOV_CMS_DATADOG_API_KEY }}" \
+          -d @- < event.json
 
   stop-runner:
     name: Stop on-demand-runner

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -22,7 +22,9 @@ concurrency:
   cancel-in-progress: ${{ github.event.inputs.deploy_environment != 'prod' }}
 
 env:
-  CHANNEL_ID: CJT90C0UT # cms-notifications
+  CMS_NOTIFICATIONS_SLACK: CJT90C0UT # cms-notifications
+  VFS_PLATFORM_BUILDS_SLACK: C0MQ281DJ # vfs-platform-builds
+  BROKEN_LINKS_SLACK: C030F5WV2TF # content-broken-links
   DSVA_SCHEDULE_ENABLED: true
 
 jobs:
@@ -199,7 +201,7 @@ jobs:
         continue-on-error: true
         with:
           payload: '{"attachments": [{"color": "#2EB67D","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "Stand by, content release for content-build coming up. <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"}}]}]}'
-          channel_id: ${{ env.CHANNEL_ID }}
+          channel_id: ${{ env.CMS_NOTIFICATIONS_SLACK }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
@@ -391,7 +393,7 @@ jobs:
         if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
         run: aws s3 cp ./logs/${{ needs.set-env.outputs.BUILDTYPE }}-broken-links.json s3://vetsgov-website-builds-s3-upload/broken-link-reports/${{ needs.set-env.outputs.BUILDTYPE }}-broken-links.json --acl public-read --region us-gov-west-1
 
-      - name: Notify Slack about broken links
+      - name: Notify VFS Platform Builds channel about broken links
         uses: slackapi/slack-github-action@v1.16.0
         if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
         continue-on-error: true
@@ -400,7 +402,18 @@ jobs:
           SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
         with:
           payload: ${{ steps.get-broken-link-info.outputs.SLACK_ATTACHMENTS }}
-          channel-id: ${{ env.CHANNEL_ID }}
+          channel-id: ${{ env.VFS_PLATFORM_BUILDS_SLACK }}
+
+      - name: Notify content broken links channel about broken links
+        uses: slackapi/slack-github-action@v1.16.0
+        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
+        continue-on-error: true
+        env:
+          SSL_CERT_DIR: /etc/ssl/certs
+          SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
+        with:
+          payload: ${{ steps.get-broken-link-info.outputs.SLACK_ATTACHMENTS }}
+          channel-id: ${{ env.BROKEN_LINKS_SLACK }}
 
       - name: Export build end time
         id: export-build-end-time

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -621,7 +621,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-gov-west-1
 
-      - name: Get datadog token from ssm
+      - name: Get Datadog token from Parameter Store
         uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
         with:
           ssm_parameter: /cms/common/datadog/api_key
@@ -750,7 +750,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-gov-west-1
 
-      - name: Get datadog token from ssm
+      - name: Get Datadog token from Parameter Store
         uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
         with:
           ssm_parameter: /cms/common/datadog/api_key


### PR DESCRIPTION
See https://github.com/department-of-veterans-affairs/va.gov-cms/issues/7262

This transitions `notify-failure` from direct Slack notification to sending a Datadog event, which in turn triggers PagerDuty. 

It also shifts the target channel from #vfs-platform-builds to #cms-notifications for build start and broken link issues. The PagerDuty incidents will also transition to reporting into #cms-notifications.
