### PR TITLE
Standardize table of content markup in liquid templates

### DIFF
--- a/src/site/facilities/health_care_region_detail_content.drupal.liquid
+++ b/src/site/facilities/health_care_region_detail_content.drupal.liquid
@@ -20,7 +20,7 @@
 
   {% if fieldTableOfContentsBoolean != empty and fieldTableOfContentsBoolean %}
     <nav id="table-of-contents" aria-labelledby="on-this-page">
-      <h2 class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
+      <h2 id="on-this-page" class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
       <ul class="usa-unstyled-list" role="list"></ul>
     </nav>
   {% endif %}

--- a/src/site/layouts/basic_landing_page.drupal.liquid
+++ b/src/site/layouts/basic_landing_page.drupal.liquid
@@ -32,7 +32,7 @@
           <!-- TOC -->
           {% if fieldTableOfContentsBoolean %}
             <nav id="table-of-contents" aria-labelledby="on-this-page">
-              <h2 class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
+              <h2 id="on-this-page" class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
               <ul class="usa-unstyled-list" role="list"></ul>
             </nav>
           {% endif %}

--- a/src/site/layouts/faq_multiple_q_a.drupal.liquid
+++ b/src/site/layouts/faq_multiple_q_a.drupal.liquid
@@ -39,7 +39,7 @@
             {% if fieldTableOfContentsBoolean %}
               <nav id="table-of-contents" aria-labelledby="on-this-page">
                 <button type="button" class="vads-u-visibility--screen-reader">Back to top</button>
-                <h2 class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
+                <h2 id="on-this-page" class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
                 <ul class="usa-unstyled-list" role="list"></ul>
               </nav>
             {% endif %}

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -25,7 +25,7 @@
           </div>
 
           <nav id="table-of-contents" class="vads-u-margin-bottom--5" aria-labelledby="on-this-page">
-            <h2 class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
+            <h2 id="on-this-page" class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
             <ul class="usa-unstyled-list" role="list"></ul>
           </nav>
 

--- a/src/site/layouts/health_services_listing.drupal.liquid
+++ b/src/site/layouts/health_services_listing.drupal.liquid
@@ -25,7 +25,7 @@
           </div>
 
           <nav id="table-of-contents" aria-labelledby="on-this-page">
-            <h2 class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
+            <h2 id="on-this-page" class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
             <ul class="usa-unstyled-list" role="list"></ul>
           </nav>
 

--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -27,7 +27,7 @@
           <h2 id="on-this-page" class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
           <ul class="usa-unstyled-list" role="list">
             {% for spoke in fieldSpokes %}
-              <li>
+              <li class="vads-u-margin-bottom--2">
                 <a 
                   href="#{% if spoke.entity.fieldTitle != empty %}{{ spoke.entity.fieldTitle | hashReference: 30 }}{% endif %}"
                   class="vads-u-display--flex vads-u-text-decoration--none"

--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -23,16 +23,22 @@
         </div>
 
         {% if fieldSpokes != empty and fieldSpokes.length > 1 %}
-          <h2 class="vads-u-margin-bottom--2 vads-u-font-size--lg" aria-labelledby="on-this-page">On this page</h2>
-          <ul>
+        <nav id="table-of-contents" aria-labelledby="on-this-page">
+          <h2 id="on-this-page" class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
+          <ul class="usa-unstyled-list" role="list">
             {% for spoke in fieldSpokes %}
               <li>
-                <a href="#{% if spoke.entity.fieldTitle != empty %}{{ spoke.entity.fieldTitle | hashReference: 30 }}{% endif %}">
+                <a 
+                  href="#{% if spoke.entity.fieldTitle != empty %}{{ spoke.entity.fieldTitle | hashReference: 30 }}{% endif %}"
+                  class="vads-u-display--flex vads-u-text-decoration--none"
+                >
+                  <i class="fas fa-arrow-down va-c-font-size--xs vads-u-margin-top--1 vads-u-margin-right--1" aria-hidden="true"></i>
                   {{ spoke.entity.fieldTitle }}
                 </a>
               </li>
             {% endfor %}
           </ul>
