### PR TITLE
[VA-9374] Remove extra wrapping on Events header

### DIFF
--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -10,17 +10,13 @@
 			{% endunless %}
 
 			<div class="events vads-u-display--flex vads-u-flex-direction--column vads-u-padding-x--1p5 medium-screen:vads-u-padding-x--0 vads-u-padding-bottom--2">
-				<div class="vads-l-grid-container--full">
-					<h1 id="article-heading">{{ title }}</h1>
-					<div class="vads-l-grid-container--full">
-						<div class="va-introtext">
-							{% if fieldIntroText %}
-								<p class="events-show" id="office-events-description">
-									{{ fieldIntroText }}
-								</p>
-							{% endif %}
-						</div>
-					</div>
+				<h1 id="article-heading">{{ title }}</h1>
+				<div class="va-introtext">
+					{% if fieldIntroText %}
+						<p class="events-show" id="office-events-description">
+							{{ fieldIntroText }}
+						</p>
+					{% endif %}
 				</div>
 			</div>
 


### PR DESCRIPTION
## Description

The Events header isn't properly aligned. This is due to unneeded wrapper classes around the header, which were likely added for the legacy events page. Now that legacy events is being removed, these extra wrappers can also be removed.

Closes [#9374.](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9374)

## Testing done

Visual
* http://localhost:3002/preview?nodeId=736
* http://localhost:3002/preview?nodeId=2807

## Screenshots

<img width="1116" alt="Screen Shot 2022-06-13 at 12 22 00 PM" src="https://user-images.githubusercontent.com/10790736/173399689-b20d551a-a414-4a8c-9e12-3f1c99530638.png">
<img width="891" alt="Screen Shot 2022-06-13 at 12 22 06 PM" src="https://user-images.githubusercontent.com/10790736/173399692-e4b755d9-52d5-4a09-86f1-c08bdc16aa1a.png">

## Acceptance criteria
- [ ] Header and page body contents left align correctly on /outreach-and-events/events/
- [ ] Header and page body contents left align correctly on VAMC events pages, e.g. /boston-health-care/events/46953

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs