### PR TITLE
Add manual trigger and schedule to CI job

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -6,6 +6,9 @@ on:
       - '**'
     tags-ignore:
       - '**'
+  workflow_dispatch:
+  schedule:
+    - cron: '17 10 * * *'
 
 env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver


### PR DESCRIPTION
## Description
Right now, we don't have a way to redeploy staging other than by pushing a commit to main in this repo. It would be helpful to periodically rebuild and redeploy dev and staging + have a way to manually do that.

This is probably not technically the _right_ way to do this, but it works for now. We'll probably look at upgrading the content release workflow to support deploying dev and staging as well, at which point we can back this change out.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
