### PR TITLE
35103 Banner Web Component Migration

### DIFF
--- a/src/site/components/banners.drupal.liquid
+++ b/src/site/components/banners.drupal.liquid
@@ -3,17 +3,18 @@
 
 <!-- Banners -->
 {% for banner in visibleBanners %}
-  <div
-    aria-label="{{ banner.title | escape }}"
+  <va-banner
     data-template="components/banners.drupal.liquid"
-    data-content="{{ banner.body.processed | escape }}"
-    data-dismissible-status="{{ banner.fieldDismissibleOption }}"
-    data-title="{{ banner.title | escape }}"
-    data-type="{{ banner.fieldAlertType | formatAlertType }}"
-    data-visible="true"
-    data-widget-type="banner"
-    role="region"
-  ></div>
+    {% if banner.fieldDismissibleOption != 'perm' %}
+    show-close="true"
+    {% endif %}
+    {% if banner.fieldDismissibleOption == 'dismiss-session' %}
+    window-session="true"
+    {% endif %}
+    headline="{{ banner.title }}"
+    type="{{ banner.fieldAlertType | formatAlertType }}"
+    visible="true"
+  >{{ banner.body.processed }}</va-banner>
 {% endfor %}
 
 <!-- Maintenance banner -->


### PR DESCRIPTION
## Description / Issue Number
https://github.com/department-of-veterans-affairs/va.gov-team/issues/35103

The `va-banner` web component has been deployed to Vets-Website and is now available for usage. This PR will allow for the usage of the web component and migrate away from the deprecated React Component for Banner. Following the steps outlined here: https://vfs.atlassian.net/wiki/spaces/DST/pages/2051080448/Liquid+template+migration+guidance#va-banner

## Related PR
https://github.com/department-of-veterans-affairs/vets-website/pull/20381

## Testing done / Screenshots
<img width="1440" alt="155389265-4de11a08-fa56-4103-9afe-f6b08eacbe47" src="https://user-images.githubusercontent.com/11822533/156247140-bb62ee9e-2e08-497b-b8a8-f97a6076a7da.png">

## Acceptance criteria
- [X] Migrate from React Component to new Web Component

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
