### PR TITLE
VACMS-37833: fixes incorrect date showing for recurring events.

### DIFF
--- a/src/site/components/situation_updates.drupal.liquid
+++ b/src/site/components/situation_updates.drupal.liquid
@@ -15,7 +15,8 @@
           <div class="vads-u-margin-bottom--0 no-p-bottom-margin">
             <h4 class="vads-u-margin-top--1 vads-u-margin-bottom--2">
               <!-- Derive most recent date -->
-              {% assign mostRecentDate = update.entity.fieldDatetimeRangeTimezone | deriveMostRecentDate %}
+              {% assign now = '' | currentTime %}
+              {% assign mostRecentDate = update.entity.fieldDatetimeRangeTimezone | deriveMostRecentDate: now %}
 
               {% if mostRecentDate.value != empty %}
                 {{ mostRecentDate.value | dateFromUnix: "dddd, MMM D, h:mm A"}}

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1335,6 +1335,10 @@ module.exports = function registerFilters() {
     return basePath.includes(searchValue);
   };
 
+  liquid.filters.currentTime = () => {
+    return moment().unix();
+  };
+
   liquid.filters.deriveMostRecentDate = (
     fieldDatetimeRangeTimezone,
     now = moment().unix(), // This is done so that we can mock the current time in tests.

--- a/src/site/includes/date.drupal.liquid
+++ b/src/site/includes/date.drupal.liquid
@@ -2,7 +2,8 @@
 {% assign defaultTZ = "America/New_York" %}
 
 <!-- Derive most recent date -->
-{% assign mostRecentDate = fieldDatetimeRangeTimezone | deriveMostRecentDate %}
+{% assign now = '' | currentTime %}
+{% assign mostRecentDate = fieldDatetimeRangeTimezone | deriveMostRecentDate: now %}
 
 {% if mostRecentDate.timezone != empty %}
   {% assign timezone = mostRecentDate.timezone |  timezoneAbbrev: mostRecentDate.value %}

--- a/src/site/includes/social-share.drupal.liquid
+++ b/src/site/includes/social-share.drupal.liquid
@@ -2,7 +2,8 @@
   <ul class="usa-unstyled-list" role="list">
     <li class="vads-u-margin-bottom--2p5">
       <!-- Derive most recent date -->
-      {% assign mostRecentDate = mostRecentDate | deriveMostRecentDate %}
+      {% assign now = '' | currentTime %}
+      {% assign mostRecentDate = mostRecentDate | deriveMostRecentDate: now %}
 
       <a
         data-description="{{ fieldDescription }}"

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -377,7 +377,8 @@
                   <p class="vads-u-font-weight--bold vads-u-margin--0 vads-u-margin-right--2">When</p>
                   <p class="vads-u-margin--0">
                     <!-- Derive most recent date -->
-                    {% assign mostRecentDate = eventReference.entity.fieldDatetimeRangeTimezone | deriveMostRecentDate %}
+                    {% assign now = '' | currentTime %}
+                    {% assign mostRecentDate = eventReference.entity.fieldDatetimeRangeTimezone | deriveMostRecentDate: now %}
 
                     {% if mostRecentDate.value != empty %}
                       {{ mostRecentDate.value | dateFromUnix: "dddd, MMM D, h:mm A" }} -
@@ -649,7 +650,7 @@
           {% endfor %}
         </div>
         <va-back-to-top></va-back-to-top>
-        {% include "src/site/includes/above-footer-elements.drupal.liquid" %}          
+        {% include "src/site/includes/above-footer-elements.drupal.liquid" %}
       </div>
     {% endif %}
     <!--/  VA Benefits -->

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -198,7 +198,8 @@
 
                 <div class="vads-u-display--flex vads-u-flex-direction--column">
                   <!-- Derive most recent date -->
-                  {% assign mostRecentDate = fieldDatetimeRangeTimezone | deriveMostRecentDate %}
+                  {% assign now = '' | currentTime %}
+                  {% assign mostRecentDate = fieldDatetimeRangeTimezone | deriveMostRecentDate: now %}
 
                   <!-- Starts at + ends at -->
                   <p class="vads-u-margin--0">


### PR DESCRIPTION
## Description
Recurring events date is showing last date (largest date value) rather than the nearest date in the future.  This PR fixes that.

Note: the problem is that a phantom object is being passed to the filter `deriveMostRecentDate`, and so the default parameter `now` is not actually setting to the default.  This ultimately leads to an empty `futureDates` array, which leaves the logic to just grab the last item in the original data set (rather than the first item of the now-empty `futureDates` data set).

It's unclear why this phantom parameter is being passed, but this PR implements a workaround by explicitly passing the current time as the second parameter.

## Testing done
See screenshot below.  Screenshot taken March 8.  Notice all dates are conceivably the _next_ date in the series.


## Screenshots
![image](https://user-images.githubusercontent.com/6863534/157339511-2567154a-1991-427a-9a99-fcacf01c6f66.png)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
