### PR TITLE
Adds VAMC Facility Supplemental Status static data file

### DIFF
--- a/src/site/stages/build/drupal/static-data-files/config.js
+++ b/src/site/stages/build/drupal/static-data-files/config.js
@@ -3,6 +3,11 @@ const {
   postProcess: postProcessVamcEhrSystem,
 } = require('./vamcEhrSystem');
 
+const {
+  query: queryVamcFacilitySupplementalStatus,
+  postProcess: postProcessVamcFacilitySupplementalStatus,
+} = require('./vamcFacilitySupplementalStatus');
+
 const DATA_FILE_PATH = 'data/cms';
 
 /**
@@ -20,6 +25,12 @@ const DATA_FILES = [
     filename: 'vamc-ehr.json',
     query: queryVamcEhrSystem,
     postProcess: postProcessVamcEhrSystem,
+  },
+  {
+    description: 'VAMC Facility Supplemental Status',
+    filename: 'vamc-facility-supplemental-status.json',
+    query: queryVamcFacilitySupplementalStatus,
+    postProcess: postProcessVamcFacilitySupplementalStatus,
   },
 ];
 

--- a/src/site/stages/build/drupal/static-data-files/vamcFacilitySupplementalStatus/index.js
+++ b/src/site/stages/build/drupal/static-data-files/vamcFacilitySupplementalStatus/index.js
@@ -1,0 +1,34 @@
+const query = `
+  query {
+    taxonomyTermQuery(limit: 10, offset: 0, filter: {conditions: [{operator: EQUAL, field: "vid", value: ["facility_supplemental_status"]}]}) {
+      entities {
+        ...on TaxonomyTermFacilitySupplementalStatus {
+          name,
+          description {
+            value
+          },
+          fieldStatusId
+        }
+      }
+    }
+  }
+`;
+
+/* eslint-disable camelcase */
+const postProcess = queryResult => {
+  const entities = queryResult?.data?.taxonomyTermQuery?.entities;
+  if (entities) {
+    return entities.map(({ name, description, fieldStatusId }) => ({
+      name,
+      description: description?.value,
+      status_id: fieldStatusId, // existing front-end code expecting this identifier `status_id`
+    }));
+  }
+
+  return queryResult;
+};
+
+module.exports = {
+  query,
+  postProcess,
+};


### PR DESCRIPTION
## Description
Defines a query and post-processing function to generate a static data file representing VAMC Facility Supplemental Status data.

## Testing done
Locally built.

## Screenshots
![image](https://user-images.githubusercontent.com/6863534/171674759-b1d85ba9-95f1-46ff-ae74-5a38db4afe19.png)


## Acceptance criteria
- [ ] JSON file available at `/data/cms/vamc-facility-supplemental-status.json`
