### PR TITLE
VAVFA-8986: Add queries and include for vamc covid status.

### DIFF
--- a/src/site/includes/covid-status.drupal.liquid
+++ b/src/site/includes/covid-status.drupal.liquid
@@ -13,7 +13,11 @@
 		{% assign covidLevel = 'info' %}
 	{% endif %}
 
-	<div data-widget-type="expandable-supplemental-status-node-{{ entityId}}" facilityid="node-{{ entityId}}" statuslabel="{{ fieldSupplementalStatus.entity.name }}" status="warning" {% if fieldSupplementalStatus.entity.description.processed %} info="{{ fieldSupplementalStatus.entity.description.processed }}" {% endif %}></div>
+	<div
+  {% if addBottomMargin %}
+    class="vads-u-margin-bottom--3"
+  {% endif %}
+  data-widget-type="expandable-supplemental-status-node-{{ entityId}}" facilityid="node-{{ entityId}}" statuslabel="{{ fieldSupplementalStatus.entity.name }}" status="warning" {% if fieldSupplementalStatus.entity.description.processed %} info="{{ fieldSupplementalStatus.entity.description.processed }}" {% endif %}></div>
 
 	<style>
 		.expandable-supplemental-status {

--- a/src/site/includes/covid-status.drupal.liquid
+++ b/src/site/includes/covid-status.drupal.liquid
@@ -1,34 +1,15 @@
 {% if fieldSupplementalStatus.entity.name %}
-	{% assign covidLevel = 'default' %}
-
-	{% if fieldSupplementalStatus.entity.fieldStatusId == 'COVID_HIGH' %}
-		{% assign covidLevel = 'error' %}
-	{% endif %}
-
-	{% if fieldSupplementalStatus.entity.fieldStatusId == 'COVID_MEDIUM' %}
-		{% assign covidLevel = 'warning' %}
-	{% endif %}
-
-	{% if fieldSupplementalStatus.entity.fieldStatusId == 'COVID_LOW' %}
-		{% assign covidLevel = 'info' %}
-	{% endif %}
-
-	<div
-  {% if addBottomMargin %}
-    class="vads-u-margin-bottom--3"
-  {% endif %}
-  data-widget-type="expandable-supplemental-status-node-{{ entityId}}" facilityid="node-{{ entityId}}" statuslabel="{{ fieldSupplementalStatus.entity.name }}" status="warning" {% if fieldSupplementalStatus.entity.description.processed %} info="{{ fieldSupplementalStatus.entity.description.processed }}" {% endif %}></div>
-
-	<style>
-		.expandable-supplemental-status {
-			width: 350px;
-		}
-		.expandable-supplemental-status .content {
-			padding: 0 15px;
-			width: inherit;
-		}
-		.expandable-supplemental-status button.collapsible {
-			width: inherit;
-		}
-	</style>
+	<va-alert-expandable
+		data-template="components/covid-status.drupal.liquid"
+		class="{% if addBottomMargin %}vads-u-margin-bottom--3{% endif %}"
+		status="info"
+		trigger="{{ fieldSupplementalStatus.entity.name }}"
+		onclick="recordEvent({
+			'event': 'covid-status',
+			'covid-status-entity-id': '{{ entityId }}'
+			'covid-status-heading':  '{{ fieldSupplementalStatus.entity.fieldStatusId }}',
+		});"
+	>
+		{{ fieldSupplementalStatus.entity.description.processed }}
+	</va-alert-expandable>
 {% endif %}

--- a/src/site/includes/covid-status.drupal.liquid
+++ b/src/site/includes/covid-status.drupal.liquid
@@ -1,8 +1,7 @@
 {% if fieldSupplementalStatus.entity.name %}
 	<va-alert-expandable
 		data-template="components/covid-status.drupal.liquid"
-		class="{% if addBottomMargin %}vads-u-margin-bottom--3{% endif %}
-		vamc-facility-expandable-alert"
+class="vads-u-margin-top--{{topMargin}} vads-u-margin-bottom--{{bottomMargin}} vamc-facility-expandable-alert"
 		status="info"
 		trigger="{{ fieldSupplementalStatus.entity.name }}"
 		onclick="recordEvent({

