### PR TITLE
VACMS-9220: Replace custom js toc with component.

### DIFF
--- a/src/site/facilities/health_care_region_detail_content.drupal.liquid
+++ b/src/site/facilities/health_care_region_detail_content.drupal.liquid
@@ -19,10 +19,7 @@
 
 
   {% if fieldTableOfContentsBoolean != empty and fieldTableOfContentsBoolean %}
-    <nav id="table-of-contents" aria-labelledby="on-this-page">
-      <h2 id="on-this-page" class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
-      <ul class="usa-unstyled-list" role="list"></ul>
-    </nav>
+    <va-on-this-page class="vads-u-margin-left--1 vads-u-margin-bottom--0 vads-u-padding-bottom--0"></va-on-this-page>
   {% endif %}
 
   {% if fieldFeaturedContent != empty and fieldFeaturedContent.length > 0 %}

--- a/src/site/layouts/basic_landing_page.drupal.liquid
+++ b/src/site/layouts/basic_landing_page.drupal.liquid
@@ -31,10 +31,7 @@
 
           <!-- TOC -->
           {% if fieldTableOfContentsBoolean %}
-            <nav id="table-of-contents" aria-labelledby="on-this-page">
-              <h2 id="on-this-page" class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
-              <ul class="usa-unstyled-list" role="list"></ul>
-            </nav>
+            <va-on-this-page class="vads-u-margin-left--1 vads-u-margin-bottom--0 vads-u-padding-bottom--0"></va-on-this-page>
           {% endif %}
 
           <!-- Search bar -->
@@ -75,7 +72,7 @@
         <div class="usa-width-three-fourths">
           <div class="usa-content">
   <!-- Last updated & feedback button-->
-          {% include "src/site/includes/above-footer-elements.drupal.liquid" %}   
+          {% include "src/site/includes/above-footer-elements.drupal.liquid" %}
          </div>
         </div>
       </div>

--- a/src/site/layouts/faq_multiple_q_a.drupal.liquid
+++ b/src/site/layouts/faq_multiple_q_a.drupal.liquid
@@ -37,11 +37,8 @@
 
             <!-- TOC -->
             {% if fieldTableOfContentsBoolean %}
-              <nav id="table-of-contents" aria-labelledby="on-this-page">
-                <button type="button" class="vads-u-visibility--screen-reader">Back to top</button>
-                <h2 id="on-this-page" class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
-                <ul class="usa-unstyled-list" role="list"></ul>
-              </nav>
+              <button type="button" class="vads-u-visibility--screen-reader">Back to top</button>
+              <va-on-this-page class="vads-u-margin-left--1 vads-u-margin-bottom--0 vads-u-padding-bottom--0"></va-on-this-page>
             {% endif %}
 
             <!-- QAs -->
@@ -127,7 +124,7 @@
         <div class="usa-content">
           <va-back-to-top></va-back-to-top>
     <!-- Last updated & feedback button-->
-          {% include "src/site/includes/above-footer-elements.drupal.liquid" %}          
+          {% include "src/site/includes/above-footer-elements.drupal.liquid" %}
         </div>
       </div>
     </div>

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -24,10 +24,7 @@
             {% include "src/site/facilities/facilities_health_services_buttons.drupal.liquid" with path = basePath %}
           </div>
 
-          <nav id="table-of-contents" class="vads-u-margin-bottom--5" aria-labelledby="on-this-page">
-            <h2 id="on-this-page" class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
-            <ul class="usa-unstyled-list" role="list"></ul>
-          </nav>
+          <va-on-this-page class="vads-u-margin-left--1 vads-u-margin-bottom--0 vads-u-padding--0"></va-on-this-page>
 
           <h2 class="vads-u-line-height--1 vads-u-margin-bottom--3">Location and
             contact information</h2>

--- a/src/site/layouts/health_services_listing.drupal.liquid
+++ b/src/site/layouts/health_services_listing.drupal.liquid
@@ -24,10 +24,7 @@
             </div>
           </div>
 
-          <nav id="table-of-contents" aria-labelledby="on-this-page">
-            <h2 id="on-this-page" class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
-            <ul class="usa-unstyled-list" role="list"></ul>
-          </nav>
+          <va-on-this-page class="vads-u-margin-left--1 vads-u-margin-bottom--0 vads-u-padding-bottom--0"></va-on-this-page>
 
           {% if fieldFeaturedContentHealthser %}
           <section class="featured-services" id="featured-services">

--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -23,22 +23,7 @@
         </div>
 
         {% if fieldSpokes != empty and fieldSpokes.length > 1 %}
-        <nav id="table-of-spoke-contents" aria-labelledby="on-this-page">
-          <h2 id="on-this-page" class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
-          <ul class="usa-unstyled-list" role="list">
-            {% for spoke in fieldSpokes %}
-              <li class="vads-u-margin-bottom--2">
-                <a 
-                  href="#{% if spoke.entity.fieldTitle != empty %}{{ spoke.entity.fieldTitle | hashReference: 30 }}{% endif %}"
-                  class="vads-u-display--flex vads-u-text-decoration--none"
-                >
-                  <i class="fas fa-arrow-down va-c-font-size--xs vads-u-margin-top--1 vads-u-margin-right--1" aria-hidden="true"></i>
-                  {{ spoke.entity.fieldTitle }}
-                </a>
-              </li>
-            {% endfor %}
-          </ul>
-        </nav>
+          <va-on-this-page class="vads-u-margin-left--1 vads-u-margin-bottom--0 vads-u-padding-bottom--0"></va-on-this-page>
         {% endif %}
 
         {% if fieldAlert.length %}

