### PR TITLE
Revert commenting out build validation

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -118,10 +118,10 @@ jobs:
         id: get-latest-release
         uses: thebritican/fetch-latest-release@v2.0.0
 
-      # - name: Validate build status
-      #   run: node ./script/github-actions/validate-build-status.js ${{ steps.get-latest-release.outputs.target_commitish }}
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Validate build status
+        run: node ./script/github-actions/validate-build-status.js ${{ steps.get-latest-release.outputs.target_commitish }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   notify-start:
     name: Notify Start

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -750,13 +750,11 @@ jobs:
     if: ${{ always() && github.ref == 'refs/heads/master' && needs.cache-drupal-content.result == 'success' }}
     needs: cache-drupal-content
     outputs:
-      latest_commit_sha: ${{ steps.latest-run-number.outputs.latest_commit_sha }}
+      latest_run_number: ${{ steps.latest-run-number.outputs.latest_run_number }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       - name: Install dependencies
         uses: ./.github/workflows/install
@@ -768,17 +766,16 @@ jobs:
             .cache/yarn
             node_modules
 
-      - name: Set output of latest_commit_sha
+      - name: Set output of latest_run_number
         id: latest-run-number
-        # run: echo ::set-output name=latest_run_number::$(node ./script/github-actions/get-latest-run-number.js)
-        run: echo ::set-output name=latest_commit_sha::$(git log -n 1 master --pretty=format:"%H")
+        run: echo ::set-output name=latest_run_number::$(node ./script/github-actions/get-latest-run-number.js)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   deploy:
     name: Deploy
     runs-on: self-hosted
-    if: ${{ always() && github.ref == 'refs/heads/master' && needs.get-latest-run-number.result == 'success' && needs.get-latest-run-number.outputs.latest_commit_sha == github.sha }}
+    if: ${{ always() && github.ref == 'refs/heads/master' && needs.get-latest-run-number.result == 'success' && needs.get-latest-run-number.outputs.latest_run_number == github.run_number }}
     needs: [build, archive, cache-drupal-content, get-latest-run-number]
 
     env:

--- a/.github/workflows/daily-production-release.yml
+++ b/.github/workflows/daily-production-release.yml
@@ -57,10 +57,10 @@ jobs:
         id: get-current-ref
         run: echo ::set-output name=REF::$(git rev-parse HEAD)
 
-      # - name: Validate build status
-      #   run: node ./script/github-actions/validate-build-status.js ${{ steps.get-current-ref.outputs.REF }}
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Validate build status
+        run: node ./script/github-actions/validate-build-status.js ${{ steps.get-current-ref.outputs.REF }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get latest tag
         id: get-latest-tag


### PR DESCRIPTION
## Description
This PR reverts the changes made in https://github.com/department-of-veterans-affairs/content-build/pull/1075 and https://github.com/department-of-veterans-affairs/content-build/pull/1084 that were workarounds for the GitHub Actions API issues. Now that the issues are resolved, we can merge this.


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
