### PR TITLE
Updating the Education Inbox rootURL

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1247,10 +1247,11 @@
   {
     "appName": "Education Inbox",
     "entryName": "education-inbox",
-    "rootUrl": "/education-inbox",
+    "rootUrl": "/education/education-inbox",
     "template": {
       "vagovprod": false,
-      "layout": "page-react.html"
+      "layout": "page-react.html",
+      "title": "Check your VA education inbox"
     }
   }
 ]


### PR DESCRIPTION
sibling PR for backend https://github.com/department-of-veterans-affairs/vets-api/pull/9077

## Description
This updates the root url path Education Inbox app in the src/applications/registry.json

As well as the title property

[Original issue](https://github.com/department-of-veterans-affairs/vets-website/pull/20057)

## Definition of done
- [X] Events are logged appropriately
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
