### PR TITLE
VACMS-7863: Add p tags around link text to ensure line break on event

### DIFF
--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -12,7 +12,7 @@
       <!-- ======== -->
       <!-- Event v1 -->
       <!-- ======== -->
-      {% if buildtype == 'vagovprod' %}
+      {% if buildtype != 'vagovprod' %}
         {% include "src/site/includes/date.drupal.liquid" %}
 
         <div class="usa-width-three-fourths">
@@ -149,10 +149,12 @@
             {% assign index = entityUrl.breadcrumb.length | minus: 2 %}
 
             {% if fieldUrlOfAnOnlineEvent.uri %}
-            <a class="vads-u-padding-bottom--3 vads-u-margin-top--1 vads-u-font-weight--bold" onclick="recordEvent({ event: 'nav-secondary-button-click' });" href="{{ fieldUrlOfAnOnlineEvent.uri }}">
-              Link to event
-              <i aria-hidden="true" class='vads-u-font-size--sm vads-u-margin-left--1 fa fa-chevron-right' role="presentation"></i>
-            </a>
+            <p>
+              <a class="vads-u-padding-bottom--3 vads-u-margin-top--1 vads-u-font-weight--bold" onclick="recordEvent({ event: 'nav-secondary-button-click' });" href="{{ fieldUrlOfAnOnlineEvent.uri }}">
+                Link to event
+                <i aria-hidden="true" class='vads-u-font-size--sm vads-u-margin-left--1 fa fa-chevron-right' role="presentation"></i>
+              </a>
+            </p>
             {% endif %}
 
             <a class="vads-u-padding-bottom--3 vads-u-margin-top--1 vads-u-font-weight--bold" onclick="recordEvent({ event: 'nav-secondary-button-click' });" href="{{ entityUrl.breadcrumb | getValueFromArrayObjPath: index, 'url.path' }}">


### PR DESCRIPTION
## Description
`Link to event` link text appears on same line as `See all events` on event pages, creating confusion.
This pr breaks them into two lines.

## Testing done
Visual / build

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/160933281-44a0af5f-89e7-4257-9641-70c1309cb0cd.png)

## Acceptance criteria
- [ ] Go to `/wichita-health-care/events/43137/](https://www.va.gov/wichita-health-care/events/43137/` and visually verify `Link to event` text is on its own line