### PR TITLE
VAHELP-3729: Remove Daylight/Standard placeholder in timezones.

### DIFF
--- a/src/site/components/situation_updates.drupal.liquid
+++ b/src/site/components/situation_updates.drupal.liquid
@@ -24,7 +24,7 @@
               {% if mostRecentDate.timezone != empty %}
                 {{ mostRecentDate.timezone | timezoneAbbrev: mostRecentDate.value }}
               {% else %}
-                {{ timezone }}
+                {{ timezone | replace: "D", ""| replace: "S", ""}}
               {% endif %}
             </h4>
 

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -63,7 +63,7 @@
                         <span>{{ end_date_full }}</span>
                       {% endif %}
                     {% endif %}
-                    <span>{{ timezone }}</span>
+                    <span>{{ timezone | replace: "D", ""| replace: "S", ""}}</span>
                   </dd>
                 </dl>
 

--- a/src/site/layouts/events_page.drupal.liquid
+++ b/src/site/layouts/events_page.drupal.liquid
@@ -55,7 +55,6 @@ Example data:
           <h1>Events</h1>
 
           {% include "src/site/facilities/facilities_events_toggle.drupal.liquid" with url = entityUrl.path %}
-
           {% assign featuredUrl = null %}
           {% if paginator.prev == null %}
             {% for featuredEvent in eventTeasers.entities %}

--- a/src/site/teasers/event.drupal.liquid
+++ b/src/site/teasers/event.drupal.liquid
@@ -25,7 +25,7 @@
                     <span class="event-date event-time">{{ end_date_full }}</span>
                 {% endif %}
             {% endif %}
-            <span class="event-time-zone">{{ timezone }}</span>
+            <span class="event-time-zone">{{ timezone | replace: "D", ""| replace: "S", ""}}</span>
         </div>
       </div>
       {% if node.fieldFacilityLocation != empty %}

--- a/src/site/teasers/event_featured.drupal.liquid
+++ b/src/site/teasers/event_featured.drupal.liquid
@@ -32,7 +32,7 @@
             <span>{{ end_date_full }}</span>
           {% endif %}
         {% endif %}
-        <span>{{ timezone }}</span>
+        <span>{{ timezone | replace: "D", ""| replace: "S", ""}}</span>
       </div>
     </div>
     {% if node.fieldFacilityLocation != empty %}


### PR DESCRIPTION
## Description
Events should display with two letter timezone format. This pr removes the "S" and the "D" from {{ timezone }} in liquid templates that output dates.

## Testing done
Visual and build on local instance

## Screenshots
**NO**
![image](https://user-images.githubusercontent.com/2404547/158825973-3bb502dd-c262-499c-acc7-6c6d6835f217.png)
**YES**
![image](https://user-images.githubusercontent.com/2404547/158826071-fa7b66fa-b952-41a6-8ab2-ca76cc881e48.png)

## Acceptance criteria
- [ ] Event timezone listings on `/western-colorado-health-care/events/44322/` & `/western-colorado-health-care/events/` display two letter timezone format. E.g.: `MT` (not `MST` or `MDT`)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
