### PR TITLE
Vagov 0000 verbose download logging

### DIFF
--- a/src/site/stages/build/plugins/download-drupal-assets.js
+++ b/src/site/stages/build/plugins/download-drupal-assets.js
@@ -35,7 +35,7 @@ async function downloadFile(
     try {
       // Add log before attempting to download for diagnostics.
       if (global.verbose) {
-        log(`Attempting to download ${asset.src}`);
+        log(`Downloading ${asset.src}...`);
       }
       // eslint-disable-next-line no-await-in-loop
       response = await client.proxyFetch(asset.src);
@@ -69,9 +69,7 @@ async function downloadFile(
 
     downloadResults.downloadCount++;
 
-    if (global.verbose) {
-      log(`Finished downloading ${asset.src}`);
-    } else {
+    if (!global.verbose) {
       process.stdout.write('.');
       if (!assetsToDownload.length) process.stdout.write('\n');
     }

--- a/src/site/stages/build/plugins/download-drupal-assets.js
+++ b/src/site/stages/build/plugins/download-drupal-assets.js
@@ -33,6 +33,10 @@ async function downloadFile(
   let retries = 3;
   while (retries--) {
     try {
+      // Add log before attempting to download for diagnostics.
+      if (global.verbose) {
+        log(`Attempting to download ${asset.src}`);
+      }
       // eslint-disable-next-line no-await-in-loop
       response = await client.proxyFetch(asset.src);
       break;


### PR DESCRIPTION
## Description
This moves reporting of downloading an asset from after completion to before attempt. If there is no error, we can assume the asset was downloaded.

Right now, if an asset is problematic for any reason, we get a failure without any reporting of which asset is the problematic one. Reporting a successful download is not useful information in this case.