### PR TITLE
[VA-8991] Remove unneeded Ohio logic in Cerner filter

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1302,29 +1302,27 @@ module.exports = function registerFilters() {
     return sidebarData;
   };
 
-  liquid.filters.topTaskUrl = (flag, path, systemName) => {
+  liquid.filters.topTaskUrl = (flag, path) => {
     if (flag === 'cerner' && path === 'refill-track-prescriptions/') {
       return 'https://patientportal.myhealth.va.gov/pages/medications/current';
     }
+
     if (flag === 'cerner' && path === 'secure-messaging/') {
       return 'https://patientportal.myhealth.va.gov/pages/messaging/inbox';
     }
+
     if (flag === 'cerner' && path === 'schedule-view-va-appointments/') {
       return 'https://patientportal.myhealth.va.gov/pages/scheduling/upcoming';
     }
+
     if (flag === 'cerner' && path === 'get-medical-records/') {
       return 'https://patientportal.myhealth.va.gov/pages/health_record/clinical_documents/open_notes?pagelet=https%3A%2F%2Fportal.myhealth.va.gov%2Fperson%2F1056308125V679416%2Fhealth-record%2Fopen-notes';
     }
+
     if (flag === 'cerner' && path === 'view-test-and-lab-results/') {
       return 'https://patientportal.myhealth.va.gov/pages/health_record/results';
     }
-    if (
-      flag === 'cerner' ||
-      (systemName === 'VA Central Ohio health care' &&
-        path === 'schedule-view-va-appointments/')
-    ) {
-      return 'https://patientportal.myhealth.va.gov';
-    }
+
     return `/health-care/${path}`;
   };
 


### PR DESCRIPTION
## Description

Closes [department-of-veterans-affairs/va.gov-cms#8991](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/8991). There's some extra logic in the `topTaskUrl` filter related to Ohio that's not needed. I also cleaned up some of the syntax so it's cleaner and matches with what `eslint` looks for.

Many other `eslint` changes are automatically being added into this file. The ones this PR are focused on are on lines `1303-1325`.

## Testing done

Visual

## Screenshots

<img width="836" alt="Screen Shot 2022-05-25 at 1 37 19 PM" src="https://user-images.githubusercontent.com/10790736/170328172-404cabe6-83b9-46c8-a953-1e3ec8d5d586.png">

## Acceptance criteria

- [ ] Check the [VA Central Ohio health care page](http://localhost:3002/preview?nodeId=14996), and that all the "manage your health online" links still work.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
