### PR TITLE
Trigger Jenkins Preview Job After Content Release (3)

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -87,575 +87,575 @@ jobs:
               {"Key": "environment", "Value": "utility"}
             ]
 
-  validate-build-status:
-    name: Validate Build Status
-    runs-on:
-      - self-hosted
-      - linux
-      - x64
-    needs: start-runner
-    outputs:
-      REF: ${{ steps.get-latest-release.outputs.target_commitish }}
-      TAG: ${{ steps.get-latest-release.outputs.tag_name }}
-    steps:
-      - name: Cancel workflow due to DSVA schedule
-        if: ${{ github.event_name == 'schedule' && env.DSVA_SCHEDULE_ENABLED != 'true' }}
-        uses: andymckay/cancel-action@0.2
-
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Install dependencies
-        uses: ./.github/workflows/install
-        with:
-          key: ${{ hashFiles('yarn.lock') }}
-          yarn_cache_folder: ~/.cache/yarn
-          path: |
-            ~/.cache/yarn
-            node_modules
-
-      - name: Get latest release
-        id: get-latest-release
-        uses: thebritican/fetch-latest-release@v2.0.0
-
-      - name: Validate build status
-        run: node ./script/github-actions/validate-build-status.js ${{ steps.get-latest-release.outputs.target_commitish }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  notify-start:
-    name: Notify Start
-    runs-on:
-      - self-hosted
-      - linux
-      - x64
-    needs: validate-build-status
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Notify Slack
-        uses: ./.github/workflows/slack-notify
-        continue-on-error: true
-        with:
-          payload: '{"attachments": [{"color": "#2EB67D","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "Stand by, content release for content-build coming up (using ${{ needs.validate-build-status.outputs.TAG }}). <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"}}]}]}'
-          channel_id: ${{ env.CMS_NOTIFICATIONS_SLACK }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-  build:
-    name: Build
-    runs-on: ${{ needs.start-runner.outputs.label }}
-    needs:
-      - start-runner
-      - validate-build-status
-    timeout-minutes: 30
-    defaults:
-      run:
-        working-directory: content-build
-    outputs:
-      vagovprod_buildtime: ${{ env.vagovprod_buildtime }}
-      BUILD_START_TIME: ${{ steps.export-build-start-time.outputs.BUILD_START_TIME }}
-      BUILD_END_TIME: ${{ steps.export-build-end-time.outputs.BUILD_END_TIME }}
-      CONTENT_BUILD_START_TIME: ${{ steps.export-content-build-start-time.outputs.CONTENT_BUILD_START_TIME }}
-      CONTENT_BUILD_END_TIME: ${{ steps.export-content-build-end.outputs.CONTENT_BUILD_END_TIME }}
-      GQL_QUERY_DURATION: ${{ steps.export-gql-query-duration.outputs.GQL_QUERY_DURATION }}
-      GQL_PAGE_COUNT: ${{ steps.export-gql-page-count.outputs.GQL_PAGE_COUNT }}
-    env:
-      CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
-
-    steps:
-      - name: Export build start time
-        id: export-build-start-time
-        run: echo ::set-output name=BUILD_START_TIME::$(date +"%s")
-        working-directory: ${{ github.workspace }}
-
-      - name: Checkout vagov-content
-        uses: actions/checkout@v2
-        with:
-          repository: department-of-veterans-affairs/vagov-content
-          path: vagov-content
-
-      - name: Checkout content-build
-        uses: actions/checkout@v2
-        with:
-          path: content-build
-          ref: ${{ needs.validate-build-status.outputs.REF }}
-
-      - name: Get Node version
-        id: get-node-version
-        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
-
-      - name: Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
-
-      - name: Cache dependencies
-        id: cache-dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            .cache/yarn
-            **/node_modules
-          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-
-
-      - name: Install dependencies
-        uses: nick-invision/retry@v2
-        with:
-          command: cd content-build && yarn install --frozen-lockfile --prefer-offline
-          max_attempts: 3
-          timeout_minutes: 7
-        env:
-          YARN_CACHE_FOLDER: .cache/yarn
-
-      - name: Wait for the CMS to be ready
-        uses: ./content-build/.github/workflows/wait-for-cms-ready
-
-      - name: Export content build start time
-        id: export-content-build-start-time
-        run: echo ::set-output name=CONTENT_BUILD_START_TIME::$(date +"%s")
-        working-directory: ${{ github.workspace }}
-
-      - name: Get buildtime
-        id: buildtime
-        run: |
-          BUILDTIME=$(date +%s)
-          echo ::set-output name=buildtime::$BUILDTIME
-          echo "${{ env.BUILDTYPE }}_buildtime=$BUILDTIME" >> $GITHUB_ENV
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
-
-      - name: set Drupal prod password
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-        with:
-          ssm_parameter: /cms/prod/drupal_api_users/content_build_api/password
-          env_variable_name: DRUPAL_PASSWORD
-
-      - name: set Drupal prod username
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-        with:
-          ssm_parameter: /cms/prod/drupal_api_users/content_build_api/username
-          env_variable_name: DRUPAL_USERNAME
-
-      - name: Build
-        run: yarn build --buildtype=${{ env.BUILDTYPE }} --asset-source=local --drupal-address=${{ env.DRUPAL_ADDRESS }} --drupal-user=${{ env.DRUPAL_USERNAME }} --drupal-password="${{ env.DRUPAL_PASSWORD }}" --pull-drupal --drupal-max-parallel-requests=15 --no-drupal-proxy --verbose | tee build-output.txt
-        timeout-minutes: 30
-
-      - name: Export content build end time
-        id: export-content-build-end
-        run: echo ::set-output name=CONTENT_BUILD_END_TIME::$(date +"%s")
-        working-directory: ${{ github.workspace }}
-
-      - name: Export gql query duration
-        id: export-gql-query-duration
-        run: echo ::set-output name=GQL_QUERY_DURATION::$(cat build-output.txt | grep -oP 'queries in \d+s' | grep -oP '\d+')
-
-      - name: Export gql page count
-        id: export-gql-page-count
-        run: echo ::set-output name=GQL_PAGE_COUNT::$(cat build-output.txt | grep -oP 'with \d+ pages' | grep -oP '\d+')
-
-      - name: Check broken links
-        id: get-broken-link-info
-        run: node ./script/github-actions/check-broken-links.js ${{ env.BUILDTYPE }}
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
-
-      - name: Get Slack app token
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
-        with:
-          ssm_parameter: /devops/github_actions_slack_socket_token
-          env_variable_name: SLACK_APP_TOKEN
-
-      - name: Get Slack bot token
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
-        with:
-          ssm_parameter: /devops/github_actions_slack_bot_user_token
-          env_variable_name: SLACK_BOT_TOKEN
-
-      - name: Get role from Parameter Store
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
-        with:
-          ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
-          env_variable_name: AWS_FRONTEND_NONPROD_ROLE
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
-          role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
-          role-duration-seconds: 900
-          role-session-name: vsp-frontendteam-githubaction
-
-      - name: Upload broken links file
-        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
-        run: aws s3 cp ./logs/${{ env.BUILDTYPE }}-broken-links.json s3://vetsgov-website-builds-s3-upload/broken-link-reports/${{ env.BUILDTYPE }}-broken-links.json --acl public-read --region us-gov-west-1
-
-      - name: Notify VFS Platform Builds channel about broken links
-        uses: slackapi/slack-github-action@v1.16.0
-        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
-        continue-on-error: true
-        env:
-          SSL_CERT_DIR: /etc/ssl/certs
-          SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
-        with:
-          payload: ${{ steps.get-broken-link-info.outputs.SLACK_ATTACHMENTS }}
-          channel-id: ${{ env.VFS_PLATFORM_BUILDS_SLACK }}
-
-      - name: Notify content broken links channel about broken links
-        uses: slackapi/slack-github-action@v1.16.0
-        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
-        continue-on-error: true
-        env:
-          SSL_CERT_DIR: /etc/ssl/certs
-          SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
-        with:
-          payload: ${{ steps.get-broken-link-info.outputs.SLACK_ATTACHMENTS }}
-          channel-id: ${{ env.BROKEN_LINKS_SLACK }}
-
-      - name: Generate build details
-        run: |
-          cat > build/${{ env.BUILDTYPE }}/BUILD.txt << EOF
-          BUILDTYPE=${{ env.BUILDTYPE }}
-          NODE_ENV=production
-          BRANCH_NAME=$(echo "${GITHUB_REF#refs/heads/}")
-          CHANGE_TARGET=null
-          RUN_ID=${{ github.run_id }}
-          RUN_NUMBER=${{ github.run_number }}
-          REF=${{ needs.validate-build-status.outputs.REF }}
-          TAG=${{ needs.validate-build-status.outputs.TAG }}
-          BUILDTIME=${{ steps.buildtime.outputs.buildtime }}
-          EOF
-
-      - name: Prearchive
-        run: node ./script/prearchive.js --buildtype=${{ env.BUILDTYPE }}
-
-      - name: Compress build
-        run: tar -C build/${{ env.BUILDTYPE }} -cf ${{ env.BUILDTYPE }}.tar.bz2 .
-
-      - name: Persist prearchived build
-        run: |
-          mkdir -p /tmp/${{ github.run_id }}
-          rm -rf /tmp/${{ github.run_id }}/${{ env.BUILDTYPE }}
-          mv ${{ env.BUILDTYPE }}.tar.bz2 /tmp/${{ github.run_id }}
-
-      - name: Export build end time
-        id: export-build-end-time
-        run: echo ::set-output name=BUILD_END_TIME::$(date +"%s")
-        working-directory: ${{ github.workspace }}
-
-  archive:
-    name: Archive
-    runs-on: ${{ needs.start-runner.outputs.label }}
-    needs:
-      - start-runner
-      - validate-build-status
-      - build
-    outputs:
-      ARCHIVE_END_TIME: ${{ steps.export-archive-end-time.outputs.ARCHIVE_END_TIME }}
-
-    steps:
-      - name: Restore ${{ env.BUILDTYPE }} build
-        run: |
-          mv /tmp/${{ github.run_id }}/${{ env.BUILDTYPE }}.tar.bz2 .
-          df -h
-          du -h ${{ env.BUILDTYPE }}.tar.bz2
-
-      - name: Configure AWS credentials (1)
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
-
-      - name: Get role from Parameter Store
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-        with:
-          ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
-          env_variable_name: AWS_FRONTEND_NONPROD_ROLE
-
-      - name: Configure AWS Credentials (2)
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
-          role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
-          role-duration-seconds: 900
-          role-session-name: vsp-frontendteam-githubaction
-
-      - name: Upload build
-        run: aws s3 cp ${{ env.BUILDTYPE }}.tar.bz2 s3://vetsgov-website-builds-s3-upload/content-build/${{needs.validate-build-status.outputs.REF}}/${{ env.BUILDTYPE }}.tar.bz2 --acl public-read --region us-gov-west-1
-
-      - name: Export archive end time
-        id: export-archive-end-time
-        run: echo ::set-output name=ARCHIVE_END_TIME::$(date +"%s")
-
-  deploy:
-    name: Deploy
-    runs-on:
-      - self-hosted
-      - linux
-      - x64
-    needs:
-      - validate-build-status
-      - build
-      - archive
-    outputs:
-      DEPLOY_END_TIME: ${{ steps.export-deploy-end-time.outputs.DEPLOY_END_TIME }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Configure AWS credentials (1)
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
-
-      - name: Get role from Parameter Store
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-        with:
-          ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_PROD_ROLE
-          env_variable_name: AWS_FRONTEND_PROD_ROLE
-
-      - name: Get Drupal prod password
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-        with:
-          ssm_parameter: /cms/prod/drupal_api_users/content_build_api/password
-          env_variable_name: DRUPAL_PASSWORD
-
-      - name: Get Drupal prod username
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-        with:
-          ssm_parameter: /cms/prod/drupal_api_users/content_build_api/username
-          env_variable_name: DRUPAL_USERNAME
-
-      - name: Configure AWS Credentials (2)
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
-          role-to-assume: ${{ env.AWS_FRONTEND_PROD_ROLE }}
-          role-duration-seconds: 900
-          role-session-name: vsp-frontendteam-githubaction
-
-      - name: Deploy
-        run: ./script/github-actions/deploy.sh -s $SRC -d $DEST -v
-        env:
-          SRC: s3://vetsgov-website-builds-s3-upload/content-build/${{needs.validate-build-status.outputs.REF}}/${{env.BUILDTYPE}}.tar.bz2
-          DEST: s3://${{ env.DEPLOY_BUCKET }}
-
-      - name: Wait for the CMS to be ready
-        uses: ./.github/workflows/wait-for-cms-ready
-
-      - name: CMS GovDelivery callback
-        uses: fjogeleit/http-request-action@master
-        with:
-          url: https://prod.cms.va.gov/api/govdelivery_bulletins/queue?EndTime=${{ needs.build.outputs.vagovprod_buildtime }}&src=gha&runId=${{ github.run_id }}&runNumber=${{ github.run_number }}
-          method: GET
-          username: ${{ env.DRUPAL_USERNAME }}
-          password: ${{ env.DRUPAL_PASSWORD }}
-          timeout: 10000
-
-      - name: Export deploy end time
-        id: export-deploy-end-time
-        run: echo ::set-output name=DEPLOY_END_TIME::$(date +"%s")
-
-  notify-success:
-    name: Notify Success
-    runs-on:
-      - self-hosted
-      - linux
-      - x64
-    needs:
-      - validate-build-status
-      - deploy
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Notify Slack
-        uses: ./.github/workflows/slack-notify
-        continue-on-error: true
-        with:
-          payload: '{"attachments": [{"color": "#2EB67D","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "content release using ${{ needs.validate-build-status.outputs.TAG }} is complete."}}]}]}'
-          channel_id: ${{ env.CONTENT_BUILD_CHANNEL_ID }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-  notify-failure:
-    name: Notify Failure
-    runs-on:
-      - self-hosted
-      - linux
-      - x64
-    if: |
-      (failure() && needs.deploy.result != 'success')
-    needs: deploy
-
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
-
-      - name: Get Datadog token from Parameter Store
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-        with:
-          ssm_parameter: /dsva-vagov/content-build/GHA_CONTENT_BUILD_DATADOG_API_KEY
-          env_variable_name: GHA_CONTENT_BUILD_DATADOG_API_KEY
-
-      - name: Build JSON object
-        run: |
-          jq --null-input '{}' | \
-          jq '.title = "VA.gov CMS content release has failed"' | \
-          jq '.text = "VA.gov Content release ${{github.run_id}} failed at \(now|strftime("%Y-%m-%d %H:%M:%S"))! https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"' | \
-          jq '.date_happened = now' | \
-          jq '.aggregation_key = "content release ${{github.run_id}}"' | \
-          jq '.tags[0] = "project:vagov"' | \
-          jq '.tags[1] = "repo:content-build"' | \
-          jq '.tags[2] = "workflow:content-release"' | \
-          jq '.tags[3] = "env:${{env.DEPLOY_ENV}}"' | \
-          jq '.tags[5] = "status:${{needs.deploy.result}}"' | \
-          jq '.tags[6] = "trigger:${{env.BUILD_TRIGGER}}"' | \
-          jq '.alert_type = "error"' > event.json
-
-      - name: Send event to Datadog
-        run: |
-          curl -X POST "https://api.datadoghq.com/api/v1/events" \
-          -H "Content-Type: text/json" \
-          -H "DD-API-KEY: ${{ env.GHA_CONTENT_BUILD_DATADOG_API_KEY }}" \
-          -d @- < event.json
-
-  record-metrics:
-    name: Record metrics in Datadog
-    runs-on:
-      - self-hosted
-      - linux
-      - x64
-    needs:
-      - start-runner
-      - build
-      - archive
-      - deploy
-    env:
-      METRIC_NAMESPACE: dsva_vagov.content_build
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Get current timestamp
-        run: echo "NOW=$(date +"%s")" >> $GITHUB_ENV
-
-      - name: Set vars for scheduled runs
-        if: ${{ github.event_name == 'schedule' }}
-        run: |
-          echo "DEPLOY_ENV=prod" >> $GITHUB_ENV
-          echo "BUILD_TRIGGER=scheduled" >> $GITHUB_ENV
-
-      - name: Set vars for manual runs
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          echo "DEPLOY_ENV=prod" >> $GITHUB_ENV
-          echo "BUILD_TRIGGER=manual" >> $GITHUB_ENV
-
-      - name: Calculate durations
-        run: |
-          echo "SETUP_DURATION=$(expr ${{needs.build.outputs.BUILD_START_TIME}} - ${{needs.start-runner.outputs.APPROX_WORKFLOW_START_TIME}})" >> $GITHUB_ENV
-          echo "BUILD_DURATION=$(expr ${{needs.build.outputs.BUILD_END_TIME}} - ${{needs.build.outputs.BUILD_START_TIME}})" >> $GITHUB_ENV
-          echo "CONTENT_BUILD_DURATION=$(expr ${{needs.build.outputs.CONTENT_BUILD_END_TIME}} - ${{needs.build.outputs.CONTENT_BUILD_START_TIME}})" >> $GITHUB_ENV
-          echo "ARCHIVE_DURATION=$(expr ${{needs.archive.outputs.ARCHIVE_END_TIME}} - ${{needs.build.outputs.BUILD_END_TIME}})" >> $GITHUB_ENV
-          echo "DEPLOY_DURATION=$(expr ${{needs.deploy.outputs.DEPLOY_END_TIME}} - ${{needs.create-release.outputs.ARCHIVE_END_TIME}})" >> $GITHUB_ENV
-          echo "OVERALL_DURATION=$(expr ${{needs.deploy.outputs.DEPLOY_END_TIME}} - ${{needs.start-runner.outputs.APPROX_WORKFLOW_START_TIME}})" >> $GITHUB_ENV
-
-      - name: Build JSON object
-        run: |
-          jq --null-input '{}' | \
-          jq '.series[0].metric = "${{env.METRIC_NAMESPACE}}.setup.duration"' | \
-          jq '.series[0].points[0] = [${{env.NOW}}, ${{env.SETUP_DURATION}}]' | \
-          jq '.series[1].metric = "${{env.METRIC_NAMESPACE}}.build.duration"' | \
-          jq '.series[1].points[0] = [${{env.NOW}}, ${{env.BUILD_DURATION}}]' | \
-          jq '.series[2].metric = "${{env.METRIC_NAMESPACE}}.build.gql.pages"' | \
-          jq '.series[2].points[0] = [${{env.NOW}}, ${{needs.build.outputs.GQL_PAGE_COUNT}}]' | \
-          jq '.series[3].metric = "${{env.METRIC_NAMESPACE}}.build.gql.duration"' | \
-          jq '.series[3].points[0] = [${{env.NOW}}, ${{needs.build.outputs.GQL_QUERY_DURATION}}]' | \
-          jq '.series[4].metric = "${{env.METRIC_NAMESPACE}}.build.content-build.duration"' | \
-          jq '.series[4].points[0] = [${{env.NOW}}, ${{env.CONTENT_BUILD_DURATION}}]' | \
-          jq '.series[5].metric = "${{env.METRIC_NAMESPACE}}.archive.duration"' | \
-          jq '.series[5].points[0] = [${{env.NOW}}, ${{env.ARCHIVE_DURATION}}]' | \
-          jq '.series[6].metric = "${{env.METRIC_NAMESPACE}}.deploy.duration"' | \
-          jq '.series[6].points[0] = [${{env.NOW}}, ${{env.DEPLOY_DURATION}}]' | \
-          jq '.series[7].metric = "${{env.METRIC_NAMESPACE}}.overall.duration"' | \
-          jq '.series[7].points[0] = [${{env.NOW}}, ${{env.OVERALL_DURATION}}]' | \
-          jq '.series[].tags[0] = "env:${{env.DEPLOY_ENV}}"' | \
-          jq '.series[].tags[1] = "build_number:${{github.run_number}}"' | \
-          jq '.series[].tags[2] = "status:${{needs.deploy.result}}"' | \
-          jq '.series[].tags[3] = "trigger:${{env.BUILD_TRIGGER}}"' > metrics.json
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
-
-      - name: Get Datadog api key from Parameter Store
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-        with:
-          ssm_parameter: /dsva-vagov/content-build/GHA_CONTENT_BUILD_DATADOG_API_KEY
-          env_variable_name: GHA_CONTENT_BUILD_DATADOG_API_KEY
-
-      - name: Get Datadog app key from Parameter Store
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-        with:
-          ssm_parameter: /dsva-vagov/content-build/GHA_CONTENT_BUILD_DATADOG_APP_KEY
-          env_variable_name: GHA_CONTENT_BUILD_DATADOG_APP_KEY
-
-      - name: Send metrics to Datadog
-        run: |
-          curl -X POST "https://api.datadoghq.com/api/v1/series" \
-          -H "Content-Type: text/json" \
-          -H "DD-API-KEY: ${{ env.GHA_CONTENT_BUILD_DATADOG_API_KEY }}" \
-          -d @- < metrics.json
-
-      - name: Record deployment event
-        uses: ./.github/workflows/record-release-interval
-        with:
-          datadog_api_key: ${{ env.GHA_CONTENT_BUILD_DATADOG_API_KEY }}
-          datadog_app_key: ${{ env.GHA_CONTENT_BUILD_DATADOG_APP_KEY }}
-          metric_namespace: ${{ env.METRIC_NAMESPACE }}
+#  validate-build-status:
+#    name: Validate Build Status
+#    runs-on:
+#      - self-hosted
+#      - linux
+#      - x64
+#    needs: start-runner
+#    outputs:
+#      REF: ${{ steps.get-latest-release.outputs.target_commitish }}
+#      TAG: ${{ steps.get-latest-release.outputs.tag_name }}
+#    steps:
+#      - name: Cancel workflow due to DSVA schedule
+#        if: ${{ github.event_name == 'schedule' && env.DSVA_SCHEDULE_ENABLED != 'true' }}
+#        uses: andymckay/cancel-action@0.2
+#
+#      - name: Checkout
+#        uses: actions/checkout@v2
+#
+#      - name: Install dependencies
+#        uses: ./.github/workflows/install
+#        with:
+#          key: ${{ hashFiles('yarn.lock') }}
+#          yarn_cache_folder: ~/.cache/yarn
+#          path: |
+#            ~/.cache/yarn
+#            node_modules
+#
+#      - name: Get latest release
+#        id: get-latest-release
+#        uses: thebritican/fetch-latest-release@v2.0.0
+#
+#      - name: Validate build status
+#        run: node ./script/github-actions/validate-build-status.js ${{ steps.get-latest-release.outputs.target_commitish }}
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#
+#  notify-start:
+#    name: Notify Start
+#    runs-on:
+#      - self-hosted
+#      - linux
+#      - x64
+#    needs: validate-build-status
+#    steps:
+#      - name: Checkout
+#        uses: actions/checkout@v2
+#
+#      - name: Notify Slack
+#        uses: ./.github/workflows/slack-notify
+#        continue-on-error: true
+#        with:
+#          payload: '{"attachments": [{"color": "#2EB67D","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "Stand by, content release for content-build coming up (using ${{ needs.validate-build-status.outputs.TAG }}). <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"}}]}]}'
+#          channel_id: ${{ env.CMS_NOTIFICATIONS_SLACK }}
+#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#
+#  build:
+#    name: Build
+#    runs-on: ${{ needs.start-runner.outputs.label }}
+#    needs:
+#      - start-runner
+#      - validate-build-status
+#    timeout-minutes: 30
+#    defaults:
+#      run:
+#        working-directory: content-build
+#    outputs:
+#      vagovprod_buildtime: ${{ env.vagovprod_buildtime }}
+#      BUILD_START_TIME: ${{ steps.export-build-start-time.outputs.BUILD_START_TIME }}
+#      BUILD_END_TIME: ${{ steps.export-build-end-time.outputs.BUILD_END_TIME }}
+#      CONTENT_BUILD_START_TIME: ${{ steps.export-content-build-start-time.outputs.CONTENT_BUILD_START_TIME }}
+#      CONTENT_BUILD_END_TIME: ${{ steps.export-content-build-end.outputs.CONTENT_BUILD_END_TIME }}
+#      GQL_QUERY_DURATION: ${{ steps.export-gql-query-duration.outputs.GQL_QUERY_DURATION }}
+#      GQL_PAGE_COUNT: ${{ steps.export-gql-page-count.outputs.GQL_PAGE_COUNT }}
+#    env:
+#      CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
+#
+#    steps:
+#      - name: Export build start time
+#        id: export-build-start-time
+#        run: echo ::set-output name=BUILD_START_TIME::$(date +"%s")
+#        working-directory: ${{ github.workspace }}
+#
+#      - name: Checkout vagov-content
+#        uses: actions/checkout@v2
+#        with:
+#          repository: department-of-veterans-affairs/vagov-content
+#          path: vagov-content
+#
+#      - name: Checkout content-build
+#        uses: actions/checkout@v2
+#        with:
+#          path: content-build
+#          ref: ${{ needs.validate-build-status.outputs.REF }}
+#
+#      - name: Get Node version
+#        id: get-node-version
+#        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+#
+#      - name: Setup Node
+#        uses: actions/setup-node@v2
+#        with:
+#          node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
+#
+#      - name: Cache dependencies
+#        id: cache-dependencies
+#        uses: actions/cache@v2
+#        with:
+#          path: |
+#            .cache/yarn
+#            **/node_modules
+#          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-${{ hashFiles('**/yarn.lock') }}
+#          restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-
+#
+#      - name: Install dependencies
+#        uses: nick-invision/retry@v2
+#        with:
+#          command: cd content-build && yarn install --frozen-lockfile --prefer-offline
+#          max_attempts: 3
+#          timeout_minutes: 7
+#        env:
+#          YARN_CACHE_FOLDER: .cache/yarn
+#
+#      - name: Wait for the CMS to be ready
+#        uses: ./content-build/.github/workflows/wait-for-cms-ready
+#
+#      - name: Export content build start time
+#        id: export-content-build-start-time
+#        run: echo ::set-output name=CONTENT_BUILD_START_TIME::$(date +"%s")
+#        working-directory: ${{ github.workspace }}
+#
+#      - name: Get buildtime
+#        id: buildtime
+#        run: |
+#          BUILDTIME=$(date +%s)
+#          echo ::set-output name=buildtime::$BUILDTIME
+#          echo "${{ env.BUILDTYPE }}_buildtime=$BUILDTIME" >> $GITHUB_ENV
+#
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v1
+#        with:
+#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#          aws-region: us-gov-west-1
+#
+#      - name: set Drupal prod password
+#        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+#        with:
+#          ssm_parameter: /cms/prod/drupal_api_users/content_build_api/password
+#          env_variable_name: DRUPAL_PASSWORD
+#
+#      - name: set Drupal prod username
+#        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+#        with:
+#          ssm_parameter: /cms/prod/drupal_api_users/content_build_api/username
+#          env_variable_name: DRUPAL_USERNAME
+#
+#      - name: Build
+#        run: yarn build --buildtype=${{ env.BUILDTYPE }} --asset-source=local --drupal-address=${{ env.DRUPAL_ADDRESS }} --drupal-user=${{ env.DRUPAL_USERNAME }} --drupal-password="${{ env.DRUPAL_PASSWORD }}" --pull-drupal --drupal-max-parallel-requests=15 --no-drupal-proxy --verbose | tee build-output.txt
+#        timeout-minutes: 30
+#
+#      - name: Export content build end time
+#        id: export-content-build-end
+#        run: echo ::set-output name=CONTENT_BUILD_END_TIME::$(date +"%s")
+#        working-directory: ${{ github.workspace }}
+#
+#      - name: Export gql query duration
+#        id: export-gql-query-duration
+#        run: echo ::set-output name=GQL_QUERY_DURATION::$(cat build-output.txt | grep -oP 'queries in \d+s' | grep -oP '\d+')
+#
+#      - name: Export gql page count
+#        id: export-gql-page-count
+#        run: echo ::set-output name=GQL_PAGE_COUNT::$(cat build-output.txt | grep -oP 'with \d+ pages' | grep -oP '\d+')
+#
+#      - name: Check broken links
+#        id: get-broken-link-info
+#        run: node ./script/github-actions/check-broken-links.js ${{ env.BUILDTYPE }}
+#
+#      - name: Configure AWS credentials
+#        uses: aws-actions/configure-aws-credentials@v1
+#        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
+#        with:
+#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#          aws-region: us-gov-west-1
+#
+#      - name: Get Slack app token
+#        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+#        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
+#        with:
+#          ssm_parameter: /devops/github_actions_slack_socket_token
+#          env_variable_name: SLACK_APP_TOKEN
+#
+#      - name: Get Slack bot token
+#        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+#        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
+#        with:
+#          ssm_parameter: /devops/github_actions_slack_bot_user_token
+#          env_variable_name: SLACK_BOT_TOKEN
+#
+#      - name: Get role from Parameter Store
+#        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+#        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
+#        with:
+#          ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
+#          env_variable_name: AWS_FRONTEND_NONPROD_ROLE
+#
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v1
+#        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
+#        with:
+#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#          aws-region: us-gov-west-1
+#          role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
+#          role-duration-seconds: 900
+#          role-session-name: vsp-frontendteam-githubaction
+#
+#      - name: Upload broken links file
+#        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
+#        run: aws s3 cp ./logs/${{ env.BUILDTYPE }}-broken-links.json s3://vetsgov-website-builds-s3-upload/broken-link-reports/${{ env.BUILDTYPE }}-broken-links.json --acl public-read --region us-gov-west-1
+#
+#      - name: Notify VFS Platform Builds channel about broken links
+#        uses: slackapi/slack-github-action@v1.16.0
+#        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
+#        continue-on-error: true
+#        env:
+#          SSL_CERT_DIR: /etc/ssl/certs
+#          SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
+#        with:
+#          payload: ${{ steps.get-broken-link-info.outputs.SLACK_ATTACHMENTS }}
+#          channel-id: ${{ env.VFS_PLATFORM_BUILDS_SLACK }}
+#
+#      - name: Notify content broken links channel about broken links
+#        uses: slackapi/slack-github-action@v1.16.0
+#        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
+#        continue-on-error: true
+#        env:
+#          SSL_CERT_DIR: /etc/ssl/certs
+#          SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
+#        with:
+#          payload: ${{ steps.get-broken-link-info.outputs.SLACK_ATTACHMENTS }}
+#          channel-id: ${{ env.BROKEN_LINKS_SLACK }}
+#
+#      - name: Generate build details
+#        run: |
+#          cat > build/${{ env.BUILDTYPE }}/BUILD.txt << EOF
+#          BUILDTYPE=${{ env.BUILDTYPE }}
+#          NODE_ENV=production
+#          BRANCH_NAME=$(echo "${GITHUB_REF#refs/heads/}")
+#          CHANGE_TARGET=null
+#          RUN_ID=${{ github.run_id }}
+#          RUN_NUMBER=${{ github.run_number }}
+#          REF=${{ needs.validate-build-status.outputs.REF }}
+#          TAG=${{ needs.validate-build-status.outputs.TAG }}
+#          BUILDTIME=${{ steps.buildtime.outputs.buildtime }}
+#          EOF
+#
+#      - name: Prearchive
+#        run: node ./script/prearchive.js --buildtype=${{ env.BUILDTYPE }}
+#
+#      - name: Compress build
+#        run: tar -C build/${{ env.BUILDTYPE }} -cf ${{ env.BUILDTYPE }}.tar.bz2 .
+#
+#      - name: Persist prearchived build
+#        run: |
+#          mkdir -p /tmp/${{ github.run_id }}
+#          rm -rf /tmp/${{ github.run_id }}/${{ env.BUILDTYPE }}
+#          mv ${{ env.BUILDTYPE }}.tar.bz2 /tmp/${{ github.run_id }}
+#
+#      - name: Export build end time
+#        id: export-build-end-time
+#        run: echo ::set-output name=BUILD_END_TIME::$(date +"%s")
+#        working-directory: ${{ github.workspace }}
+#
+#  archive:
+#    name: Archive
+#    runs-on: ${{ needs.start-runner.outputs.label }}
+#    needs:
+#      - start-runner
+#      - validate-build-status
+#      - build
+#    outputs:
+#      ARCHIVE_END_TIME: ${{ steps.export-archive-end-time.outputs.ARCHIVE_END_TIME }}
+#
+#    steps:
+#      - name: Restore ${{ env.BUILDTYPE }} build
+#        run: |
+#          mv /tmp/${{ github.run_id }}/${{ env.BUILDTYPE }}.tar.bz2 .
+#          df -h
+#          du -h ${{ env.BUILDTYPE }}.tar.bz2
+#
+#      - name: Configure AWS credentials (1)
+#        uses: aws-actions/configure-aws-credentials@v1
+#        with:
+#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#          aws-region: us-gov-west-1
+#
+#      - name: Get role from Parameter Store
+#        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+#        with:
+#          ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
+#          env_variable_name: AWS_FRONTEND_NONPROD_ROLE
+#
+#      - name: Configure AWS Credentials (2)
+#        uses: aws-actions/configure-aws-credentials@v1
+#        with:
+#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#          aws-region: us-gov-west-1
+#          role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
+#          role-duration-seconds: 900
+#          role-session-name: vsp-frontendteam-githubaction
+#
+#      - name: Upload build
+#        run: aws s3 cp ${{ env.BUILDTYPE }}.tar.bz2 s3://vetsgov-website-builds-s3-upload/content-build/${{needs.validate-build-status.outputs.REF}}/${{ env.BUILDTYPE }}.tar.bz2 --acl public-read --region us-gov-west-1
+#
+#      - name: Export archive end time
+#        id: export-archive-end-time
+#        run: echo ::set-output name=ARCHIVE_END_TIME::$(date +"%s")
+#
+#  deploy:
+#    name: Deploy
+#    runs-on:
+#      - self-hosted
+#      - linux
+#      - x64
+#    needs:
+#      - validate-build-status
+#      - build
+#      - archive
+#    outputs:
+#      DEPLOY_END_TIME: ${{ steps.export-deploy-end-time.outputs.DEPLOY_END_TIME }}
+#
+#    steps:
+#      - name: Checkout
+#        uses: actions/checkout@v2
+#
+#      - name: Configure AWS credentials (1)
+#        uses: aws-actions/configure-aws-credentials@v1
+#        with:
+#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#          aws-region: us-gov-west-1
+#
+#      - name: Get role from Parameter Store
+#        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+#        with:
+#          ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_PROD_ROLE
+#          env_variable_name: AWS_FRONTEND_PROD_ROLE
+#
+#      - name: Get Drupal prod password
+#        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+#        with:
+#          ssm_parameter: /cms/prod/drupal_api_users/content_build_api/password
+#          env_variable_name: DRUPAL_PASSWORD
+#
+#      - name: Get Drupal prod username
+#        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+#        with:
+#          ssm_parameter: /cms/prod/drupal_api_users/content_build_api/username
+#          env_variable_name: DRUPAL_USERNAME
+#
+#      - name: Configure AWS Credentials (2)
+#        uses: aws-actions/configure-aws-credentials@v1
+#        with:
+#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#          aws-region: us-gov-west-1
+#          role-to-assume: ${{ env.AWS_FRONTEND_PROD_ROLE }}
+#          role-duration-seconds: 900
+#          role-session-name: vsp-frontendteam-githubaction
+#
+#      - name: Deploy
+#        run: ./script/github-actions/deploy.sh -s $SRC -d $DEST -v
+#        env:
+#          SRC: s3://vetsgov-website-builds-s3-upload/content-build/${{needs.validate-build-status.outputs.REF}}/${{env.BUILDTYPE}}.tar.bz2
+#          DEST: s3://${{ env.DEPLOY_BUCKET }}
+#
+#      - name: Wait for the CMS to be ready
+#        uses: ./.github/workflows/wait-for-cms-ready
+#
+#      - name: CMS GovDelivery callback
+#        uses: fjogeleit/http-request-action@master
+#        with:
+#          url: https://prod.cms.va.gov/api/govdelivery_bulletins/queue?EndTime=${{ needs.build.outputs.vagovprod_buildtime }}&src=gha&runId=${{ github.run_id }}&runNumber=${{ github.run_number }}
+#          method: GET
+#          username: ${{ env.DRUPAL_USERNAME }}
+#          password: ${{ env.DRUPAL_PASSWORD }}
+#          timeout: 10000
+#
+#      - name: Export deploy end time
+#        id: export-deploy-end-time
+#        run: echo ::set-output name=DEPLOY_END_TIME::$(date +"%s")
+#
+#  notify-success:
+#    name: Notify Success
+#    runs-on:
+#      - self-hosted
+#      - linux
+#      - x64
+#    needs:
+#      - validate-build-status
+#      - deploy
+#
+#    steps:
+#      - name: Checkout
+#        uses: actions/checkout@v2
+#
+#      - name: Notify Slack
+#        uses: ./.github/workflows/slack-notify
+#        continue-on-error: true
+#        with:
+#          payload: '{"attachments": [{"color": "#2EB67D","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "content release using ${{ needs.validate-build-status.outputs.TAG }} is complete."}}]}]}'
+#          channel_id: ${{ env.CONTENT_BUILD_CHANNEL_ID }}
+#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#
+#  notify-failure:
+#    name: Notify Failure
+#    runs-on:
+#      - self-hosted
+#      - linux
+#      - x64
+#    if: |
+#      (failure() && needs.deploy.result != 'success')
+#    needs: deploy
+#
+#    steps:
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v1
+#        with:
+#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#          aws-region: us-gov-west-1
+#
+#      - name: Get Datadog token from Parameter Store
+#        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+#        with:
+#          ssm_parameter: /dsva-vagov/content-build/GHA_CONTENT_BUILD_DATADOG_API_KEY
+#          env_variable_name: GHA_CONTENT_BUILD_DATADOG_API_KEY
+#
+#      - name: Build JSON object
+#        run: |
+#          jq --null-input '{}' | \
+#          jq '.title = "VA.gov CMS content release has failed"' | \
+#          jq '.text = "VA.gov Content release ${{github.run_id}} failed at \(now|strftime("%Y-%m-%d %H:%M:%S"))! https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"' | \
+#          jq '.date_happened = now' | \
+#          jq '.aggregation_key = "content release ${{github.run_id}}"' | \
+#          jq '.tags[0] = "project:vagov"' | \
+#          jq '.tags[1] = "repo:content-build"' | \
+#          jq '.tags[2] = "workflow:content-release"' | \
+#          jq '.tags[3] = "env:${{env.DEPLOY_ENV}}"' | \
+#          jq '.tags[5] = "status:${{needs.deploy.result}}"' | \
+#          jq '.tags[6] = "trigger:${{env.BUILD_TRIGGER}}"' | \
+#          jq '.alert_type = "error"' > event.json
+#
+#      - name: Send event to Datadog
+#        run: |
+#          curl -X POST "https://api.datadoghq.com/api/v1/events" \
+#          -H "Content-Type: text/json" \
+#          -H "DD-API-KEY: ${{ env.GHA_CONTENT_BUILD_DATADOG_API_KEY }}" \
+#          -d @- < event.json
+#
+#  record-metrics:
+#    name: Record metrics in Datadog
+#    runs-on:
+#      - self-hosted
+#      - linux
+#      - x64
+#    needs:
+#      - start-runner
+#      - build
+#      - archive
+#      - deploy
+#    env:
+#      METRIC_NAMESPACE: dsva_vagov.content_build
+#    steps:
+#      - name: Checkout
+#        uses: actions/checkout@v2
+#
+#      - name: Get current timestamp
+#        run: echo "NOW=$(date +"%s")" >> $GITHUB_ENV
+#
+#      - name: Set vars for scheduled runs
+#        if: ${{ github.event_name == 'schedule' }}
+#        run: |
+#          echo "DEPLOY_ENV=prod" >> $GITHUB_ENV
+#          echo "BUILD_TRIGGER=scheduled" >> $GITHUB_ENV
+#
+#      - name: Set vars for manual runs
+#        if: ${{ github.event_name == 'workflow_dispatch' }}
+#        run: |
+#          echo "DEPLOY_ENV=prod" >> $GITHUB_ENV
+#          echo "BUILD_TRIGGER=manual" >> $GITHUB_ENV
+#
+#      - name: Calculate durations
+#        run: |
+#          echo "SETUP_DURATION=$(expr ${{needs.build.outputs.BUILD_START_TIME}} - ${{needs.start-runner.outputs.APPROX_WORKFLOW_START_TIME}})" >> $GITHUB_ENV
+#          echo "BUILD_DURATION=$(expr ${{needs.build.outputs.BUILD_END_TIME}} - ${{needs.build.outputs.BUILD_START_TIME}})" >> $GITHUB_ENV
+#          echo "CONTENT_BUILD_DURATION=$(expr ${{needs.build.outputs.CONTENT_BUILD_END_TIME}} - ${{needs.build.outputs.CONTENT_BUILD_START_TIME}})" >> $GITHUB_ENV
+#          echo "ARCHIVE_DURATION=$(expr ${{needs.archive.outputs.ARCHIVE_END_TIME}} - ${{needs.build.outputs.BUILD_END_TIME}})" >> $GITHUB_ENV
+#          echo "DEPLOY_DURATION=$(expr ${{needs.deploy.outputs.DEPLOY_END_TIME}} - ${{needs.create-release.outputs.ARCHIVE_END_TIME}})" >> $GITHUB_ENV
+#          echo "OVERALL_DURATION=$(expr ${{needs.deploy.outputs.DEPLOY_END_TIME}} - ${{needs.start-runner.outputs.APPROX_WORKFLOW_START_TIME}})" >> $GITHUB_ENV
+#
+#      - name: Build JSON object
+#        run: |
+#          jq --null-input '{}' | \
+#          jq '.series[0].metric = "${{env.METRIC_NAMESPACE}}.setup.duration"' | \
+#          jq '.series[0].points[0] = [${{env.NOW}}, ${{env.SETUP_DURATION}}]' | \
+#          jq '.series[1].metric = "${{env.METRIC_NAMESPACE}}.build.duration"' | \
+#          jq '.series[1].points[0] = [${{env.NOW}}, ${{env.BUILD_DURATION}}]' | \
+#          jq '.series[2].metric = "${{env.METRIC_NAMESPACE}}.build.gql.pages"' | \
+#          jq '.series[2].points[0] = [${{env.NOW}}, ${{needs.build.outputs.GQL_PAGE_COUNT}}]' | \
+#          jq '.series[3].metric = "${{env.METRIC_NAMESPACE}}.build.gql.duration"' | \
+#          jq '.series[3].points[0] = [${{env.NOW}}, ${{needs.build.outputs.GQL_QUERY_DURATION}}]' | \
+#          jq '.series[4].metric = "${{env.METRIC_NAMESPACE}}.build.content-build.duration"' | \
+#          jq '.series[4].points[0] = [${{env.NOW}}, ${{env.CONTENT_BUILD_DURATION}}]' | \
+#          jq '.series[5].metric = "${{env.METRIC_NAMESPACE}}.archive.duration"' | \
+#          jq '.series[5].points[0] = [${{env.NOW}}, ${{env.ARCHIVE_DURATION}}]' | \
+#          jq '.series[6].metric = "${{env.METRIC_NAMESPACE}}.deploy.duration"' | \
+#          jq '.series[6].points[0] = [${{env.NOW}}, ${{env.DEPLOY_DURATION}}]' | \
+#          jq '.series[7].metric = "${{env.METRIC_NAMESPACE}}.overall.duration"' | \
+#          jq '.series[7].points[0] = [${{env.NOW}}, ${{env.OVERALL_DURATION}}]' | \
+#          jq '.series[].tags[0] = "env:${{env.DEPLOY_ENV}}"' | \
+#          jq '.series[].tags[1] = "build_number:${{github.run_number}}"' | \
+#          jq '.series[].tags[2] = "status:${{needs.deploy.result}}"' | \
+#          jq '.series[].tags[3] = "trigger:${{env.BUILD_TRIGGER}}"' > metrics.json
+#
+#      - name: Configure AWS credentials
+#        uses: aws-actions/configure-aws-credentials@v1
+#        with:
+#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#          aws-region: us-gov-west-1
+#
+#      - name: Get Datadog api key from Parameter Store
+#        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+#        with:
+#          ssm_parameter: /dsva-vagov/content-build/GHA_CONTENT_BUILD_DATADOG_API_KEY
+#          env_variable_name: GHA_CONTENT_BUILD_DATADOG_API_KEY
+#
+#      - name: Get Datadog app key from Parameter Store
+#        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+#        with:
+#          ssm_parameter: /dsva-vagov/content-build/GHA_CONTENT_BUILD_DATADOG_APP_KEY
+#          env_variable_name: GHA_CONTENT_BUILD_DATADOG_APP_KEY
+#
+#      - name: Send metrics to Datadog
+#        run: |
+#          curl -X POST "https://api.datadoghq.com/api/v1/series" \
+#          -H "Content-Type: text/json" \
+#          -H "DD-API-KEY: ${{ env.GHA_CONTENT_BUILD_DATADOG_API_KEY }}" \
+#          -d @- < metrics.json
+#
+#      - name: Record deployment event
+#        uses: ./.github/workflows/record-release-interval
+#        with:
+#          datadog_api_key: ${{ env.GHA_CONTENT_BUILD_DATADOG_API_KEY }}
+#          datadog_app_key: ${{ env.GHA_CONTENT_BUILD_DATADOG_APP_KEY }}
+#          metric_namespace: ${{ env.METRIC_NAMESPACE }}
 
   stop-runner:
     name: Stop on-demand-runner
     needs:
       - start-runner
-      - deploy
-      - record-metrics
+#      - deploy
+#      - record-metrics
     runs-on: ubuntu-latest
     if: ${{ always() }} # Even if an error happened, let's stop the runner
     env:

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -87,575 +87,575 @@ jobs:
               {"Key": "environment", "Value": "utility"}
             ]
 
-#  validate-build-status:
-#    name: Validate Build Status
-#    runs-on:
-#      - self-hosted
-#      - linux
-#      - x64
-#    needs: start-runner
-#    outputs:
-#      REF: ${{ steps.get-latest-release.outputs.target_commitish }}
-#      TAG: ${{ steps.get-latest-release.outputs.tag_name }}
-#    steps:
-#      - name: Cancel workflow due to DSVA schedule
-#        if: ${{ github.event_name == 'schedule' && env.DSVA_SCHEDULE_ENABLED != 'true' }}
-#        uses: andymckay/cancel-action@0.2
-#
-#      - name: Checkout
-#        uses: actions/checkout@v2
-#
-#      - name: Install dependencies
-#        uses: ./.github/workflows/install
-#        with:
-#          key: ${{ hashFiles('yarn.lock') }}
-#          yarn_cache_folder: ~/.cache/yarn
-#          path: |
-#            ~/.cache/yarn
-#            node_modules
-#
-#      - name: Get latest release
-#        id: get-latest-release
-#        uses: thebritican/fetch-latest-release@v2.0.0
-#
-#      - name: Validate build status
-#        run: node ./script/github-actions/validate-build-status.js ${{ steps.get-latest-release.outputs.target_commitish }}
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#
-#  notify-start:
-#    name: Notify Start
-#    runs-on:
-#      - self-hosted
-#      - linux
-#      - x64
-#    needs: validate-build-status
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v2
-#
-#      - name: Notify Slack
-#        uses: ./.github/workflows/slack-notify
-#        continue-on-error: true
-#        with:
-#          payload: '{"attachments": [{"color": "#2EB67D","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "Stand by, content release for content-build coming up (using ${{ needs.validate-build-status.outputs.TAG }}). <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"}}]}]}'
-#          channel_id: ${{ env.CMS_NOTIFICATIONS_SLACK }}
-#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#
-#  build:
-#    name: Build
-#    runs-on: ${{ needs.start-runner.outputs.label }}
-#    needs:
-#      - start-runner
-#      - validate-build-status
-#    timeout-minutes: 30
-#    defaults:
-#      run:
-#        working-directory: content-build
-#    outputs:
-#      vagovprod_buildtime: ${{ env.vagovprod_buildtime }}
-#      BUILD_START_TIME: ${{ steps.export-build-start-time.outputs.BUILD_START_TIME }}
-#      BUILD_END_TIME: ${{ steps.export-build-end-time.outputs.BUILD_END_TIME }}
-#      CONTENT_BUILD_START_TIME: ${{ steps.export-content-build-start-time.outputs.CONTENT_BUILD_START_TIME }}
-#      CONTENT_BUILD_END_TIME: ${{ steps.export-content-build-end.outputs.CONTENT_BUILD_END_TIME }}
-#      GQL_QUERY_DURATION: ${{ steps.export-gql-query-duration.outputs.GQL_QUERY_DURATION }}
-#      GQL_PAGE_COUNT: ${{ steps.export-gql-page-count.outputs.GQL_PAGE_COUNT }}
-#    env:
-#      CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
-#
-#    steps:
-#      - name: Export build start time
-#        id: export-build-start-time
-#        run: echo ::set-output name=BUILD_START_TIME::$(date +"%s")
-#        working-directory: ${{ github.workspace }}
-#
-#      - name: Checkout vagov-content
-#        uses: actions/checkout@v2
-#        with:
-#          repository: department-of-veterans-affairs/vagov-content
-#          path: vagov-content
-#
-#      - name: Checkout content-build
-#        uses: actions/checkout@v2
-#        with:
-#          path: content-build
-#          ref: ${{ needs.validate-build-status.outputs.REF }}
-#
-#      - name: Get Node version
-#        id: get-node-version
-#        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
-#
-#      - name: Setup Node
-#        uses: actions/setup-node@v2
-#        with:
-#          node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
-#
-#      - name: Cache dependencies
-#        id: cache-dependencies
-#        uses: actions/cache@v2
-#        with:
-#          path: |
-#            .cache/yarn
-#            **/node_modules
-#          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-${{ hashFiles('**/yarn.lock') }}
-#          restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-
-#
-#      - name: Install dependencies
-#        uses: nick-invision/retry@v2
-#        with:
-#          command: cd content-build && yarn install --frozen-lockfile --prefer-offline
-#          max_attempts: 3
-#          timeout_minutes: 7
-#        env:
-#          YARN_CACHE_FOLDER: .cache/yarn
-#
-#      - name: Wait for the CMS to be ready
-#        uses: ./content-build/.github/workflows/wait-for-cms-ready
-#
-#      - name: Export content build start time
-#        id: export-content-build-start-time
-#        run: echo ::set-output name=CONTENT_BUILD_START_TIME::$(date +"%s")
-#        working-directory: ${{ github.workspace }}
-#
-#      - name: Get buildtime
-#        id: buildtime
-#        run: |
-#          BUILDTIME=$(date +%s)
-#          echo ::set-output name=buildtime::$BUILDTIME
-#          echo "${{ env.BUILDTYPE }}_buildtime=$BUILDTIME" >> $GITHUB_ENV
-#
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v1
-#        with:
-#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#          aws-region: us-gov-west-1
-#
-#      - name: set Drupal prod password
-#        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-#        with:
-#          ssm_parameter: /cms/prod/drupal_api_users/content_build_api/password
-#          env_variable_name: DRUPAL_PASSWORD
-#
-#      - name: set Drupal prod username
-#        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-#        with:
-#          ssm_parameter: /cms/prod/drupal_api_users/content_build_api/username
-#          env_variable_name: DRUPAL_USERNAME
-#
-#      - name: Build
-#        run: yarn build --buildtype=${{ env.BUILDTYPE }} --asset-source=local --drupal-address=${{ env.DRUPAL_ADDRESS }} --drupal-user=${{ env.DRUPAL_USERNAME }} --drupal-password="${{ env.DRUPAL_PASSWORD }}" --pull-drupal --drupal-max-parallel-requests=15 --no-drupal-proxy --verbose | tee build-output.txt
-#        timeout-minutes: 30
-#
-#      - name: Export content build end time
-#        id: export-content-build-end
-#        run: echo ::set-output name=CONTENT_BUILD_END_TIME::$(date +"%s")
-#        working-directory: ${{ github.workspace }}
-#
-#      - name: Export gql query duration
-#        id: export-gql-query-duration
-#        run: echo ::set-output name=GQL_QUERY_DURATION::$(cat build-output.txt | grep -oP 'queries in \d+s' | grep -oP '\d+')
-#
-#      - name: Export gql page count
-#        id: export-gql-page-count
-#        run: echo ::set-output name=GQL_PAGE_COUNT::$(cat build-output.txt | grep -oP 'with \d+ pages' | grep -oP '\d+')
-#
-#      - name: Check broken links
-#        id: get-broken-link-info
-#        run: node ./script/github-actions/check-broken-links.js ${{ env.BUILDTYPE }}
-#
-#      - name: Configure AWS credentials
-#        uses: aws-actions/configure-aws-credentials@v1
-#        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
-#        with:
-#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#          aws-region: us-gov-west-1
-#
-#      - name: Get Slack app token
-#        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-#        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
-#        with:
-#          ssm_parameter: /devops/github_actions_slack_socket_token
-#          env_variable_name: SLACK_APP_TOKEN
-#
-#      - name: Get Slack bot token
-#        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-#        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
-#        with:
-#          ssm_parameter: /devops/github_actions_slack_bot_user_token
-#          env_variable_name: SLACK_BOT_TOKEN
-#
-#      - name: Get role from Parameter Store
-#        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-#        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
-#        with:
-#          ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
-#          env_variable_name: AWS_FRONTEND_NONPROD_ROLE
-#
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v1
-#        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
-#        with:
-#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#          aws-region: us-gov-west-1
-#          role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
-#          role-duration-seconds: 900
-#          role-session-name: vsp-frontendteam-githubaction
-#
-#      - name: Upload broken links file
-#        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
-#        run: aws s3 cp ./logs/${{ env.BUILDTYPE }}-broken-links.json s3://vetsgov-website-builds-s3-upload/broken-link-reports/${{ env.BUILDTYPE }}-broken-links.json --acl public-read --region us-gov-west-1
-#
-#      - name: Notify VFS Platform Builds channel about broken links
-#        uses: slackapi/slack-github-action@v1.16.0
-#        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
-#        continue-on-error: true
-#        env:
-#          SSL_CERT_DIR: /etc/ssl/certs
-#          SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
-#        with:
-#          payload: ${{ steps.get-broken-link-info.outputs.SLACK_ATTACHMENTS }}
-#          channel-id: ${{ env.VFS_PLATFORM_BUILDS_SLACK }}
-#
-#      - name: Notify content broken links channel about broken links
-#        uses: slackapi/slack-github-action@v1.16.0
-#        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
-#        continue-on-error: true
-#        env:
-#          SSL_CERT_DIR: /etc/ssl/certs
-#          SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
-#        with:
-#          payload: ${{ steps.get-broken-link-info.outputs.SLACK_ATTACHMENTS }}
-#          channel-id: ${{ env.BROKEN_LINKS_SLACK }}
-#
-#      - name: Generate build details
-#        run: |
-#          cat > build/${{ env.BUILDTYPE }}/BUILD.txt << EOF
-#          BUILDTYPE=${{ env.BUILDTYPE }}
-#          NODE_ENV=production
-#          BRANCH_NAME=$(echo "${GITHUB_REF#refs/heads/}")
-#          CHANGE_TARGET=null
-#          RUN_ID=${{ github.run_id }}
-#          RUN_NUMBER=${{ github.run_number }}
-#          REF=${{ needs.validate-build-status.outputs.REF }}
-#          TAG=${{ needs.validate-build-status.outputs.TAG }}
-#          BUILDTIME=${{ steps.buildtime.outputs.buildtime }}
-#          EOF
-#
-#      - name: Prearchive
-#        run: node ./script/prearchive.js --buildtype=${{ env.BUILDTYPE }}
-#
-#      - name: Compress build
-#        run: tar -C build/${{ env.BUILDTYPE }} -cf ${{ env.BUILDTYPE }}.tar.bz2 .
-#
-#      - name: Persist prearchived build
-#        run: |
-#          mkdir -p /tmp/${{ github.run_id }}
-#          rm -rf /tmp/${{ github.run_id }}/${{ env.BUILDTYPE }}
-#          mv ${{ env.BUILDTYPE }}.tar.bz2 /tmp/${{ github.run_id }}
-#
-#      - name: Export build end time
-#        id: export-build-end-time
-#        run: echo ::set-output name=BUILD_END_TIME::$(date +"%s")
-#        working-directory: ${{ github.workspace }}
-#
-#  archive:
-#    name: Archive
-#    runs-on: ${{ needs.start-runner.outputs.label }}
-#    needs:
-#      - start-runner
-#      - validate-build-status
-#      - build
-#    outputs:
-#      ARCHIVE_END_TIME: ${{ steps.export-archive-end-time.outputs.ARCHIVE_END_TIME }}
-#
-#    steps:
-#      - name: Restore ${{ env.BUILDTYPE }} build
-#        run: |
-#          mv /tmp/${{ github.run_id }}/${{ env.BUILDTYPE }}.tar.bz2 .
-#          df -h
-#          du -h ${{ env.BUILDTYPE }}.tar.bz2
-#
-#      - name: Configure AWS credentials (1)
-#        uses: aws-actions/configure-aws-credentials@v1
-#        with:
-#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#          aws-region: us-gov-west-1
-#
-#      - name: Get role from Parameter Store
-#        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-#        with:
-#          ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
-#          env_variable_name: AWS_FRONTEND_NONPROD_ROLE
-#
-#      - name: Configure AWS Credentials (2)
-#        uses: aws-actions/configure-aws-credentials@v1
-#        with:
-#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#          aws-region: us-gov-west-1
-#          role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
-#          role-duration-seconds: 900
-#          role-session-name: vsp-frontendteam-githubaction
-#
-#      - name: Upload build
-#        run: aws s3 cp ${{ env.BUILDTYPE }}.tar.bz2 s3://vetsgov-website-builds-s3-upload/content-build/${{needs.validate-build-status.outputs.REF}}/${{ env.BUILDTYPE }}.tar.bz2 --acl public-read --region us-gov-west-1
-#
-#      - name: Export archive end time
-#        id: export-archive-end-time
-#        run: echo ::set-output name=ARCHIVE_END_TIME::$(date +"%s")
-#
-#  deploy:
-#    name: Deploy
-#    runs-on:
-#      - self-hosted
-#      - linux
-#      - x64
-#    needs:
-#      - validate-build-status
-#      - build
-#      - archive
-#    outputs:
-#      DEPLOY_END_TIME: ${{ steps.export-deploy-end-time.outputs.DEPLOY_END_TIME }}
-#
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v2
-#
-#      - name: Configure AWS credentials (1)
-#        uses: aws-actions/configure-aws-credentials@v1
-#        with:
-#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#          aws-region: us-gov-west-1
-#
-#      - name: Get role from Parameter Store
-#        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-#        with:
-#          ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_PROD_ROLE
-#          env_variable_name: AWS_FRONTEND_PROD_ROLE
-#
-#      - name: Get Drupal prod password
-#        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-#        with:
-#          ssm_parameter: /cms/prod/drupal_api_users/content_build_api/password
-#          env_variable_name: DRUPAL_PASSWORD
-#
-#      - name: Get Drupal prod username
-#        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-#        with:
-#          ssm_parameter: /cms/prod/drupal_api_users/content_build_api/username
-#          env_variable_name: DRUPAL_USERNAME
-#
-#      - name: Configure AWS Credentials (2)
-#        uses: aws-actions/configure-aws-credentials@v1
-#        with:
-#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#          aws-region: us-gov-west-1
-#          role-to-assume: ${{ env.AWS_FRONTEND_PROD_ROLE }}
-#          role-duration-seconds: 900
-#          role-session-name: vsp-frontendteam-githubaction
-#
-#      - name: Deploy
-#        run: ./script/github-actions/deploy.sh -s $SRC -d $DEST -v
-#        env:
-#          SRC: s3://vetsgov-website-builds-s3-upload/content-build/${{needs.validate-build-status.outputs.REF}}/${{env.BUILDTYPE}}.tar.bz2
-#          DEST: s3://${{ env.DEPLOY_BUCKET }}
-#
-#      - name: Wait for the CMS to be ready
-#        uses: ./.github/workflows/wait-for-cms-ready
-#
-#      - name: CMS GovDelivery callback
-#        uses: fjogeleit/http-request-action@master
-#        with:
-#          url: https://prod.cms.va.gov/api/govdelivery_bulletins/queue?EndTime=${{ needs.build.outputs.vagovprod_buildtime }}&src=gha&runId=${{ github.run_id }}&runNumber=${{ github.run_number }}
-#          method: GET
-#          username: ${{ env.DRUPAL_USERNAME }}
-#          password: ${{ env.DRUPAL_PASSWORD }}
-#          timeout: 10000
-#
-#      - name: Export deploy end time
-#        id: export-deploy-end-time
-#        run: echo ::set-output name=DEPLOY_END_TIME::$(date +"%s")
-#
-#  notify-success:
-#    name: Notify Success
-#    runs-on:
-#      - self-hosted
-#      - linux
-#      - x64
-#    needs:
-#      - validate-build-status
-#      - deploy
-#
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v2
-#
-#      - name: Notify Slack
-#        uses: ./.github/workflows/slack-notify
-#        continue-on-error: true
-#        with:
-#          payload: '{"attachments": [{"color": "#2EB67D","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "content release using ${{ needs.validate-build-status.outputs.TAG }} is complete."}}]}]}'
-#          channel_id: ${{ env.CONTENT_BUILD_CHANNEL_ID }}
-#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#
-#  notify-failure:
-#    name: Notify Failure
-#    runs-on:
-#      - self-hosted
-#      - linux
-#      - x64
-#    if: |
-#      (failure() && needs.deploy.result != 'success')
-#    needs: deploy
-#
-#    steps:
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v1
-#        with:
-#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#          aws-region: us-gov-west-1
-#
-#      - name: Get Datadog token from Parameter Store
-#        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-#        with:
-#          ssm_parameter: /dsva-vagov/content-build/GHA_CONTENT_BUILD_DATADOG_API_KEY
-#          env_variable_name: GHA_CONTENT_BUILD_DATADOG_API_KEY
-#
-#      - name: Build JSON object
-#        run: |
-#          jq --null-input '{}' | \
-#          jq '.title = "VA.gov CMS content release has failed"' | \
-#          jq '.text = "VA.gov Content release ${{github.run_id}} failed at \(now|strftime("%Y-%m-%d %H:%M:%S"))! https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"' | \
-#          jq '.date_happened = now' | \
-#          jq '.aggregation_key = "content release ${{github.run_id}}"' | \
-#          jq '.tags[0] = "project:vagov"' | \
-#          jq '.tags[1] = "repo:content-build"' | \
-#          jq '.tags[2] = "workflow:content-release"' | \
-#          jq '.tags[3] = "env:${{env.DEPLOY_ENV}}"' | \
-#          jq '.tags[5] = "status:${{needs.deploy.result}}"' | \
-#          jq '.tags[6] = "trigger:${{env.BUILD_TRIGGER}}"' | \
-#          jq '.alert_type = "error"' > event.json
-#
-#      - name: Send event to Datadog
-#        run: |
-#          curl -X POST "https://api.datadoghq.com/api/v1/events" \
-#          -H "Content-Type: text/json" \
-#          -H "DD-API-KEY: ${{ env.GHA_CONTENT_BUILD_DATADOG_API_KEY }}" \
-#          -d @- < event.json
-#
-#  record-metrics:
-#    name: Record metrics in Datadog
-#    runs-on:
-#      - self-hosted
-#      - linux
-#      - x64
-#    needs:
-#      - start-runner
-#      - build
-#      - archive
-#      - deploy
-#    env:
-#      METRIC_NAMESPACE: dsva_vagov.content_build
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v2
-#
-#      - name: Get current timestamp
-#        run: echo "NOW=$(date +"%s")" >> $GITHUB_ENV
-#
-#      - name: Set vars for scheduled runs
-#        if: ${{ github.event_name == 'schedule' }}
-#        run: |
-#          echo "DEPLOY_ENV=prod" >> $GITHUB_ENV
-#          echo "BUILD_TRIGGER=scheduled" >> $GITHUB_ENV
-#
-#      - name: Set vars for manual runs
-#        if: ${{ github.event_name == 'workflow_dispatch' }}
-#        run: |
-#          echo "DEPLOY_ENV=prod" >> $GITHUB_ENV
-#          echo "BUILD_TRIGGER=manual" >> $GITHUB_ENV
-#
-#      - name: Calculate durations
-#        run: |
-#          echo "SETUP_DURATION=$(expr ${{needs.build.outputs.BUILD_START_TIME}} - ${{needs.start-runner.outputs.APPROX_WORKFLOW_START_TIME}})" >> $GITHUB_ENV
-#          echo "BUILD_DURATION=$(expr ${{needs.build.outputs.BUILD_END_TIME}} - ${{needs.build.outputs.BUILD_START_TIME}})" >> $GITHUB_ENV
-#          echo "CONTENT_BUILD_DURATION=$(expr ${{needs.build.outputs.CONTENT_BUILD_END_TIME}} - ${{needs.build.outputs.CONTENT_BUILD_START_TIME}})" >> $GITHUB_ENV
-#          echo "ARCHIVE_DURATION=$(expr ${{needs.archive.outputs.ARCHIVE_END_TIME}} - ${{needs.build.outputs.BUILD_END_TIME}})" >> $GITHUB_ENV
-#          echo "DEPLOY_DURATION=$(expr ${{needs.deploy.outputs.DEPLOY_END_TIME}} - ${{needs.create-release.outputs.ARCHIVE_END_TIME}})" >> $GITHUB_ENV
-#          echo "OVERALL_DURATION=$(expr ${{needs.deploy.outputs.DEPLOY_END_TIME}} - ${{needs.start-runner.outputs.APPROX_WORKFLOW_START_TIME}})" >> $GITHUB_ENV
-#
-#      - name: Build JSON object
-#        run: |
-#          jq --null-input '{}' | \
-#          jq '.series[0].metric = "${{env.METRIC_NAMESPACE}}.setup.duration"' | \
-#          jq '.series[0].points[0] = [${{env.NOW}}, ${{env.SETUP_DURATION}}]' | \
-#          jq '.series[1].metric = "${{env.METRIC_NAMESPACE}}.build.duration"' | \
-#          jq '.series[1].points[0] = [${{env.NOW}}, ${{env.BUILD_DURATION}}]' | \
-#          jq '.series[2].metric = "${{env.METRIC_NAMESPACE}}.build.gql.pages"' | \
-#          jq '.series[2].points[0] = [${{env.NOW}}, ${{needs.build.outputs.GQL_PAGE_COUNT}}]' | \
-#          jq '.series[3].metric = "${{env.METRIC_NAMESPACE}}.build.gql.duration"' | \
-#          jq '.series[3].points[0] = [${{env.NOW}}, ${{needs.build.outputs.GQL_QUERY_DURATION}}]' | \
-#          jq '.series[4].metric = "${{env.METRIC_NAMESPACE}}.build.content-build.duration"' | \
-#          jq '.series[4].points[0] = [${{env.NOW}}, ${{env.CONTENT_BUILD_DURATION}}]' | \
-#          jq '.series[5].metric = "${{env.METRIC_NAMESPACE}}.archive.duration"' | \
-#          jq '.series[5].points[0] = [${{env.NOW}}, ${{env.ARCHIVE_DURATION}}]' | \
-#          jq '.series[6].metric = "${{env.METRIC_NAMESPACE}}.deploy.duration"' | \
-#          jq '.series[6].points[0] = [${{env.NOW}}, ${{env.DEPLOY_DURATION}}]' | \
-#          jq '.series[7].metric = "${{env.METRIC_NAMESPACE}}.overall.duration"' | \
-#          jq '.series[7].points[0] = [${{env.NOW}}, ${{env.OVERALL_DURATION}}]' | \
-#          jq '.series[].tags[0] = "env:${{env.DEPLOY_ENV}}"' | \
-#          jq '.series[].tags[1] = "build_number:${{github.run_number}}"' | \
-#          jq '.series[].tags[2] = "status:${{needs.deploy.result}}"' | \
-#          jq '.series[].tags[3] = "trigger:${{env.BUILD_TRIGGER}}"' > metrics.json
-#
-#      - name: Configure AWS credentials
-#        uses: aws-actions/configure-aws-credentials@v1
-#        with:
-#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#          aws-region: us-gov-west-1
-#
-#      - name: Get Datadog api key from Parameter Store
-#        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-#        with:
-#          ssm_parameter: /dsva-vagov/content-build/GHA_CONTENT_BUILD_DATADOG_API_KEY
-#          env_variable_name: GHA_CONTENT_BUILD_DATADOG_API_KEY
-#
-#      - name: Get Datadog app key from Parameter Store
-#        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-#        with:
-#          ssm_parameter: /dsva-vagov/content-build/GHA_CONTENT_BUILD_DATADOG_APP_KEY
-#          env_variable_name: GHA_CONTENT_BUILD_DATADOG_APP_KEY
-#
-#      - name: Send metrics to Datadog
-#        run: |
-#          curl -X POST "https://api.datadoghq.com/api/v1/series" \
-#          -H "Content-Type: text/json" \
-#          -H "DD-API-KEY: ${{ env.GHA_CONTENT_BUILD_DATADOG_API_KEY }}" \
-#          -d @- < metrics.json
-#
-#      - name: Record deployment event
-#        uses: ./.github/workflows/record-release-interval
-#        with:
-#          datadog_api_key: ${{ env.GHA_CONTENT_BUILD_DATADOG_API_KEY }}
-#          datadog_app_key: ${{ env.GHA_CONTENT_BUILD_DATADOG_APP_KEY }}
-#          metric_namespace: ${{ env.METRIC_NAMESPACE }}
+  validate-build-status:
+    name: Validate Build Status
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+    needs: start-runner
+    outputs:
+      REF: ${{ steps.get-latest-release.outputs.target_commitish }}
+      TAG: ${{ steps.get-latest-release.outputs.tag_name }}
+    steps:
+      - name: Cancel workflow due to DSVA schedule
+        if: ${{ github.event_name == 'schedule' && env.DSVA_SCHEDULE_ENABLED != 'true' }}
+        uses: andymckay/cancel-action@0.2
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        uses: ./.github/workflows/install
+        with:
+          key: ${{ hashFiles('yarn.lock') }}
+          yarn_cache_folder: ~/.cache/yarn
+          path: |
+            ~/.cache/yarn
+            node_modules
+
+      - name: Get latest release
+        id: get-latest-release
+        uses: thebritican/fetch-latest-release@v2.0.0
+
+      - name: Validate build status
+        run: node ./script/github-actions/validate-build-status.js ${{ steps.get-latest-release.outputs.target_commitish }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  notify-start:
+    name: Notify Start
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+    needs: validate-build-status
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Notify Slack
+        uses: ./.github/workflows/slack-notify
+        continue-on-error: true
+        with:
+          payload: '{"attachments": [{"color": "#2EB67D","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "Stand by, content release for content-build coming up (using ${{ needs.validate-build-status.outputs.TAG }}). <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"}}]}]}'
+          channel_id: ${{ env.CMS_NOTIFICATIONS_SLACK }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+  build:
+    name: Build
+    runs-on: ${{ needs.start-runner.outputs.label }}
+    needs:
+      - start-runner
+      - validate-build-status
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: content-build
+    outputs:
+      vagovprod_buildtime: ${{ env.vagovprod_buildtime }}
+      BUILD_START_TIME: ${{ steps.export-build-start-time.outputs.BUILD_START_TIME }}
+      BUILD_END_TIME: ${{ steps.export-build-end-time.outputs.BUILD_END_TIME }}
+      CONTENT_BUILD_START_TIME: ${{ steps.export-content-build-start-time.outputs.CONTENT_BUILD_START_TIME }}
+      CONTENT_BUILD_END_TIME: ${{ steps.export-content-build-end.outputs.CONTENT_BUILD_END_TIME }}
+      GQL_QUERY_DURATION: ${{ steps.export-gql-query-duration.outputs.GQL_QUERY_DURATION }}
+      GQL_PAGE_COUNT: ${{ steps.export-gql-page-count.outputs.GQL_PAGE_COUNT }}
+    env:
+      CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
+
+    steps:
+      - name: Export build start time
+        id: export-build-start-time
+        run: echo ::set-output name=BUILD_START_TIME::$(date +"%s")
+        working-directory: ${{ github.workspace }}
+
+      - name: Checkout vagov-content
+        uses: actions/checkout@v2
+        with:
+          repository: department-of-veterans-affairs/vagov-content
+          path: vagov-content
+
+      - name: Checkout content-build
+        uses: actions/checkout@v2
+        with:
+          path: content-build
+          ref: ${{ needs.validate-build-status.outputs.REF }}
+
+      - name: Get Node version
+        id: get-node-version
+        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
+
+      - name: Cache dependencies
+        id: cache-dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            .cache/yarn
+            **/node_modules
+          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-on-demand-runner-
+
+      - name: Install dependencies
+        uses: nick-invision/retry@v2
+        with:
+          command: cd content-build && yarn install --frozen-lockfile --prefer-offline
+          max_attempts: 3
+          timeout_minutes: 7
+        env:
+          YARN_CACHE_FOLDER: .cache/yarn
+
+      - name: Wait for the CMS to be ready
+        uses: ./content-build/.github/workflows/wait-for-cms-ready
+
+      - name: Export content build start time
+        id: export-content-build-start-time
+        run: echo ::set-output name=CONTENT_BUILD_START_TIME::$(date +"%s")
+        working-directory: ${{ github.workspace }}
+
+      - name: Get buildtime
+        id: buildtime
+        run: |
+          BUILDTIME=$(date +%s)
+          echo ::set-output name=buildtime::$BUILDTIME
+          echo "${{ env.BUILDTYPE }}_buildtime=$BUILDTIME" >> $GITHUB_ENV
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: set Drupal prod password
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /cms/prod/drupal_api_users/content_build_api/password
+          env_variable_name: DRUPAL_PASSWORD
+
+      - name: set Drupal prod username
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /cms/prod/drupal_api_users/content_build_api/username
+          env_variable_name: DRUPAL_USERNAME
+
+      - name: Build
+        run: yarn build --buildtype=${{ env.BUILDTYPE }} --asset-source=local --drupal-address=${{ env.DRUPAL_ADDRESS }} --drupal-user=${{ env.DRUPAL_USERNAME }} --drupal-password="${{ env.DRUPAL_PASSWORD }}" --pull-drupal --drupal-max-parallel-requests=15 --no-drupal-proxy --verbose | tee build-output.txt
+        timeout-minutes: 30
+
+      - name: Export content build end time
+        id: export-content-build-end
+        run: echo ::set-output name=CONTENT_BUILD_END_TIME::$(date +"%s")
+        working-directory: ${{ github.workspace }}
+
+      - name: Export gql query duration
+        id: export-gql-query-duration
+        run: echo ::set-output name=GQL_QUERY_DURATION::$(cat build-output.txt | grep -oP 'queries in \d+s' | grep -oP '\d+')
+
+      - name: Export gql page count
+        id: export-gql-page-count
+        run: echo ::set-output name=GQL_PAGE_COUNT::$(cat build-output.txt | grep -oP 'with \d+ pages' | grep -oP '\d+')
+
+      - name: Check broken links
+        id: get-broken-link-info
+        run: node ./script/github-actions/check-broken-links.js ${{ env.BUILDTYPE }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Get Slack app token
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
+        with:
+          ssm_parameter: /devops/github_actions_slack_socket_token
+          env_variable_name: SLACK_APP_TOKEN
+
+      - name: Get Slack bot token
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
+        with:
+          ssm_parameter: /devops/github_actions_slack_bot_user_token
+          env_variable_name: SLACK_BOT_TOKEN
+
+      - name: Get role from Parameter Store
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
+        with:
+          ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
+          env_variable_name: AWS_FRONTEND_NONPROD_ROLE
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+          role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
+          role-duration-seconds: 900
+          role-session-name: vsp-frontendteam-githubaction
+
+      - name: Upload broken links file
+        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
+        run: aws s3 cp ./logs/${{ env.BUILDTYPE }}-broken-links.json s3://vetsgov-website-builds-s3-upload/broken-link-reports/${{ env.BUILDTYPE }}-broken-links.json --acl public-read --region us-gov-west-1
+
+      - name: Notify VFS Platform Builds channel about broken links
+        uses: slackapi/slack-github-action@v1.16.0
+        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
+        continue-on-error: true
+        env:
+          SSL_CERT_DIR: /etc/ssl/certs
+          SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
+        with:
+          payload: ${{ steps.get-broken-link-info.outputs.SLACK_ATTACHMENTS }}
+          channel-id: ${{ env.VFS_PLATFORM_BUILDS_SLACK }}
+
+      - name: Notify content broken links channel about broken links
+        uses: slackapi/slack-github-action@v1.16.0
+        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
+        continue-on-error: true
+        env:
+          SSL_CERT_DIR: /etc/ssl/certs
+          SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
+        with:
+          payload: ${{ steps.get-broken-link-info.outputs.SLACK_ATTACHMENTS }}
+          channel-id: ${{ env.BROKEN_LINKS_SLACK }}
+
+      - name: Generate build details
+        run: |
+          cat > build/${{ env.BUILDTYPE }}/BUILD.txt << EOF
+          BUILDTYPE=${{ env.BUILDTYPE }}
+          NODE_ENV=production
+          BRANCH_NAME=$(echo "${GITHUB_REF#refs/heads/}")
+          CHANGE_TARGET=null
+          RUN_ID=${{ github.run_id }}
+          RUN_NUMBER=${{ github.run_number }}
+          REF=${{ needs.validate-build-status.outputs.REF }}
+          TAG=${{ needs.validate-build-status.outputs.TAG }}
+          BUILDTIME=${{ steps.buildtime.outputs.buildtime }}
+          EOF
+
+      - name: Prearchive
+        run: node ./script/prearchive.js --buildtype=${{ env.BUILDTYPE }}
+
+      - name: Compress build
+        run: tar -C build/${{ env.BUILDTYPE }} -cf ${{ env.BUILDTYPE }}.tar.bz2 .
+
+      - name: Persist prearchived build
+        run: |
+          mkdir -p /tmp/${{ github.run_id }}
+          rm -rf /tmp/${{ github.run_id }}/${{ env.BUILDTYPE }}
+          mv ${{ env.BUILDTYPE }}.tar.bz2 /tmp/${{ github.run_id }}
+
+      - name: Export build end time
+        id: export-build-end-time
+        run: echo ::set-output name=BUILD_END_TIME::$(date +"%s")
+        working-directory: ${{ github.workspace }}
+
+  archive:
+    name: Archive
+    runs-on: ${{ needs.start-runner.outputs.label }}
+    needs:
+      - start-runner
+      - validate-build-status
+      - build
+    outputs:
+      ARCHIVE_END_TIME: ${{ steps.export-archive-end-time.outputs.ARCHIVE_END_TIME }}
+
+    steps:
+      - name: Restore ${{ env.BUILDTYPE }} build
+        run: |
+          mv /tmp/${{ github.run_id }}/${{ env.BUILDTYPE }}.tar.bz2 .
+          df -h
+          du -h ${{ env.BUILDTYPE }}.tar.bz2
+
+      - name: Configure AWS credentials (1)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Get role from Parameter Store
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
+          env_variable_name: AWS_FRONTEND_NONPROD_ROLE
+
+      - name: Configure AWS Credentials (2)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+          role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
+          role-duration-seconds: 900
+          role-session-name: vsp-frontendteam-githubaction
+
+      - name: Upload build
+        run: aws s3 cp ${{ env.BUILDTYPE }}.tar.bz2 s3://vetsgov-website-builds-s3-upload/content-build/${{needs.validate-build-status.outputs.REF}}/${{ env.BUILDTYPE }}.tar.bz2 --acl public-read --region us-gov-west-1
+
+      - name: Export archive end time
+        id: export-archive-end-time
+        run: echo ::set-output name=ARCHIVE_END_TIME::$(date +"%s")
+
+  deploy:
+    name: Deploy
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+    needs:
+      - validate-build-status
+      - build
+      - archive
+    outputs:
+      DEPLOY_END_TIME: ${{ steps.export-deploy-end-time.outputs.DEPLOY_END_TIME }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Configure AWS credentials (1)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Get role from Parameter Store
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_PROD_ROLE
+          env_variable_name: AWS_FRONTEND_PROD_ROLE
+
+      - name: Get Drupal prod password
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /cms/prod/drupal_api_users/content_build_api/password
+          env_variable_name: DRUPAL_PASSWORD
+
+      - name: Get Drupal prod username
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /cms/prod/drupal_api_users/content_build_api/username
+          env_variable_name: DRUPAL_USERNAME
+
+      - name: Configure AWS Credentials (2)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+          role-to-assume: ${{ env.AWS_FRONTEND_PROD_ROLE }}
+          role-duration-seconds: 900
+          role-session-name: vsp-frontendteam-githubaction
+
+      - name: Deploy
+        run: ./script/github-actions/deploy.sh -s $SRC -d $DEST -v
+        env:
+          SRC: s3://vetsgov-website-builds-s3-upload/content-build/${{needs.validate-build-status.outputs.REF}}/${{env.BUILDTYPE}}.tar.bz2
+          DEST: s3://${{ env.DEPLOY_BUCKET }}
+
+      - name: Wait for the CMS to be ready
+        uses: ./.github/workflows/wait-for-cms-ready
+
+      - name: CMS GovDelivery callback
+        uses: fjogeleit/http-request-action@master
+        with:
+          url: https://prod.cms.va.gov/api/govdelivery_bulletins/queue?EndTime=${{ needs.build.outputs.vagovprod_buildtime }}&src=gha&runId=${{ github.run_id }}&runNumber=${{ github.run_number }}
+          method: GET
+          username: ${{ env.DRUPAL_USERNAME }}
+          password: ${{ env.DRUPAL_PASSWORD }}
+          timeout: 10000
+
+      - name: Export deploy end time
+        id: export-deploy-end-time
+        run: echo ::set-output name=DEPLOY_END_TIME::$(date +"%s")
+
+  notify-success:
+    name: Notify Success
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+    needs:
+      - validate-build-status
+      - deploy
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Notify Slack
+        uses: ./.github/workflows/slack-notify
+        continue-on-error: true
+        with:
+          payload: '{"attachments": [{"color": "#2EB67D","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "content release using ${{ needs.validate-build-status.outputs.TAG }} is complete."}}]}]}'
+          channel_id: ${{ env.CONTENT_BUILD_CHANNEL_ID }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+  notify-failure:
+    name: Notify Failure
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+    if: |
+      (failure() && needs.deploy.result != 'success')
+    needs: deploy
+
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Get Datadog token from Parameter Store
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /dsva-vagov/content-build/GHA_CONTENT_BUILD_DATADOG_API_KEY
+          env_variable_name: GHA_CONTENT_BUILD_DATADOG_API_KEY
+
+      - name: Build JSON object
+        run: |
+          jq --null-input '{}' | \
+          jq '.title = "VA.gov CMS content release has failed"' | \
+          jq '.text = "VA.gov Content release ${{github.run_id}} failed at \(now|strftime("%Y-%m-%d %H:%M:%S"))! https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"' | \
+          jq '.date_happened = now' | \
+          jq '.aggregation_key = "content release ${{github.run_id}}"' | \
+          jq '.tags[0] = "project:vagov"' | \
+          jq '.tags[1] = "repo:content-build"' | \
+          jq '.tags[2] = "workflow:content-release"' | \
+          jq '.tags[3] = "env:${{env.DEPLOY_ENV}}"' | \
+          jq '.tags[5] = "status:${{needs.deploy.result}}"' | \
+          jq '.tags[6] = "trigger:${{env.BUILD_TRIGGER}}"' | \
+          jq '.alert_type = "error"' > event.json
+
+      - name: Send event to Datadog
+        run: |
+          curl -X POST "https://api.datadoghq.com/api/v1/events" \
+          -H "Content-Type: text/json" \
+          -H "DD-API-KEY: ${{ env.GHA_CONTENT_BUILD_DATADOG_API_KEY }}" \
+          -d @- < event.json
+
+  record-metrics:
+    name: Record metrics in Datadog
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+    needs:
+      - start-runner
+      - build
+      - archive
+      - deploy
+    env:
+      METRIC_NAMESPACE: dsva_vagov.content_build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Get current timestamp
+        run: echo "NOW=$(date +"%s")" >> $GITHUB_ENV
+
+      - name: Set vars for scheduled runs
+        if: ${{ github.event_name == 'schedule' }}
+        run: |
+          echo "DEPLOY_ENV=prod" >> $GITHUB_ENV
+          echo "BUILD_TRIGGER=scheduled" >> $GITHUB_ENV
+
+      - name: Set vars for manual runs
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          echo "DEPLOY_ENV=prod" >> $GITHUB_ENV
+          echo "BUILD_TRIGGER=manual" >> $GITHUB_ENV
+
+      - name: Calculate durations
+        run: |
+          echo "SETUP_DURATION=$(expr ${{needs.build.outputs.BUILD_START_TIME}} - ${{needs.start-runner.outputs.APPROX_WORKFLOW_START_TIME}})" >> $GITHUB_ENV
+          echo "BUILD_DURATION=$(expr ${{needs.build.outputs.BUILD_END_TIME}} - ${{needs.build.outputs.BUILD_START_TIME}})" >> $GITHUB_ENV
+          echo "CONTENT_BUILD_DURATION=$(expr ${{needs.build.outputs.CONTENT_BUILD_END_TIME}} - ${{needs.build.outputs.CONTENT_BUILD_START_TIME}})" >> $GITHUB_ENV
+          echo "ARCHIVE_DURATION=$(expr ${{needs.archive.outputs.ARCHIVE_END_TIME}} - ${{needs.build.outputs.BUILD_END_TIME}})" >> $GITHUB_ENV
+          echo "DEPLOY_DURATION=$(expr ${{needs.deploy.outputs.DEPLOY_END_TIME}} - ${{needs.create-release.outputs.ARCHIVE_END_TIME}})" >> $GITHUB_ENV
+          echo "OVERALL_DURATION=$(expr ${{needs.deploy.outputs.DEPLOY_END_TIME}} - ${{needs.start-runner.outputs.APPROX_WORKFLOW_START_TIME}})" >> $GITHUB_ENV
+
+      - name: Build JSON object
+        run: |
+          jq --null-input '{}' | \
+          jq '.series[0].metric = "${{env.METRIC_NAMESPACE}}.setup.duration"' | \
+          jq '.series[0].points[0] = [${{env.NOW}}, ${{env.SETUP_DURATION}}]' | \
+          jq '.series[1].metric = "${{env.METRIC_NAMESPACE}}.build.duration"' | \
+          jq '.series[1].points[0] = [${{env.NOW}}, ${{env.BUILD_DURATION}}]' | \
+          jq '.series[2].metric = "${{env.METRIC_NAMESPACE}}.build.gql.pages"' | \
+          jq '.series[2].points[0] = [${{env.NOW}}, ${{needs.build.outputs.GQL_PAGE_COUNT}}]' | \
+          jq '.series[3].metric = "${{env.METRIC_NAMESPACE}}.build.gql.duration"' | \
+          jq '.series[3].points[0] = [${{env.NOW}}, ${{needs.build.outputs.GQL_QUERY_DURATION}}]' | \
+          jq '.series[4].metric = "${{env.METRIC_NAMESPACE}}.build.content-build.duration"' | \
+          jq '.series[4].points[0] = [${{env.NOW}}, ${{env.CONTENT_BUILD_DURATION}}]' | \
+          jq '.series[5].metric = "${{env.METRIC_NAMESPACE}}.archive.duration"' | \
+          jq '.series[5].points[0] = [${{env.NOW}}, ${{env.ARCHIVE_DURATION}}]' | \
+          jq '.series[6].metric = "${{env.METRIC_NAMESPACE}}.deploy.duration"' | \
+          jq '.series[6].points[0] = [${{env.NOW}}, ${{env.DEPLOY_DURATION}}]' | \
+          jq '.series[7].metric = "${{env.METRIC_NAMESPACE}}.overall.duration"' | \
+          jq '.series[7].points[0] = [${{env.NOW}}, ${{env.OVERALL_DURATION}}]' | \
+          jq '.series[].tags[0] = "env:${{env.DEPLOY_ENV}}"' | \
+          jq '.series[].tags[1] = "build_number:${{github.run_number}}"' | \
+          jq '.series[].tags[2] = "status:${{needs.deploy.result}}"' | \
+          jq '.series[].tags[3] = "trigger:${{env.BUILD_TRIGGER}}"' > metrics.json
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Get Datadog api key from Parameter Store
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /dsva-vagov/content-build/GHA_CONTENT_BUILD_DATADOG_API_KEY
+          env_variable_name: GHA_CONTENT_BUILD_DATADOG_API_KEY
+
+      - name: Get Datadog app key from Parameter Store
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /dsva-vagov/content-build/GHA_CONTENT_BUILD_DATADOG_APP_KEY
+          env_variable_name: GHA_CONTENT_BUILD_DATADOG_APP_KEY
+
+      - name: Send metrics to Datadog
+        run: |
+          curl -X POST "https://api.datadoghq.com/api/v1/series" \
+          -H "Content-Type: text/json" \
+          -H "DD-API-KEY: ${{ env.GHA_CONTENT_BUILD_DATADOG_API_KEY }}" \
+          -d @- < metrics.json
+
+      - name: Record deployment event
+        uses: ./.github/workflows/record-release-interval
+        with:
+          datadog_api_key: ${{ env.GHA_CONTENT_BUILD_DATADOG_API_KEY }}
+          datadog_app_key: ${{ env.GHA_CONTENT_BUILD_DATADOG_APP_KEY }}
+          metric_namespace: ${{ env.METRIC_NAMESPACE }}
 
   stop-runner:
     name: Stop on-demand-runner
     needs:
       - start-runner
-#      - deploy
-#      - record-metrics
+      - deploy
+      - record-metrics
     runs-on: ubuntu-latest
     if: ${{ always() }} # Even if an error happened, let's stop the runner
     env:

--- a/.github/workflows/deploy-content-preview-server.yml
+++ b/.github/workflows/deploy-content-preview-server.yml
@@ -1,7 +1,6 @@
 name: Deploy Content Preview Server
 
 on:
-  workflow_dispatch:
   workflow_run:
     workflows:
       - Content Release


### PR DESCRIPTION
## Description
Follow up of:
* https://github.com/department-of-veterans-affairs/content-build/pull/1048
* https://github.com/department-of-veterans-affairs/content-build/pull/1065

See https://github.com/department-of-veterans-affairs/va.gov-cms/issues/8132.

## Testing done
- [x] Tested Content Deploy workflow, which triggered a Content Preview Server Deploy successfully. 

## Screenshots
Yay

![image](https://user-images.githubusercontent.com/1504756/161171772-eb5622cd-de0f-49bc-a4b8-a070543b8d13.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
