### PR TITLE
35157 Promo Banner Web Component Migration

### DIFF
--- a/src/site/components/banners.drupal.liquid
+++ b/src/site/components/banners.drupal.liquid
@@ -29,15 +29,12 @@
 
 <!-- Promo Banners -->
 {% for promoBanner in visiblePromoBanners %}
-  <div
-    aria-label="{{ promoBanner.title | escape }}"
-    data-id="{{ promoBanner.entityId }}"
-    data-link="{{ promoBanner.fieldLink.url.path }}"
-    data-template="components/banners.drupal.liquid"
-    data-title="{{ promoBanner.title | escape }}"
-    data-type="{{ promoBanner.fieldPromoType }}"
-    data-visible="true"
-    data-widget-type="promo-banner"
+  <va-promo-banner
+    aria-label="{{ promoBanner.title }}"
     role="region"
-  ></div>
+    data-template="components/banners.drupal.liquid"
+    id="{{ promoBanner.entityId }}"
+    href="{{ promoBanner.fieldLink.url.path }}"
+    type="{{ promoBanner.fieldPromoType }}"
+  >{{ promoBanner.title }}</va-promo-banner>
 {% endfor %}


### PR DESCRIPTION
Description / Issue Number
https://github.com/department-of-veterans-affairs/va.gov-team/issues/35157

The `va-promo-banner` web component has been deployed to Vets-Website and is now available for usage. This PR will allow for the usage of the web component and migrate away from the deprecated React Component for Promo Banner. Following the steps outlined here: https://vfs.atlassian.net/wiki/spaces/DST/pages/2051080448/Liquid+template+migration+guidance#va-promo-banner

Related PR
https://github.com/department-of-veterans-affairs/vets-website/pull/20457

Acceptance criteria
- [x] Migrate from React Component to new Web Component

Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs