### PR TITLE
Remove unnecessary GHA steps fromd daily accessibility scan

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -80,24 +80,10 @@ jobs:
           max_attempts: 3
           timeout_minutes: 10
 
-      - name: List changed files
-        id: changed-files
-        working-directory: vets-website
-        run: echo ::set-output name=all_changed_files::$(git diff --name-only origin/master...)
-
-      - name: Get app entries for changed files
-        id: get-changed-apps
-        working-directory: vets-website
-        run: echo ::set-output name=app_entries::$(node script/github-actions/get-changed-apps.js)
-        env:
-          CHANGED_FILE_PATHS: ${{ steps.changed-files.outputs.all_changed_files }}
-
       - name: Build vets-website
-        run: yarn build --verbose --buildtype=vagovprod ${ENTRY:+"--entry=$ENTRY"}
+        run: yarn build --verbose --buildtype=vagovprod
         working-directory: vets-website
         timeout-minutes: 30
-        env:
-          ENTRY: ${{ steps.get-changed-apps.outputs.app_entries }}
 
       - name: Cache dependencies
         id: cache-dependencies


### PR DESCRIPTION
## Description
Quick PR to remove unneeded steps from the `vets-website` build in the daily a11y scan as discussed [here](https://github.com/department-of-veterans-affairs/content-build/pull/931#discussion_r804879416).