### PR TITLE
Covid vax trials - remove V2 and promote update to prod

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -835,26 +835,6 @@
     }
   },
   {
-    "appName": "Coronavirus Research - Volunteer - V2",
-    "entryName": "coronavirus-research-v2",
-    "rootUrl": "/coronavirus-research/volunteer/v2",
-    "template": {
-      "vagovprod": false,
-      "layout": "page-react.html",
-      "includeBreadcrumbs": true,
-      "breadcrumbs_override": [
-        {
-          "path": "coronavirus-research/",
-          "name": "Participating in coronavirus research at VA"
-        },
-        {
-          "path": "coronavirus-research/volunteer/v2",
-          "name": "Sign up to volunteer"
-        }
-      ]
-    }
-  },
-  {
     "appName": "Coronavirus Research - Volunteer",
     "entryName": "coronavirus-research",
     "rootUrl": "/coronavirus-research/volunteer",
@@ -879,7 +859,7 @@
     "entryName": "coronavirus-research-update",
     "rootUrl": "/coronavirus-research/volunteer/update",
     "template": {
-      "vagovprod": false,
+      "vagovprod": true,
       "layout": "page-react.html",
       "includeBreadcrumbs": true,
       "breadcrumbs_override": [


### PR DESCRIPTION
## Description
This PR removes the entry for `Coronavirus Research - Volunteer - V2` and promotes `Coronavirus Research - Update` to prod.  V2 was used for testing in Staging and with that being successful the original URL and routing will point to the new VAFS app. 

devops PR: https://github.com/department-of-veterans-affairs/devops/pull/10756
vets-website PR: https://github.com/department-of-veterans-affairs/vets-website/pull/20245


## Testing done
Manual testing locally

## Screenshots


## Acceptance criteria
- [ ] V2 URL no longer has custom routing
- [ ] update endpoint is available in prod 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
