### PR TITLE
Fix facilities templates using accordion component

### DIFF
--- a/src/site/facilities/facility_health_service.drupal.liquid
+++ b/src/site/facilities/facility_health_service.drupal.liquid
@@ -1,5 +1,3 @@
-<div data-template="facilities/facilities_health_service" class="facilities_health_service">
-  <va-accordion bordered>
     {% assign serviceTaxonomy = healthService.fieldServiceNameAndDescripti.entity %}
     <va-accordion-item
       {% if serviceTaxonomy.fieldAlsoKnownAs %}
@@ -7,6 +5,7 @@
       {% endif %}
       data-label="{{ serviceTaxonomy.name }}"
       data-childlabel="{{ serviceTaxonomy.fieldAlsoKnownAs }}"
+      data-template="facilities/facilities_health_service"
     >
       <h3 slot="headline">
         {{ serviceTaxonomy.name }}
@@ -41,5 +40,3 @@
         {% endif %}
       </div>
     </va-accordion-item>
-  </va-accordion>
-</div>

--- a/src/site/facilities/health_service.drupal.liquid
+++ b/src/site/facilities/health_service.drupal.liquid
@@ -1,5 +1,3 @@
-<div data-template="facilities/health_service" class="service-accordion-output">
-    <va-accordion bordered>
         {% assign serviceTaxonomy = healthService.fieldServiceNameAndDescripti.entity %}
         <va-accordion-item
             header="{{ serviceTaxonomy.name }}"
@@ -8,6 +6,7 @@
                 data-childlabel="{{ serviceTaxonomy.fieldAlsoKnownAs }}"
             {% endif %}
             data-label="{{ serviceTaxonomy.name }}"
+            data-template="facilities/health_service"
         >
             <div id="{{ serviceTaxonomy.entityBundle }}-{{ serviceTaxonomy.entityId }}">
                 {% if serviceTaxonomy.fieldCommonlyTreatedCondition %}
@@ -54,5 +53,3 @@
                 {% endif %}
             </div>
         </va-accordion-item>
-    </va-accordion>
-</div>

--- a/src/site/includes/health_services_listing_services.liquid
+++ b/src/site/includes/health_services_listing_services.liquid
@@ -4,11 +4,13 @@
 {% if servicesListOrderedByName.length > 0 %}
   <section data-label="{{typeOfCare}}">
     <h2>{{typeOfCare}}</h2>
+    <va-accordion bordered>
     {% for service in servicesListOrderedByName %}
       {% include "src/site/facilities/health_service.drupal.liquid" with
         healthService = service
         sectionName = typeOfCare
       %}
     {% endfor%}
+    </va-accordion>
   </section>
 {% endif %}

--- a/src/site/includes/vet_centers/services.liquid
+++ b/src/site/includes/vet_centers/services.liquid
@@ -1,7 +1,7 @@
 <div class="vads-u-margin-bottom--3">
-    {% for entity in services %}
+    <va-accordion bordered id="{{ idService }}-accordion-{{ entity.entity.fieldServiceNameAndDescripti.entity.name }}">
+      {% for entity in services %}
         {% assign idService = entity.entity.fieldServiceNameAndDescripti.entity.fieldVetCenterTypeOfCare %}
-        <va-accordion bordered id="{{ idService }}-accordion-{{ entity.entity.fieldServiceNameAndDescripti.entity.name }}">
             <va-accordion-item
                     id="{{ idService }}-item-{{ entity.entity.fieldServiceNameAndDescripti.entity.name}}"
                     header="{{ entity.entity.fieldServiceNameAndDescripti.entity.name }}"
@@ -22,6 +22,6 @@
                     </div>
                 {% endif %}
             </va-accordion-item>
-        </va-accordion>
-    {% endfor %}
+      {% endfor %}
+    </va-accordion>
 </div>

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -174,6 +174,8 @@
             <section class="local-health-services" id="local-health-services" data-label="Health services">
 
               {% assign localHealthServices = fieldLocalHealthCareService | sortObjectsBy: 'entity.fieldRegionalHealthService.entity.fieldServiceNameAndDescripti.entity.name' %}
+
+              <va-accordion bordered>
               {% for localService in localHealthServices %}
                 {% assign localHealthService = localService.entity | featureFieldRegionalHealthService %}
                 {% if localHealthService != empty and localService.entity.status == true %}
@@ -188,6 +190,7 @@
 
                 {% endif %}
               {% endfor %}
+              </va-accordion>
             </section>
           {% endif %}
 

