### PR TITLE
Covid Vaccine Trials - fix breadcrumb broken link

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -868,7 +868,7 @@
           "name": "Participating in coronavirus research at VA"
         },
         {
-          "path": "coronavirus-research/update/",
+          "path": "coronavirus-research/volunteer/update/",
           "name": "Update your information"
         }
       ]


### PR DESCRIPTION
## Description
A [PR earlier today](https://github.com/department-of-veterans-affairs/content-build/pull/974) included a broken link in the `breadcrumb_override`.  This PR fixes that. 

## Testing done


## Screenshots


## Acceptance criteria
- [ ] no broken links

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
