### PR TITLE
VACMS-2509: Remove "fieldBody" from "fieldLocalHealthCareService" GraphQL

### DIFF
--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -184,7 +184,6 @@
                       healthService = localHealthService
                       locationEntity = localService.entity
                       locations = localService.entity.fieldServiceLocation
-                      localServiceDescription = localService.entity.fieldBody.processed
                       fieldFacilityLocatorApiId = fieldFacilityLocatorApiId
                   %}
 
@@ -209,7 +208,7 @@
                     fieldFlickr = fieldRegionPage.entity.fieldFlickr
           %}
   <!-- Last updated & feedback button-->
-        {% include "src/site/includes/above-footer-elements.drupal.liquid" %}    
+        {% include "src/site/includes/above-footer-elements.drupal.liquid" %}
         </article>
 
       </div>

--- a/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
@@ -65,7 +65,7 @@ const healthCareLocalFacilityPageFragment = `
               ... listOfLinkTeasers
             }
           }
-          ${socialMediaFields}          
+          ${socialMediaFields}
           fieldGovdeliveryIdEmerg
           fieldGovdeliveryIdNews
           fieldOperatingStatus {
@@ -79,17 +79,14 @@ const healthCareLocalFacilityPageFragment = `
     fieldLocalHealthCareService {
       entity {
         ... on NodeHealthCareLocalHealthService {
-          status        
-          fieldBody {
-            processed
-          }
+          status
           ${serviceLocation}
           ${appointmentItems}
           fieldRegionalHealthService
           {
             entity {
               ... on NodeRegionalHealthCareServiceDes {
-                status              
+                status
                 entityBundle
                 fieldBody {
                   processed


### PR DESCRIPTION
- Removed "fieldBody" from "fieldLocalHealthCareService" GraphQL query.

## Description
closes #2509

## Testing done
Passes all tests

## Screenshots


## Acceptance criteria
- [ ] The `fieldBody` field have been removed from the `fieldLocalHealthCareService` GraphQL query

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
