### PR TITLE
VAVFA-9196: Add copay query and template variable to billing.

### DIFF
--- a/src/site/layouts/vamc_system_billing_insurance.drupal.liquid
+++ b/src/site/layouts/vamc_system_billing_insurance.drupal.liquid
@@ -25,18 +25,27 @@
           </nav>
 
           <div class="usa-content">
-            <h2>Questions about copay balance</h2>
-            <p>
-              For questions about the copay balance of your
-              {{ fieldOffice.entity.entityLabel }}
-              bill, call us toll free at the number below. You won't need to pay
-              any copays for X-rays, lab tests,
-              preventative tests, and services like health screenings or
-              immunizations.
-            </p>
-            <b>Phone</b>
-            <p><a href="tel:{{ fieldPhoneNumber }}">{{ fieldPhoneNumber }}</a>
-            </p>
+            {% if fieldCcAboveTopOfPage.fetched.fieldWysiwyg.0.processed %}
+              {% include "src/site/includes/centralized-content.drupal.liquid" with
+              entity = fieldCcAboveTopOfPage.fetched
+              contentType = fieldCcAboveTopOfPage.fetchedBundle
+              %}
+            {% else %}
+              <h2>Questions about copay balance</h2>
+              <p>
+                For questions about the copay balance of your
+                {{ fieldOffice.entity.entityLabel }}
+                bill, call us toll free at the number below. You won't need to pay
+                any copays for X-rays, lab tests,
+                preventative tests, and services like health screenings or
+                immunizations.
+              </p>
+            {% endif %}
+            {% if fieldPhoneNumber %}
+              <b>Phone</b>
+              <p><a href="tel:{{ fieldPhoneNumber }}">{{ fieldPhoneNumber }}</a>
+              </p>
+            {% endif %}
             <div class="vads-u-margin-bottom--3">
               {% include 'src/site/includes/hours.liquid' with allHours = fieldHoursForCopayInquiries headerType = 'small' %}
             </div>

--- a/src/site/stages/build/drupal/graphql/vamcBillingAndInsurancePage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vamcBillingAndInsurancePage.graphql.js
@@ -18,6 +18,10 @@ const billingAndInsuranceFragment = `
       endhours
       comment
     }
+    fieldCcAboveTopOfPage {
+      fetched
+      fetchedBundle
+    }
     fieldCcTopOfPageContent {
       fetched
       fetchedBundle


### PR DESCRIPTION
## Description
Removes hardcoded copay info from template and replaces with cms data: 
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9196
Follow up pr to https://github.com/department-of-veterans-affairs/va.gov-cms/pull/9264 (wait until 9264 is deployed to prod to merge this pr)

## Testing done
Visual / build

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/171033269-ace5661a-9e07-44e3-886c-2869f070a900.png)

## Acceptance criteria
- [ ] `beckley-health-care/billing-and-insurance/` (`preview?nodeId=45680`) displays copay info on top of page content like screenshot

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
