### PR TITLE
Add crisis line test for crisis line link in main homepage content

### DIFF
--- a/src/platform/site-wide/tests/accessible-modal.cypress.spec.js
+++ b/src/platform/site-wide/tests/accessible-modal.cypress.spec.js
@@ -1,0 +1,52 @@
+const overlay = '#modal-crisisline';
+const firstModalItem = 'a[href="tel:18002738255"]';
+const closeControl = '.va-crisis-panel.va-modal-inner button';
+const firstOpenControl = 'button.va-crisis-line.va-overlay-trigger';
+const secondOpenControl = '.homepage-button.vcl.va-overlay-trigger';
+const thirdOpenControl = 'footer .va-button-link.va-overlay-trigger';
+const lastModalItem = 'a[href="https://www.veteranscrisisline.net/"]';
+
+describe('Accessible Modal Test', () => {
+  it('Modal behaves appropriately in line with key presses', () => {
+    cy.visit('/');
+
+    // Open modal
+    cy.get(firstOpenControl)
+      .focus()
+      .realPress('Enter');
+
+    // Trap backward traversal
+    cy.get(firstModalItem)
+      .should('be.focused')
+      .repeatKey(['Shift', 'Tab'], 2);
+    cy.get(lastModalItem).should('be.focused');
+
+    // Trap forward traversal
+    cy.realPress('Tab');
+    cy.get(closeControl).should('be.focused');
+
+    // Escape modal
+    cy.realPress('Escape');
+    cy.get(overlay).should('not.have.class', 'va-overlay--open');
+    cy.get('body').should('not.have.class', 'va-pos-fixed');
+
+    // REturn focus to appropriate open controls
+    cy.get(firstOpenControl).should('be.focused');
+
+    cy.get(secondOpenControl)
+      .focus()
+      .realPress('Enter');
+    cy.get(firstModalItem).should('be.focused');
+
+    cy.realPress('Escape');
+    cy.get(secondOpenControl).should('be.focused');
+
+    cy.get(thirdOpenControl)
+      .focus()
+      .realPress('Enter');
+    cy.get(firstModalItem).should('be.focused');
+
+    cy.realPress('Escape');
+    cy.get(thirdOpenControl).should('be.focused');
+  });
+});

--- a/src/platform/site-wide/tests/accessible-modal.cypress.spec.js
+++ b/src/platform/site-wide/tests/accessible-modal.cypress.spec.js
@@ -1,17 +1,16 @@
 const overlay = '#modal-crisisline';
 const firstModalItem = 'a[href="tel:18002738255"]';
 const closeControl = '.va-crisis-panel.va-modal-inner button';
-const firstOpenControl = 'button.va-crisis-line.va-overlay-trigger';
 const secondOpenControl = '.homepage-button.vcl.va-overlay-trigger';
-const thirdOpenControl = 'footer .va-button-link.va-overlay-trigger';
 const lastModalItem = 'a[href="https://www.veteranscrisisline.net/"]';
 
 describe('Accessible Modal Test', () => {
   it('Modal behaves appropriately in line with key presses', () => {
     cy.visit('/');
+    cy.injectAxeThenAxeCheck();
 
     // Open modal
-    cy.get(firstOpenControl)
+    cy.get(secondOpenControl)
       .focus()
       .realPress('Enter');
 
@@ -31,22 +30,6 @@ describe('Accessible Modal Test', () => {
     cy.get('body').should('not.have.class', 'va-pos-fixed');
 
     // REturn focus to appropriate open controls
-    cy.get(firstOpenControl).should('be.focused');
-
-    cy.get(secondOpenControl)
-      .focus()
-      .realPress('Enter');
-    cy.get(firstModalItem).should('be.focused');
-
-    cy.realPress('Escape');
     cy.get(secondOpenControl).should('be.focused');
-
-    cy.get(thirdOpenControl)
-      .focus()
-      .realPress('Enter');
-    cy.get(firstModalItem).should('be.focused');
-
-    cy.realPress('Escape');
-    cy.get(thirdOpenControl).should('be.focused');
   });
 });


### PR DESCRIPTION
Reverts part of department-of-veterans-affairs/content-build#943

This PR re-adds part of the crisis line Cypress test to test the crisis line link in the main content of the homepage.