### PR TITLE
Covid Vaccine Trials - change order so v2 route is picked up first

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -835,26 +835,6 @@
     }
   },
   {
-    "appName": "Coronavirus Research - Volunteer",
-    "entryName": "coronavirus-research",
-    "rootUrl": "/coronavirus-research/volunteer",
-    "template": {
-      "vagovprod": true,
-      "layout": "page-react.html",
-      "includeBreadcrumbs": true,
-      "breadcrumbs_override": [
-        {
-          "path": "coronavirus-research/",
-          "name": "Participating in coronavirus research at VA"
-        },
-        {
-          "path": "coronavirus-research/volunteer/",
-          "name": "Sign up to volunteer"
-        }
-      ]
-    }
-  },
-  {
     "appName": "Coronavirus Research - Volunteer - V2",
     "entryName": "coronavirus-research-v2",
     "rootUrl": "/coronavirus-research/volunteer/v2",
@@ -869,6 +849,26 @@
         },
         {
           "path": "coronavirus-research/volunteer/v2",
+          "name": "Sign up to volunteer"
+        }
+      ]
+    }
+  },
+  {
+    "appName": "Coronavirus Research - Volunteer",
+    "entryName": "coronavirus-research",
+    "rootUrl": "/coronavirus-research/volunteer",
+    "template": {
+      "vagovprod": true,
+      "layout": "page-react.html",
+      "includeBreadcrumbs": true,
+      "breadcrumbs_override": [
+        {
+          "path": "coronavirus-research/",
+          "name": "Participating in coronavirus research at VA"
+        },
+        {
+          "path": "coronavirus-research/volunteer/",
           "name": "Sign up to volunteer"
         }
       ]


### PR DESCRIPTION
## Description
This PR just changes the order of the routing configs so the correct routing is used. 

## Testing done
will be tested in Staging, prod flag is still false

## Screenshots


## Acceptance criteria
- [ ] https://staging.va.gov/coronavirus-research/volunteer/v2/sign-up loads in staging

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
