### PR TITLE
VAVSA-37366: Add remaining spec items to billing tpl.

### DIFF
--- a/src/site/facilities/vha_facility_nonclinical_services.drupal.liquid
+++ b/src/site/facilities/vha_facility_nonclinical_services.drupal.liquid
@@ -1,5 +1,5 @@
 {% for facility in facilities %}
-  <h3>{{ facility.entityLabel }}</h3>
+  <h4><a href="{{ facility.entityUrl.path }}">{{ facility.entityLabel }}</a></h4>
 
   {% comment %}
     Facility Address

--- a/src/site/includes/hours-item.liquid
+++ b/src/site/includes/hours-item.liquid
@@ -1,0 +1,15 @@
+<li>
+	{% if headerType == 'clinical' %}
+		<b class="abbrv-day">{{ hours.day | officeHoursDayFormatter }}:</b>
+	{% else %}
+		<span class="abbrv-day">{{ hours.day | officeHoursDayFormatter }}.</span>
+	{% endif %}
+	{% if hours.starthours %}
+		{{ hours.starthours | officeHoursTimeFormatter}}
+		to
+	{% endif %}
+	{% if hours.endhours %}
+		{{ hours.endhours | officeHoursTimeFormatter}}
+	{% endif %}
+	{{ hours.comment }}
+</li>

--- a/src/site/includes/hours.liquid
+++ b/src/site/includes/hours.liquid
@@ -1,60 +1,52 @@
 {% if allHours %}
-<div class="vads-u-margin-bottom--0" data-template="hours">
-    <div class="clinicalhours">
-        {% if headerType == 'small' %}
-        <h4
-            class="force-small-header vads-u-margin-top--0 vads-u-line-height--1 vads-u-margin-bottom--1">
-            Hours</h4>
-        {% elsif headerType == 'standard' %}
-        <h4
-            class="vads-u-font-size--lg vads-u-margin-top--0 vads-u-line-height--1 vads-u-margin-bottom--1">
-            Hours</h4>
-        {% elsif headerType == 'clinical' %}
-        <h3 class="vads-u-margin-top--2p5 vads-u-margin-bottom--1">
-            Clinical hours
-        </h3>
-        {% endif %}
-
-        <div
-            class="vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row vads-u-margin-bottom--0">
-            <ul
-                class="vads-u-flex--1 va-c-facility-hours-list vads-u-margin-top--0 vads-u-margin-bottom--1 small-screen:vads-u-margin-bottom--0 vads-u-margin-right--3">
-
-                {% for hours in allHours %}
-                {% if hours.day == 0 %}
-                {% assign sunday = hours %}
-                {% endif %}
-                {% if hours.day != 0 %}
-                <li>
-                    {% if headerType == 'clinical' %}
-                    <b
-                        class="abbrv-day">{{ hours.day | officeHoursDayFormatter }}:</b>
-                    {% else %}
-                    <span
-                        class="abbrv-day">{{ hours.day | officeHoursDayFormatter }}.</span>
-                    {% endif %}
-                    {% if hours.starthours %}{{ hours.starthours | officeHoursTimeFormatter}}
-                    to
-                    {% endif %}{% if hours.endhours %}{{ hours.endhours | officeHoursTimeFormatter}}{% endif %}
-                    {{ hours.comment }}
-                </li>
-                {% endif %}
-                {% endfor %}
-                <li>
-                    {% if headerType == 'clinical' %}
-                    <b
-                        class="abbrv-day">{{ sunday.day | officeHoursDayFormatter }}:</b>
-                    {% else %}
-                    <span
-                        class="abbrv-day">{{ sunday.day | officeHoursDayFormatter }}.</span>
-                    {% endif %}
-                    {% if sunday.starthours %}{{ sunday.starthours | officeHoursTimeFormatter}}
-                    to
-                    {% endif %}{% if sunday.endhours %}{{ sunday.endhours | officeHoursTimeFormatter}}{% endif %}
-                    {{ sunday.comment }}
-                </li>
-            </ul>
-        </div>
-    </div>
-</div>
+	<div class="vads-u-margin-bottom--0" data-template="hours">
+		<div class="clinicalhours">
+			{% if headerType == 'small' %}
+				<h4 class="force-small-header vads-u-margin-top--0 vads-u-line-height--1 vads-u-margin-bottom--1">
+					Hours</h4>
+			{% elsif headerType == 'standard' %}
+				<h4 class="vads-u-font-size--lg vads-u-margin-top--0 vads-u-line-height--1 vads-u-margin-bottom--1">
+					Hours</h4>
+			{% elsif headerType == 'clinical' %}
+				<h3 class="vads-u-margin-top--2p5 vads-u-margin-bottom--1">
+					Clinical hours
+				</h3>
+			{% endif %}
+			<div class="vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row vads-u-margin-bottom--0">
+				<ul class="vads-u-flex--1 va-c-facility-hours-list vads-u-margin-top--0 vads-u-margin-bottom--1 small-screen:vads-u-margin-bottom--0 vads-u-margin-right--3">
+					{% assign saturday = false %}
+					{% assign sunday = false %}
+					{% for hours in allHours %}
+						{% if hours.day == 6 %}
+							{% assign saturday = hours %}
+						{% elsif hours.day == 0 %}
+							{% assign sunday = hours %}
+						{% else %}
+							{% include "src/site/includes/hours-item.liquid" with hours = hours %}
+						{% endif %}
+					{% endfor %}
+					{% if saturday %}
+						{% include "src/site/includes/hours-item.liquid" with hours = saturday %}
+					{% else %}
+						<li>
+							{% if headerType == 'clinical' %}
+								<b class="abbrv-day">Sat:</b>
+							{% else %}
+								<span class="abbrv-day">Sat.</span>
+							{% endif %}
+						</li>
+					{% endif %}
+					{% if sunday %}
+						{% include "src/site/includes/hours-item.liquid" with hours = sunday %}
+					{% else %}
+						{% if headerType == 'clinical' %}
+							<b class="abbrv-day">Sun:</b>
+						{% else %}
+							<span class="abbrv-day">Sun.</span>
+						{% endif %}
+					{% endif %}
+				</ul>
+			</div>
+		</div>
+	</div>
 {% endif %}

