### PR TITLE
Revert "VACMS-1317: Update featured content logic."

### DIFF
--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -31,14 +31,16 @@
               {% endif %}
 
               {% assign featuredEventUrl = null %}
-              {% assign upcomingEvents = reverseFieldListingNode.entities | filterUpcomingEvents | sort: "fieldOrder" %}
+              {% assign featuredItemSet = false %}
+              {% assign upcomingEvents = reverseFieldListingNode.entities | filterUpcomingEvents  %}
 
               {% for featuredEvent in upcomingEvents %}
-                {% if featuredEvent.fieldOrder != null %}
+                {% if featuredEvent.fieldFeatured == true %}
                   {% unless entityUrl.path contains 'past-events' %}
+                    {% if featuredItemSet == false %}
                       {% assign featuredEventUrl = featuredEvent.entityUrl.path %}
                       <div class="usa-width-two-thirds">
-                        <div class="usa-grid usa-grid-full vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4 vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-border-left--7px vads-u-border-color--primary-alt-lightest featured-content">
+                        <div class="usa-grid usa-grid-full vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4 vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-border-left--7px vads-u-border-color--primary-alt-lightest" id="featured-content">
                           <div class="usa-width-full vads-u-padding-left--2">
                             <div class="vads-u-margin-bottom--2">
                               <strong>In the spotlight at
@@ -48,7 +50,9 @@
                           </div>
                         </div>
                       </div>
+                    {% endif %}
                   {% endunless %}
+                  {% assign featuredItemSet = true %}
                 {% endif %}
               {% endfor %}
 
@@ -66,7 +70,7 @@
 
               {% for event in pagedItems %}
                 {% comment %} Don't render the featured event again {% endcomment %}
-                {% if event.fieldOrder == null %}
+                {% if featuredEventUrl != event.entityUrl.path %}
                   <div class="clearfix-text">
                     {% include "src/site/teasers/event.drupal.liquid" with node = event %}
                   </div>
@@ -83,7 +87,7 @@
             </div>
           </div>
               <!-- Last updated & feedback button-->
-          {% include "src/site/includes/above-footer-elements.drupal.liquid" %}
+          {% include "src/site/includes/above-footer-elements.drupal.liquid" %}  
         </article>
       </div>
     </div>

--- a/src/site/layouts/news_stories_page.drupal.liquid
+++ b/src/site/layouts/news_stories_page.drupal.liquid
@@ -72,7 +72,7 @@ Example data:
           {% endfor %}
           {% endif %}
           {% for story in pagedItems %}
-            {% if story.fieldOrder == null %}
+            {% if story.fieldFeatured == false %}
               {% include "src/site/teasers/news_story_page.drupal.liquid" with node = story %}
             {% endif %}
           {% endfor %}

--- a/src/site/layouts/story_listing.drupal.liquid
+++ b/src/site/layouts/story_listing.drupal.liquid
@@ -18,20 +18,22 @@
                 {% endif %}
               </div>
           {% assign stories = reverseFieldListingNode.entities %}
-          {% assign featuredStories = reverseFieldListingNode.entities | sort: 'fieldOrder' %}
+          {% assign featuredStories = reverseFieldListingNode.entities | filterBy: 'fieldFeatured', true %}
           {% assign isFirstPage = isPreview or paginator | isFirstPage %}
           {% if isPreview %}
             {% assign pagingResult = debug | paginatePages: stories, 'story' %}
             {% assign pagedItems = pagingResult.pagedItems%}
             {% assign paginator = pagingResult.paginator%}
           {% endif %}
+          {% if isFirstPage and featuredStories %}
             {% for storyFeature in featuredStories limit:2 %}
-            {% if storyFeature.fieldOrder != null and isFirstPage %}
                 {% include "src/site/teasers/news_story_page_feature.drupal.liquid" with node = storyFeature %}
-            {% endif %}
             {% endfor %}
+          {% endif %}
           {% for story in pagedItems %}
+            {% if story.fieldFeatured == false %}
               {% include "src/site/teasers/news_story_page.drupal.liquid" with node = story %}
+            {% endif %}
           {% endfor %}
           {% if stories.length == 0 %}
             <div class="clearfix-text">No stories at this time.</div>

--- a/src/site/layouts/vet_center.drupal.liquid
+++ b/src/site/layouts/vet_center.drupal.liquid
@@ -11,7 +11,7 @@
           {% if title != empty %}
             <h1 aria-describedby="vet-center-title">{{ title }}</h1>
             {% if fieldOfficialName and title != fieldOfficialName %}
-              <p id="vet-center-title" class="field-official-name vads-u-line-height--4 vads-u-font-family--sans vads-u-font-size--lg
+              <p id="vet-center-title" class="field-official-name vads-u-line-height--4 vads-u-font-family--sans vads-u-font-size--lg 
               vads-u-font-weight--bold vads-u-padding-bottom--0p5">
                 Also called the {{fieldOfficialName}}
               </p>
@@ -19,7 +19,7 @@
           {% elsif fieldOfficialName != empty %}
             <h1>{{ fieldOfficialName}}</h1>
           {% endif %}
-
+          
           {% if fieldIntroText != empty %}
             <div class="va-introtext">
               <p>{{ fieldIntroText }}</p>
