### PR TITLE
Replace internal ELB URLs with their public counterparts.

### DIFF
--- a/.github/workflows/a11y-heading-order.yml
+++ b/.github/workflows/a11y-heading-order.yml
@@ -70,7 +70,7 @@ jobs:
           timeout_minutes: 7
 
       - name: Set Drupal address
-        run: echo "DRUPAL_ADDRESS=http://internal-dsva-vagov-prod-cms-2000800896.us-gov-west-1.elb.amazonaws.com" >> $GITHUB_ENV
+        run: echo "DRUPAL_ADDRESS=https://prod.cms.va.gov" >> $GITHUB_ENV
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -92,7 +92,7 @@ jobs:
           env_variable_name: DRUPAL_USERNAME
 
       - name: Build content-build
-        run: yarn build --buildtype=${{ env.BUILD_TYPE }} --asset-source=local --drupal-address=http://internal-dsva-vagov-prod-cms-2000800896.us-gov-west-1.elb.amazonaws.com --drupal-user=${{ env.DRUPAL_USERNAME }} --drupal-password="${{ env.DRUPAL_PASSWORD }}" --pull-drupal --drupal-max-parallel-requests=15 --no-drupal-proxy --verbose
+        run: yarn build --buildtype=${{ env.BUILD_TYPE }} --asset-source=local --drupal-address=https://prod.cms.va.gov --drupal-user=${{ env.DRUPAL_USERNAME }} --drupal-password="${{ env.DRUPAL_PASSWORD }}" --pull-drupal --drupal-max-parallel-requests=15 --no-drupal-proxy --verbose
         env:
           NODE_ENV: production
 

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -103,7 +103,7 @@ jobs:
           timeout_minutes: 7
 
       - name: Set Drupal address
-        run: echo "DRUPAL_ADDRESS=http://internal-dsva-vagov-prod-cms-2000800896.us-gov-west-1.elb.amazonaws.com" >> $GITHUB_ENV
+        run: echo "DRUPAL_ADDRESS=https://prod.cms.va.gov" >> $GITHUB_ENV
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -125,7 +125,7 @@ jobs:
           env_variable_name: DRUPAL_USERNAME
 
       - name: Build content-build
-        run: yarn build --buildtype=vagovprod --asset-source=local --drupal-address=http://internal-dsva-vagov-prod-cms-2000800896.us-gov-west-1.elb.amazonaws.com --drupal-user=${{ env.DRUPAL_USERNAME }} --drupal-password="${{ env.DRUPAL_PASSWORD }}" --pull-drupal --drupal-max-parallel-requests=15 --no-drupal-proxy --verbose
+        run: yarn build --buildtype=vagovprod --asset-source=local --drupal-address=https://prod.cms.va.gov --drupal-user=${{ env.DRUPAL_USERNAME }} --drupal-password="${{ env.DRUPAL_PASSWORD }}" --pull-drupal --drupal-max-parallel-requests=15 --no-drupal-proxy --verbose
         env:
           NODE_ENV: production
 

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -19,7 +19,7 @@ env:
   NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
   BUILDTYPE: vagovprod
   DEPLOY_BUCKET: content.www.va.gov
-  DRUPAL_ADDRESS: http://internal-dsva-vagov-prod-cms-2000800896.us-gov-west-1.elb.amazonaws.com
+  DRUPAL_ADDRESS: https://prod.cms.va.gov
 
 jobs:
   start-runner:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -125,7 +125,7 @@ jobs:
           - buildtype: vagovstaging
             drupal-address: https://cms-content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov
           - buildtype: vagovprod