--- a/src/site/includes/covid-status.drupal.liquid
+++ b/src/site/includes/covid-status.drupal.liquid
@@ -1,7 +1,8 @@
 {% if fieldSupplementalStatus.entity.name %}
 	<va-alert-expandable
 		data-template="components/covid-status.drupal.liquid"
-		class="{% if addBottomMargin %}vads-u-margin-bottom--3{% endif %}"
+		class="{% if addBottomMargin %}vads-u-margin-bottom--3{% endif %}
+		vamc-facility-expandable-alert"
 		status="info"
 		trigger="{{ fieldSupplementalStatus.entity.name }}"
 		onclick="recordEvent({

--- a/src/site/includes/covid-status.drupal.liquid
+++ b/src/site/includes/covid-status.drupal.liquid
@@ -1,0 +1,30 @@
+{% if fieldSupplementalStatus.entity.name %}
+	{% assign covidLevel = 'default' %}
+
+	{% if fieldSupplementalStatus.entity.fieldStatusId == 'COVID_HIGH' %}
+		{% assign covidLevel = 'error' %}
+	{% endif %}
+
+	{% if fieldSupplementalStatus.entity.fieldStatusId == 'COVID_MEDIUM' %}
+		{% assign covidLevel = 'warning' %}
+	{% endif %}
+
+	{% if fieldSupplementalStatus.entity.fieldStatusId == 'COVID_LOW' %}
+		{% assign covidLevel = 'info' %}
+	{% endif %}
+
+	<div data-widget-type="expandable-supplemental-status-node-{{ entityId}}" facilityid="node-{{ entityId}}" statuslabel="{{ fieldSupplementalStatus.entity.name }}" status="warning" {% if fieldSupplementalStatus.entity.description.processed %} info="{{ fieldSupplementalStatus.entity.description.processed }}" {% endif %}></div>
+
+	<style>
+		.expandable-supplemental-status {
+			width: 350px;
+		}
+		.expandable-supplemental-status .content {
+			padding: 0 15px;
+			width: inherit;
+		}
+		.expandable-supplemental-status button.collapsible {
+			width: inherit;
+		}
+	</style>
+{% endif %}

--- a/src/site/includes/facilityListing.drupal.liquid
+++ b/src/site/includes/facilityListing.drupal.liquid
@@ -1,9 +1,17 @@
 <div data-template="includes/facilityListing"
      class="region-list usa-width-one-whole vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row facility vads-u-margin-bottom--4 medium-screen:vads-u-margin-bottom--5">
   <section class="region-grid vads-u-margin-right--2">
+
     <h3
         class="vads-u-margin-bottom--1 vads-u-margin-top--0 vads-u-font-size--md medium-screen:vads-u-font-size--lg">
       <a href="{{ entity.entityUrl.path }}">{{ entity.title }}</a></h3>
+
+    {% for covidStatus in fieldOffice.entity.reverseFieldRegionPageNode.entities %}
+      {% if covidStatus.entityId == entity.entityId %}
+        {% include "src/site/includes/covid-status.drupal.liquid" with covidStatus %}
+      {% endif %}
+    {% endfor %}
+
     {% if entity.fieldOperatingStatusFacility and entity.fieldOperatingStatusFacility != 'normal' %}
       <div class="vads-u-display--inline-block vads-u-margin-bottom--1">
         {% include "src/site/includes/operatingStatusFlagsLinks.drupal.liquid" with entity %}

--- a/src/site/includes/facilityListing.drupal.liquid
+++ b/src/site/includes/facilityListing.drupal.liquid
@@ -6,17 +6,20 @@
         class="vads-u-margin-bottom--1 vads-u-margin-top--0 vads-u-font-size--md medium-screen:vads-u-font-size--lg">
       <a href="{{ entity.entityUrl.path }}">{{ entity.title }}</a></h3>
 
-    {% for covidStatus in fieldOffice.entity.reverseFieldRegionPageNode.entities %}
-      {% if covidStatus.entityId == entity.entityId %}
-        {% include "src/site/includes/covid-status.drupal.liquid" with covidStatus %}
-      {% endif %}
-    {% endfor %}
-
     {% if entity.fieldOperatingStatusFacility and entity.fieldOperatingStatusFacility != 'normal' %}
       <div class="vads-u-display--inline-block vads-u-margin-bottom--1">
         {% include "src/site/includes/operatingStatusFlagsLinks.drupal.liquid" with entity %}
       </div>
     {% endif %}
