### PR TITLE
Get latest commit before deploy

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -771,7 +771,7 @@ jobs:
       - name: Set output of latest_commit_sha
         id: latest-run-number
         # run: echo ::set-output name=latest_run_number::$(node ./script/github-actions/get-latest-run-number.js)
-        run: echo ::set-output name=latest_commit_sha::$(git log -n 1 --pretty=format:"%H")
+        run: echo ::set-output name=latest_commit_sha::$(git log -n 1 master --pretty=format:"%H")
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -750,11 +750,13 @@ jobs:
     if: ${{ always() && github.ref == 'refs/heads/master' && needs.cache-drupal-content.result == 'success' }}
     needs: cache-drupal-content
     outputs:
-      latest_run_number: ${{ steps.latest-run-number.outputs.latest_run_number }}
+      latest_commit_sha: ${{ steps.latest-run-number.outputs.latest_commit_sha }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Install dependencies
         uses: ./.github/workflows/install
@@ -766,25 +768,17 @@ jobs:
             .cache/yarn
             node_modules
 
-      - name: Install dependencies
-        uses: nick-invision/retry@v2
-        with:
-          command: yarn install --frozen-lockfile --prefer-offline --production=false
-          max_attempts: 3
-          timeout_minutes: 7
-        env:
-          YARN_CACHE_FOLDER: .cache/yarn
-
-      - name: Set output of latest_run_number
+      - name: Set output of latest_commit_sha
         id: latest-run-number
-        run: echo ::set-output name=latest_run_number::$(node ./script/github-actions/get-latest-run-number.js)
+        # run: echo ::set-output name=latest_run_number::$(node ./script/github-actions/get-latest-run-number.js)
+        run: echo ::set-output name=latest_commit_sha::$(git log -n 1 --pretty=format:"%H")
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   deploy:
     name: Deploy
     runs-on: self-hosted
-    if: ${{ always() && github.ref == 'refs/heads/master' && needs.get-latest-run-number.result == 'success' && needs.get-latest-run-number.outputs.latest_run_number == github.run_number }}
+    if: ${{ always() && github.ref == 'refs/heads/master' && needs.get-latest-run-number.result == 'success' && needs.get-latest-run-number.outputs.latest_commit_sha == github.sha }}
     needs: [build, archive, cache-drupal-content, get-latest-run-number]
 
     env:


### PR DESCRIPTION
## Description
This PR temporarily updates the `get-latest-run-number` job to fetch the latest commit instead of the latest workflow run number. This is a workaround for the issues with the GitHub API that will allow us to deploy to dev & staging without running into race conditions.

## Acceptance criteria
- [x] The CI workflow can trigger dev & staging deploys without running into race conditions.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
