### PR TITLE
Upgrade Docker image used for Cypress tests in CI

### DIFF
--- a/.github/workflows/a11y-heading-order.yml
+++ b/.github/workflows/a11y-heading-order.yml
@@ -117,7 +117,7 @@ jobs:
     timeout-minutes: 120
     runs-on: [self-hosted, asg]
     container:
-      image: public.ecr.aws/cypress-io/cypress/browsers:node14.16.0-chrome89-ff77
+      image: public.ecr.aws/cypress-io/cypress/browsers:node16.13.2-chrome100-ff98
       options: -u 1001:1001 -v /usr/local/share:/share
     strategy:
       fail-fast: false

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -150,7 +150,7 @@ jobs:
     timeout-minutes: 120
     runs-on: [self-hosted, asg]
     container:
-      image: public.ecr.aws/cypress-io/cypress/browsers:node14.16.0-chrome89-ff77
+      image: public.ecr.aws/cypress-io/cypress/browsers:node16.13.2-chrome100-ff98
       options: -u 1001:1001 -v /usr/local/share:/share
     strategy:
       fail-fast: false

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -413,7 +413,7 @@ jobs:
     needs: [start-runner, build]
     timeout-minutes: 30
     container:
-      image: public.ecr.aws/cypress-io/cypress/browsers:node14.16.0-chrome90-ff88
+      image: public.ecr.aws/cypress-io/cypress/browsers:node16.13.2-chrome100-ff98
       options: -u 0
       volumes:
         - /usr/local/share:/share


### PR DESCRIPTION
## Description
This PR upgrades the `cypress/browsers` Docker image to the latest version.

## Acceptance criteria
- [ ] CI passes.