### PR TITLE
Keep the CMS updated as the build progresses (Step 1)

### DIFF
--- a/.github/workflows/authenticated-cms-request/action.yml
+++ b/.github/workflows/authenticated-cms-request/action.yml
@@ -1,0 +1,55 @@
+name: Authenticated CMS request
+description: Make an authenticated HTTP request to a specified CMS URL.
+
+inputs:
+  aws_access_key_id:
+    description: AWS access key ID
+    required: true
+  aws_secret_access_key:
+    description: AWS secret access key
+    required: true
+  aws_region:
+    description: AWS region
+    required: false
+    default: "us-gov-west-1"
+  url:
+    description: URL
+    required: true
+  method:
+    description: HTTP method
+    required: true
+  timeout:
+    description: Request timeout
+    required: false
+    default: 10000
+
+runs:
+  using: composite
+  steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ inputs.aws_access_key_id }}
+        aws-secret-access-key: ${{ inputs.aws_secret_access_key }}
+        aws-region: ${{ inputs.aws_region }}
+
+    - name: Get Drupal prod password
+      uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+      with:
+        ssm_parameter: /cms/prod/drupal_api_users/content_build_api/password
+        env_variable_name: DRUPAL_PASSWORD
+
+    - name: Get Drupal prod username
+      uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+      with:
+        ssm_parameter: /cms/prod/drupal_api_users/content_build_api/username
+        env_variable_name: DRUPAL_USERNAME
+
+    - name: HTTP request
+      uses: fjogeleit/http-request-action@master
+      with:
+        url: ${{ inputs.url}}
+        method: ${{ inputs.method }}
+        username: ${{ env.DRUPAL_USERNAME }}
+        password: ${{ env.DRUPAL_PASSWORD }}
+        timeout: ${{ inputs.timeout }}

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -105,6 +105,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Notify CMS - starting
+        uses: ./.github/workflows/authenticated-cms-request
+        with:
+          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          url: https://prod.cms.va.gov/api/content_release/starting
+          method: GET
+
       - name: Install dependencies
         uses: ./.github/workflows/install
         with:
@@ -243,6 +251,14 @@ jobs:
         with:
           ssm_parameter: /cms/prod/drupal_api_users/content_build_api/username
           env_variable_name: DRUPAL_USERNAME
+
+      - name: Notify CMS - In Progress
+        uses: ./.github/workflows/authenticated-cms-request
+        with:
+          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          url: https://prod.cms.va.gov/api/content_release/inprogress
+          method: GET
 
       - name: Build
         run: yarn build --buildtype=${{ env.BUILDTYPE }} --asset-source=local --drupal-address=${{ env.DRUPAL_ADDRESS }} --drupal-user=${{ env.DRUPAL_USERNAME }} --drupal-password="${{ env.DRUPAL_PASSWORD }}" --pull-drupal --drupal-max-parallel-requests=15 --no-drupal-proxy --verbose | tee build-output.txt
@@ -429,18 +445,6 @@ jobs:
           ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_PROD_ROLE
           env_variable_name: AWS_FRONTEND_PROD_ROLE
 
-      - name: Get Drupal prod password
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-        with:
-          ssm_parameter: /cms/prod/drupal_api_users/content_build_api/password
-          env_variable_name: DRUPAL_PASSWORD
-
-      - name: Get Drupal prod username
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-        with:
-          ssm_parameter: /cms/prod/drupal_api_users/content_build_api/username
-          env_variable_name: DRUPAL_USERNAME
-
       - name: Configure AWS Credentials (2)
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -457,17 +461,24 @@ jobs:
           SRC: s3://vetsgov-website-builds-s3-upload/content-build/${{needs.validate-build-status.outputs.REF}}/${{env.BUILDTYPE}}.tar.bz2
           DEST: s3://${{ env.DEPLOY_BUCKET }}
 
+      - name: Notify CMS - Complete
+        uses: ./.github/workflows/authenticated-cms-request
+        with:
+          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          url: https://prod.cms.va.gov/api/content_release/complete
+          method: GET
+
       - name: Wait for the CMS to be ready
         uses: ./.github/workflows/wait-for-cms-ready
 
       - name: CMS GovDelivery callback
-        uses: fjogeleit/http-request-action@master
+        uses: ./.github/workflows/authenticated-cms-request
         with:
+          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           url: https://prod.cms.va.gov/api/govdelivery_bulletins/queue?EndTime=${{ needs.build.outputs.vagovprod_buildtime }}&src=gha&runId=${{ github.run_id }}&runNumber=${{ github.run_number }}
           method: GET
-          username: ${{ env.DRUPAL_USERNAME }}
-          password: ${{ env.DRUPAL_PASSWORD }}
-          timeout: 10000
 
       - name: Export deploy end time
         id: export-deploy-end-time
@@ -495,6 +506,14 @@ jobs:
           channel_id: ${{ env.CONTENT_BUILD_CHANNEL_ID }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      
+      - name: Notify CMS - Ready
+        uses: ./.github/workflows/authenticated-cms-request
+        with:
+          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          url: https://prod.cms.va.gov/api/content_release/ready
+          method: GET
 
   notify-failure:
     name: Notify Failure


### PR DESCRIPTION
## Description

This is in preparation for https://github.com/department-of-veterans-affairs/va.gov-cms/issues/8108 -- we'll be keeping track of the status of content release in the CMS and holding/sending build requests accordingly. I also took the authenticated request steps and broke them out into a separate workflow to keep things tidy.

This should not be merged until today's CMS release is live (which hasn't happened yet).

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
