### PR TITLE
Move accessibility scan Slack channel ID to global variable

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
+  CHANNEL_ID: C01RAS1KAQK
 
 jobs:
   build:
@@ -20,7 +21,6 @@ jobs:
     env:
       DRUPAL_ADDRESS: https://cms-content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov
       NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
-      CHANNEL_ID: C01RAS1KAQK
 
     steps:
       - name: Configure AWS credentials
@@ -233,9 +233,6 @@ jobs:
       run:
         working-directory: content-build
 
-    env:
-      CHANNEL_ID: C01RAS1KAQK
-
     steps:
       - name: Checkout content-build
         uses: actions/checkout@v2
@@ -362,9 +359,6 @@ jobs:
     defaults:
       run:
         working-directory: content-build
-
-    env:
-      CHANNEL_ID: C01RAS1KAQK
 
     steps:
       - name: Checkout content-build


### PR DESCRIPTION
## Description
Quick PR to move the `CHANNEL_ID` environment variable to the global environment in the daily accessibility scan so that the ID does not have to be updated in multiple lines in the workflow file.