### PR TITLE
Add vagov-platform dependency check

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -375,17 +375,36 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Get Node version
-        id: get-node-version
-        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
-
-      - name: Setup Node
-        uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
+          fetch-depth: 0
+
+      - name: Install dependencies
+        uses: ./.github/workflows/install
+        timeout-minutes: 30
+        with:
+          key: ${{ hashFiles('yarn.lock') }}
+          yarn_cache_folder: .cache/yarn
+          path: |
+            .cache/yarn
+            node_modules
+
+      - name: List changed files
+        id: changed-files
+        run: |
+          if [[ ${{ github.ref }} == 'refs/heads/master' ]]; then
+            echo ::set-output name=all_changed_files::$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }})
+          else
+            echo ::set-output name=all_changed_files::$(git diff --name-only origin/master...)
+          fi
+
+      - name: Get app entries for changed files
+        id: get-changed-apps
+        run: echo ::set-output name=app_entries::$(node script/github-actions/get-changed-apps.js)
+        env:
+          CHANGED_FILE_PATHS: ${{ steps.changed-files.outputs.all_changed_files }}
 
       - name: Audit dependencies
+        if: steps.get-changed-apps.outputs.app_entries == ''
         run: yarn security-check
 
   drupal-cache-test:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint:js:changed": "LIST=`git diff-index --diff-filter=d --name-only --cached HEAD | grep \"\\.js[x]\\{0,1\\}$\"`; if [ \"$LIST\" ]; then eslint --quiet --config changed.eslintrc.js $LIST; fi",
     "lint:js:changed:fix": "LIST=`git diff-index --name-only HEAD | grep \"\\.js[x]\\{0,1\\}$\"`; if [ \"$LIST\" ]; then eslint --fix --quiet $LIST; fi",
     "pr-check": "node script/pr-check.js",
-    "security-check": "node ./script/security-check.js",
+    "security-check": "yarn vagov-dependency-check",
     "serve": "node script/serve.js",
     "test": "npm run test:unit",
     "test:coverage": "./script/run-coverage.sh",
@@ -200,6 +200,7 @@
   },
   "private": true,
   "dependencies": {
+    "@department-of-veterans-affairs/vagov-platform": "^0.0.1",
     "blob-polyfill": "^4.0.20200601",
     "core-js": "^3.17.3",
     "diff2html": "^3.4.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1076,6 +1076,13 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
+"@department-of-veterans-affairs/vagov-platform@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/vagov-platform/-/vagov-platform-0.0.1.tgz#a971b3398feb0627297917a9df1fd7d07262412e"
+  integrity sha512-FpMWFknWkRZ5uSv4Qr5cfZ3Ad1uTuYAZkt/FxZbY1IP5/I3p6IrOJ8NTgoS69lUoHsrZ4vZ774d/Obo2OseRLg==
+  dependencies:
+    minimist "^1.2.6"
+
 "@discoveryjs/json-ext@^0.5.0":
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.5.tgz#9283c9ce5b289a3c4f61c12757469e59377f81f3"


### PR DESCRIPTION
## Description

Integrating the new vagov-platform package and replacing the old security-check script with `yarn vagov-dependency-check`

## Original issue(s)

department-of-veterans-affairs/va.gov-team#40725

## Testing

Just needs to pass in CI since that's where this runs