### PR TITLE
Add a fallback notification for when there are too many broken links to post to slack

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -358,7 +358,7 @@ jobs:
           SSL_CERT_DIR: /etc/ssl/certs
           SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
         with:
-          channel-id: ${{ env.VFS_PLATFORM_BUILDS_SLACK }}
+          channel-id: ${{ env.BROKEN_LINKS_SLACK }}
           slack-message: "@cms-helpdesk Broken links found in vagovprod, but there are too many to post to Slack. See <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}> for details."
 
       - name: Generate build details

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -311,6 +311,7 @@ jobs:
 
       - name: Notify VFS Platform Builds channel about broken links
         uses: slackapi/slack-github-action@v1.16.0
+        id: notify-vfs-platform-builds-broken-links
         if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
         continue-on-error: true
         env:
@@ -320,8 +321,23 @@ jobs:
           payload: ${{ steps.get-broken-link-info.outputs.SLACK_ATTACHMENTS }}
           channel-id: ${{ env.VFS_PLATFORM_BUILDS_SLACK }}
 
+      - name: Output broken links info (fallback)
+        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && steps.notify-vfs-platform-builds-broken-links.outcome == 'failure' && always() }}
+        run: cat ./logs/${{ env.BUILDTYPE }}-broken-links.json | jq
+
+      - name: Notify VFS Platform Builds channel about broken links (fallback)
+        uses: slackapi/slack-github-action@v1.16.0
+        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && steps.notify-vfs-platform-builds-broken-links.outcome == 'failure' && always() }}
+        env:
+          SSL_CERT_DIR: /etc/ssl/certs
+          SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
+        with:
+          channel-id: ${{ env.VFS_PLATFORM_BUILDS_SLACK }}
+          slack-message: "@cms-helpdesk Broken links found in vagovprod, but there are too many to post to Slack. See <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}> for details."
+
       - name: Notify content broken links channel about broken links
         uses: slackapi/slack-github-action@v1.16.0
+        id: notify-content-broken-links
         if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
         continue-on-error: true
         env:
@@ -330,6 +346,20 @@ jobs:
         with:
           payload: ${{ steps.get-broken-link-info.outputs.SLACK_ATTACHMENTS }}
           channel-id: ${{ env.BROKEN_LINKS_SLACK }}
+
+      - name: Output broken links info (fallback)
+        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && steps.notify-content-broken-links.outcome == 'failure' && always() }}
+        run: cat ./logs/${{ env.BUILDTYPE }}-broken-links.json | jq
+
+      - name: Notify VFS Platform Builds channel about broken links (fallback)
+        uses: slackapi/slack-github-action@v1.16.0
+        if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && steps.notify-content-broken-links.outcome == 'failure' && always() }}
+        env:
+          SSL_CERT_DIR: /etc/ssl/certs
+          SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
+        with:
+          channel-id: ${{ env.VFS_PLATFORM_BUILDS_SLACK }}
+          slack-message: "@cms-helpdesk Broken links found in vagovprod, but there are too many to post to Slack. See <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}> for details."
 
       - name: Generate build details
         run: |


### PR DESCRIPTION
Ref https://github.com/department-of-veterans-affairs/va.gov-cms/issues/8602

Recent fail: https://github.com/department-of-veterans-affairs/content-build/runs/5836038162?check_suite_focus=true#step:27:31

## Description


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