--- a/src/site/layouts/page.drupal.liquid
+++ b/src/site/layouts/page.drupal.liquid
@@ -35,10 +35,7 @@
           {% endif %}
 
           {% if fieldTableOfContentsBoolean != empty and fieldTableOfContentsBoolean %}
-            <nav id="table-of-contents" aria-labelledby="on-this-page">
-              <h2 id="on-this-page" class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
-              <ul class="usa-unstyled-list" role="list"></ul>
-            </nav>
+            <va-on-this-page class="vads-u-margin-left--1 vads-u-margin-bottom--0 vads-u-padding-bottom--0"></va-on-this-page>
           {% endif %}
 
           {% assign featureCount = fieldFeaturedContent | size  %}
@@ -69,7 +66,7 @@
           {% if lang != "en" %}
             <va-back-to-top></va-back-to-top>
         <!-- Last updated & feedback button-->
-            {% include "src/site/includes/above-footer-elements.drupal.liquid" %}            
+            {% include "src/site/includes/above-footer-elements.drupal.liquid" %}
           {% endif %}
         </article>
       </div>

--- a/src/site/layouts/support_resources_detail_page.drupal.liquid
+++ b/src/site/layouts/support_resources_detail_page.drupal.liquid
@@ -35,11 +35,9 @@
 
             <!-- TOC -->
             {% if fieldTableOfContentsBoolean %}
-              <nav id="table-of-contents" aria-labelledby="on-this-page">
-                <h2 id="on-this-page" class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
-                <ul class="usa-unstyled-list" role="list"></ul>
-              </nav>
+              <va-on-this-page class="vads-u-margin-left--1 vads-u-margin-bottom--0 vads-u-padding-bottom--0"></va-on-this-page>
             {% endif %}
+
 
             <!-- Content blocks -->
             {% for block in fieldContentBlock %}
@@ -83,7 +81,7 @@
         <div class="usa-content">
           <va-back-to-top></va-back-to-top>
         <!-- Last updated & feedback button-->
-          {% include "src/site/includes/above-footer-elements.drupal.liquid" %}          
+          {% include "src/site/includes/above-footer-elements.drupal.liquid" %}
         </div>
       </div>
     </div>

--- a/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
+++ b/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
@@ -29,9 +29,7 @@
             </div>
           {% endif %}
           <section aria-labelledby="on-this-page" class="table-of-contents" class="vads-u-margin-bottom--5">
-            <h2 id="on-this-page" class="vads-u-margin-bottom--2 vads-u-font-size--lg">
-              On this page
-            </h2>
+	          <va-on-this-page class="vads-u-margin-left--1 vads-u-margin-bottom--0 vads-u-padding-bottom--0"/>
             <ul class="usa-unstyled-list" role="list">
 
               {% if fieldBannerAlert.0.entity.status != false and fieldBannerAlert.0.entity.fieldSituationUpdates.0.entity %}

--- a/src/site/layouts/vamc_system_billing_insurance.drupal.liquid
+++ b/src/site/layouts/vamc_system_billing_insurance.drupal.liquid
@@ -17,12 +17,7 @@
             </p>
           </div>
 
-          <nav id="table-of-contents" aria-labelledby="on-this-page">
-            <h2 id="on-this-page"
-              class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page
-            </h2>
-            <ul class="usa-unstyled-list" role="list"></ul>
-          </nav>
+          <va-on-this-page class="vads-u-margin-left--1 vads-u-margin-bottom--0 vads-u-padding-bottom--0"></va-on-this-page>
 
           <div class="usa-content">
             {% if fieldCcAboveTopOfPage.fetched.fieldWysiwyg.0.processed %}

--- a/src/site/layouts/vamc_system_medical_records_offi.drupal.liquid
+++ b/src/site/layouts/vamc_system_medical_records_offi.drupal.liquid
@@ -20,11 +20,7 @@
 						</p>
 					</div>
 
-					<nav id="table-of-contents" aria-labelledby="on-this-page">
-						<h2 id="on-this-page" class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page
-						</h2>
-						<ul class="usa-unstyled-list" role="list"></ul>
-					</nav>
+					<va-on-this-page class="vads-u-margin-left--1 vads-u-margin-bottom--0 vads-u-padding-bottom--0"></va-on-this-page>
 
 					{% include "src/site/includes/centralized-content.drupal.liquid" with
             entity = fieldCcTopOfPageContent.fetched

--- a/src/site/layouts/vamc_system_policies_page.drupal.liquid
+++ b/src/site/layouts/vamc_system_policies_page.drupal.liquid
@@ -16,10 +16,7 @@
             %}
           </div>
 
