### PR TITLE
VAVFA-9061: Display verbiage for hours on caps lists.

### DIFF
--- a/src/site/includes/vet_centers/address_phone_image.liquid
+++ b/src/site/includes/vet_centers/address_phone_image.liquid
@@ -62,10 +62,16 @@
         <div class="vads-u-margin-bottom--3">
             {% include 'src/site/includes/hours.liquid' with allHours = vetCenter.fieldOfficeHours headerType = 'small' %}
         </div>
-      {% elsif vetCenter.entityBundle == "vet_center_cap" or vetCenter.entityBundle == "vet_center" or vetCenter.entityBundle == "vet_center_outstation" %}
+      {% elsif vetCenter.entityBundle == "vet_center" or vetCenter.entityBundle == "vet_center_outstation" %}
         <div class="vads-u-margin-bottom--3">
             {% include 'src/site/includes/hours.liquid' with allHours = vetCenterHours headerType = 'small' %}
         </div>
+      {% elsif vetCenter.entityBundle == "vet_center_cap" and vetCenterUseCapHours == true %}
+        <div class="vads-u-margin-bottom--3">
+            {% include 'src/site/includes/hours.liquid' with allHours = vetCenterHours headerType = 'small' %}
+        </div>
+      {% elsif vetCenter.entityBundle == "vet_center_cap" %}
+        <p>Veterans should call main Vet Center for hours</p>
     {% endif %}
   </section>
 

--- a/src/site/layouts/vet_center_locations_list.drupal.liquid
+++ b/src/site/layouts/vet_center_locations_list.drupal.liquid
@@ -48,6 +48,7 @@
                   mainVetCenterPhone = fieldOffice.entity.fieldPhoneNumber
                   vetCenterHoursKey = myVetCenterHoursKeys
                   vetCenterHours = entityVetCenter.fieldOfficeHours
+                  vetCenterUseCapHours = entityVetCenter.fieldVetcenterCapHoursOptIn
                   isSatelliteLocation = true
                   isMainOffice = false
                   facilityMedia = entityVetCenter.fieldMedia
@@ -81,7 +82,7 @@
           </p>
           <va-back-to-top></va-back-to-top>
     <!-- Last updated & feedback button -->
-          {% include "src/site/includes/above-footer-elements.drupal.liquid" %}        
+          {% include "src/site/includes/above-footer-elements.drupal.liquid" %}
         </article>
       </div>
     </div>

--- a/src/site/stages/build/drupal/graphql/vetCenterLocations.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vetCenterLocations.graphql.js
@@ -90,6 +90,7 @@ fragment vetCenterLocationsFragment on NodeVetCenterLocationsList {
               title
               entityBundle
               fieldFacilityLocatorApiId
+              fieldVetcenterCapHoursOptIn
               fieldOperatingStatusFacility
               fieldOperatingStatusMoreInfo
               ${derivativeImage('_32MEDIUMTHUMBNAIL')}


### PR DESCRIPTION
## Description
closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9061

## Testing done
Visual / build

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/170775439-cbaee781-6225-4e34-a3dc-07af906d729a.png)

## Acceptance criteria
- [ ] on local version of `content-build` running yarn preview with prod as endpoint, go to `preview?nodeId=28246` and visually verify cap location listings show `Veterans should call main Vet Center for hours ` verbiage below phone numbers

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
