### PR TITLE
VACMS-7835: pass in a value for onlyPublishedContent in nonNodeQuerie…

### DIFF
--- a/script/preview.js
+++ b/script/preview.js
@@ -149,7 +149,12 @@ const nonNodeContent = {
       console.time(queryName);
 
       // eslint-disable-next-line no-await-in-loop
-      const json = await drupalClient.query({ query });
+      const json = await drupalClient.query({
+        query,
+        variables: {
+          onlyPublishedContent: false,
+        },
+      });
       if (json.errors) {
         console.error('Error executing', queryName, json);
         console.error('query:', query);
@@ -358,7 +363,7 @@ async function start() {
     nonNodeContent.refresh();
   }
 
-  // Refresh the non-node data every 10 minutes...
+  // Refresh the non-node data every 15 minutes...
   const fifteenMinutes = 15 * 60 * 1000;
   setInterval(() => nonNodeContent.refresh(), fifteenMinutes);
 


### PR DESCRIPTION
See https://github.com/department-of-veterans-affairs/va.gov-cms/issues/7835.

Tested by running the server locally and observing output. See below for sample output before & after.

`onlyPublishedContent: false` is the correct value here, since preview.js is explicitly not a published content scenario.

<details>
<summary>before change</summary>
<pre>
source .env; node --use-openssl-ca script/preview.js --drupal-address=http://va-gov-cms.ddev.site
Non-node content not found in local cache at /Users/timcosgrove/code/content-build/.cache/localhost/preview-server/nonNodeContent.json...
Refreshing the non-node content (e.g. sidebars and other menus)...
This will take a few minutes but will be cached into file storage once done.
Content preview server running on port 3002
GetLocationsOperatingStatus: 8.452s
GetIcsFiles: 497.906ms
GetSidebars: 1.806s
GetFacilitySidebar__vaBedfordHealthCareFacilitySidebarQuery: 716.695ms
<========= snip ============>
GetFacilitySidebar__vaStCloudHealthCareFacilitySidebarQuery: 861.815ms
GetOutreachSidebar: 472.382ms
GetAlerts: 1.384s
GetBanners: 495.876ms
GetPromoBanners: 424.313ms
GetBannnerAlerts: 5.338s
Error executing GetOutreachAssets {
  errors: [
    {
      message: 'Variable "$onlyPublishedContent" of required type "Boolean!" was not provided.',
      category: 'graphql',
      locations: [Array]
    }
  ]
}
query: 
  query($onlyPublishedContent: Boolean!) {
    
  outreachAssets: nodeQuery(filter: {conditions: [{field: "type", value: "outreach_asset", field: "status", value: ["1"], enabled: $onlyPublishedContent}]}, limit: 10000) {
    entities {
      ... on NodeOutreachAsset {
        entityId
        title
        status
        changed
        fieldFormat
        fieldBenefits
        fieldDescription
        fieldListing {
          targetId
        }
        fieldMedia {
          entity {
            ... on MediaImage {
              entityBundle
              image {
                entity{
                  filesize
                }
                url
                alt
              }
            }
            ... on MediaDocument {
              entityBundle
              fieldDocument {
                entity {
                  filesize
                  url
                }
              }
            }
            ... on MediaVideo {
              entityBundle
              fieldMediaVideoEmbedField
              thumbnail {
                derivative(style: LARGE) {
                  url
                }
              }
            }
          }
        }
      }
    }
  }

  }

GetOutreachAssets: 376.526ms
GetHomepage: 645.297ms
GetMenuLinks: 1.285s
GetTaxonomies: 1.560s
Node-node queries: 2:06.585 (m:ss.mmm)
Caching non-node content into /Users/timcosgrove/code/content-build/.cache/localhost/preview-server/nonNodeContent.json...
Done!
</pre>
</details>

<details>
<summary>after change</summary>
<pre>
❯ source .env; node --use-openssl-ca script/preview.js --drupal-address=http://va-gov-cms.ddev.site
Non-node content initializing from /Users/timcosgrove/code/content-build/.cache/localhost/preview-server/nonNodeContent.json
Content preview server running on port 3002
Refreshing the non-node content (e.g. sidebars and other menus)...
(This process will happen in the background)
GetLocationsOperatingStatus: 7.847s
GetIcsFiles: 434.889ms
GetSidebars: 1.759s
GetFacilitySidebar__vaBedfordHealthCareFacilitySidebarQuery: 668.617ms
<========= snip ============>
GetFacilitySidebar__vaStCloudHealthCareFacilitySidebarQuery: 822.601ms
GetOutreachSidebar: 447.169ms
GetAlerts: 1.216s
GetBanners: 498.826ms
GetPromoBanners: 409.742ms
GetBannnerAlerts: 5.133s
GetOutreachAssets: 2:39.792 (m:ss.mmm)
GetHomepage: 714.045ms
GetMenuLinks: 1.264s
GetTaxonomies: 1.499s
Node-node queries: 4:40.095 (m:ss.mmm)
Caching non-node content into /Users/timcosgrove/code/content-build/.cache/localhost/preview-server/nonNodeContent.json...
Done!
</pre>
</details>