### PR TITLE
VAVSA-28918: Add events v2 header to template.

### DIFF
--- a/script/preview.js
+++ b/script/preview.js
@@ -155,10 +155,10 @@ const nonNodeContent = {
           onlyPublishedContent: false,
         },
       });
-      if (json.errors) {
+      if (json && json.errors) {
         console.error('Error executing', queryName, json);
         console.error('query:', query);
-      } else {
+      } else if (freshNonNodeContent && json) {
         Object.assign(freshNonNodeContent.data, json.data);
       }
       console.timeEnd(queryName);

--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -3,100 +3,117 @@
 {% include "src/site/includes/breadcrumbs.drupal.liquid" %}
 
 <div class="interior vads-u-padding-bottom--3" id="content" data-template="event_listing.drupal.liquid">
-  <main class="va-l-detail-page va-facility-page">
-    <div class="usa-grid usa-grid-full">
-      {% unless entityUrl.path contains "/outreach-and-events" %}
-        {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
-      {% endunless %}
+	<main class="va-l-detail-page va-facility-page">
+		<div class="usa-grid usa-grid-full">
+			{% unless entityUrl.path contains "/outreach-and-events" %}
+				{% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
+			{% endunless %}
 
-      <!-- Events page v2 -->
-      <div data-widget-type="events"></div>
+			<!-- Events page v2 -->
+			<div class="events events-v2 vads-u-flex-direction--column vads-u-padding-x--1p5 medium-screen:vads-u-padding-x--0 vads-u-padding-bottom--2">
+				<div class="vads-l-grid-container--full">
+					<h1 id="article-heading">{{ title }}</h1>
+					<div class="vads-l-grid-container--full">
+						<div class="va-introtext">
+							{% if fieldIntroText %}
+								<p class="events-show" id="office-events-description">
+									{{ fieldIntroText }}
+								</p>
+							{% endif %}
+						</div>
+					</div>
+				</div>
+			</div>
 
-      <!-- Events page v1 -->
-      <div id="events-v1" class="usa-width-three-fourths">
-        <article aria-labelledby="article-heading" class="vads-l-grid-container--full" role="region">
-          <div class="vads-l-grid-container--full">
-            <h1 id="article-heading">{{ title }}</h1>
-            <div class="vads-l-grid-container--full">
-              <div class="va-introtext">
-                {% if fieldIntroText %}
-                  <p class="events-show" id="office-events-description">
-                    {{ fieldIntroText }}
-                  </p>
-                {% endif %}
-              </div>
+			<div data-widget-type="events"></div>
 
-              {% if pastEvents.entities.length > 0 or entityUrl.path contains 'past-events' %}
-                {% include "src/site/facilities/facilities_events_toggle.drupal.liquid" with url = entityUrl.path %}
-              {% endif %}
+			<!-- Events page v1 -->
+			<div id="events-v1" class="usa-width-three-fourths">
+				<article aria-labelledby="article-heading" class="vads-l-grid-container--full" role="region">
+					<div class="vads-l-grid-container--full">
+						<h1 id="article-heading">{{ title }}</h1>
+						<div class="vads-l-grid-container--full">
+							<div class="va-introtext">
+								{% if fieldIntroText %}
+									<p class="events-show" id="office-events-description">
+										{{ fieldIntroText }}
+									</p>
+								{% endif %}
+							</div>
 
-              {% assign featuredEventUrl = null %}
-              {% assign featuredItemSet = false %}
-              {% assign upcomingEvents = reverseFieldListingNode.entities | filterUpcomingEvents  %}
+							{% if pastEvents.entities.length > 0 or entityUrl.path contains 'past-events' %}
+								{% include "src/site/facilities/facilities_events_toggle.drupal.liquid" with url = entityUrl.path %}
+							{% endif %}
 
-              {% for featuredEvent in upcomingEvents %}
-                {% if featuredEvent.fieldFeatured == true %}
-                  {% unless entityUrl.path contains 'past-events' %}
-                    {% if featuredItemSet == false %}
-                      {% assign featuredEventUrl = featuredEvent.entityUrl.path %}
-                      <div class="usa-width-two-thirds">
-                        <div class="usa-grid usa-grid-full vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4 vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-border-left--7px vads-u-border-color--primary-alt-lightest" id="featured-content">
-                          <div class="usa-width-full vads-u-padding-left--2">
-                            <div class="vads-u-margin-bottom--2">
-                              <strong>In the spotlight at
-                                {{ fieldOffice.entity.entityLabel }}</strong>
-                            </div>
-                            {% include "src/site/teasers/event_featured.drupal.liquid" with node = featuredEvent %}
-                          </div>
-                        </div>
-                      </div>
-                    {% endif %}
-                  {% endunless %}
-                  {% assign featuredItemSet = true %}
-                {% endif %}
-              {% endfor %}
+							{% assign featuredEventUrl = null %}
+							{% assign featuredItemSet = false %}
+							{% assign upcomingEvents = reverseFieldListingNode.entities | filterUpcomingEvents  %}
 
-              {% comment %}
-                In full builds, pagedItems is computed in src/site/stages/build/drupal/health-care-region.js.
-                In preview mode and in unit tests, we need to compute pagedItems here.
-                TODO: remove the addPager call in health-care-region.js for full builds. (requires updates of all listing pages)
-              {% endcomment %}
-              {% if pagedItems == empty %}
-                {% assign sortedUpcomingEvents = upcomingEvents | sortByDateKey: 'fieldDatetimeRangeTimezone', false %}
-                {% assign pagingResult = debug | paginatePages: sortedUpcomingEvents, 'event' %}
-                {% assign pagedItems = pagingResult.pagedItems %}
-                {% assign paginator = pagingResult.paginator %}
-              {% endif %}
+							{% for featuredEvent in upcomingEvents %}
+								{% if featuredEvent.fieldFeatured == true %}
+									{% unless entityUrl.path contains 'past-events' %}
+										{% if featuredItemSet == false %}
+											{% assign featuredEventUrl = featuredEvent.entityUrl.path %}
+											<div class="usa-width-two-thirds">
+												<div class="usa-grid usa-grid-full vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4 vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-border-left--7px vads-u-border-color--primary-alt-lightest" id="featured-content">
+													<div class="usa-width-full vads-u-padding-left--2">
+														<div class="vads-u-margin-bottom--2">
+															<strong>In the spotlight at
+																{{ fieldOffice.entity.entityLabel }}</strong>
+														</div>
+														{% include "src/site/teasers/event_featured.drupal.liquid" with node = featuredEvent %}
+													</div>
+												</div>
+											</div>
+										{% endif %}
+									{% endunless %}
+									{% assign featuredItemSet = true %}
+								{% endif %}
+							{% endfor %}
 
-              {% for event in pagedItems %}
-                {% comment %} Don't render the featured event again {% endcomment %}
-                {% if featuredEventUrl != event.entityUrl.path %}
-                  <div class="clearfix-text">
-                    {% include "src/site/teasers/event.drupal.liquid" with node = event %}
-                  </div>
-                {% endif %}
-              {% endfor %}
+							{% comment %}
+								In full builds, pagedItems is computed in src/site/stages/build/drupal/health-care-region.js.
+								                In preview mode and in unit tests, we need to compute pagedItems here.
+								                TODO: remove the addPager call in health-care-region.js for full builds. (requires updates of all listing pages)
+							{% endcomment %}
+							{% if pagedItems == empty %}
+								{% assign sortedUpcomingEvents = upcomingEvents | sortByDateKey: 'fieldDatetimeRangeTimezone', false %}
+								{% assign pagingResult = debug | paginatePages: sortedUpcomingEvents, 'event' %}
+								{% assign pagedItems = pagingResult.pagedItems %}
+								{% assign paginator = pagingResult.paginator %}
+							{% endif %}
 
-              {% assign numItems = pagedItems | size %}
-              {% if numItems < 1 %}
-                <div id="no-events-message" class="clearfix-text">No events at this time.</div>
-              {% endif %}
+							{% for event in pagedItems %}
+								{% comment %}
+									Don't render the featured event again
+								{% endcomment %}
+								{% if featuredEventUrl != event.entityUrl.path %}
+									<div class="clearfix-text">
+										{% include "src/site/teasers/event.drupal.liquid" with node = event %}
+									</div>
+								{% endif %}
+							{% endfor %}
 
-              {% include "src/site/includes/pagination.drupal.liquid" %}
+							{% assign numItems = pagedItems | size %}
+							{% if numItems < 1 %}
+								<div id="no-events-message" class="clearfix-text">No events at this time.</div>
+							{% endif %}
 
-            </div>
-          </div>
-              <!-- Last updated & feedback button-->
-          {% include "src/site/includes/above-footer-elements.drupal.liquid" %}  
-        </article>
-      </div>
-    </div>
-  </main>
+							{% include "src/site/includes/pagination.drupal.liquid" %}
+
+						</div>
+					</div>
+					<!-- Last updated & feedback button-->
+					{% include "src/site/includes/above-footer-elements.drupal.liquid" %}
+				</article>
+			</div>
+		</div>
+	</main>
 </div>
 
 <script nonce="**CSP_NONCE**" type="text/javascript">
-  window.allEventTeasers = {{ allEventTeasers | json }};
-  window.pastEvents = {{ pastEvents | json }};
+	window.allEventTeasers = {{ reverseFieldListingNode | json }};
+window.pastEvents = {{ pastEvents | json }};
 </script>
 
 {% include "src/site/includes/footer.html" %}


### PR DESCRIPTION
## Description
Fixes header and intro text, makes listings available on event listing pages

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/28918

## Testing done
Visual / build

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/166947572-9848835a-a051-47bf-98ab-1b080bcaf6b0.png)

## Acceptance criteria
- [ ] Checkout https://github.com/department-of-veterans-affairs/vets-website/pull/20977 and use this branch to run `yarn watch` on local instance of vets-website
- [ ] Checkout https://github.com/department-of-veterans-affairs/content-build/pull/1114 and use this branch to run `yarn preview --drupal-address=https://pr7981-5kfpv6vznchkcxw4bgycflzjjodfbtbe.ci.cms.va.gov/ --drupal-user=ethan.teague --drupal-password=drupal8` on local instance of content-build
- [ ] With local instance of vets-api running, enable show_events_v2 (http://localhost:3000/flipper/features/show_events_v2)
- [ ] Go to http://localhost:3002/preview?nodeId=2807
- [ ] Visually verify events appear and react widget appears on top of page
- [ ] Visually verify filters _do_ filter events
- [ ] Visually verify intro text does not read `Outreach and Events`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
