### PR TITLE
VAGOV-0000: always record metrics once build has succeeded.

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -688,7 +688,10 @@ jobs:
       - archive
       - create-release
       - deploy
-    if: ${{ !cancelled() }}
+    if: |
+      always() &&
+      needs.build.result == 'success' &&
+      needs.create-release.result == 'success'
     env:
       METRIC_NAMESPACE: dsva_vagov.content_build
     steps:


### PR DESCRIPTION
## Description
Most of this workflow is required to complete if build has completed, but the last job does not.

