### PR TITLE
Send API request to the correct datadog domain 🤦‍♂️

### DIFF
--- a/.github/workflows/record-release-interval/action.yml
+++ b/.github/workflows/record-release-interval/action.yml
@@ -23,7 +23,7 @@ runs:
         jq '.text = "Content was released to ${{ inputs.environment }}"' | \
         jq '.tags[0] = "env:${{ inputs.environment }}"' > event.json
 
-        curl -X POST "https://api.datadog.com/api/v1/events" \
+        curl -X POST "https://api.datadoghq.com/api/v1/events" \
           -H "Content-Type: text/json" \
           -H "DD-API-KEY: ${{ inputs.datadog_api_key }}" \
           -d @- < event.json


### PR DESCRIPTION
## Description


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
