### PR TITLE
Add build error notifications to accessibility heading order scan

### DIFF
--- a/.github/workflows/a11y-heading-order.yml
+++ b/.github/workflows/a11y-heading-order.yml
@@ -199,7 +199,7 @@ jobs:
     name: Notify Slack
     runs-on: ubuntu-latest
     needs: [build, a11y]
-    if: ${{ always() && (needs.a11y.result == 'success' || needs.a11y.result == 'failure' || (needs.build.result == 'success' || needs.build.result == 'failure') }}
+    if: ${{ always() && (needs.a11y.result == 'success' || needs.a11y.result == 'failure' || needs.build.result == 'success' || needs.build.result == 'failure') }}
     defaults:
       run:
         working-directory: content-build

--- a/.github/workflows/a11y-heading-order.yml
+++ b/.github/workflows/a11y-heading-order.yml
@@ -199,7 +199,7 @@ jobs:
     name: Notify Slack
     runs-on: ubuntu-latest
     needs: [build, a11y]
-    if: ${{ always() && (needs.a11y.result == 'success' || needs.a11y.result == 'failure') }}
+    if: ${{ always() && (needs.a11y.result == 'success' || needs.a11y.result == 'failure' || (needs.build.result == 'success' || needs.build.result == 'failure') }}
     defaults:
       run:
         working-directory: content-build
@@ -244,7 +244,7 @@ jobs:
 
       - name: Accessibility Test Failure
         uses: slackapi/slack-github-action@v1.18.0
-        if: ${{ needs.a11y.result == 'failure' }}
+        if: ${{ needs.a11y.result == 'failure' || needs.build.result == 'failure' }}
         continue-on-error: true
         env:
           SSL_CERT_DIR: /etc/ssl/certs


### PR DESCRIPTION
## Description
This PR modifies the weekly accessibility heading order scan to notify Slack when the `build` step in the workflow fails.