### PR TITLE
Update manual dev/staging deploy

### DIFF
--- a/.github/workflows/manual-deploy-dev-staging.yml
+++ b/.github/workflows/manual-deploy-dev-staging.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: self-hosted
     env:
       NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
+      RUN_DEPLOY: ${{ github.event.inputs.deploy_environment == matrix.environment || github.event.inputs.deploy_environment == 'both' }}
 
     strategy:
       matrix:
@@ -36,9 +37,11 @@ jobs:
 
     steps:
       - name: Checkout
+        if: env.RUN_DEPLOY
         uses: actions/checkout@v2
 
       - name: Configure AWS credentials (1)
+        if: env.RUN_DEPLOY
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -46,12 +49,14 @@ jobs:
           aws-region: us-gov-west-1
 
       - name: Get role from Parameter Store
+        if: env.RUN_DEPLOY
         uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
         with:
           ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
           env_variable_name: AWS_FRONTEND_NONPROD_ROLE
 
       - name: Configure AWS Credentials (2)
+        if: env.RUN_DEPLOY
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -62,7 +67,7 @@ jobs:
           role-session-name: vsp-frontendteam-githubaction
 
       - name: Deploy
-        if: ${{ github.event.inputs.deploy_environment == matrix.environment || github.event.inputs.deploy_environment == 'both' }}
+        if: env.RUN_DEPLOY
         run: ./script/github-actions/deploy.sh -s $SRC -d $DEST -v
         env:
           SRC: s3://vetsgov-website-builds-s3-upload/content-build/${{ github.event.inputs.commit_sha }}/${{ matrix.environment }}.tar.bz2

--- a/.github/workflows/manual-deploy-dev-staging.yml
+++ b/.github/workflows/manual-deploy-dev-staging.yml
@@ -11,8 +11,8 @@ on:
         description: The environment to deploy to
         required: true
         options:
-          - dev
-          - staging
+          - vagovdev
+          - vagovstaging
           - both
 
 env:
@@ -23,6 +23,16 @@ jobs:
   deploy:
     name: Deploy
     runs-on: self-hosted
+    env:
+      NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
+
+    strategy:
+      matrix:
+        include:
+          - environment: vagovdev
+            bucket: content.dev.va.gov
+          - environment: vagovstaging
+            bucket: content.staging.va.gov
 
     steps:
       - name: Checkout
@@ -51,19 +61,12 @@ jobs:
           role-duration-seconds: 900
           role-session-name: vsp-frontendteam-githubaction
 
-      - name: Deploy Dev
-        if: ${{ github.event.inputs.deploy_environment == 'dev' || github.event.inputs.deploy_environment == 'both' }}
+      - name: Deploy
+        if: ${{ github.event.inputs.deploy_environment == matrix.environment || github.event.inputs.deploy_environment == 'both' }}
         run: ./script/github-actions/deploy.sh -s $SRC -d $DEST -v
         env:
-          SRC: s3://vetsgov-website-builds-s3-upload/content-build/${{ github.event.inputs.commit_sha }}/vagovdev.tar.bz2
-          DEST: s3://content.dev.va.gov
-        
-      - name: Deploy Staging
-        if: ${{ github.event.inputs.deploy_environment == 'staging' || github.event.inputs.deploy_environment == 'both' }}
-        run: ./script/github-actions/deploy.sh -s $SRC -d $DEST -v
-        env:
-          SRC: s3://vetsgov-website-builds-s3-upload/content-build/${{ github.event.inputs.commit_sha }}/vagovstaging.tar.bz2
-          DEST: s3://content.staging.va.gov
+          SRC: s3://vetsgov-website-builds-s3-upload/content-build/${{ github.event.inputs.commit_sha }}/${{ matrix.environment }}.tar.bz2
+          DEST: s3://${{ matrix.bucket }}
   
   notify-failure:
     name: Notify Failure

