### PR TITLE
Wrap Legacy & V2 header layouts in global header element

### DIFF
--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -123,18 +123,21 @@
   <a class="show-on-focus" href="#content" onclick="focusContent(event)">Skip to Content</a>
 
   <!-- Header -->
-  <div
-    data-widget-type="header"
-    data-show="{{ !noHeader }}"
-    data-show-nav-login="{{ !noNavOrLogin }}"
-    data-show-mega-menu="{{ !noMegamenu }}"
-    id="header-v2"
-  ></div>
+  <header class="header" role="banner">
+    <!-- Mobile Layout -->
+    <div
+      data-widget-type="header"
+      data-show="{{ !noHeader }}"
+      data-show-nav-login="{{ !noNavOrLogin }}"
+      data-show-mega-menu="{{ !noMegamenu }}"
+      id="header-v2"
+    ></div>
 
-  <!-- Legacy Header -->
-  {% if !noHeader %}
-    {% include "src/site/includes/top-nav.html" %}
-  {% endif %}
+    <!-- Tablet/Desktop Layout -->
+    {% if !noHeader %}
+      {% include "src/site/includes/top-nav.html" %}
+    {% endif %}
+  </header>
 
   <!-- Fullwidth banner alerts -->
   {% include "src/site/components/fullwidth_banner_alerts.drupal.liquid" %}

--- a/src/site/includes/top-nav.html
+++ b/src/site/includes/top-nav.html
@@ -1,4 +1,4 @@
-<header class="header" id="legacy-header" role="banner">
+<div id="legacy-header" class="vads-u-display--none">
   <div class="incompatible-browser-warning">
     <div class="row full">
       <div class="small-12">
@@ -50,4 +50,4 @@
       <div class="mega-menu" id="mega-menu"></div>
     </div>
   {% endunless %}
-</header>
+</div>


### PR DESCRIPTION
## Description
This PR corrects a header layout shift during page load between the tablet/desktop layout and mobile layout. We momentarily see the legacy layout before the reactive mobile header component loads and chooses which layout is appropriate, based on the user's viewport width. This PR wraps both layouts in a global header element and hides the legacy layout with CSS while the reactive element loads and chooses which layout needs displayed. This PR will also have an associated PR in the Vets-Website repo.

## Associated PR
[department-of-veterans-affairs/va.gov-team#35933](https://github.com/department-of-veterans-affairs/vets-website/pull/20309)

## Original issue(s)
department-of-veterans-affairs/va.gov-team#35933

## Testing done
- [x] Unit tests

## Acceptance criteria
- [x] No layout shifts occur during page load

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