+    {% assign topMargin = '1' %}
+    {% assign bottomMargin = '2' %}
+    {% for covidStatus in fieldOffice.entity.reverseFieldRegionPageNode.entities %}
+      {% if covidStatus.entityId == entity.entityId %}
+      {% include "src/site/includes/covid-status.drupal.liquid" with covidStatus %}
+
+      {% endif %}
+    {% endfor %}
+
     {% unless type == 'mobile' %}
       <div class="vads-u-margin-bottom--1">
         <address class="vads-u-margin-bottom--0">

--- a/src/site/includes/operatingStatusFlagsLinks.drupal.liquid
+++ b/src/site/includes/operatingStatusFlagsLinks.drupal.liquid
@@ -5,7 +5,7 @@
   'infoBoxText': 'Facility notice'});"
   href="{{ facilitySidebar.links.0.url.path }}/operating-status">
     <span
-      class="operating-status-flag operating-status-flag-notice operating-status usa-alert usa-alert-info background-color-only vads-u-margin-top--1 vads-u-padding-y--1 vads-u-padding-x--1p5">
+      class="operating-status-flag operating-status-flag-notice operating-status usa-alert usa-alert-info background-color-only vads-u-margin-top--1 vads-u-padding-y--2 vads-u-padding-x--1p5">
       <i class="fa fa-info-circle" aria-hidden="true"></i>
         Facility notice
       <i class="fa fa-chevron-right vads-u-padding-left--0p5" aria-hidden="true"></i>
@@ -18,7 +18,7 @@
   'infoBoxText': 'Facility limited'});"
      href="{{ facilitySidebar.links.0.url.path }}/operating-status">
     <span
-      class="operating-status-flag operating-status-flag-warning operating-status usa-alert usa-alert-warning background-color-only vads-u-margin-top--1 vads-u-padding-y--1 vads-u-padding-x--1p5">
+      class="operating-status-flag operating-status-flag-warning operating-status usa-alert usa-alert-warning background-color-only vads-u-margin-top--1 vads-u-padding-y--2 vads-u-padding-x--1p5">
       <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
         Limited services and hours
       <i class="fa fa-chevron-right vads-u-padding-left--0p5" aria-hidden="true"></i>
@@ -31,7 +31,7 @@
   'infoBoxText': 'Facility closed'});"
      href="{{ facilitySidebar.links.0.url.path }}/operating-status">
     <span
-      class="operating-status-flag operating-status-flag-error operating-status usa-alert usa-alert-error background-color-only vads-u-margin-top--1 vads-u-padding-y--1 vads-u-padding-x--1p5">
+      class="operating-status-flag operating-status-flag-error operating-status usa-alert usa-alert-error background-color-only vads-u-margin-top--1 vads-u-padding-y--2 vads-u-padding-x--1p5">
       <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
         Facility Closed
       <i class="fa fa-chevron-right vads-u-padding-left--0p5" aria-hidden="true"></i>

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -29,6 +29,8 @@
             <ul class="usa-unstyled-list" role="list"></ul>
           </nav>
 
+          {% include "src/site/includes/covid-status.drupal.liquid" %}
+
           <h2 class="vads-u-line-height--1 vads-u-margin-bottom--3">Location and
             contact information</h2>
           <div

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -32,8 +32,6 @@
           <h2 class="vads-u-line-height--1 vads-u-margin-bottom--3">Location and
             contact information</h2>
 
-          {% include "src/site/includes/covid-status.drupal.liquid" with addBottomMargin = true %}
-
           <div
               class="region-list usa-grid usa-grid-full vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row facility vads-u-margin-bottom--2p5 vads-u-margin-bottom--4">
 
@@ -42,6 +40,8 @@
                 class="usa-width-two-thirds vads-u-display--block vads-u-width--full">
               <div>
                 <div class="vads-c-facility-detail">