--- a/src/site/layouts/vet_center.drupal.liquid
+++ b/src/site/layouts/vet_center.drupal.liquid
@@ -121,16 +121,16 @@
           small-screen:vads-u-font-size--xl vads-u-margin-bottom--2">Prepare for your visit</h2>
             <p> Click on a topic for more details. </p>
             <div class="vads-u-margin-bottom--3">
-              {% for entity in fieldPrepareForVisit %}
-                <va-accordion bordered
-                              id="prepare-for-your-visit-accordion-{{ entity.entity.fieldHeader }}">
+              <va-accordion bordered
+                            id="prepare-for-your-visit-accordion-{{ entity.entity.fieldHeader }}">
+                {% for entity in fieldPrepareForVisit %}
                   <va-accordion-item
                       id="prepare-for-your-visit-accordion-item-{{ entity.entity.fieldHeader }}"
                       header="{{ entity.entity.fieldHeader }}" level="3">
                     {{ entity.entity.fieldRichWysiwyg.processed | drupalToVaPath | phoneLinks }}
                   </va-accordion-item>
-                </va-accordion>
-              {% endfor %}
+                {% endfor %}
+              </va-accordion>
             </div>
           {% endif %}
 


### PR DESCRIPTION
## Description

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/38741

This fixes some templates which were using the `<va-accordion>` component incorrectly inside of a loop.


## Testing done

Identified the `<va-accordion-item>`s in the 11 templates. Result from using `rg "<va-accordion-item"` on this branch:

```
src/site/paragraphs/collapsible_panel.drupal.liquid
38:            <va-accordion-item

src/site/components/merger-social-sco.html
11:    <va-accordion-item level="3" open="true" header="{{ group.heading }}">

src/site/paragraphs/q_a.collapsible_panel.drupal.liquid
10:      <va-accordion-item

src/site/facilities/facility_health_service.drupal.liquid
2:    <va-accordion-item

src/site/facilities/health_service.drupal.liquid
2:        <va-accordion-item

src/site/layouts/vet_center.drupal.liquid
127:                  <va-accordion-item

src/site/layouts/faq_multiple_q_a.drupal.liquid
59:                      <va-accordion-item

src/site/layouts/campaign_landing_page.drupal.liquid
465:                  <va-accordion-item

src/site/includes/vet_centers/services.liquid
5:            <va-accordion-item

src/site/layouts/health_care_local_facility.drupal.liquid
146:                  <va-accordion-item

src/site/layouts/landing_page.drupal.liquid
80:          <va-accordion-item level="3" open="true" header="Ask questions">
126:            <va-accordion-item level="3" open="true" header="Not a Veteran?">
146:            <va-accordion-item level="3" header="Connect with us" open="true">
```

Here are the correct implementations which aren't modified in this PR:

### src/site/paragraphs/collapsible_panel.drupal.liquid

https://github.com/department-of-veterans-affairs/content-build/blob/edcd5d32fe63d7aa9b71eae491efa8f4ad952eba/src/site/paragraphs/collapsible_panel.drupal.liquid#L30-L38

### src/site/components/merger-social-sco.html

https://github.com/department-of-veterans-affairs/content-build/blob/edcd5d32fe63d7aa9b71eae491efa8f4ad952eba/src/site/components/merger-social-sco.html#L9-L11

### src/site/paragraphs/q_a.collapsible_panel.drupal.liquid

https://github.com/department-of-veterans-affairs/content-build/blob/edcd5d32fe63d7aa9b71eae491efa8f4ad952eba/src/site/paragraphs/q_a.collapsible_panel.drupal.liquid#L2-L10

### src/site/layouts/faq_multiple_q_a.drupal.liquid

https://github.com/department-of-veterans-affairs/content-build/blob/edcd5d32fe63d7aa9b71eae491efa8f4ad952eba/src/site/layouts/faq_multiple_q_a.drupal.liquid#L56-L59

### src/site/layouts/campaign_landing_page.drupal.liquid

https://github.com/department-of-veterans-affairs/content-build/blob/edcd5d32fe63d7aa9b71eae491efa8f4ad952eba/src/site/layouts/campaign_landing_page.drupal.liquid#L462-L465

### src/site/layouts/health_care_local_facility.drupal.liquid

This template was modified but there was a correct implementation up above.

https://github.com/department-of-veterans-affairs/content-build/blob/edcd5d32fe63d7aa9b71eae491efa8f4ad952eba/src/site/layouts/health_care_local_facility.drupal.liquid#L140-L146


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
