### PR TITLE
DNM: Revert "VACMS-9449: restrict asset download to VA domains."

### DIFF
--- a/src/site/stages/build/drupal/assets.js
+++ b/src/site/stages/build/drupal/assets.js
@@ -84,15 +84,9 @@ function convertDrupalFilesToLocal(drupalData, files) {
       const newPath = convertAssetPath(data);
       const decodedFileName = decodeURIComponent(newPath).substring(1);
       const htmlRegex = new RegExp(/<\/?[a-z][\s\S]*>/i);
-      const vaDomainRegex = new RegExp(
-        /^https?:\/\/([a-z0-9]+(-[a-z0-9]+)*\.)+cms\.va\.gov/i,
-      );
 
-      // Check that this item is on a VA domain.
-      // @todo Allow specified domains not of form *.cms.va.gov.
-      // @todo alternately, check against DRUPAL_ADDRESS, accounting for protocol.
       // If this item contains HTML, don't queue it for download
-      if (vaDomainRegex.test(data) && !htmlRegex.test(decodedFileName)) {
+      if (!htmlRegex.test(decodedFileName)) {
         // eslint-disable-next-line no-param-reassign
         files[decodedFileName] = {
           path: decodedFileName,


### PR DESCRIPTION
Reverts department-of-veterans-affairs/content-build#1172.

Keeping this ready in the event of unforeseen issues with this PR. 