+                  {% include "src/site/includes/covid-status.drupal.liquid" with addBottomMargin = true %}
+
                   {% if fieldOperatingStatusFacility and fieldOperatingStatusFacility != 'normal' %}
                     <div class="vads-u-display--inline-block vads-u-margin-bottom--2p5">
                       {% include "src/site/includes/operatingStatusFlagsLinks.drupal.liquid" %}

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -40,13 +40,17 @@
                 class="usa-width-two-thirds vads-u-display--block vads-u-width--full">
               <div>
                 <div class="vads-c-facility-detail">
-                  {% include "src/site/includes/covid-status.drupal.liquid" with addBottomMargin = true %}
 
                   {% if fieldOperatingStatusFacility and fieldOperatingStatusFacility != 'normal' %}
-                    <div class="vads-u-display--inline-block vads-u-margin-bottom--2p5">
+                    <div class="vads-u-display--inline-block vads-u-margin-bottom--1">
                       {% include "src/site/includes/operatingStatusFlagsLinks.drupal.liquid" %}
                     </div>
                   {% endif %}
+
+                  {% assign bottomMargin = '2' %}
+                  {% assign topMargin = '0p5' %}
+                  {% include "src/site/includes/covid-status.drupal.liquid" %}
+
                   <section class="vads-facility-detail">
                     <h3
                         class="vads-u-font-size--lg vads-u-margin-top--0 vads-u-line-height--1 vads-u-margin-bottom--1">

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -29,10 +29,11 @@
             <ul class="usa-unstyled-list" role="list"></ul>
           </nav>
 
-          {% include "src/site/includes/covid-status.drupal.liquid" %}
-
           <h2 class="vads-u-line-height--1 vads-u-margin-bottom--3">Location and
             contact information</h2>
+
+          {% include "src/site/includes/covid-status.drupal.liquid" %}
+
           <div
               class="region-list usa-grid usa-grid-full vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row facility vads-u-margin-bottom--2p5 vads-u-margin-bottom--4">
 

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -32,7 +32,7 @@
           <h2 class="vads-u-line-height--1 vads-u-margin-bottom--3">Location and
             contact information</h2>
 
-          {% include "src/site/includes/covid-status.drupal.liquid" %}
+          {% include "src/site/includes/covid-status.drupal.liquid" with addBottomMargin = true %}
 
           <div
               class="region-list usa-grid usa-grid-full vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row facility vads-u-margin-bottom--2p5 vads-u-margin-bottom--4">

--- a/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
+++ b/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
@@ -79,12 +79,12 @@
                   {% assign statusId = status.entity.entityId %}
 
                   <div class="vads-l-row vads-u-border-top--1px vads-u-border-color--gray-light">
-                    <dt class="vads-l-col--6 vads-u-margin-y--3 vads-u-display--flex operating-status-title">
+                    <dt class="vads-l-col--12 medium-screen:vads-l-col--6 vads-u-margin-y--3 vads-u-display--flex operating-status-title">
                       <a class="facility-title-width vads-u-font-weight--bold" onclick="recordEvent({
                                                                 'event':'nav-health-care-facility-status-click'});"
                          href="{{ status.entity.entityUrl.path }}">{{ status.entity.title }}</a>
                     </dt>
-                    <dd class="vads-l-col--6">
+                    <dd class="vads-l-col--12 medium-screen:vads-l-col--6">
                       <div class="operating-status-info vads-u-padding-y--1p5 vads-u-padding-x--0">
                         {% if status.entity.fieldOperatingStatusFacility == 'notice' %}
                           <span

--- a/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
+++ b/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
@@ -109,7 +109,8 @@
                             Facility Closed
                           </span>
                         {% endif %}
-                        {% if status.entity.fieldOperatingStatusMoreInfo %}
+
+                        {% if status.entity.fieldOperatingStatusMoreInfo  and status.entity.fieldOperatingStatusFacility != 'normal' %}
                           <div class="vads-u-margin-top--1p5">
                             {{ status.entity.fieldOperatingStatusMoreInfo }}
                           </div>

--- a/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
+++ b/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
@@ -116,10 +116,13 @@
                           </div>
                         {% endif %}
 
