### PR TITLE
VACMS-7771: Generates json data file for office-directory app.

### DIFF
--- a/src/site/stages/build/drupal/graphql/CountEntityTypes.graphql.js
+++ b/src/site/stages/build/drupal/graphql/CountEntityTypes.graphql.js
@@ -121,6 +121,16 @@ const CountEntityTypes = `
     count
   }
 
+  office: nodeQuery(
+    filter: {
+      conditions: [
+        {field: "status", value: ["1"]},
+        {field: "type", value: ["office"]}
+      ]}
+  	) {
+    count
+  }
+
   nodeQa: nodeQuery(
     filter: {
       conditions: [

--- a/src/site/stages/build/drupal/individual-queries.js
+++ b/src/site/stages/build/drupal/individual-queries.js
@@ -10,7 +10,7 @@ const {
   getNodeHealthCareRegionPageQueries,
 } = require('./graphql/healthCareRegionPage.graphql');
 
-const { GetNodeOffices } = require('./graphql/nodeOffice.graphql');
+const { getNodeOfficeQueries } = require('./graphql/nodeOffice.graphql');
 
 const {
   getNodeHealthCareLocalFacilityPageQueries,
@@ -113,7 +113,7 @@ function getNodeQueries(entityCounts) {
     ...getNodeVaFormQueries(entityCounts),
     ...getNodeHealthCareRegionPageQueries(entityCounts),
     ...getNodePersonProfileQueries(entityCounts),
-    GetNodeOffices,
+    ...getNodeOfficeQueries(entityCounts),
     ...getNodeHealthCareLocalFacilityPageQueries(entityCounts),
     ...getNodeHealthServicesListingPageQueries(entityCounts),
     ...getNewsStoryQueries(entityCounts),

--- a/src/site/stages/build/index.js
+++ b/src/site/stages/build/index.js
@@ -25,6 +25,7 @@ const downloadAssets = require('./plugins/download-assets');
 const createDrupalDebugPage = require('./plugins/create-drupal-debug');
 const createEnvironmentFilter = require('./plugins/create-environment-filter');
 const createHeaderFooter = require('./plugins/create-header-footer');
+const createOfficeDirectoryData = require('./plugins/create-office-directory-data');
 const createOutreachAssetsData = require('./plugins/create-outreach-assets-data');
 const createResourcesAndSupportWebsiteSection = require('./plugins/create-resources-and-support-section');
 const createSitemaps = require('./plugins/create-sitemaps');
@@ -87,6 +88,11 @@ function build(BUILD_OPTIONS) {
 
   smith.use(getDrupalContent(BUILD_OPTIONS), 'Get Drupal content');
   smith.use(addDrupalPrefix(BUILD_OPTIONS), 'Add Drupal Prefix');
+
+  smith.use(
+    createOfficeDirectoryData(BUILD_OPTIONS),
+    'Create office-directory data',
+  );
 
   smith.use(
     createOutreachAssetsData(BUILD_OPTIONS),

--- a/src/site/stages/build/plugins/create-office-directory-data.js
+++ b/src/site/stages/build/plugins/create-office-directory-data.js
@@ -1,0 +1,26 @@
+/* eslint-disable no-param-reassign */
+const { ENTITY_BUNDLES } = require('../../../constants/content-modeling');
+const { logDrupal } = require('../drupal/utilities-drupal');
+
+function getOfficeNodes(files) {
+  return Object.entries(files)
+    .filter(([_fileName, file]) => file.entityBundle === ENTITY_BUNDLES.OFFICE)
+    .map(([_fileName, file]) => file);
+}
+
+function createDataFile(files) {
+  const allOffices = getOfficeNodes(files);
+  const filePath = 'office-directory/offices.json';
+  logDrupal(`Generating office-directory data file at: ${filePath}`);
+  files[filePath] = {
+    contents: Buffer.from(JSON.stringify(allOffices)),
+  };
+}
+
+function createOfficeDataFile() {
+  return files => {
+    createDataFile(files);
+  };
+}
+
+module.exports = createOfficeDataFile;


### PR DESCRIPTION
## Description
The `/office-directory` app requires a data file consisting of Office nodes.  This file needs to be generated at build time and `fetch`ed from the browser at runtime.  The fetching is done in a [related PR](https://github.com/department-of-veterans-affairs/vets-website/pull/20387) on `vets-website`.  This PR handles the generation of the data file.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
