### PR TITLE
VACMS-2509: Remove "fieldBody" from "fieldLocalHealthCareService" GraphQL

### DIFF
--- a/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
@@ -65,7 +65,7 @@ const healthCareLocalFacilityPageFragment = `
               ... listOfLinkTeasers
             }
           }
-          ${socialMediaFields}          
+          ${socialMediaFields}
           fieldGovdeliveryIdEmerg
           fieldGovdeliveryIdNews
           fieldOperatingStatus {
@@ -79,17 +79,14 @@ const healthCareLocalFacilityPageFragment = `
     fieldLocalHealthCareService {
       entity {
         ... on NodeHealthCareLocalHealthService {
-          status        
-          fieldBody {
-            processed
-          }
+          status
           ${serviceLocation}
           ${appointmentItems}
           fieldRegionalHealthService
           {
             entity {
               ... on NodeRegionalHealthCareServiceDes {
-                status              
+                status
                 entityBundle
                 fieldBody {
                   processed


### PR DESCRIPTION
- The FE PR build test keeps failing: Recreated feature branch with shorter name.
- Removed "fieldBody" from FE "fieldLocalHealthCareService" GraphQL query.

## Description
closes #2509

## Testing done
Passes all tests

## Screenshots


## Acceptance criteria
- [ ] The `fieldBody` field have been removed from the `fieldLocalHealthCareService` GraphQL query

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