+                        {% assign bottomMargin = '1' %}
+                        {% assign topMargin = '2' %}
                         {% for covidStatus in fieldOffice.entity.reverseFieldRegionPageNode.entities %}
                           {% if statusId == covidStatus.entityId %}
                           {{facilityId}}
-                            {% include "src/site/includes/covid-status.drupal.liquid" with covidStatus %}
+                          {% include "src/site/includes/covid-status.drupal.liquid" with covidStatus %}
+
                           {% endif %}
                         {% endfor %}
 

--- a/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
+++ b/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
@@ -76,6 +76,8 @@
               <h2>Facility operating statuses</h2>
               <dl class="vads-l-grid-container vads-u-padding-x--0 vads-l-row vads-u-border-bottom--1px vads-u-border-color--gray-light">
                 {% for status in fieldFacilityOperatingStatus %}
+                  {% assign statusId = status.entity.entityId %}
+
                   <div class="vads-l-row vads-u-border-top--1px vads-u-border-color--gray-light">
                     <dt class="vads-l-col--6 vads-u-margin-y--3 vads-u-display--flex operating-status-title">
                       <a class="facility-title-width vads-u-font-weight--bold" onclick="recordEvent({
@@ -107,12 +109,19 @@
                             Facility Closed
                           </span>
                         {% endif %}
-
                         {% if status.entity.fieldOperatingStatusMoreInfo %}
                           <div class="vads-u-margin-top--1p5">
                             {{ status.entity.fieldOperatingStatusMoreInfo }}
                           </div>
                         {% endif %}
+
+                        {% for covidStatus in fieldOffice.entity.reverseFieldRegionPageNode.entities %}
+                          {% if statusId == covidStatus.entityId %}
+                          {{facilityId}}
+                            {% include "src/site/includes/covid-status.drupal.liquid" with covidStatus %}
+                          {% endif %}
+                        {% endfor %}
+
                       </div>
                     </dd>
                   </div>

--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareLocalFacility.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareLocalFacility.node.graphql.js
@@ -16,6 +16,20 @@ const FACILITIES_RESULTS = `
       entityBundle
       changed
       fieldMobile
+      fieldSupplementalStatus {
+        entity {
+          ... on TaxonomyTermFacilitySupplementalStatus {
+            name
+            fieldStatusId
+            description {
+              processed
+            }
+            fieldGuidance {
+              processed
+            }
+          }
+        }
+      }
       fieldOperatingStatusFacility
       fieldFacilityLocatorApiId
       fieldIntroText

--- a/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
@@ -13,6 +13,20 @@ const healthCareLocalFacilityPageFragment = `
     fieldFacilityLocatorApiId
     title
     fieldIntroText
