### PR TITLE
Change recurring sort to grab first instance of date of event listing pages

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1365,6 +1365,17 @@ module.exports = function registerFilters() {
     return futureDates[0];
   };
 
+  liquid.filters.deriveMostRecentDateOnEventsListingPage = fieldDatetimeRangeTimezone => {
+    const dates = [];
+    fieldDatetimeRangeTimezone.forEach(element => {
+      if (element?.endValue > moment().unix()) {
+        dates.push(element);
+      }
+    });
+    const sortedDates = _.sortBy(dates, 'endValue');
+    return sortedDates[0];
+  };
+
   // Given an array of services provided at a facility,
   // return a flattened array of service locations that
   // offer service of type `serviceType`

--- a/src/site/includes/date.drupal.liquid
+++ b/src/site/includes/date.drupal.liquid
@@ -1,13 +1,7 @@
 {% assign timezone = "ET" %}
 {% assign defaultTZ = "America/New_York" %}
 
-{% assign lastPathArg = entityUrl.path | split: "/" | last %}
-<!-- Derive most recent date -->
-{% if fieldDatetimeRangeTimezone.length > 1 and lastPathArg == 'events' %}
-  {% assign mostRecentDate = fieldDatetimeRangeTimezone | deriveMostRecentDateOnEventsListingPage %}
-{% else %}
-  {% assign mostRecentDate = fieldDatetimeRangeTimezone | deriveMostRecentDate %}
-{% endif %}
+{% assign mostRecentDate = fieldDatetimeRangeTimezone | deriveMostRecentEventDate %}
 
 {% if mostRecentDate.timezone != empty %}
   {% assign timezone = mostRecentDate.timezone |  timezoneAbbrev: mostRecentDate.value %}

--- a/src/site/includes/date.drupal.liquid
+++ b/src/site/includes/date.drupal.liquid
@@ -1,8 +1,13 @@
 {% assign timezone = "ET" %}
 {% assign defaultTZ = "America/New_York" %}
 
+{% assign lastPathArg = entityUrl.path | split: "/" | last %}
 <!-- Derive most recent date -->
-{% assign mostRecentDate = fieldDatetimeRangeTimezone | deriveMostRecentDate %}
+{% if fieldDatetimeRangeTimezone.length > 1 and lastPathArg == 'events' %}
+  {% assign mostRecentDate = fieldDatetimeRangeTimezone | deriveMostRecentDateOnEventsListingPage %}
+{% else %}
+  {% assign mostRecentDate = fieldDatetimeRangeTimezone | deriveMostRecentDate %}
+{% endif %}
 
 {% if mostRecentDate.timezone != empty %}
   {% assign timezone = mostRecentDate.timezone |  timezoneAbbrev: mostRecentDate.value %}

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -198,7 +198,7 @@
 
                 <div class="vads-u-display--flex vads-u-flex-direction--column">
                   <!-- Derive most recent date -->
-                  {% assign mostRecentDate = fieldDatetimeRangeTimezone | deriveMostRecentDate %}
+                  {% assign mostRecentDate = fieldDatetimeRangeTimezone | deriveMostRecentEventDate %}
 
                   <!-- Starts at + ends at -->
                   <p class="vads-u-margin--0">

--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -87,7 +87,7 @@
             </div>
           </div>
               <!-- Last updated & feedback button-->
-          {% include "src/site/includes/above-footer-elements.drupal.liquid" %}  
+          {% include "src/site/includes/above-footer-elements.drupal.liquid" %}
         </article>
       </div>
     </div>


### PR DESCRIPTION
## Description
When event listings have events with multiple recurrences, we want the soonest one to appear.
closes #[37833](https://github.com/department-of-veterans-affairs/va.gov-team/issues/37833)

## Testing done
Visual

## Screenshots
Yes:
![image](https://user-images.githubusercontent.com/2404547/156252001-5f51c8aa-ad92-4e4d-9894-417a733e035f.png)

No:
![image](https://user-images.githubusercontent.com/2404547/156252144-f401a93a-5cf6-4161-b893-381b25e80b24.png)

## Acceptance criteria
- [ ] Recurring events created for Pittsburgh in https://pr7981-5kfpv6vznchkcxw4bgycflzjjodfbtbe.ci.cms.va.gov/ environment show soonest occurrence on listing page https://pr7981-5kfpv6vznchkcxw4bgycflzjjodfbtbe.ci.cms.va.gov/pittsburgh-health-care
- [ ] Event listing past event pages do not show upcoming events
- [ ] Featured events appear when appropriate on listing pages
- [ ] Regressions are not introduced on VAMC pages that have featured events
- [ ] Single instance (non-recurring) events still appear on listing pages when expected