### PR TITLE
Add a flag that allows us to run the graphql queries and nothing else

### DIFF
--- a/src/site/stages/build/index.js
+++ b/src/site/stages/build/index.js
@@ -87,6 +87,24 @@ function build(BUILD_OPTIONS) {
   }
 
   smith.use(getDrupalContent(BUILD_OPTIONS), 'Get Drupal content');
+
+  // For CMS testing, we only need to ensure that the graphql queries run. We
+  // don't need any actual HTML output, so we can just stop here.
+  if (BUILD_OPTIONS.gqlQueriesOnly) {
+    smith.process(async (err, files) => {
+      if (err) {
+        smith.endGarbageCollection();
+        throw err;
+      }
+
+      smith.printSummary(BUILD_OPTIONS);
+      smith.printPeakMemory();
+      console.log('GraphQL queries have been run');
+      smith.endGarbageCollection();
+    });
+    return;
+  }
+
   smith.use(addDrupalPrefix(BUILD_OPTIONS), 'Add Drupal Prefix');
 
   smith.use(

--- a/src/site/stages/build/index.js
+++ b/src/site/stages/build/index.js
@@ -91,7 +91,7 @@ function build(BUILD_OPTIONS) {
   // For CMS testing, we only need to ensure that the graphql queries run. We
   // don't need any actual HTML output, so we can just stop here.
   if (BUILD_OPTIONS.gqlQueriesOnly) {
-    smith.process(async (err, files) => {
+    smith.process(async err => {
       if (err) {
         smith.endGarbageCollection();
         throw err;

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -77,6 +77,9 @@ const COMMAND_LINE_OPTIONS_DEFINITIONS = [
 
   // use the --use-cached-assets flag with a build to bypass re-downloading asset files
   { name: 'use-cached-assets', type: Boolean, defaultValue: false },
+
+  // use the --gql-queries-only flag to only run graphql queries
+  { name: 'gql-queries-only', type: Boolean, defaultValue: false },
 ];
 
 function gatherFromCommandLine() {
@@ -130,6 +133,7 @@ function applyDefaultOptions(options) {
     ],
     cacheDirectory: path.join(projectRoot, '.cache', options.buildtype),
     paramsDirectory: path.join(utilities, 'query-params'),
+    gqlQueriesOnly: !!options['gql-queries-only'],
   });
 }
 


### PR DESCRIPTION
## Description

The CMS test suite is presently running a full content build (on every PR + every merge to `main`). We intend to stop doing that, and instead only run the graphql queries as part of our test suite. Keeping the gql queries helps us stay aware of any API <--> content build breakage in our tests -- we just don't need the full HTML output.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
