### PR TITLE
Bump Up the Timeout for the Content Build Steps

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -149,7 +149,7 @@ jobs:
     needs:
       - start-runner
       - validate-build-status
-    timeout-minutes: 30
+    timeout-minutes: 45 
     defaults:
       run:
         working-directory: content-build


### PR DESCRIPTION
## Description
Build steps may take longer that the timeout allows for. Specifically it looks like the post-checkout steps are taking longer to finish. Increase the timeout so this can finish without skipping all other jobs in the workflow.

Example of the failure.
https://github.com/department-of-veterans-affairs/content-build/actions/runs/2283032287

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
