### PR TITLE
Vacms 0000 correct s3 urls

### DIFF
--- a/script/preview.js
+++ b/script/preview.js
@@ -94,16 +94,6 @@ const cacheDir = path.join(
 const app = express();
 const drupalClient = getDrupalClient(options);
 
-const urls = {
-  [ENVIRONMENTS.LOCALHOST]: 'http://localhost:3002',
-  [ENVIRONMENTS.VAGOVDEV]:
-    'http://content.dev.va.gov.s3-website-us-gov-west-1.amazonaws.com',
-  [ENVIRONMENTS.VAGOVSTAGING]:
-    'http://content.staging.va.gov.s3-website-us-gov-west-1.amazonaws.com',
-  [ENVIRONMENTS.VAGOVPROD]:
-    'http://content.www.va.gov.s3-website-us-gov-west-1.amazonaws.com',
-};
-
 const getContentUrl = env => {
   return env === ENVIRONMENTS.LOCALHOST
     ? 'http://localhost:3002'
@@ -200,18 +190,18 @@ function fetchAllPageData(nodeId) {
 
   const requests = [
     nodeQuery,
-    fetch(`${urls[options.buildtype]}/generated/file-manifest.json`).then(
-      resp => {
-        if (resp.ok) {
-          return resp.json();
-        }
-        throw new Error(
-          options.buildtype !== ENVIRONMENTS.LOCALHOST
-            ? `HTTP error when fetching manifest: ${resp.status} ${resp.statusText}`
-            : 'file-manifest.json is missing. Try running "yarn build" in vets-website.',
-        );
-      },
-    ),
+    fetch(
+      `${getContentUrl(options.buildtype)}/generated/file-manifest.json`,
+    ).then(resp => {
+      if (resp.ok) {
+        return resp.json();
+      }
+      throw new Error(
+        options.buildtype !== ENVIRONMENTS.LOCALHOST
+          ? `HTTP error when fetching manifest: ${resp.status} ${resp.statusText}`
+          : 'file-manifest.json is missing. Try running "yarn build" in vets-website.',
+      );
+    }),
   ];
 
   return Promise.all(requests);
@@ -334,7 +324,7 @@ app.get(
 );
 
 if (options.buildtype !== ENVIRONMENTS.LOCALHOST) {
-  app.use(proxy(urls[options.buildtype]));
+  app.use(proxy(getContentUrl(options.buildtype)));
 } else {
   app.use(express.static(path.join(__dirname, '..', options.buildpath)));
 }

--- a/script/preview.js
+++ b/script/preview.js
@@ -97,11 +97,11 @@ const drupalClient = getDrupalClient(options);
 const urls = {
   [ENVIRONMENTS.LOCALHOST]: 'http://localhost:3002',
   [ENVIRONMENTS.VAGOVDEV]:
-    'http://dev.va.gov.s3-website-us-gov-west-1.amazonaws.com',
+    'http://content.dev.va.gov.s3-website-us-gov-west-1.amazonaws.com',
   [ENVIRONMENTS.VAGOVSTAGING]:
-    'http://staging.va.gov.s3-website-us-gov-west-1.amazonaws.com',
+    'http://content.staging.va.gov.s3-website-us-gov-west-1.amazonaws.com',
   [ENVIRONMENTS.VAGOVPROD]:
-    'http://www.va.gov.s3-website-us-gov-west-1.amazonaws.com',
+    'http://content.www.va.gov.s3-website-us-gov-west-1.amazonaws.com',
 };
 
 const getContentUrl = env => {

--- a/script/preview.js
+++ b/script/preview.js
@@ -22,6 +22,7 @@ const ENVIRONMENTS = require('../src/site/constants/environments');
 const HOSTNAMES = require('../src/site/constants/hostnames');
 const DRUPALS = require('../src/site/constants/drupals');
 const bucketsContent = require('../src/site/constants/buckets-content');
+const buckets = require('../src/site/constants/buckets');
 const singlePageDiff = require('./preview-routes/single-page-diff');
 const createMetalSmithSymlink = require('../src/site/stages/build/plugins/create-symlink');
 
@@ -94,10 +95,15 @@ const cacheDir = path.join(
 const app = express();
 const drupalClient = getDrupalClient(options);
 
-const getContentUrl = env => {
+const getContentBucketUrl = env => {
   return env === ENVIRONMENTS.LOCALHOST
     ? 'http://localhost:3002'
     : bucketsContent[options.buildtype];
+};
+const getBucketUrl = env => {
+  return env === ENVIRONMENTS.LOCALHOST
+    ? 'http://localhost:3002'
+    : buckets[options.buildtype];
 };
 
 if (process.env.SENTRY_DSN) {
@@ -191,7 +197,7 @@ function fetchAllPageData(nodeId) {
   const requests = [
     nodeQuery,
     fetch(
-      `${getContentUrl(options.buildtype)}/generated/file-manifest.json`,
+      `${getBucketUrl(options.buildtype)}/generated/file-manifest.json`,
     ).then(resp => {
       if (resp.ok) {
         return resp.json();
@@ -320,11 +326,16 @@ app.get('/preview', async (req, res, next) => {
 
 app.get(
   '/diff',
-  singlePageDiff(nonNodeContent, options, fetchAllPageData, getContentUrl),
+  singlePageDiff(
+    nonNodeContent,
+    options,
+    fetchAllPageData,
+    getContentBucketUrl,
+  ),
 );
 
 if (options.buildtype !== ENVIRONMENTS.LOCALHOST) {
-  app.use(proxy(getContentUrl(options.buildtype)));
+  app.use(proxy(getContentBucketUrl(options.buildtype)));
 } else {
   app.use(express.static(path.join(__dirname, '..', options.buildpath)));
 }


### PR DESCRIPTION
## Description
A previous pass at this failed because it was attempting to pull manifest.json from the same S3 bucket as content static assets. manifest.json is not available at the content s3 bucket.