### PR TITLE
Trigger Jenkins Preview Job After Content Release (2)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,15 +11,16 @@
 
 # Content release
 .github/workflows/content-release.yml @department-of-veterans-affairs/cms-infrastructure @department-of-veterans-affairs/frontend-review-group
+.github/workflows/deploy-content-preview-server.yml @department-of-veterans-affairs/cms-infrastructure
 .github/workflows/wait-for-cms-ready @department-of-veterans-affairs/cms-infrastructure @department-of-veterans-affairs/frontend-review-group
 .github/workflows/record-release-interval @department-of-veterans-affairs/cms-infrastructure @department-of-veterans-affairs/frontend-review-group
 script @department-of-veterans-affairs/cms-infrastructure @department-of-veterans-affairs/frontend-review-group
- 
+
 # VSP QA Standards
 src/platform/testing/e2e/ @department-of-veterans-affairs/qa-standards
 config/cypress.json @department-of-veterans-affairs/qa-standards
 .github/workflows/a11y.yml @department-of-veterans-affairs/qa-standards
- 
+
 # Shared templates
 src/site/includes @department-of-veterans-affairs/vsa-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend @department-of-veterans-affairs/vsa-caregiver-frontend
 src/site/components @department-of-veterans-affairs/vsa-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend @department-of-veterans-affairs/vsa-caregiver-frontend

--- a/.github/workflows/deploy-content-preview-server.yml
+++ b/.github/workflows/deploy-content-preview-server.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   deploy-preview-server:
-    name: Deploy Preview Server(s) (PROD, STAGING, DEV)
+    name: Deploy Preview Servers (PROD, STAGING, DEV)
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on:
       - self-hosted

--- a/.github/workflows/deploy-content-preview-server.yml
+++ b/.github/workflows/deploy-content-preview-server.yml
@@ -1,6 +1,7 @@
 name: Deploy Content Preview Server
 
 on:
+  workflow_dispatch:
   workflow_run:
     workflows:
       - Content Release
@@ -9,7 +10,7 @@ on:
 
 jobs:
   deploy-preview-server:
-    name: Deploy Preview Server
+    name: Deploy Preview Server(s) (PROD, STAGING, DEV)
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on:
       - self-hosted


### PR DESCRIPTION
## Description
Follow up to [Trigger Jenkins Preview Job After Content Release #1048](https://github.com/department-of-veterans-affairs/content-build/pull/1048) which had to be merged before it was ready because of the fact a workflow file needs to exist in the default branch in order for it to be run from the actions tab. Subsequent changes can then be tested by a branch selection when running the job, but it must first be registered by existing as a file in the default branch. 





## Testing done

- [ ] Run a Content Release workflow and ensure that the Content Preview Server Deploy is triggered. If not, then work on a second PR, the second PR will be testable

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