+    fieldSupplementalStatus {
+      entity {
+        ... on TaxonomyTermFacilitySupplementalStatus {
+          name
+          fieldStatusId
+          description {
+            processed
+          }
+          fieldGuidance {
+            processed
+          }
+        }
+      }
+    }
     fieldOperatingStatusFacility
     fieldLocationServices {
       entity {

--- a/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
@@ -57,6 +57,21 @@ const nodeHealthCareRegionPage = `
         ... on NodeHealthCareLocalFacility {
           title
           fieldOperatingStatusFacility
+          fieldFacilityLocatorApiId
+          fieldSupplementalStatus {
+            entity {
+              ... on TaxonomyTermFacilitySupplementalStatus {
+                name
+                fieldStatusId
+                description {
+                  processed
+                }
+                fieldGuidance {
+                  processed
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/src/site/stages/build/drupal/graphql/locationsListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/locationsListingPage.graphql.js
@@ -16,6 +16,30 @@ const locationListingPage = `
       targetId
       entity {
         ...on NodeHealthCareRegionPage {
+          reverseFieldRegionPageNode(limit: 100000, filter:{conditions:[{field: "status", value: ["1"]},{field: "type", value: "health_care_local_facility"}]}) {
+            entities {
+              ... on NodeHealthCareLocalFacility {
+                title
+                entityId
+                fieldFacilityLocatorApiId
+                fieldOperatingStatusFacility
+                fieldSupplementalStatus {
+                  entity {
+                    ... on TaxonomyTermFacilitySupplementalStatus {
+                      name
+                      fieldStatusId
+                      description {
+                        processed
+                      }
+                      fieldGuidance {
+                        processed
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
           fieldVaHealthConnectPhone
           ${healthCareLocalFacilities}
           fieldOtherVaLocations

--- a/src/site/stages/build/drupal/graphql/locationsOperatingStatus.graphql.js
+++ b/src/site/stages/build/drupal/graphql/locationsOperatingStatus.graphql.js
@@ -1,7 +1,7 @@
 const locationsOperatingStatus = `
-  locationsOperatingStatus: nodeQuery(limit: 3000, filter: 
+  locationsOperatingStatus: nodeQuery(limit: 3000, filter:
     {conditions: [
-      {field: "status", value: ["1"]}, 
+      {field: "status", value: ["1"]},
       {field: "type", value: ["health_care_local_facility"]}]
     }) {
     entities {
@@ -12,7 +12,22 @@ const locationsOperatingStatus = `
         fieldMainLocation
         entityUrl {
           path
-        }        
+        }
+        fieldFacilityLocatorApiId
+        fieldSupplementalStatus {
+          entity {
+            ... on TaxonomyTermFacilitySupplementalStatus {
+              name
+              fieldStatusId
+              description {
+                processed
+              }
+              fieldGuidance {
+                processed
+              }
+            }
+          }
+        }
         fieldOperatingStatusFacility
         fieldOperatingStatusMoreInfo
         fieldRegionPage {

--- a/src/site/stages/build/drupal/graphql/vamcOperatingStatusAndAlerts.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vamcOperatingStatusAndAlerts.graphql.js
@@ -10,6 +10,28 @@ const vamcOperatingStatusAndAlerts = `
       entity {
         ... on NodeHealthCareRegionPage {
           entityLabel
+          reverseFieldRegionPageNode(limit: 100000, filter:{conditions:[{field: "status", value: ["1"]},{field: "type", value: "health_care_local_facility"}]}) {
+            entities {
+              ... on NodeHealthCareLocalFacility {
+                title
+                entityId
+                fieldSupplementalStatus {
+                  entity {
+                    ... on TaxonomyTermFacilitySupplementalStatus {
+                      name
+                      fieldStatusId
+                      description {
+                        processed
+                      }
+                      fieldGuidance {
+                        processed
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## Description
Adds expandable alert for facility covid status usage. See:
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/8986
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/8981
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/8982
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/8983
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9083

Sibling pr for vets-website vamc expandable widget needed for functionality: https://github.com/department-of-veterans-affairs/vets-website/pull/21037

Tugboat data endpoint to use for testing: https://pr9028-sjpg4ebinnl4eooevngpwufok19n4akk.ci.cms.va.gov/
Adding @maxx1128 & @swirtSJW for situational awareness.

## Testing done
Visual / build

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/167750716-4d918eee-077a-4572-823b-32ae618e9e3b.png)

![image](https://user-images.githubusercontent.com/2404547/167750728-2f95f9a9-a5c3-4a90-a771-4643d3f53729.png)

![image](https://user-images.githubusercontent.com/2404547/167884603-bdc8dadb-33db-41d2-80fe-1987fb317240.png)

![image](https://user-images.githubusercontent.com/2404547/167884634-64710951-58ca-4e92-98b9-2eed035a47d6.png)

## Acceptance criteria
- [ ] Check out `https://github.com/department-of-veterans-affairs/vets-website/pull/21037` and run `yarn watch` (in vets-website)
- [ ] In content-build, run `yarn preview --drupal-address=https://pr9028-sjpg4ebinnl4eooevngpwufok19n4akk.ci.cms.va.gov/ --drupal-user=ethan.teague --drupal-password=drupal8`
- [ ] Visually verify presence and functionality of expandable/collapsible covid status alerts when visiting http://localhost:3002/preview?nodeId=90
- [ ] - [ ] Visually verify presence and functionality of expandable/collapsible covid status alerts when visiting http://localhost:3002/preview?nodeId=1010
- [ ] - [ ] Visually verify presence and functionality of expandable/collapsible covid status alerts when visiting http://localhost:3002/preview?nodeId=2802
