### PR TITLE
VACMS-9449: restrict asset download to VA domains.

### DIFF
--- a/src/site/stages/build/drupal/assets.js
+++ b/src/site/stages/build/drupal/assets.js
@@ -84,9 +84,15 @@ function convertDrupalFilesToLocal(drupalData, files) {
       const newPath = convertAssetPath(data);
       const decodedFileName = decodeURIComponent(newPath).substring(1);
       const htmlRegex = new RegExp(/<\/?[a-z][\s\S]*>/i);
+      const vaDomainRegex = new RegExp(
+        /^https?:\/\/([a-z0-9]+(-[a-z0-9]+)*\.)+cms\.va\.gov/i,
+      );
 
+      // Check that this item is on a VA domain.
+      // @todo Allow specified domains not of form *.cms.va.gov.
+      // @todo alternately, check against DRUPAL_ADDRESS, accounting for protocol.
       // If this item contains HTML, don't queue it for download
-      if (!htmlRegex.test(decodedFileName)) {
+      if (vaDomainRegex.test(data) && !htmlRegex.test(decodedFileName)) {
         // eslint-disable-next-line no-param-reassign
         files[decodedFileName] = {
           path: decodedFileName,


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9449

content-build downloads any URI that contains `sites/*/files`. This ends up capturing non-VA Drupal URLs, for example https://www.parkinson.org/sites/default/files/attachments/Parkinsons-Foundation-Veterans-FAQ.pdf

This causes breaks when running these downloads through the proxy. This primarily affects local development.

## Testing done
Local testing.

## Acceptance criteria
- [ ] File download continues to work correctly in GHA
- [ ] Local builds without failure