+        </nav>
         {% endif %}
 
         {% if fieldAlert.length %}

--- a/src/site/layouts/page.drupal.liquid
+++ b/src/site/layouts/page.drupal.liquid
@@ -36,7 +36,7 @@
 
           {% if fieldTableOfContentsBoolean != empty and fieldTableOfContentsBoolean %}
             <nav id="table-of-contents" aria-labelledby="on-this-page">
-              <h2 class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
+              <h2 id="on-this-page" class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
               <ul class="usa-unstyled-list" role="list"></ul>
             </nav>
           {% endif %}

--- a/src/site/layouts/support_resources_detail_page.drupal.liquid
+++ b/src/site/layouts/support_resources_detail_page.drupal.liquid
@@ -36,7 +36,7 @@
             <!-- TOC -->
             {% if fieldTableOfContentsBoolean %}
               <nav id="table-of-contents" aria-labelledby="on-this-page">
-                <h2 class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
+                <h2 id="on-this-page" class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
                 <ul class="usa-unstyled-list" role="list"></ul>
               </nav>
             {% endif %}

--- a/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
+++ b/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
@@ -29,7 +29,7 @@
             </div>
           {% endif %}
           <section aria-labelledby="on-this-page" class="table-of-contents" class="vads-u-margin-bottom--5">
-            <h2 class="vads-u-margin-bottom--2 vads-u-font-size--lg" id="on-this-page">
+            <h2 id="on-this-page" class="vads-u-margin-bottom--2 vads-u-font-size--lg">
               On this page
             </h2>
             <ul class="usa-unstyled-list" role="list">

--- a/src/site/layouts/vamc_system_billing_insurance.drupal.liquid
+++ b/src/site/layouts/vamc_system_billing_insurance.drupal.liquid
@@ -16,7 +16,7 @@
           </div>
 
           <nav id="table-of-contents" aria-labelledby="on-this-page">
-            <h2 class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
+            <h2 id="on-this-page" class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
             <ul class="usa-unstyled-list" role="list"></ul>
           </nav>
 

--- a/src/site/layouts/vamc_system_medical_records_offi.drupal.liquid
+++ b/src/site/layouts/vamc_system_medical_records_offi.drupal.liquid
@@ -17,7 +17,7 @@
           </div>
 
           <nav id="table-of-contents" aria-labelledby="on-this-page">
-            <h2 class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
+            <h2 id="on-this-page" class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
             <ul class="usa-unstyled-list" role="list"></ul>
           </nav>
 

--- a/src/site/layouts/vamc_system_policies_page.drupal.liquid
+++ b/src/site/layouts/vamc_system_policies_page.drupal.liquid
@@ -17,7 +17,7 @@
           </div>
 
           <nav id="table-of-contents" aria-labelledby="on-this-page">
-            <h2 class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
+            <h2 id="on-this-page" class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
             <ul class="usa-unstyled-list" role="list"></ul>
           </nav>
 


### PR DESCRIPTION
## Description
This PR address an issue of table of contents markup being inconsistent between liquid templates. Specifically, on landing pages, the markup is considerably less structured and features default styling, instead of the desired styling with custom icons for the list item bullets.

## Original Issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/34502

## Screenshots
**Current markup / stying:**
<img width="669" alt="Screen Shot 2022-03-07 at 10 34 42 AM" src="https://user-images.githubusercontent.com/6738544/157084018-b55c8181-fc2f-4bf1-8b09-f3c164a86427.png">

**Desired result:** 
<img width="598" alt="Screen Shot 2022-03-07 at 10 31 45 AM" src="https://user-images.githubusercontent.com/6738544/157084084-96a35e43-0b9c-47a3-8fd5-47e6308ec5a4.png">

## Acceptance criteria
- [x] Landing page table of contents displays custom list markup & styling

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
