### PR TITLE
Update 686 breadcrumb

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -217,7 +217,7 @@
         },
         {
           "path": "view-change-dependents/add-remove-form-21-686c/",
-          "name": "Add or remove dependents form 21‑686c"
+          "name": "Add or remove dependents with VA Form 21-686C"
         }
       ]
     }

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -93,7 +93,7 @@
       "breadcrumbs_override": [
         {
           "path": "view-change-dependents",
-          "name": "View or change your dependents"
+          "name": "View or change dependents on your VA disability benefits"
         },
         {
           "path": "view-change-dependents/view",

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -213,7 +213,7 @@
       "breadcrumbs_override": [
         {
           "path": "view-change-dependents/",
-          "name": "View or change your dependents"
+          "name": "View or change dependents on your VA disability benefits"
         },
         {
           "path": "view-change-dependents/add-remove-form-21-686c/",


### PR DESCRIPTION
## Description

Recent IA recommendations want the breadcrumbs for both the Form 686C "Introduction" page and "View dependents" page

[Recommendations](https://github.com/department-of-veterans-affairs/va.gov-team/issues/41055#issuecomment-1122904618)

### Intro page

- Current state: breadcrumb segment: `Add or remove dependents form 21‑686c`
- New: Breadcrumb segment: `Add or remove dependents with VA Form 21-686C`
- In addition, when you are on this form, the breadcrumb segment for it's parent page is incorrect and should be fixed
    - The final full breadcrumb when on this page should be: Home > View or change dependents on your VA disability benefits > Add or remove dependents with VA Form 21-686C

### View dependents page
- The breadcrumb segment should match the H1 with the same casing structure - Your VA dependents
- When on this tool, the breadcrumb segment for the parent page is incorrect and should be fixed
  - The final full breadcrumb when on this page should be: Home > View or change dependents on your VA disability benefits > Your VA dependents 

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [x] Update breadcrumbs for view dependents & 686C intro pages

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