-            drupal-address: http://internal-dsva-vagov-prod-cms-2000800896.us-gov-west-1.elb.amazonaws.com
+            drupal-address: https://prod.cms.va.gov
 
     steps:
       - name: Checkout vagov-content

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -7,7 +7,7 @@ DRUPAL_MAPPING = [
 DRUPAL_ADDRESSES = [
   'vagovdev'    : 'http://internal-dsva-vagov-dev-cms-812329399.us-gov-west-1.elb.amazonaws.com',
   'vagovstaging': 'http://internal-dsva-vagov-staging-cms-1188006.us-gov-west-1.elb.amazonaws.com',
-  'vagovprod'   : 'http://internal-dsva-vagov-prod-cms-2000800896.us-gov-west-1.elb.amazonaws.com',
+  'vagovprod'   : 'https://prod.cms.va.gov',
    // This is a Tugboat URL, rebuilt frequently from PROD CMS. See https://tugboat.vfs.va.gov/6042f35d6a89945fd6399dc3.
    // If there are issues with this endpoint, please post in #cms-support Slack and tag @CMS DevOps Engineers.
    'sandbox'     : 'https://cms-content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov',

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -5,8 +5,8 @@ DRUPAL_MAPPING = [
 ]
 
 DRUPAL_ADDRESSES = [
-  'vagovdev'    : 'http://internal-dsva-vagov-dev-cms-812329399.us-gov-west-1.elb.amazonaws.com',
-  'vagovstaging': 'http://internal-dsva-vagov-staging-cms-1188006.us-gov-west-1.elb.amazonaws.com',
+  'vagovdev'    : 'https://dev.cms.va.gov',
+  'vagovstaging': 'https://staging.cms.va.gov',
   'vagovprod'   : 'https://prod.cms.va.gov',
    // This is a Tugboat URL, rebuilt frequently from PROD CMS. See https://tugboat.vfs.va.gov/6042f35d6a89945fd6399dc3.
    // If there are issues with this endpoint, please post in #cms-support Slack and tag @CMS DevOps Engineers.

--- a/script/preview-routes/single-page-diff.js
+++ b/script/preview-routes/single-page-diff.js
@@ -132,9 +132,7 @@ function singlePageDiff(
           ...fullPage,
           isPreview: false,
           isSinglePagePublish: true,
-          drupalSite:
-            DRUPALS.PUBLIC_URLS[options['drupal-address']] ||
-            options['drupal-address'],
+          drupalSite: options['drupal-address'],
         },
       };
 

--- a/script/preview-routes/single-page-diff.js
+++ b/script/preview-routes/single-page-diff.js
@@ -94,7 +94,6 @@ function singlePageDiff(
       const drupalDataWithUpdatedAssetRefs = convertDrupalFilesToLocal(
         drupalData,
         [],
-        buildOptions,
       );
       const drupalPage = drupalDataWithUpdatedAssetRefs.data.nodes.entities[0];
       const drupalPath = `${req.path.substring(1)}/index.html`;

--- a/script/preview-routes/single-page-diff.js
+++ b/script/preview-routes/single-page-diff.js
@@ -9,8 +9,6 @@ const {
   createFileObj,
 } = require('../../src/site/stages/build/drupal/page');
 
-const DRUPALS = require('../../src/site/constants/drupals');
-
 const convertDrupalFilesToLocal = require('../../src/site/stages/build/drupal/assets');
 const updateAssetLinkElements = require('../../src/site/stages/prearchive/helpers');
 

--- a/script/preview.js
+++ b/script/preview.js
@@ -20,7 +20,6 @@ const {
 } = require('../src/site/stages/build/drupal/page');
 const ENVIRONMENTS = require('../src/site/constants/environments');
 const HOSTNAMES = require('../src/site/constants/hostnames');
-const DRUPALS = require('../src/site/constants/drupals');
 const bucketsContent = require('../src/site/constants/buckets-content');
 const singlePageDiff = require('./preview-routes/single-page-diff');
 const createMetalSmithSymlink = require('../src/site/stages/build/plugins/create-symlink');

--- a/script/preview.js
+++ b/script/preview.js
@@ -300,8 +300,7 @@ app.get('/preview', async (req, res, next) => {
       `${compiledPage.entityBundle}.drupal.liquid`,
     );
 
-    const drupalAddressUrl = DRUPALS.PUBLIC_URLS[options['drupal-address']];
-    const drupalSite = drupalAddressUrl || 'prod.cms.va.gov';
+    const drupalSite = options['drupal-address'] || 'prod.cms.va.gov';
 
     const files = {
       'generated/file-manifest.json': {

--- a/src/site/constants/drupals.js
+++ b/src/site/constants/drupals.js
@@ -20,15 +20,5 @@ const PREFIXED_ENVIRONMENTS = new Set([
   // ENVIRONMENTS.VAGOVPROD,
 ]);
 
-const PUBLIC_URLS = {
-  'http://internal-dsva-vagov-dev-cms-812329399.us-gov-west-1.elb.amazonaws.com':
-    'http://dev.cms.va.gov',
-  'http://internal-dsva-vagov-staging-cms-1188006.us-gov-west-1.elb.amazonaws.com':
-    'http://staging.cms.va.gov',
-  'http://internal-dsva-vagov-prod-cms-2000800896.us-gov-west-1.elb.amazonaws.com':
-    'http://prod.cms.va.gov',
-};
-
 module.exports.ENABLED_ENVIRONMENTS = ENABLED_ENVIRONMENTS;
 module.exports.PREFIXED_ENVIRONMENTS = PREFIXED_ENVIRONMENTS;
-module.exports.PUBLIC_URLS = PUBLIC_URLS;

--- a/src/site/stages/build/drupal/api.js
+++ b/src/site/stages/build/drupal/api.js
@@ -4,7 +4,6 @@ const pRetry = require('p-retry');
 const chalk = require('chalk');
 const SocksProxyAgent = require('socks-proxy-agent');
 
-const { PUBLIC_URLS } = require('../../../constants/drupals');
 const syswidecas = require('syswide-cas');
 const { queries, getQuery } = require('./queries');
 const {
@@ -63,10 +62,6 @@ function getDrupalClient(buildOptions, clientOptionsArg) {
 
     getSiteUri() {
       return address;
-    },
-
-    shouldReplaceAssetPath() {
-      return !!PUBLIC_URLS[this.getSiteUri()];
     },
 
     async proxyFetch(url, options = {}) {

--- a/src/site/stages/build/drupal/assets.js
+++ b/src/site/stages/build/drupal/assets.js
@@ -1,6 +1,4 @@
 const cheerio = require('cheerio');
-const chalk = require('chalk');
-const getDrupalClient = require('./api');
 
 function replacePathInData(data, replacer, ancestors = new Set()) {
   // Circular references happen when an entity in the CMS has a child entity
@@ -80,9 +78,7 @@ function updateAttr(attr, doc) {
   return assetsToDownload;
 }
 
-function convertDrupalFilesToLocal(drupalData, files, options) {
-  const client = getDrupalClient(options);
-
+function convertDrupalFilesToLocal(drupalData, files, _options) {
   return replacePathInData(drupalData, (data, key) => {
     if (data.match(/^.*\/sites\/.*\/files\//)) {
       const newPath = convertAssetPath(data);

--- a/src/site/stages/build/drupal/assets.js
+++ b/src/site/stages/build/drupal/assets.js
@@ -78,7 +78,7 @@ function updateAttr(attr, doc) {
   return assetsToDownload;
 }
 
-function convertDrupalFilesToLocal(drupalData, files, _options) {
+function convertDrupalFilesToLocal(drupalData, files) {
   return replacePathInData(drupalData, (data, key) => {
     if (data.match(/^.*\/sites\/.*\/files\//)) {
       const newPath = convertAssetPath(data);

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -314,7 +314,7 @@ function getDrupalContent(buildOptions) {
     let drupalData = null;
     try {
       drupalData = await loadDrupal(buildOptions);
-      drupalData = convertDrupalFilesToLocal(drupalData, files, buildOptions);
+      drupalData = convertDrupalFilesToLocal(drupalData, files);
 
       await loadCachedDrupalFiles(buildOptions, files);
       pipeDrupalPagesIntoMetalsmith(drupalData, files);

--- a/src/site/stages/build/plugins/modify-dom/check-broken-links/helpers/getBrokenLinks.js
+++ b/src/site/stages/build/plugins/modify-dom/check-broken-links/helpers/getBrokenLinks.js
@@ -7,14 +7,8 @@ const isCMSUrl = require('./isCMSUrl');
  * Parses the <a> and <img> elements from an HTML file, validating each HREF/SRC value.
  * @param {*} file The HTML file from the Metalsmith pipeline
  * @param {Set<string>} allPaths The paths of all files in the website. Used to confirm the existence of a file.
- * @param {*} buildOptions The build options.
  */
-function getBrokenLinks(
-  file,
-  allPaths,
-  buildOptions,
-  isBrokenLink = _isBrokenLink,
-) {
+function getBrokenLinks(file, allPaths, isBrokenLink = _isBrokenLink) {
   const $ = file.dom;
   const elements = $('a, img, script');
   const currentPath = file.path;
@@ -44,7 +38,7 @@ function getBrokenLinks(
     }
 
     const isBroken = isBrokenLink(target, currentPath, allPaths);
-    const isCMS = isCMSUrl(target, file, buildOptions);
+    const isCMS = isCMSUrl(target, file);
 
     if (isBroken || isCMS) {
       const html = cheerio.html($node);

--- a/src/site/stages/build/plugins/modify-dom/check-broken-links/helpers/isCMSUrl.js
+++ b/src/site/stages/build/plugins/modify-dom/check-broken-links/helpers/isCMSUrl.js
@@ -16,12 +16,7 @@ function isCMSUrl(link, file, buildOptions) {
   const parsed = url.parse(link);
   if (!parsed.hostname) return false;
 
-  // If asset paths are not being replaced then do not do
-  // asset checks since all asset urls will include cms.va.gov
   const api = getApiClient(buildOptions);
-  if (api.shouldReplaceAssetPath()) {
-    return false;
-  }
 
   return !!(file.isDrupalPage && parsed.hostname.includes('cms.va.gov'));
 }

--- a/src/site/stages/build/plugins/modify-dom/check-broken-links/helpers/isCMSUrl.js
+++ b/src/site/stages/build/plugins/modify-dom/check-broken-links/helpers/isCMSUrl.js
@@ -5,10 +5,9 @@ const url = require('url');
  *
  * @param {*} link The HREF/SRC value to be validated.
  * @param {*} file The HTML file from the Metalsmith pipeline.
- * @param {*} _buildOptions The build options.
  * @returns {boolean} Does this URL point to the CMS.
  */
-function isCMSUrl(link, file, _buildOptions) {
+function isCMSUrl(link, file) {
   if (!link) return false;
 
   const parsed = url.parse(link);

--- a/src/site/stages/build/plugins/modify-dom/check-broken-links/helpers/isCMSUrl.js
+++ b/src/site/stages/build/plugins/modify-dom/check-broken-links/helpers/isCMSUrl.js
@@ -1,22 +1,18 @@
 const url = require('url');
 
-const getApiClient = require('../../../../drupal/api');
-
 /**
  * Checks if a URL points to the CMS.
  *
  * @param {*} link The HREF/SRC value to be validated.
  * @param {*} file The HTML file from the Metalsmith pipeline.
- * @param {*} buildOptions The build options.
+ * @param {*} _buildOptions The build options.
  * @returns {boolean} Does this URL point to the CMS.
  */
-function isCMSUrl(link, file, buildOptions) {
+function isCMSUrl(link, file, _buildOptions) {
   if (!link) return false;
 
   const parsed = url.parse(link);
   if (!parsed.hostname) return false;
-
-  const api = getApiClient(buildOptions);
 
   return !!(file.isDrupalPage && parsed.hostname.includes('cms.va.gov'));
 }

--- a/src/site/stages/build/plugins/modify-dom/check-broken-links/index.js
+++ b/src/site/stages/build/plugins/modify-dom/check-broken-links/index.js
@@ -43,7 +43,7 @@ module.exports = {
     const isHtml = path.extname(fileName) === '.html';
     if (!isHtml) return;
 
-    const linkErrors = getBrokenLinks(file, this.allPaths, this.buildOptions);
+    const linkErrors = getBrokenLinks(file, this.allPaths);
 
     if (linkErrors.length > 0) {
       this.brokenPages.push({

--- a/src/site/stages/build/plugins/modify-dom/check-broken-links/tests/helpers/getBrokenLinks.unit.spec.js
+++ b/src/site/stages/build/plugins/modify-dom/check-broken-links/tests/helpers/getBrokenLinks.unit.spec.js
@@ -21,42 +21,20 @@ const getFile = tag => {
 describe('getBrokenLinks', () => {
   const detectAllLinksBroken = sinon.stub().returns(true);
   const detectAllLinksOkay = sinon.stub().returns(false);
-  const buildOptions = {
-    'drupal-address': '',
-    'drupal-user': '',
-    'drupal-password': '',
-    'drupal-max-parallel-requests': 15,
-    buildtype: 'localhost',
-  };
 
   it('finds broken links', () => {
-    const linkErrors = getBrokenLinks(
-      getFile(img),
-      [],
-      buildOptions,
-      detectAllLinksBroken,
-    );
+    const linkErrors = getBrokenLinks(getFile(img), [], detectAllLinksBroken);
     expect(linkErrors).to.have.lengthOf(2);
   });
 
   it('does not detect non-links as a link', () => {
-    const linkErrors = getBrokenLinks(
-      getFile(span),
-      [],
-      buildOptions,
-      detectAllLinksBroken,
-    );
+    const linkErrors = getBrokenLinks(getFile(span), [], detectAllLinksBroken);
     expect(linkErrors).to.have.lengthOf(1);
     expect(linkErrors[0].html).to.be.equal(anchor);
   });
 
   it('does not detect valid links as broken', () => {
-    const linkErrors = getBrokenLinks(
-      getFile(img),
-      [],
-      buildOptions,
-      detectAllLinksOkay,
-    );
+    const linkErrors = getBrokenLinks(getFile(img), [], detectAllLinksOkay);
     expect(linkErrors).to.have.lengthOf(0);
   });
 
@@ -64,7 +42,6 @@ describe('getBrokenLinks', () => {
     const linkErrors = getBrokenLinks(
       getFile(anchorWithoutHref),
       [],
-      buildOptions,
       detectAllLinksBroken,
     );
     expect(linkErrors).to.have.lengthOf(1);

--- a/src/site/stages/build/plugins/modify-dom/check-broken-links/tests/helpers/isCMSUrl.unit.spec.js
+++ b/src/site/stages/build/plugins/modify-dom/check-broken-links/tests/helpers/isCMSUrl.unit.spec.js
@@ -19,20 +19,12 @@ describe('isCMSUrl', () => {
     'https://s3-us-gov-west-1.amazonaws.com/content.www.va.gov/img/styles/2_3_medium_thumbnail/public/2021-07/Jonathan-Atkinson_low-res-TEAMS.jpg',
   ];
 
-  const buildOptions = {
-    'drupal-address': 'https://prod.cms.va.gov',
-    'drupal-user': '',
-    'drupal-password': '',
-    'drupal-max-parallel-requests': 15,
-    buildtype: 'localhost',
-  };
-
   for (const cmsLink of cmsLinks) {
     it(`returns true if link points to CMS - ${cmsLink}`, () => {
       const file = {
         isDrupalPage: true,
       };
-      const result = isCMSUrl(cmsLink, file, buildOptions);
+      const result = isCMSUrl(cmsLink, file);
       expect(result).to.be.true;
     });
   }
@@ -42,7 +34,7 @@ describe('isCMSUrl', () => {
       const file = {
         isDrupalPage: true,
       };
-      const result = isCMSUrl(nonCMSLink, file, buildOptions);
+      const result = isCMSUrl(nonCMSLink, file);
       expect(result).to.be.false;
     });
   }
@@ -51,7 +43,7 @@ describe('isCMSUrl', () => {
     const file = {
       isDrupalPage: false,
     };
-    const result = isCMSUrl(cmsLinks[0], file, buildOptions);
+    const result = isCMSUrl(cmsLinks[0], file);
     expect(result).to.be.false;
   });
 });


### PR DESCRIPTION
## Description
In several places, the codebase uses some long, tall, and _ugly_ URLs for CMS environments, like `internal-dsva-vagov-prod-cms-2000800896.us-gov-west-1.elb.amazonaws.com`, tbh a hostname only a mother could love.

Why the codebase does this to us is not known; perhaps it dates from the time of GitHub-hosted runners; perhaps it goes back further, to the time of Jenkins.  Perhaps the answers are lost in the mists of antiquity.

Anyway, I'm opening this PR to see if I can do away with this nonsense, because a security audit wants us to use HSTS on everything and I don't think AMZN is gonna let us generate TLS certs with their hostnames.

There's a decent amount of work left to do, not least of which is me poring over the code and trying to understand what is happening and why it's happening to me, but I wanted to open this draft PR early and get some comments in case this is dum and doomed to failure.

See https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9217

**TL;DR**: `http://internal-dsva-vagov-prod-cms-2000800896.us-gov-west-1.elb.amazonaws.com/ -> https://prod.cms.va.gov/`

## Testing done
none lol, lemme get on that.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
