### PR TITLE
Send extra DD metric showing approximate business hours since last deploy

### DIFF
--- a/.github/workflows/record-release-interval/action.yml
+++ b/.github/workflows/record-release-interval/action.yml
@@ -35,22 +35,31 @@ runs:
         # This is all one pipeline. Edit with care.
         # [
             # Get the last 1000 events from datadog
-            curl "https://api.datadoghq.com/api/v1/events?start=${starttime}&end=${now}&tags=env:prod,deploy:true&unaggregated=true" \
+            curl "https://api.datadoghq.com/api/v1/events?start=${starttime}&end=${now}&tags=env:${{ inputs.environment }},deploy:true&unaggregated=true" \
                 -H "Content-Type: text/json" \
                 -H "DD-APPLICATION-KEY: ${{ inputs.datadog_app_key }}" \
                 -H "DD-API-KEY: ${{ inputs.datadog_api_key }}" | \
 
             # Filter the events down to just content releases and put the most recent timestamp into last_deploy.txt
-            jq '[.events[] | select(.title=="Content release (prod)")] | first | .date_happened' > last_deploy.txt
+            jq '[.events[] | select(.title=="Content release (${{ inputs.environment }})")] | first | .date_happened' > last_deploy.txt
         # ]
-
-        time_since_last_deploy="$(expr ${now} - $(cat last_deploy.txt))"
 
         # There's probably a better way to handle missing event timestamps, but
         # this is relatively simple and will work for now.
         last_deploy=$(cat last_deploy.txt || echo $CURRENT_TIME)
         echo "LAST_DEPLOY=${last_deploy})" >> $GITHUB_ENV
-        echo "TIME_SINCE_LAST_DEPLOY=$(expr ${now} - ${last_deploy})" >> $GITHUB_ENV
+
+        time_since_last_deploy=$(expr ${now} - ${last_deploy})
+        echo "TIME_SINCE_LAST_DEPLOY=${time_since_last_deploy}" >> $GITHUB_ENV
+
+        # Subtract time in 60 minute intervals until we're under 60 minutes.
+        # This should get us pretty close to actual business hours (removes
+        # nights, weekends, and other long hiatuses).
+        while [ $time_since_last_deploy -ge 3600 ]; do
+            time_since_last_deploy=$(expr ${time_since_last_deploy} - 3600)
+        done
+
+        echo "BIZTIME_SINCE_LAST_DEPLOY=${time_since_last_deploy}" >> $GITHUB_ENV
 
     - name: Record deployment event in Datadog
       shell: bash
@@ -76,6 +85,8 @@ runs:
         jq --null-input '{}' | \
         jq '.series[0].metric = "dsva_vagov.content_build.time_since_last_deploy"' | \
         jq '.series[0].points[0] = [${{ env.CURRENT_TIME }}, ${{ env.TIME_SINCE_LAST_DEPLOY }}]' | \
+        jq '.series[1].metric = "dsva_vagov.content_build.business_hours_time_since_last_deploy"' | \
+        jq '.series[1].points[0] = [${{ env.CURRENT_TIME }}, ${{ env.BIZTIME_SINCE_LAST_DEPLOY }}]' | \
         jq '.series[].tags[0] = "env:${{ inputs.environment }}"' | \
         jq '.series[].tags[1] = "build_number:${{ github.run_number }}"' > metrics.json
 


### PR DESCRIPTION
For anything longer than an hour, the second metric will subtract 60 minutes until the number is under 1 hour. We normally sit at ~30 minutes between deploys during the day, so this should get us pretty close.

## Description


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
