### PR TITLE
Changes AMI query to use multiple filters.

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -54,8 +54,7 @@ jobs:
         run: |
           echo "RUNNER_AMI_ID=$(aws ec2 describe-images \
           --owners 008577686731 \
-          --filters Name=state,Values=available \
-          --filters Name=name,Values=packer-gha-runner-ubuntu2004* \
+          --filters "Name=state,Values=available" "Name=name,Values=packer-gha-runner-ubuntu2004*" \
           --query 'sort_by(Images,&CreationDate)[-1].ImageId' \
           --output text)" >> $GITHUB_ENV
 


### PR DESCRIPTION
## Description
See [this thread](https://dsva.slack.com/archives/CBU0KDSB1/p1644539431676379).
 
Multiple invocations of `--filters` ~are logically OR'ed together~.  Only the last invocation of `--filters` is used.

This can lead to referring to an AMI that is not yet available.  Separated by spaces, they are logically AND'ed together, which is the original intent.

```
aws ec2 describe-images \
  --owners 008577686731 \
  --query 'sort_by(Images,&CreationDate)[-1].ImageId' \
  --filters "Name=name,Values=packer-gha-runner-ubuntu2004*" \
  --output text
```

```
ami-0a4813157fea1b279
```

The above is a valid GHA AMI.

```
aws ec2 describe-images \
  --owners 008577686731 \
  --query 'sort_by(Images,&CreationDate)[-1].ImageId' \
  --filters "Name=name,Values=packer-gha-runner-ubuntu2004*" \
  --filters "Name=state,Values=available" \
  --output text
```

```
ami-025370ce1ff16ca94
```

The above is available, but is NOT a GHA runner AMI.

```
aws ec2 describe-images \
  --owners 008577686731 \
  --query 'sort_by(Images,&CreationDate)[-1].ImageId' \
  --filters "Name=name,Values=packer-gha-runner-ubuntu2004*" "Name=state,Values=available" \
  --output text
```

```
ami-0a4813157fea1b279
```

The above is the GHA AMI, but now it is guaranteed to be available as well.


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
