### PR TITLE
Send content release events to datadog

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -770,6 +770,11 @@ jobs:
           -H "DD-API-KEY: ${{ env.GHA_CONTENT_BUILD_DATADOG_API_KEY }}" \
           -d @- < metrics.json
 
+      - name: Record deployment event
+        uses: ./.github/workflows/record-release-interval
+        with:
+          datadog_api_key: ${{ env.GHA_CONTENT_BUILD_DATADOG_API_KEY }}
+
   stop-runner:
     name: Stop on-demand-runner
     needs:

--- a/.github/workflows/record-release-interval/action.yml
+++ b/.github/workflows/record-release-interval/action.yml
@@ -1,0 +1,29 @@
+name: Record release interval
+description: Record events and timing between deployment events in Datadog
+
+inputs:
+  datadog_api_key:
+    description: Key for Datadog API access
+    required: true
+  environment:
+    description: Environment that content was deployed to
+    required: false
+    default: "prod"
+
+runs:
+  using: composite
+  steps:
+    - name: Record deployment event in Datadog
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      run: |
+        # Send the event to datadog.
+        jq --null-input '{}' | \
+        jq '.title = "Content release (${{ inputs.environment }})"' | \
+        jq '.text = "Content was released to ${{ inputs.environment }}"' | \
+        jq '.tags[0] = "env:${{ inputs.environment }}"' > event.json
+
+        curl -X POST "https://api.datadog.com/api/v1/events" \
+          -H "Content-Type: text/json" \
+          -H "DD-API-KEY: ${{ inputs.datadog_api_key }}" \
+          -d @- < event.json


### PR DESCRIPTION
## Description

This is part one of several to start recording the amount of time between deployments in Datadog. In order for the time calculation to work, I need to have the events in Datadog first.

Expected followups:
* Before sending the event to Datadog, calculate the amount of time since the previous event recorded in Datadog
* Also record the events in the Daily Production Deploy workflow

Related to: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/7939

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
