### PR TITLE
Update block/paragraph alert templates to match design system guidelines

### DIFF
--- a/src/site/blocks/alert.drupal.liquid
+++ b/src/site/blocks/alert.drupal.liquid
@@ -5,31 +5,29 @@
 {% endif %}
 
 {% if isPreview or alert.entityPublished %}
-  <div data-template="blocks/alert" data-entity-id="{{ alert.entityId }}" class="usa-alert usa-alert-{{ alertType }}" role="alert">
-    <div class="usa-alert-body">
-      <h2 class="usa-alert-heading vads-u-font-size--h3">
-        {{ alert.fieldAlertTitle }}
-      </h2>
+  <va-alert data-template="blocks/alert" data-entity-id="{{ alert.entityId }}" status="{{ alertType }}" class="vads-u-margin-top--3" role="alert">
+    <h2 slot="headline" class="vads-u-font-size--h3">
+      {{ alert.fieldAlertTitle }}
+    </h2>
 
-      {% if alert.fieldAlertContent.entity.fieldTextExpander == empty %}
-        {{ alert.fieldAlertContent.entity.fieldWysiwyg.processed }}
-      {% endif %}
+    {% if alert.fieldAlertContent.entity.fieldTextExpander == empty %}
+      {{ alert.fieldAlertContent.entity.fieldWysiwyg.processed }}
+    {% endif %}
 
-      {% if alert.fieldAlertContent.entity.fieldTextExpander %}
-        {% comment %}
-          NOTE: .additional-info-container is a class utilized by
-          createAdditionalInfoWidget.js to add toggle functionality to info alerts
-        {% endcomment %}
-        <div data-alert-box-title="{{ alert.fieldAlertTitle }}" data-label="{{ alert.fieldAlertContent.entity.fieldTextExpander }}" class="form-expanding-group borderless-alert additional-info-container">
-          <div class="additional-info-title">
-            {{ alert.fieldAlertContent.entity.fieldTextExpander }}
-          </div>
-
-          {% if alert.fieldAlertContent.entity.fieldWysiwyg %}
-            <div class="additional-info-content usa-alert-text" hidden>{{ alert.fieldAlertContent.entity.fieldWysiwyg.processed }}</div>
-          {% endif %}
+    {% if alert.fieldAlertContent.entity.fieldTextExpander %}
+      {% comment %}
+        NOTE: .additional-info-container is a class utilized by
+        createAdditionalInfoWidget.js to add toggle functionality to info alerts
+      {% endcomment %}
+      <div data-alert-box-title="{{ alert.fieldAlertTitle }}" data-label="{{ alert.fieldAlertContent.entity.fieldTextExpander }}" class="form-expanding-group borderless-alert additional-info-container">
+        <div class="additional-info-title">
+          {{ alert.fieldAlertContent.entity.fieldTextExpander }}
         </div>
-      {% endif %}
-    </div>
-  </div>
+
+        {% if alert.fieldAlertContent.entity.fieldWysiwyg %}
+          <div class="additional-info-content usa-alert-text" hidden>{{ alert.fieldAlertContent.entity.fieldWysiwyg.processed }}</div>
+        {% endif %}
+      </div>
+    {% endif %}
+  </va-alert>
 {% endif %}

--- a/src/site/paragraphs/alert.drupal.liquid
+++ b/src/site/paragraphs/alert.drupal.liquid
@@ -1,48 +1,47 @@
 {% comment %}
-    Example data:
-    {
+  Example data:
+  {
     "entity": {
-    "entityType": "paragraph",
-    "entityBundle": "alert",
-    "fieldAlertType": "information",
-    "fieldAlertHeading": null,
-    "fieldAlertBlockReference": {
-    "entity": {
-    "fieldAlertTitle": "You'll need to go to eBenefits to authorize us to share your health information through the Veterans Health Information Exchange.",
-    "fieldAlertType": "information",
-    "fieldReusability": "reusable",
-    "fieldAlertContent": {
-    "entity": {
-    "fieldWysiwyg": {
-    "processed": "<p>To use this feature, you'll need a Premium <strong>DS Logon</strong> account. Your My HealtheVet or ID.me credentials won’t work on the eBenefits website. Go to eBenefits to sign in, register, or upgrade your <strong>DS Logon</strong> account to Premium.<br /><a class=\"usa-button-primary\" href=\"https://www.ebenefits.va.gov/ebenefits/vapii\">Go to eBenefits</a>\n</p>"
+      "entityType": "paragraph",
+      "entityBundle": "alert",
+      "fieldAlertType": "information",
+      "fieldAlertHeading": null,
+      "fieldAlertBlockReference": {
+      "entity": {
+        "fieldAlertTitle": "You'll need to go to eBenefits to authorize us to share your health information through the Veterans Health Information Exchange.",
+        "fieldAlertType": "information",
+        "fieldReusability": "reusable",
+        "fieldAlertContent": {
+        "entity": {
+          "fieldWysiwyg": {
+            "processed": "<p>To use this feature, you'll need a Premium <strong>DS Logon</strong> account. Your My HealtheVet or ID.me credentials won’t work on the eBenefits website. Go to eBenefits to sign in, register, or upgrade your <strong>DS Logon</strong> account to Premium.<br /><a class=\"usa-button-primary\" href=\"https://www.ebenefits.va.gov/ebenefits/vapii\">Go to eBenefits</a>\n</p>"
+          }
+        }
+      }
     }
-    }
-    }
-    }
-    },
+  },
     "fieldVaParagraphs": []
-    }
+  }
 {% endcomment %}
 {% assign alertType = entity.fieldAlertType %}
 {% if alertType = "information" %}
-    {% assign alertType = "info" %}
+  {% assign alertType = "info" %}
 {% endif %}
 
 {% if entity.fieldAlertBlockReference != empty %}
-    {% assign alertBlock = entity.fieldAlertBlockReference.entity %}
-    {% include "src/site/blocks/alert.drupal.liquid" with alert = alertBlock %}
+  {% assign alertBlock = entity.fieldAlertBlockReference.entity %}
+  {% include "src/site/blocks/alert.drupal.liquid" with alert = alertBlock %}
 <!-- hide ghost alerts -->
 {% elsif entity.fieldAlertHeading != empty and entity.fieldVaParagraphs != empty %}
-    <div date-template="paragraphs/alert" data-entity-id="{{ entity.entityId }}" class="usa-alert usa-alert-{{ alertType }}" role="alert">
-        <div class="usa-alert-body">
-            <h3 class="usa-alert-heading">
-                {{ entity.fieldAlertHeading }}
-            </h3>
-            {% for paragraph in entity.fieldVaParagraphs %}
-                {% assign bundleComponent = "src/site/paragraphs/" | append: paragraph.entity.entityBundle | append: ".drupal.liquid" %}
-                {% include {{ bundleComponent }} with entity = paragraph.entity %}
-            {% endfor %}
-        </div>
-    </div>
+  <va-alert date-template="paragraphs/alert" data-entity-id="{{ entity.entityId }}" status="{{ alertType }}" class="vads-u-margin-top--3" role="alert">
+    <h2 slot="headline" class="vads-u-font-size--h3">
+      {{ entity.fieldAlertHeading }}
+    </h2>
+
+    {% for paragraph in entity.fieldVaParagraphs %}
+      {% assign bundleComponent = "src/site/paragraphs/" | append: paragraph.entity.entityBundle | append: ".drupal.liquid" %}
+      {% include {{ bundleComponent }} with entity = paragraph.entity %}
+    {% endfor %}
+  </va-alert>
 {% endif %}
 


### PR DESCRIPTION
## Description
This PR updates outdated alert markup to utilize the [`va-alert` web component](https://design.va.gov/storybook/?path=/docs/components-va-alert--default) to normalize icon sizing across various alert components. The current templates violate the [Design System Guidelines - Category Number 04, Issue Number 07](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/VA.gov-experience-standards.1683980311.html) by having inconsistent sizing and display between identical components. The reported desired icon size was the smaller size as shown in the screenshot below.

##Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/34168

## Screenshots
![Annotation on 2021-12-09 at 10-26-04](https://user-images.githubusercontent.com/6738544/155553765-ed867cd4-08f8-4295-9dfb-a0c896004fe3.png)

## Acceptance criteria
- [x] Icon size matches other alerts on pages

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
