### PR TITLE
Remove duplicate host url from og:image meta tag

### DIFF
--- a/src/site/includes/metatags.drupal.liquid
+++ b/src/site/includes/metatags.drupal.liquid
@@ -53,7 +53,7 @@
         {% endif %}
       {% when "MetaProperty" %}
         {% if tag.key == "og:image" %}
-          <meta property="og:image" content="{{ hostUrl }}{{ tag.value }}">
+          <meta property="og:image" content="{{ tag.value }}">
         {% else %}
           <meta property="{{ tag.key }}" content="{{ tag.value }}">
         {% endif %}


### PR DESCRIPTION
## Description
This PR updates a bad URL for the default og:image meta tag on site subpages with custom meta tags available. The current implementation prepends the host URL to the tag value in the markup when, in fact, the host URL is already in the tag value.

## Original Issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/33552

## Screenshots
**As is:**
<img width="1761" alt="Screen Shot 2022-03-09 at 10 46 48 AM" src="https://user-images.githubusercontent.com/6738544/157477530-071e1029-bba5-4d2f-8419-64b704437438.png">

**With Update:**
<img width="1761" alt="Screen Shot 2022-03-09 at 10 39 00 AM" src="https://user-images.githubusercontent.com/6738544/157477610-64fe1472-d2c2-4999-a4a5-1618a5e130fd.png">

## Acceptance criteria
- [x] Image path has a single host

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