--- a/.github/workflows/manual-deploy-dev-staging.yml
+++ b/.github/workflows/manual-deploy-dev-staging.yml
@@ -67,7 +67,7 @@ jobs:
   
   notify-failure:
     name: Notify Failure
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     if: ${{ failure() || cancelled() }}
     needs: deploy
 

--- a/.github/workflows/manual-deploy-dev-staging.yml
+++ b/.github/workflows/manual-deploy-dev-staging.yml
@@ -31,9 +31,9 @@ jobs:
         id: set-output
         run: |
           if [[ ${{ github.event.inputs.deploy_environment }} == 'vagovdev' ]]; then
-            echo ::set-output name=exclude::{name:vagovstaging}
+            echo ::set-output name=exclude::{\"name\":\"vagovstaging\"}
           elif [[ ${{ github.event.inputs.deploy_environment }} == 'vagovstaging' ]]; then
-            echo ::set-output name=exclude::{name:vagovdev}
+            echo ::set-output name=exclude::{\"name\":\"vagovdev\"}
           fi
 
   deploy:

--- a/.github/workflows/manual-deploy-dev-staging.yml
+++ b/.github/workflows/manual-deploy-dev-staging.yml
@@ -68,21 +68,21 @@ jobs:
           SRC: s3://vetsgov-website-builds-s3-upload/content-build/${{ github.event.inputs.commit_sha }}/${{ matrix.environment }}.tar.bz2
           DEST: s3://${{ matrix.bucket }}
   
-  notify-failure:
-    name: Notify Failure
-    runs-on: ubuntu-latest
-    if: ${{ failure() || cancelled() }}
-    needs: deploy
+  # notify-failure:
+  #   name: Notify Failure
+  #   runs-on: ubuntu-latest
+  #   if: ${{ failure() || cancelled() }}
+  #   needs: deploy
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
 
-      - name: Notify Slack
-        uses: ./.github/workflows/slack-notify
-        continue-on-error: true
-        with:
-          attachments: '[{"mrkdwn_in": ["text"], "color": "#D33834", "text": "content-build manual dev/staging deploy failed!: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"}]'
-          channel_id: ${{ env.CONTENT_BUILD_CHANNEL_ID }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #     - name: Notify Slack
+  #       uses: ./.github/workflows/slack-notify
+  #       continue-on-error: true
+  #       with:
+  #         attachments: '[{"mrkdwn_in": ["text"], "color": "#D33834", "text": "content-build manual dev/staging deploy failed!: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"}]'
+  #         channel_id: ${{ env.CONTENT_BUILD_CHANNEL_ID }}
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/manual-deploy-dev-staging.yml
+++ b/.github/workflows/manual-deploy-dev-staging.yml
@@ -29,13 +29,12 @@ jobs:
 
     strategy:
       matrix:
-        include:
-          - environment: vagovdev
-            bucket: content.dev.va.gov
-          - environment: vagovstaging
-            bucket: content.staging.va.gov
+        builds: [
+          {environment: vagovdev, bucket: content.dev.va.gov},
+          {environment: vagovstaging, bucket: content.staging.va.gov}
+        ]
         exclude:
-          - environment: vagovdev
+          - builds: {environment: vagovdev}
 
     steps:
       - name: Checkout

--- a/.github/workflows/manual-deploy-dev-staging.yml
+++ b/.github/workflows/manual-deploy-dev-staging.yml
@@ -79,28 +79,27 @@ jobs:
           role-duration-seconds: 900
           role-session-name: vsp-frontendteam-githubaction
 
-      - name: Deploy
-        run: echo "SUCCESS ${{ matrix.name }}" 
-        # run: ./script/github-actions/deploy.sh -s $SRC -d $DEST -v
+      - name: Deploy 
+        run: ./script/github-actions/deploy.sh -s $SRC -d $DEST -v
         env:
           SRC: s3://vetsgov-website-builds-s3-upload/content-build/${{ github.event.inputs.commit_sha }}/${{ matrix.name }}.tar.bz2
           DEST: s3://${{ matrix.bucket }}
   
-  # notify-failure:
-  #   name: Notify Failure
-  #   runs-on: ubuntu-latest
-  #   if: ${{ failure() || cancelled() }}
-  #   needs: deploy
+  notify-failure:
+    name: Notify Failure
+    runs-on: ubuntu-latest
+    if: ${{ failure() || cancelled() }}
+    needs: deploy
 
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
-  #     - name: Notify Slack
-  #       uses: ./.github/workflows/slack-notify
-  #       continue-on-error: true
-  #       with:
-  #         attachments: '[{"mrkdwn_in": ["text"], "color": "#D33834", "text": "content-build manual dev/staging deploy failed!: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"}]'
-  #         channel_id: ${{ env.CONTENT_BUILD_CHANNEL_ID }}
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Notify Slack
+        uses: ./.github/workflows/slack-notify
+        continue-on-error: true
+        with:
+          attachments: '[{"mrkdwn_in": ["text"], "color": "#D33834", "text": "content-build manual dev/staging deploy failed!: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"}]'
+          channel_id: ${{ env.CONTENT_BUILD_CHANNEL_ID }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/manual-deploy-dev-staging.yml
+++ b/.github/workflows/manual-deploy-dev-staging.yml
@@ -27,19 +27,19 @@ jobs:
       environment: ${{ steps.set-output.outputs.environment }}
 
     env:
-      dev: "{\"name\": \"vagovdev\", \"bucket\": \"content.dev.va.gov\"}"
-      staging: "{\"name\": \"vagovstaging\", \"bucket\": \"content.staging.va.gov\"}"
+      dev: "{\\\"name\\\": \\\"vagovdev\\\", \\\"bucket\\\": \\\"content.dev.va.gov\\\"}"
+      staging: "{\\\"name\\\": \\\"vagovstaging\\\", \\\"bucket\\\": \\\"content.staging.va.gov\\\"}"
 
     steps:
       - name: Set output
         id: set-output
         run: |
           if [[ ${{ github.event.inputs.deploy_environment }} == 'dev' ]]; then
-            echo ::set-output name=environment::{include: [${{env.dev}}]}
+            echo ::set-output name=environment::{\"include\": [${{env.dev}}]}
           elif [[ ${{ github.event.inputs.deploy_environment }} == 'staging' ]]; then
-            echo ::set-output name=environment::{include: [${{env.staging}}]}
+            echo ::set-output name=environment::{\"include\": [${{env.staging}}]}
           else
-            echo ::set-output name=environment::{include: [${{env.dev}},${{env.staging}}]}
+            echo ::set-output name=environment::{\"include\": [${{env.dev}},${{env.staging}}]}
           fi
 
   deploy:

--- a/.github/workflows/manual-deploy-dev-staging.yml
+++ b/.github/workflows/manual-deploy-dev-staging.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   deploy:
     name: Deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout
@@ -67,7 +67,7 @@ jobs:
   
   notify-failure:
     name: Notify Failure
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     if: ${{ failure() || cancelled() }}
     needs: deploy
 

--- a/.github/workflows/manual-deploy-dev-staging.yml
+++ b/.github/workflows/manual-deploy-dev-staging.yml
@@ -29,20 +29,18 @@ jobs:
 
     strategy:
       matrix:
-        builds: [
-          {environment: vagovdev, bucket: content.dev.va.gov},
-          {environment: vagovstaging, bucket: content.staging.va.gov}
+        environments: [
+          {name: vagovdev, bucket: content.dev.va.gov},
+          {name: vagovstaging, bucket: content.staging.va.gov}
         ]
-        exclude:
-          - builds: {environment: vagovdev}
+        # exclude:
+        #   - environments: {name: vagovdev}
 
     steps:
       - name: Checkout
-        if: env.RUN_DEPLOY == 'true'
         uses: actions/checkout@v2
 
       - name: Configure AWS credentials (1)
-        if: env.RUN_DEPLOY == 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -50,14 +48,12 @@ jobs:
           aws-region: us-gov-west-1
 
       - name: Get role from Parameter Store
-        if: env.RUN_DEPLOY == 'true'
         uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
         with:
           ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
           env_variable_name: AWS_FRONTEND_NONPROD_ROLE
 
       - name: Configure AWS Credentials (2)
-        if: env.RUN_DEPLOY == 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -68,7 +64,6 @@ jobs:
           role-session-name: vsp-frontendteam-githubaction
 
       - name: Deploy
-        if: env.RUN_DEPLOY == 'true'
         run: echo "SUCCESS ${{ matrix.environment }}" 
         # run: ./script/github-actions/deploy.sh -s $SRC -d $DEST -v
         env:

--- a/.github/workflows/manual-deploy-dev-staging.yml
+++ b/.github/workflows/manual-deploy-dev-staging.yml
@@ -20,9 +20,26 @@ env:
   CONTENT_BUILD_CHANNEL_ID: C02VD909V08 #status-content-build
 
 jobs:
+  set-environment-to-exclude:
+    name: Set environment to exclude
+    runs-on: ubuntu-latest
+    outputs:
+      environment: ${{ steps.set-output.outputs.exclude }}
+
+    steps:
+      - name: Set output
+        id: set-output
+        run: |
+          if [[ ${{ github.event.inputs.deploy_environment }} == 'vagovdev' ]]; then
+            echo ::set-output name=exclude::{name:vagovstaging}
+          elif [[ ${{ github.event.inputs.deploy_environment }} == 'vagovstaging' ]]; then
+            echo ::set-output name=exclude::{name:vagovdev}
+          fi
+
   deploy:
     name: Deploy
     runs-on: self-hosted
+    needs: set-environment-to-exclude
     env:
       NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
       RUN_DEPLOY: ${{ github.event.inputs.deploy_environment == matrix.environment || github.event.inputs.deploy_environment == 'both' }}
@@ -33,8 +50,8 @@ jobs:
           {name: vagovdev, bucket: content.dev.va.gov},
           {name: vagovstaging, bucket: content.staging.va.gov}
         ]
-        # exclude:
-        #   - environments: {name: vagovdev}
+        exclude:
+          - environments: ${{ fromJson(needs.set-environment-to-exclude.outputs.environment) }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/manual-deploy-dev-staging.yml
+++ b/.github/workflows/manual-deploy-dev-staging.yml
@@ -35,22 +35,22 @@ jobs:
         id: set-output
         run: |
           if [[ ${{ github.event.inputs.deploy_environment }} == 'dev' ]]; then
-            echo ::set-output name=environment::{\"include\": [${{env.dev}}]}
+            echo ::set-output name=environment::{\"include\":[${{env.dev}}]}
           elif [[ ${{ github.event.inputs.deploy_environment }} == 'staging' ]]; then
-            echo ::set-output name=environment::{\"include\": [${{env.staging}}]}
+            echo ::set-output name=environment::{\"include\":[${{env.staging}}]}
           else
-            echo ::set-output name=environment::{\"include\": [${{env.dev}},${{env.staging}}]}
+            echo ::set-output name=environment::{\"include\":[${{env.dev}},${{env.staging}}]}
           fi
 
   deploy:
     name: Deploy
     runs-on: self-hosted
     needs: set-environment
-    env:
-      NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
-
     strategy:
       matrix: ${{ fromJson(needs.set-environment.outputs.environment) }}
+
+    env:
+      NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
 
     steps:
       - name: Checkout

--- a/.github/workflows/manual-deploy-dev-staging.yml
+++ b/.github/workflows/manual-deploy-dev-staging.yml
@@ -27,8 +27,8 @@ jobs:
       environment: ${{ steps.set-output.outputs.environment }}
 
     env:
-      dev: "{\\\"name\\\": \\\"vagovdev\\\", \\\"bucket\\\": \\\"content.dev.va.gov\\\"}"
-      staging: "{\\\"name\\\": \\\"vagovstaging\\\", \\\"bucket\\\": \\\"content.staging.va.gov\\\"}"
+      dev: "{\\\"environment\\\": \\\"vagovdev\\\", \\\"bucket\\\": \\\"content.dev.va.gov\\\"}"
+      staging: "{\\\"environment\\\": \\\"vagovstaging\\\", \\\"bucket\\\": \\\"content.staging.va.gov\\\"}"
 
     steps:
       - name: Set output
@@ -82,7 +82,7 @@ jobs:
       - name: Deploy 
         run: ./script/github-actions/deploy.sh -s $SRC -d $DEST -v
         env:
-          SRC: s3://vetsgov-website-builds-s3-upload/content-build/${{ github.event.inputs.commit_sha }}/${{ matrix.name }}.tar.bz2
+          SRC: s3://vetsgov-website-builds-s3-upload/content-build/${{ github.event.inputs.commit_sha }}/${{ matrix.environment }}.tar.bz2
           DEST: s3://${{ matrix.bucket }}
   
   notify-failure:

--- a/.github/workflows/manual-deploy-dev-staging.yml
+++ b/.github/workflows/manual-deploy-dev-staging.yml
@@ -37,11 +37,11 @@ jobs:
 
     steps:
       - name: Checkout
-        if: env.RUN_DEPLOY
+        if: env.RUN_DEPLOY == 'true'
         uses: actions/checkout@v2
 
       - name: Configure AWS credentials (1)
-        if: env.RUN_DEPLOY
+        if: env.RUN_DEPLOY == 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -49,14 +49,14 @@ jobs:
           aws-region: us-gov-west-1
 
       - name: Get role from Parameter Store
-        if: env.RUN_DEPLOY
+        if: env.RUN_DEPLOY == 'true'
         uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
         with:
           ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
           env_variable_name: AWS_FRONTEND_NONPROD_ROLE
 
       - name: Configure AWS Credentials (2)
-        if: env.RUN_DEPLOY
+        if: env.RUN_DEPLOY == 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -67,8 +67,9 @@ jobs:
           role-session-name: vsp-frontendteam-githubaction
 
       - name: Deploy
-        if: env.RUN_DEPLOY
-        run: ./script/github-actions/deploy.sh -s $SRC -d $DEST -v
+        if: env.RUN_DEPLOY == 'true'
+        run: echo "SUCCESS" 
+        # run: ./script/github-actions/deploy.sh -s $SRC -d $DEST -v
         env:
           SRC: s3://vetsgov-website-builds-s3-upload/content-build/${{ github.event.inputs.commit_sha }}/${{ matrix.environment }}.tar.bz2
           DEST: s3://${{ matrix.bucket }}

--- a/.github/workflows/manual-deploy-dev-staging.yml
+++ b/.github/workflows/manual-deploy-dev-staging.yml
@@ -35,7 +35,7 @@ jobs:
           elif [[ ${{ github.event.inputs.deploy_environment }} == 'vagovstaging' ]]; then
             echo ::set-output name=exclude::{\"name\":\"vagovdev\"}
           else
-            echo ::set-output name=exclude::{}
+            echo ::set-output name=exclude::[]
           fi
 
   deploy:

--- a/.github/workflows/manual-deploy-dev-staging.yml
+++ b/.github/workflows/manual-deploy-dev-staging.yml
@@ -34,6 +34,8 @@ jobs:
             echo ::set-output name=exclude::{\"name\":\"vagovstaging\"}
           elif [[ ${{ github.event.inputs.deploy_environment }} == 'vagovstaging' ]]; then
             echo ::set-output name=exclude::{\"name\":\"vagovdev\"}
+          else
+            echo ::set-output name=exclude::{}
           fi
 
   deploy:
@@ -46,12 +48,12 @@ jobs:
 
     strategy:
       matrix:
-        environments: [
+        environment: [
           {name: vagovdev, bucket: content.dev.va.gov},
           {name: vagovstaging, bucket: content.staging.va.gov}
         ]
         exclude:
-          - environments: ${{ fromJson(needs.set-environment-to-exclude.outputs.environment) }}
+          - environment: ${{ fromJson(needs.set-environment-to-exclude.outputs.environment) }}
 
     steps:
       - name: Checkout
@@ -81,7 +83,7 @@ jobs:
           role-session-name: vsp-frontendteam-githubaction
 
       - name: Deploy
-        run: echo "SUCCESS ${{ matrix.environment }}" 
+        run: echo "SUCCESS ${{ matrix.environment.name }}" 
         # run: ./script/github-actions/deploy.sh -s $SRC -d $DEST -v
         env:
           SRC: s3://vetsgov-website-builds-s3-upload/content-build/${{ github.event.inputs.commit_sha }}/${{ matrix.environment }}.tar.bz2

--- a/.github/workflows/manual-deploy-dev-staging.yml
+++ b/.github/workflows/manual-deploy-dev-staging.yml
@@ -83,7 +83,7 @@ jobs:
         run: echo "SUCCESS ${{ matrix.name }}" 
         # run: ./script/github-actions/deploy.sh -s $SRC -d $DEST -v
         env:
-          SRC: s3://vetsgov-website-builds-s3-upload/content-build/${{ github.event.inputs.commit_sha }}/${{ matrix.environment }}.tar.bz2
+          SRC: s3://vetsgov-website-builds-s3-upload/content-build/${{ github.event.inputs.commit_sha }}/${{ matrix.name }}.tar.bz2
           DEST: s3://${{ matrix.bucket }}
   
   # notify-failure:

--- a/.github/workflows/manual-deploy-dev-staging.yml
+++ b/.github/workflows/manual-deploy-dev-staging.yml
@@ -11,8 +11,8 @@ on:
         description: The environment to deploy to
         required: true
         options:
-          - vagovdev
-          - vagovstaging
+          - dev
+          - staging
           - both
 
 env:
@@ -20,40 +20,37 @@ env:
   CONTENT_BUILD_CHANNEL_ID: C02VD909V08 #status-content-build
 
 jobs:
-  set-environment-to-exclude:
-    name: Set environment to exclude
+  set-environment:
+    name: Set environment to deploy
     runs-on: ubuntu-latest
     outputs:
-      environment: ${{ steps.set-output.outputs.exclude }}
+      environment: ${{ steps.set-output.outputs.environment }}
+
+    env:
+      dev: "{\"name\": \"vagovdev\", \"bucket\": \"content.dev.va.gov\"}"
+      staging: "{\"name\": \"vagovstaging\", \"bucket\": \"content.staging.va.gov\"}"
 
     steps:
       - name: Set output
         id: set-output
         run: |
-          if [[ ${{ github.event.inputs.deploy_environment }} == 'vagovdev' ]]; then
-            echo ::set-output name=exclude::{\"name\":\"vagovstaging\"}
-          elif [[ ${{ github.event.inputs.deploy_environment }} == 'vagovstaging' ]]; then
-            echo ::set-output name=exclude::{\"name\":\"vagovdev\"}
+          if [[ ${{ github.event.inputs.deploy_environment }} == 'dev' ]]; then
+            echo ::set-output name=environment::{\"include\": [${{env.dev}}]}
+          elif [[ ${{ github.event.inputs.deploy_environment }} == 'staging' ]]; then
+            echo ::set-output name=environment::{\"include\": [${{env.staging}}]}
           else
-            echo ::set-output name=exclude::[]
+            echo ::set-output name=environment::{\"include\": [${{env.dev}},${{env.staging}}]}
           fi
 
   deploy:
     name: Deploy
     runs-on: self-hosted
-    needs: set-environment-to-exclude
+    needs: set-environment
     env:
       NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
-      RUN_DEPLOY: ${{ github.event.inputs.deploy_environment == matrix.environment || github.event.inputs.deploy_environment == 'both' }}
 
     strategy:
-      matrix:
-        environment: [
-          {name: vagovdev, bucket: content.dev.va.gov},
-          {name: vagovstaging, bucket: content.staging.va.gov}
-        ]
-        exclude:
-          - environment: ${{ fromJson(needs.set-environment-to-exclude.outputs.environment) }}
+      matrix: ${{ fromJson(needs.set-environment.outputs.environment) }}
 
     steps:
       - name: Checkout
@@ -83,7 +80,7 @@ jobs:
           role-session-name: vsp-frontendteam-githubaction
 
       - name: Deploy
-        run: echo "SUCCESS ${{ matrix.environment.name }}" 
+        run: echo "SUCCESS ${{ matrix.name }}" 
         # run: ./script/github-actions/deploy.sh -s $SRC -d $DEST -v
         env:
           SRC: s3://vetsgov-website-builds-s3-upload/content-build/${{ github.event.inputs.commit_sha }}/${{ matrix.environment }}.tar.bz2

--- a/.github/workflows/manual-deploy-dev-staging.yml
+++ b/.github/workflows/manual-deploy-dev-staging.yml
@@ -35,11 +35,11 @@ jobs:
         id: set-output
         run: |
           if [[ ${{ github.event.inputs.deploy_environment }} == 'dev' ]]; then
-            echo ::set-output name=environment::{\"include\": [${{env.dev}}]}
+            echo ::set-output name=environment::{include: [${{env.dev}}]}
           elif [[ ${{ github.event.inputs.deploy_environment }} == 'staging' ]]; then
-            echo ::set-output name=environment::{\"include\": [${{env.staging}}]}
+            echo ::set-output name=environment::{include: [${{env.staging}}]}
           else
-            echo ::set-output name=environment::{\"include\": [${{env.dev}},${{env.staging}}]}
+            echo ::set-output name=environment::{include: [${{env.dev}},${{env.staging}}]}
           fi
 
   deploy:

--- a/.github/workflows/manual-deploy-dev-staging.yml
+++ b/.github/workflows/manual-deploy-dev-staging.yml
@@ -34,6 +34,8 @@ jobs:
             bucket: content.dev.va.gov
           - environment: vagovstaging
             bucket: content.staging.va.gov
+        exclude:
+          - environment: vagovdev
 
     steps:
       - name: Checkout
@@ -68,7 +70,7 @@ jobs:
 
       - name: Deploy
         if: env.RUN_DEPLOY == 'true'
-        run: echo "SUCCESS" 
+        run: echo "SUCCESS ${{ matrix.environment }}" 
         # run: ./script/github-actions/deploy.sh -s $SRC -d $DEST -v
         env:
           SRC: s3://vetsgov-website-builds-s3-upload/content-build/${{ github.event.inputs.commit_sha }}/${{ matrix.environment }}.tar.bz2


### PR DESCRIPTION
## Description
This PR makes some enhancements to the manual dev/staging deploy:
- Uses the `self-hosted` runner for the `Deploy` job (the deploy was timing out due to lack of resources)
- Defines and uses a matrix for the `Deploy` job, so both environments can be deployed simultaneously


## Testing done
Tested using changes in branch:
_Deploy script was commented out for testing purposes_

- [dev deploy](https://github.com/department-of-veterans-affairs/content-build/actions/runs/2158500589)
- [stging deploy](https://github.com/department-of-veterans-affairs/content-build/actions/runs/2158496736)
- [both deployed](https://github.com/department-of-veterans-affairs/content-build/actions/runs/2158504214)

## Acceptance criteria
- [x] Manual dev/staging deploy uses the `self-hosted` runner
- [x] Both dev and staging can be deployed simultaneously

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
