### PR TITLE
Restore broken link summary print-out.

### DIFF
--- a/script/github-actions/check-broken-links-blocks.js
+++ b/script/github-actions/check-broken-links-blocks.js
@@ -75,7 +75,9 @@ if (fs.existsSync(reportPath)) {
     };
     payload.blocks.splice(1, 0, truncateWarning);
   }
-
+  console.log(
+    `${brokenLinks.brokenLinksCount} broken links found. \n ${brokenLinks.summary}`,
+  );
   console.log(`::set-output name=SLACK_BLOCKS::${JSON.stringify(payload)}`);
 
   if (!IS_PROD_BRANCH && !contentOnlyBuild) {


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/8964

Restoring something that was removed in the prior Slack reporting work. https://github.com/department-of-veterans-affairs/content-build/blob/master/script/github-actions/check-broken-links.js#L28