### PR TITLE
Comment out validate build status step

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -118,10 +118,10 @@ jobs:
         id: get-latest-release
         uses: thebritican/fetch-latest-release@v2.0.0
 
-      - name: Validate build status
-        run: node ./script/github-actions/validate-build-status.js ${{ steps.get-latest-release.outputs.target_commitish }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Validate build status
+      #   run: node ./script/github-actions/validate-build-status.js ${{ steps.get-latest-release.outputs.target_commitish }}
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   notify-start:
     name: Notify Start

--- a/.github/workflows/daily-production-release.yml
+++ b/.github/workflows/daily-production-release.yml
@@ -57,10 +57,10 @@ jobs:
         id: get-current-ref
         run: echo ::set-output name=REF::$(git rev-parse HEAD)
 
-      - name: Validate build status
-        run: node ./script/github-actions/validate-build-status.js ${{ steps.get-current-ref.outputs.REF }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Validate build status
+      #   run: node ./script/github-actions/validate-build-status.js ${{ steps.get-current-ref.outputs.REF }}
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get latest tag
         id: get-latest-tag


### PR DESCRIPTION
## Description
This PR temporarily comments out the `validate build status` steps so that we can use the latest commit for content releases. This is a workaround for GitHub Action issues that are preventing us from getting the latest workflow runs from the API. The changes in this PR should be reverted once the issue has been resolved.

[Slack thread](https://dsva.slack.com/archives/CU1E4CX9U/p1649705784825259)
[Slack thread](https://dsva.slack.com/archives/C02VD909V08/p1649700395739759)

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
