### PR TITLE
Add a repository dispatch trigger (Step 2)

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -1,6 +1,8 @@
 name: Content Release
 
 on:
+  repository_dispatch:
+    types: [content-release]
   workflow_dispatch:
   schedule:
     - cron: '54 13-21 * * 1-5'


### PR DESCRIPTION
## Description

This is based off of branch for #1125 . Once that's merged, I'll rebase this onto `master`.

The CMS is going to switch to using the repository dispatch trigger to kick off content build, so we need that trigger to be available on the workflow.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
