### PR TITLE
Uses `aws s3 cp --no-progress` to reduce noise in content build logs.

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -433,7 +433,7 @@ jobs:
           role-session-name: vsp-frontendteam-githubaction
 
       - name: Upload build
-        run: aws s3 cp ${{ env.BUILDTYPE }}.tar.bz2 s3://vetsgov-website-builds-s3-upload/content-build/${{needs.validate-build-status.outputs.REF}}/${{ env.BUILDTYPE }}.tar.bz2 --acl public-read --region us-gov-west-1
+        run: aws s3 cp ${{ env.BUILDTYPE }}.tar.bz2 s3://vetsgov-website-builds-s3-upload/content-build/${{needs.validate-build-status.outputs.REF}}/${{ env.BUILDTYPE }}.tar.bz2 --acl public-read --region us-gov-west-1 --no-progress
 
       - name: Export archive end time
         id: export-archive-end-time


### PR DESCRIPTION
## Description
Scrolling through the logs for this action can be kinda tedious, see e.g.

<img width="561" alt="Screen Shot 2022-04-11 at 11 53 01 AM" src="https://user-images.githubusercontent.com/1318579/162780837-125dff3e-fec9-4551-8506-49c30726b934.png">

```
       --no-progress  (boolean)  File transfer progress is not displayed. This
       flag is only applied when the quiet and only-show-errors flags are  not
       provided.
```

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
