### PR TITLE
Increase build job timeouts in accessibility scans

### DIFF
--- a/.github/workflows/a11y-heading-order.yml
+++ b/.github/workflows/a11y-heading-order.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     name: Build
     runs-on: [self-hosted, asg]
-    timeout-minutes: 120
+    timeout-minutes: 180
     defaults:
       run:
         working-directory: content-build

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     name: Build
     runs-on: [self-hosted, asg]
-    timeout-minutes: 120
+    timeout-minutes: 180
     defaults:
       run:
         working-directory: content-build


### PR DESCRIPTION
## Description
This PR increases the timeout for the build job in the accessibility scans to three hours due to recent builds timing out after two hours.