### PR TITLE
Add missing certs to self-hosted runners

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -144,6 +144,10 @@ jobs:
     if: |
       always() &&
       ((github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_environment == 'prod') || github.event_name == 'schedule')
+
+    env:
+      NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -168,6 +172,9 @@ jobs:
     if: always() && needs.set-env.result == 'success'
     needs: set-env
 
+    env:
+      NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -191,6 +198,9 @@ jobs:
     runs-on: [self-hosted, linux, x64]
     needs: set-env
     if: ${{ always() && needs.set-env.outputs.BUILDTYPE == 'vagovprod' }}
+
+    env:
+      NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Description

Self-hosted runners require certs when doing yarn install. This PR adds certs where applicable. 

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
