### PR TITLE
Followups for decoupling content release from daily prod deploy

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -419,6 +419,7 @@ jobs:
     needs:
       - validate-build-status
       - build
+      - archive
     outputs:
       DEPLOY_END_TIME: ${{ steps.export-deploy-end-time.outputs.DEPLOY_END_TIME }}
 

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -100,7 +100,7 @@ jobs:
       TAG: ${{ steps.get-latest-release.outputs.tag_name }}
     steps:
       - name: Cancel workflow due to DSVA schedule
-        if: ${{ github.event_name == "schedule" && env.DSVA_SCHEDULE_ENABLED != 'true' }}
+        if: ${{ github.event_name == 'schedule' && env.DSVA_SCHEDULE_ENABLED != 'true' }}
         uses: andymckay/cancel-action@0.2
 
       - name: Checkout

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -118,7 +118,6 @@ jobs:
       - name: Get latest release
         id: get-latest-release
         uses: thebritican/fetch-latest-release@v2.0.0
-        working-directory: ${{ github.workspace }}
 
       - name: Validate build status
         run: node ./script/github-actions/validate-build-status.js ${{ steps.get-latest-release.outputs.target_commitish }}


### PR DESCRIPTION
## Description


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
