### PR TITLE
Master -> main branch name change (vets-website)

### DIFF
--- a/certs/README.md
+++ b/certs/README.md
@@ -6,4 +6,4 @@ The VA uses self-signed certificates with a non-globally trusted Root Certificat
 authority. 
 
 
-Used in [the Drupal client](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/site/stages/build/drupal/api.js)'s `proxyFetch` function when using the SOCKS proxy.
+Used in [the Drupal client](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/site/stages/build/drupal/api.js)'s `proxyFetch` function when using the SOCKS proxy.

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -82,7 +82,7 @@ def setup() {
     }
 
     dir("vets-website") {
-      checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'CloneOption', noTags: true, reference: '', shallow: true]], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'va-bot', url: 'git@github.com:department-of-veterans-affairs/vets-website.git']]]
+      checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/main']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'CloneOption', noTags: true, reference: '', shallow: true]], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'va-bot', url: 'git@github.com:department-of-veterans-affairs/vets-website.git']]]
     }
 
     dir("content-build") {


### PR DESCRIPTION
## Description
Change vets-website `master` branch references to `main`.

**DO NOT MERGE UNTIL READY**.

Ticket: [#40469](https://app.zenhub.com/workspaces/vsp---release-tools-fe-5fc9325744944e0015ed1861/issues/department-of-veterans-affairs/va.gov-team/40469)

## Testing done
Successful CI run

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
