### PR TITLE
Remove education-inbox entry

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1196,16 +1196,6 @@
     }
   },
   {
-    "appName": "Education Inbox",
-    "entryName": "education-inbox",
-    "rootUrl": "/education/education-inbox",
-    "template": {
-      "vagovprod": false,
-      "layout": "page-react.html",
-      "title": "Check your VA education inbox"
-    }
-  },
-  {
     "appName": "Connect Your Device",
     "entryName": "dhp-consent-flow",
     "rootUrl": "/health-care/connected-devices",


### PR DESCRIPTION
## Description
The `education-inbox` application was removed in this [PR](https://github.com/department-of-veterans-affairs/vets-website/pull/20697). Since the app's assets no longer exist in S3, we are getting CI [failures](https://github.com/department-of-veterans-affairs/content-build/runs/6040575580?check_suite_focus=true). This PR removes the entry in the registry for the app.

## Acceptance criteria
- [x] The `education-inbox` entry should no longer be present.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
