### PR TITLE
Update Deploy Script

### DIFF
--- a/script/github-actions/deploy.sh
+++ b/script/github-actions/deploy.sh
@@ -122,7 +122,6 @@ aws s3 sync --only-show-errors \
     --include '*.jpg' \
     --include '*.svg' \
     --include generated/headerFooter.json \
-    --include data/cms/*.json \
     . "$DEST"
 
 # Sync content to s3

--- a/script/github-actions/deploy.sh
+++ b/script/github-actions/deploy.sh
@@ -122,6 +122,7 @@ aws s3 sync --only-show-errors \
     --include '*.jpg' \
     --include '*.svg' \
     --include generated/headerFooter.json \
+    --include 'data/cms/*.json' \
     . "$DEST"
 
 # Sync content to s3


### PR DESCRIPTION
## Description
This PR adds quotes around the `data/cms/*.json` glob in the first S3 sync. This was causing issues with deployments for dev/staging in CI. [Slack thread](https://dsva.slack.com/archives/C02VD909V08/p1654193402960219)

## Testing done
Tested in a [manual dev deploy](https://github.com/department-of-veterans-affairs/content-build/actions/runs/2430746188) using this branch.

## Acceptance criteria
- [x] `data/cms/*.json` should be surrounded in quotes.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