--- a/src/site/layouts/vamc_system_billing_insurance.drupal.liquid
+++ b/src/site/layouts/vamc_system_billing_insurance.drupal.liquid
@@ -2,23 +2,45 @@
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
 
-<div class="interior" id="content" data-template="vamc_system_billing_insurance_page.drupal.liquid">
+<div class="interior" id="content"
+  data-template="vamc_system_billing_insurance_page.drupal.liquid">
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
       <div class="usa-width-three-fourths">
-        <article aria-labelledby="article-heading" role="region" class="usa-content">
+        <article aria-labelledby="article-heading" role="region"
+          class="usa-content">
           <h1 id="article-heading">{{ title }}</h1>
           <div class="va-introtext">
             <p>
-              You can pay your bill online by phone, mail, or in person.
+              You can pay your {{ fieldOffice.entity.entityLabel }} bill online, by phone, mail, or in person.
             </p>
           </div>
 
           <nav id="table-of-contents" aria-labelledby="on-this-page">
-            <h2 id="on-this-page" class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
+            <h2 id="on-this-page"
+              class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page
+            </h2>
             <ul class="usa-unstyled-list" role="list"></ul>
           </nav>
+
+          <div class="usa-content">
+            <h2>Questions about copay balance</h2>
+            <p>
+              For questions about the copay balance of your
+              {{ fieldOffice.entity.entityLabel }}
+              bill, call us toll free at the number below. You won't need to pay
+              any copays for X-rays, lab tests,
+              preventitive tests, and services like health screenings or
+              immunizations.
+            </p>
+            <b>Phone</b>
+            <p><a href="tel:{{ fieldPhoneNumber }}">{{ fieldPhoneNumber }}</a>
+            </p>
+            <div class="vads-u-margin-bottom--3">
+              {% include 'src/site/includes/hours.liquid' with allHours = fieldHoursForCopayInquiries headerType = 'small' %}
+            </div>
+          </div>
 
           <div class="usa-content">
             {% include "src/site/includes/centralized-content.drupal.liquid" with
@@ -29,8 +51,8 @@
 
           <!-- Details for facilities offering this non-clinical service -->
           {% if fieldOffice.entity.reverseFieldRegionPageNode.entities %}
-            {% assign billingAndInsuranceFacilities = fieldOffice.entity.reverseFieldRegionPageNode.entities | healthCareRegionNonClinicalServiceLocationsByType: 'Billing and insurance' %}
-            {% include "src/site/facilities/vha_facility_nonclinical_services.drupal.liquid" with
+          {% assign billingAndInsuranceFacilities = fieldOffice.entity.reverseFieldRegionPageNode.entities | healthCareRegionNonClinicalServiceLocationsByType: 'Billing and insurance' %}
+          {% include "src/site/facilities/vha_facility_nonclinical_services.drupal.liquid" with
               facilities = billingAndInsuranceFacilities
             %}
           {% endif %}

--- a/src/site/stages/build/drupal/graphql/vamcBillingAndInsurancePage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vamcBillingAndInsurancePage.graphql.js
@@ -9,6 +9,13 @@ const billingAndInsuranceFragment = `
     entityUrl {
       path
     }
+    fieldPhoneNumber
+    fieldHoursForCopayInquiries {
+      day
+      starthours
+      endhours
+      comment
+    }
     fieldCcTopOfPageContent {
       fetched
       fetchedBundle


### PR DESCRIPTION
## Description
Implements remaining items for TTP billing from https://github.com/department-of-veterans-affairs/va.gov-team/issues/37366
**DOES NOT INCLUDE TBD CERNER WORK**
![image](https://user-images.githubusercontent.com/2404547/164342686-be626e7b-96a0-4f94-874d-d99b9191fb2f.png)

## Testing done
Visual / build

## Screenshots
Facility name in intro text
![image](https://user-images.githubusercontent.com/2404547/164344434-89a5cb5a-ea74-4dc0-ac95-66366ffa82c1.png)

Questions about copay h2 (jump linkable) with system name in text
![image](https://user-images.githubusercontent.com/2404547/164345618-ddd1d9e9-3cdc-41ca-8ae5-156a0efb95f5.png)

Linked # and facility hours
![image](https://user-images.githubusercontent.com/2404547/164345652-4175c7e7-8c91-4ebb-b092-f17993a4aacc.png)

Styled Pay online jump link
![image](https://user-images.githubusercontent.com/2404547/164345677-80432c6b-fdc6-4379-8c25-c328645d5dde.png)

Linked h4 facility
![image](https://user-images.githubusercontent.com/2404547/164345721-c69ed674-ad7f-4939-b9ba-9e7374ba1758.png)


## Acceptance criteria
**Go to `/minneapolis-health-care/billing-and-insurance` and visually verify:**
- [x] Name of facility in intro text
- [x] Presence of h4 `Questions about copay balance` and body text below with facility name
- [x] Phone label and linked # below
- [x] `Pay online, by phone, or by mail` with new arrow style icon
- [x] Pay in person facility wrapped in h4 and linked to facility
- [x] Hours below are correctly displayed
