### PR TITLE
VAVSA-9353: Remove events v1

### DIFF
--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -9,7 +9,6 @@
 				{% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
 			{% endunless %}
 
-			<!-- Events page v2 -->
 			<div class="events events-v2 vads-u-flex-direction--column vads-u-padding-x--1p5 medium-screen:vads-u-padding-x--0 vads-u-padding-bottom--2">
 				<div class="vads-l-grid-container--full">
 					<h1 id="article-heading">{{ title }}</h1>
@@ -27,86 +26,6 @@
 
 			<div data-widget-type="events"></div>
 
-			<!-- Events page v1 -->
-			<div id="events-v1" class="usa-width-three-fourths">
-				<article aria-labelledby="article-heading" class="vads-l-grid-container--full" role="region">
-					<div class="vads-l-grid-container--full">
-						<h1 id="article-heading-legacy">{{ title }}</h1>
-						<div class="vads-l-grid-container--full">
-							<div class="va-introtext">
-								{% if fieldIntroText %}
-									<p class="events-show" id="office-events-description">
-										{{ fieldIntroText }}
-									</p>
-								{% endif %}
-							</div>
-
-							{% if pastEvents.entities.length > 0 or entityUrl.path contains 'past-events' %}
-								{% include "src/site/facilities/facilities_events_toggle.drupal.liquid" with url = entityUrl.path %}
-							{% endif %}
-
-							{% assign featuredEventUrl = null %}
-							{% assign featuredItemSet = false %}
-							{% assign upcomingEvents = reverseFieldListingNode.entities | filterUpcomingEvents  %}
-
-							{% for featuredEvent in upcomingEvents %}
-								{% if featuredEvent.fieldFeatured == true %}
-									{% unless entityUrl.path contains 'past-events' %}
-										{% if featuredItemSet == false %}
-											{% assign featuredEventUrl = featuredEvent.entityUrl.path %}
-											<div class="usa-width-two-thirds">
-												<div class="usa-grid usa-grid-full vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4 vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-border-left--7px vads-u-border-color--primary-alt-lightest" id="featured-content">
-													<div class="usa-width-full vads-u-padding-left--2">
-														<div class="vads-u-margin-bottom--2">
-															<strong>In the spotlight at
-																{{ fieldOffice.entity.entityLabel }}</strong>
-														</div>
-														{% include "src/site/teasers/event_featured.drupal.liquid" with node = featuredEvent %}
-													</div>
-												</div>
-											</div>
-										{% endif %}
-									{% endunless %}
-									{% assign featuredItemSet = true %}
-								{% endif %}
-							{% endfor %}
-
-							{% comment %}
-								In full builds, pagedItems is computed in src/site/stages/build/drupal/health-care-region.js.
-								                In preview mode and in unit tests, we need to compute pagedItems here.
-								                TODO: remove the addPager call in health-care-region.js for full builds. (requires updates of all listing pages)
-							{% endcomment %}
-							{% if pagedItems == empty %}
-								{% assign sortedUpcomingEvents = upcomingEvents | sortByDateKey: 'fieldDatetimeRangeTimezone', false %}
-								{% assign pagingResult = debug | paginatePages: sortedUpcomingEvents, 'event' %}
-								{% assign pagedItems = pagingResult.pagedItems %}
-								{% assign paginator = pagingResult.paginator %}
-							{% endif %}
-
-							{% for event in pagedItems %}
-								{% comment %}
-									Don't render the featured event again
-								{% endcomment %}
-								{% if featuredEventUrl != event.entityUrl.path %}
-									<div class="clearfix-text">
-										{% include "src/site/teasers/event.drupal.liquid" with node = event %}
-									</div>
-								{% endif %}
-							{% endfor %}
-
-							{% assign numItems = pagedItems | size %}
-							{% if numItems < 1 %}
-								<div id="no-events-message" class="clearfix-text">No events at this time.</div>
-							{% endif %}
-
-							{% include "src/site/includes/pagination.drupal.liquid" %}
-
-						</div>
-					</div>
-					<!-- Last updated & feedback button-->
-					{% include "src/site/includes/above-footer-elements.drupal.liquid" %}
-				</article>
-			</div>
 		</div>
 	</main>
 </div>

--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -9,7 +9,7 @@
 				{% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
 			{% endunless %}
 
-			<div class="events events-v2 vads-u-flex-direction--column vads-u-padding-x--1p5 medium-screen:vads-u-padding-x--0 vads-u-padding-bottom--2">
+			<div class="events vads-u-display--flex vads-u-flex-direction--column vads-u-padding-x--1p5 medium-screen:vads-u-padding-x--0 vads-u-padding-bottom--2">
 				<div class="vads-l-grid-container--full">
 					<h1 id="article-heading">{{ title }}</h1>
 					<div class="vads-l-grid-container--full">


### PR DESCRIPTION
## Description
see: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9353
Events v2 has been released - this pr removes events v1 from listing page template.

## Testing done
Visual / build

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/172487283-5f0baaea-8b78-46ba-b43d-8ec20ee3113e.png)


## Acceptance criteria
- [ ] Events and filters are visible here `alaska-health-care/events/` and here `outreach-and-events/events/`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
