### PR TITLE
VAVFA-000: Remove duplicate header id.

### DIFF
--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -31,7 +31,7 @@
 			<div id="events-v1" class="usa-width-three-fourths">
 				<article aria-labelledby="article-heading" class="vads-l-grid-container--full" role="region">
 					<div class="vads-l-grid-container--full">
-						<h1 id="article-heading">{{ title }}</h1>
+						<h1 id="article-heading-legacy">{{ title }}</h1>
 						<div class="vads-l-grid-container--full">
 							<div class="va-introtext">
 								{% if fieldIntroText %}


### PR DESCRIPTION
## Description
Events v1 and events v2 have a header with the same id (one is obscured by flipper). This pr renames the v1 header id from 
`article-heading` to `article-heading-legacy` to prevent accessibility errors.

## Testing done
Visual / build

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/172258200-23f0a8f6-d412-4204-908b-237cf9ce6179.png)

## Acceptance criteria
- [ ] Only one element with `article-heading` id on `/alaska-health-care/events/` 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