@@ -162,8 +162,8 @@
 
           {% if fieldCcVetCenterFaqs.fetched %}
             <div class="vads-u-margin-bottom--3" id="field-vet-center-faqs">
-              {% include "src/site/includes/centralized-content.drupal.liquid"
-                entity = fieldCcVetCenterFaqs.fetched
+              {% include "src/site/includes/centralized-content.drupal.liquid" 
+                entity = fieldCcVetCenterFaqs.fetched 
                 contentType = fieldCcVetCenterFaqs.fetchedBundle
                 level = 3
               %}
@@ -171,7 +171,7 @@
           {% endif %}
           <va-back-to-top></va-back-to-top>
     <!-- Last updated & feedback button -->
-          {% include "src/site/includes/above-footer-elements.drupal.liquid" %}
+          {% include "src/site/includes/above-footer-elements.drupal.liquid" %}          
         </article>
       </div>
     </div>

--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionEvents.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionEvents.node.graphql.js
@@ -17,7 +17,7 @@ function queryFilter(isAll) {
     ${
       isAll
         ? ''
-        : '{ field: "field_order" value: ["0", "1"]}, { field: "field_datetime_range_timezone", value: [$today], operator: GREATER_THAN}'
+        : '{ field: "field_featured" value: "1"}, { field: "field_datetime_range_timezone", value: [$today], operator: GREATER_THAN}'
     }
   ]} sort: [{field: "field_order", direction: ASC }, {field: "field_datetime_range_timezone", direction: ASC }] limit: ${
     isAll ? '5000' : '2'

--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionNewsStories.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionNewsStories.node.graphql.js
@@ -7,7 +7,7 @@ const NEWS_STORIES_RESULTS = `
     entityId
     ... on NodeNewsStory {
       title
-      fieldOrder
+      fieldFeatured
       fieldIntroText
       fieldMedia {
         entity {
@@ -37,7 +37,7 @@ function queryFilter(isAll) {
       conditions: [
         { field: "type", value: "news_story"}
         { field: "status", value: "1"}
-        ${isAll ? '' : '{ field: "field_order" value: ["0", "1"]}'}
+        ${isAll ? '' : '{ field: "field_featured" value: "1"}'}
       ]} sort: {field: "created", direction: DESC }, limit:${
         isAll ? '500' : '2'
       })

--- a/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
@@ -95,7 +95,7 @@ const nodeHealthCareRegionPage = `
     eventTeasersFeatured: reverseFieldOfficeNode(limit: 1000, filter: {conditions: [{field: "type", value: "event_listing"}]}) {
       entities {
         ... on NodeEventListing {
-          reverseFieldListingNode(limit: 5000, filter: {conditions: [{field: "type", value: "event"}, {field: "status", value: "1"}, {field: "field_order", value: ["0", "1"]}, { field: "field_datetime_range_timezone", value: [$today], operator: GREATER_THAN}]}) {
+          reverseFieldListingNode(limit: 5000, filter: {conditions: [{field: "type", value: "event"}, {field: "status", value: "1"}, {field: "field_featured", value: "1"}, { field: "field_datetime_range_timezone", value: [$today], operator: GREATER_THAN}]}) {
             entities {
               ... nodeEventWithoutBreadcrumbs
             }
@@ -106,11 +106,11 @@ const nodeHealthCareRegionPage = `
     newsStoryTeasersFeatured: reverseFieldOfficeNode(limit: 1000, filter: {conditions: [{field: "type", value: "story_listing"}]}) {
       entities {
         ... on NodeStoryListing {
-          reverseFieldListingNode(limit: 1000, filter: {conditions: [{field: "type", value: "news_story"}, {field: "status", value: "1"}, {field: "field_order", value: ["0", "1"]}]}) {
+          reverseFieldListingNode(limit: 1000, filter: {conditions: [{field: "type", value: "news_story"}, {field: "status", value: "1"}, {field: "field_featured", value: "1"}]}) {
             entities {
               ... on NodeNewsStory {
                 title
-                fieldOrder
+                fieldFeatured
                 fieldIntroText
                 fieldMedia {
                   entity {

--- a/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
@@ -80,6 +80,7 @@ const nodeEvent = `
         }
       }
     }
+    fieldFeatured
     fieldLink {
       uri
       url {
@@ -229,6 +230,7 @@ const nodeEventWithoutBreadcrumbs = `
         }
       }
     }
+    fieldFeatured
     fieldLink {
       uri
       url {

--- a/src/site/stages/build/drupal/graphql/storyListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/storyListingPage.graphql.js
@@ -13,7 +13,7 @@ const storyListingPage = `
         ... on NodeNewsStory {
           entityId
           title
-          fieldOrder
+          fieldFeatured
           entityUrl {
             path
           }


### PR DESCRIPTION
## Description
This reverts commit 26ba9912a3b6440387bd39af88b58d8c80d21036.
introduced in https://github.com/department-of-veterans-affairs/content-build/pull/680
Per convos with @davidconlon @mmiddaugh @swirtSJW @kevwalsh , we are going to further research the implications of using `fieldOrder` vs `fieldFeatured` before continuing. 
