### PR TITLE
Housekeeping for job decoupling

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -138,7 +138,7 @@ jobs:
         uses: ./.github/workflows/slack-notify
         continue-on-error: true
         with:
-          payload: '{"attachments": [{"color": "#2EB67D","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "Stand by, content release for content-build coming up ([using ${{ needs.validate-build-status.outputs.TAG }}](https://github.com/${{github.repository}}/tree/${{ needs.validate-build-status.outputs.TAG }})). <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"}}]}]}'
+          payload: '{"attachments": [{"color": "#2EB67D","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "Stand by, content release for content-build coming up (using ${{ needs.validate-build-status.outputs.TAG }}). <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"}}]}]}'
           channel_id: ${{ env.CMS_NOTIFICATIONS_SLACK }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -3,8 +3,7 @@ name: Content Release
 on:
   workflow_dispatch:
   schedule:
-    - cron: '54 13-17,20-21 * * 1-5'
-    - cron: '45 18 * * 1-5'
+    - cron: '54 13-21 * * 1-5'
 
 concurrency:
   group: content-release-prod

--- a/.github/workflows/daily-production-release.yml
+++ b/.github/workflows/daily-production-release.yml
@@ -1,4 +1,4 @@
-name: Daily Production Deploy
+name: Daily Production Release
 
 on:
   workflow_dispatch:
@@ -6,7 +6,7 @@ on:
     - cron: 0 18 * * 1-5
 
 concurrency:
-  group: daily-deploy-prod
+  group: daily-prod-release
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/daily-production-release.yml
+++ b/.github/workflows/daily-production-release.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Export new release name
         id: export-release-name
         run: |
-          echo ::set-output name=RELEASE_NAME:v0.0.${{ env.new_patch }}
+          echo ::set-output name=RELEASE_NAME::v0.0.${{ env.new_patch }}
 
   notify-success:
     name: Notify Success

--- a/.github/workflows/daily-release-warning.yml
+++ b/.github/workflows/daily-release-warning.yml
@@ -1,11 +1,11 @@
-name: Daily Deploy Warning
+name: Daily Release Warning
 
 on:
   schedule:
     - cron: 0 17 * * 1-5
 
 concurrency:
-  group: daily-deploy-warning
+  group: daily-release-warning
   cancel-in-progress: true
 
 env:
@@ -36,7 +36,7 @@ jobs:
         uses: ./.github/workflows/slack-notify
         continue-on-error: true
         with:
-          payload: '{"attachments": [{"color": "#07711E","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "Stand by, production deploy for content-build coming up in 60 minutes. Please review staging before then. View what coming here: <https://github.com/${{ github.repository }}/compare/${{ steps.get-latest-tag.outputs.LATEST_TAG_VERSION }}...master>"}}]}]}'
+          payload: '{"attachments": [{"color": "#07711E","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "Stand by, production release for content-build coming up in 60 minutes. Please review staging before then. View what coming here: <https://github.com/${{ github.repository }}/compare/${{ steps.get-latest-tag.outputs.LATEST_TAG_VERSION }}...master>"}}]}]}'
           channel_id: ${{ env.CONTENT_BUILD_CHANNEL_ID }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Description

* Content release should run every hour 13:00-21:00 UTC
* Daily prod deploy is now the daily production release (since it's not actually deploying anything)
* Daily deploy warning is now the daily release warning
* Verbiage changes for the above
* Include release name in slack notification for daily prod release workflow


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