-          <nav id="table-of-contents" aria-labelledby="on-this-page">
-            <h2 id="on-this-page" class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
-            <ul class="usa-unstyled-list" role="list"></ul>
-          </nav>
+          <va-on-this-page class="vads-u-margin-left--1 vads-u-margin-bottom--0 vads-u-padding-bottom--0"></va-on-this-page>
 
           {% include "src/site/includes/centralized-content.drupal.liquid" with
             entity = fieldCcTopOfPageContent.fetched

--- a/src/site/layouts/vamc_system_register_for_care.drupal.liquid
+++ b/src/site/layouts/vamc_system_register_for_care.drupal.liquid
@@ -15,11 +15,8 @@
               Not yet enrolled in VA health care? We can help you apply in person or get started online.
             </p>
           </div>
-          <nav id="table-of-contents" aria-labelledby="on-this-page">
-            <h2 id="on-this-page" class="vads-u-margin-bottom--2 vads-u-font-size--lg">On
-              this page</h2>
-            <ul class="usa-unstyled-list" role="list"></ul>
-          </nav>
+          <va-on-this-page class="vads-u-margin-left--1 vads-u-margin-bottom--0 vads-u-padding-bottom--0"></va-on-this-page>
+
           <div class="usa-content">
             {% include "src/site/includes/centralized-content.drupal.liquid" with
                 entity = fieldCcTopOfPageContent.fetched

--- a/src/site/layouts/vet_center.drupal.liquid
+++ b/src/site/layouts/vet_center.drupal.liquid
@@ -26,10 +26,7 @@
             </div>
           {% endif %}
 
-          <nav id="table-of-contents" aria-labelledby="on-this-page">
-            <h2 id="on-this-page" class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
-            <ul class="usa-unstyled-list" role="list"></ul>
-          </nav>
+          <va-on-this-page class="vads-u-margin-left--1 vads-u-margin-bottom--0 vads-u-padding-bottom--0"></va-on-this-page>
 
           <h2 id="locations-and-contact-information" class="vads-u-line-height--1 vads-u-margin-bottom--3 vads-u-font-size--lg
           small-screen:vads-u-font-size--xl">Locations and contact information</h2>


### PR DESCRIPTION
## Description
relates to https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9220
Replaces the custom js table of contents found on various content types with storybook/design system component

## Testing done
Visual / build

## Screenshots
Facility
![image](https://user-images.githubusercontent.com/2404547/173670883-42435cda-668f-4ed2-a5ea-4a14ded3bb82.png)

Billing
![image](https://user-images.githubusercontent.com/2404547/173670921-b2e3007a-f4f9-47ae-abd0-512b80eb56b1.png)

Medical
![image](https://user-images.githubusercontent.com/2404547/173670949-e5c47e19-d8ba-4b29-9c13-e0f7bcd3e0a3.png)

Pharmacy
![image](https://user-images.githubusercontent.com/2404547/173670976-5ed42128-6c4f-44ca-aa86-30247811ace0.png)

Resources
![image](https://user-images.githubusercontent.com/2404547/173671026-ebed5c58-5ba3-4324-ad94-4876fced5c51.png)

Faq
![image](https://user-images.githubusercontent.com/2404547/173671051-8c4a8e66-e868-454f-9008-30b0d6f50d26.png)

Health services
![image](https://user-images.githubusercontent.com/2404547/173671077-5d244f40-76e6-45c7-8033-712e456d14e5.png)

Health care detail
![image](https://user-images.githubusercontent.com/2404547/173671109-c5eedb7f-9c41-487e-964a-0f4f60bea239.png)

Page
![image](https://user-images.githubusercontent.com/2404547/173671138-8dd1b18f-07a1-4eaf-8ed8-912f17d9c441.png)

Support Resource
![image](https://user-images.githubusercontent.com/2404547/173671165-63198786-6fb5-44de-961e-bee67ea9854c.png)

Op-Status
![image](https://user-images.githubusercontent.com/2404547/173671190-beb11bed-d20f-4098-8a29-2a5ee59806fb.png)

Vet Center
![image](https://user-images.githubusercontent.com/2404547/173671211-4109f171-a165-4f05-a463-e7070076d15c.png)


## Acceptance criteria
- [ ] On each of the paths listed below, visually verify `On this page` is no longer an H2 (should be a dt) and TOC appears with links to all H2's on page in content section
**Note: paths not included for testing that appear in above screenshots typically do not display a table of contents, as they have a toggle on the node form to turn on, with default setting to off - I enabled them locally just to confirm they would work properly if enabled**
- [ ] `/palo-alto-health-care/locations/palo-alto-va-medical-center`
- [ ] `/palo-alto-health-care/billing-and-insurance`
- [ ] `/palo-alto-health-care/medical-records-office`
- [ ] `/palo-alto-health-care/pharmacy`
- [ ] `/palo-alto-health-care/health-services`
- [ ] `/pittsburgh-health-care/about-us`
- [ ] `/education/benefit-rates/montgomery-active-duty-rates`
- [ ] `/pittsburgh-health-care/operating-status`
- [ ] `/palo-alto-health-care/temecula-vet-center`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
