### PR TITLE
[VA-9450] Remove EventV1 template without recurrence icon

### DIFF
--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -9,367 +9,205 @@
         {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
       {% endunless %}
 
-      <!-- ======== -->
-      <!-- Event v1 -->
-      <!-- ======== -->
-      {% if buildtype == 'vagovprod' %}
-        {% include "src/site/includes/date.drupal.liquid" %}
+      <div class="usa-width-three-fourths vads-u-display--flex vads-u-flex-direction--column vads-u-padding-x--1p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--2">
+        <!-- Title -->
+        <h1>{{ title }}</h1>
 
-        <div class="usa-width-three-fourths">
-          <article aria-labelledby="article-heading" class="usa-content" role="region">
-            <div class="usa-grid usa-grid-full">
-              <h1 id="article-heading" class="{% if fieldMedia %}vads-u-margin-bottom--4{% else %}vads-u-margin-bottom--2{% endif %}">
-                {{ title }}
-              </h1>
+        <!-- Event image -->
+        {% if fieldMedia %}
+          <img
+            alt="{{ fieldMedia.entity.image.alt }}"
+            class="event-detail-img vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4"
+            src="{{ fieldMedia.entity.image.derivative.url }}"
+          />
+        {% endif %}
 
-              {% if fieldMedia %}
-                <img
-                  alt="{{ fieldMedia.entity.image.alt }}"
-                  class="event-detail-img vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4"
-                  src="{{ fieldMedia.entity.image.derivative.url }}"
-                />
-              {% endif %}
+        <!-- Intro text -->
+        {% if fieldDescription %}
+          <p class="va-introtext vads-u-margin-top--0">
+            {{ fieldDescription }}
+          </p>
+        {% endif %}
 
-              <div class="va-introtext">
-                <p class="vads-u-margin-top--0 vads-u-margin-bottom--1 medium-screen:vads-u-margin-bottom--4">
-                  {{ fieldDescription }}
+        <div class="vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row">
+          <div class="vads-u-display--flex vads-u-flex-direction--column vads-u-flex--1">
+            <!-- When -->
+            <div class="vads-u-display--flex vads-u-flex-direction--row vads-u-margin-bottom--1">
+              <p class="vads-u-margin--0 vads-u-margin-right--0p5">
+                <strong>When:</strong>
+              </p>
+
+              <div class="vads-u-display--flex vads-u-flex-direction--column">
+                <!-- Derive most recent date -->
+                {% assign now = '' | currentTime %}
+                {% assign mostRecentDate = fieldDatetimeRangeTimezone | deriveMostRecentDate: now %}
+
+                <!-- Starts at + ends at -->
+                <p class="vads-u-margin--0">
+                  {{ mostRecentDate | deriveFormattedTimestamp }}
                 </p>
-              </div>
 
-              <div class="usa-width-one-half vads-u-margin-bottom--2p5 medium-screen:vads-u-margin-bottom--0">
-                {% assign facility = fieldFacilityLocation.entity %}
-
-                <dl class="va-c-event-info">
-                  <dt class="vads-u-font-weight--bold when-where-width vads-u-margin-right--2">
-                    When
-                  </dt>
-
-                  <dd>
-                    {% if date_type == "start_date_only" %}
-                      <span>{{ start_date_no_time }}</span>
-                      <br>
-                      <span>{{ start_time }}</span>
-                    {% else %}
-                      {% if date_type == "same_day" %}
-                        <span>{{ start_date_no_time }}</span>
-                        <br>
-                        <span>{{ start_time }}
-                          -
-                          {{ end_time }}</span>
-                      {% else %}
-                        <span>{{ start_date_full }}
-                          -</span>
-                          <br>
-                        <span>{{ end_date_full }}</span>
-                      {% endif %}
-                    {% endif %}
-                    <span>{{ timezone | replace: "D", ""| replace: "S", ""}}</span>
-                  </dd>
-                </dl>
-
-                {% if fieldFacilityLocation or fieldAddress.addressLine1 %}
-                  <dl class="va-c-event-info">
-                    <dt class="vads-u-font-weight--bold when-where-width vads-u-margin-right--2">
-                      Where</dt>
-                    <dd>
-                      {% if facility %}
-                        <p class="vads-u-margin--0">
-                          <a href="{{ facility.entityUrl.path }}">{{ facility.title }}</a>
-                        </p>
-                        <p class="vads-u-margin--0">{{ fieldLocationHumanreadable }}</p>
-                      {% else %}
-                        {% if fieldAddress.addressLine1 %}
-                          <p class="vads-u-margin--0">{{ fieldAddress.addressLine1 }}</p>
-                        {% endif %}
-                        {% if fieldAddress.addressLine2 %}
-                          <p class="vads-u-margin--0">{{ fieldAddress.addressLine2 }}</p>
-                        {% endif %}
-                        <p class="vads-u-margin--0">
-                          {% if fieldAddress.locality %}
-                            {{ fieldAddress.locality }}
-                          {% endif %}
-                          {% if fieldAddress.administrativeArea %}
-                            , {{ fieldAddress.administrativeArea }}
-                          {% endif %}
-                        </p>
-                      {% endif %}
-                    </dd>
-                  </dl>
+                {% if fieldDatetimeRangeTimezone.length > 1 %}
+                  <!-- Repeats -->
+                  <p class="vads-u-margin--0">
+                    <i aria-hidden="true" class="fa fa-sync vads-u-font-size--sm vads-u-margin-right--0p5"></i> Repeats
+                  </p>
                 {% endif %}
-
-                {% if fieldEventCost %}
-                  <dl class="va-c-event-info">
-                    <dt class="vads-u-font-weight--bold vads-u-margin-right--2">Cost</dt>
-                    <dd>
-                      <span>{{ fieldEventCost }}</span>
-                    </dd>
-                  </dl>
-                {% endif %}
-
-                {% if fieldLink or fieldEventCta or fieldAdditionalInformationAbo %}
-                  <div class="registration vads-u-margin-top--4 vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--1">
-                    <p class="vads-u-font-weight--bold vads-u-margin-top--0 vads-u-margin-bottom--1">Registration</p>
-
-                    {% if start_timestamp < current_timestamp %}
-                      <p class="vads-u-margin--0 vads-u-color--secondary vads-u-font-weight--bold">This event already happened.</p>
-                    {% else %}
-                      {% if fieldLink %}
-                        <p class="vads-u-margin--0">
-                          <a href="{{ fieldLink.url.path }}">
-                            <button class="vads-u-margin--0">
-                              {% if fieldEventCta %}
-                                {{ fieldEventCta | removeUnderscores | capitalize }}
-                              {% else %}
-                                More details
-                              {% endif %}
-                            </button>
-                          </a>
-                        </p>
-                      {% endif %}
-
-                      {% if fieldAdditionalInformationAbo %}
-                        <p class="vads-u-margin--0">{{ fieldAdditionalInformationAbo.processed | phoneLinks }}</p>
-                      {% endif %}
-                    {% endif %}
-                  </div>
-                {% endif %}
-              </div>
-
-              <div class="usa-width-one-half va-c-event-share vads-u-margin-bottom--1">
-                {% include "src/site/includes/social-share.drupal.liquid" %}
               </div>
             </div>
 
-            <div class="usa-grid usa-grid-full vads-u-margin-top--2">
-              <div class="event-description">
-                {{ fieldBody.processed }}
+            <!-- Where -->
+            {% if fieldFacilityLocation or fieldAddress.addressLine1 %}
+              <div class="vads-u-display--flex vads-u-flex-direction--row vads-u-margin-top--1">
+                <p class="vads-u-margin--0 vads-u-margin-right--0p5">
+                  <strong>Where:</strong>
+                </p>
+
+                {% if facility %}
+                  <p class="vads-u-margin--0">
+                    <a href="{{ facility.entityUrl.path }}">{{ facility.title }}</a>
+                  </p>
+
+                  <p class="vads-u-margin--0">{{ fieldLocationHumanreadable }}</p>
+                {% else %}
+                <div class="vads-u-display--flex vads-u-flex-direction--column">
+                  {% if fieldAddress.addressLine1 %}
+                    <p class="vads-u-margin--0">{{ fieldAddress.addressLine1 }}</p>
+                  {% endif %}
+
+                  {% if fieldAddress.addressLine2 %}
+                    <p class="vads-u-margin--0">{{ fieldAddress.addressLine2 }}</p>
+                  {% endif %}
+
+                  <p class="vads-u-margin--0">
+                    {% if fieldAddress.locality %}
+                      {{ fieldAddress.locality }}
+                    {% endif %}
+
+                    {% if fieldAddress.administrativeArea %}
+                      , {{ fieldAddress.administrativeArea }}
+                    {% endif %}
+                  </p>
+                </div>
+                {% endif %}
               </div>
-            </div>
-
-            {% assign index = entityUrl.breadcrumb.length | minus: 2 %}
-
-            {% if fieldUrlOfAnOnlineEvent.uri %}
-            <p>
-              <a class="vads-u-padding-bottom--3 vads-u-margin-top--1 vads-u-font-weight--bold" onclick="recordEvent({ event: 'nav-secondary-button-click' });" href="{{ fieldUrlOfAnOnlineEvent.uri }}">
-                Link to event
-                <i aria-hidden="true" class='vads-u-font-size--sm vads-u-margin-left--1 fa fa-chevron-right' role="presentation"></i>
-              </a>
-            </p>
             {% endif %}
 
-            <a class="vads-u-padding-bottom--3 vads-u-margin-top--1 vads-u-font-weight--bold" onclick="recordEvent({ event: 'nav-secondary-button-click' });" href="{{ entityUrl.breadcrumb | getValueFromArrayObjPath: index, 'url.path' }}">
-              See all events
-              <i aria-hidden="true" class='vads-u-font-size--sm vads-u-margin-left--1 fa fa-chevron-right' role="presentation"></i>
-            </a>
-      <!-- Last updated & feedback button-->
-           {% include "src/site/includes/above-footer-elements.drupal.liquid" %}
-          </article>
-        </div>
-
-      <!-- ======== -->
-      <!-- Event v2 -->
-      <!-- ======== -->
-      {% else %}
-        <div class="usa-width-three-fourths vads-u-display--flex vads-u-flex-direction--column vads-u-padding-x--1p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--2">
-          <!-- Title -->
-          <h1>{{ title }}</h1>
-
-          <!-- Event image -->
-          {% if fieldMedia %}
-            <img
-              alt="{{ fieldMedia.entity.image.alt }}"
-              class="event-detail-img vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4"
-              src="{{ fieldMedia.entity.image.derivative.url }}"
-            />
-          {% endif %}
-
-          <!-- Intro text -->
-          {% if fieldDescription %}
-            <p class="va-introtext vads-u-margin-top--0">
-              {{ fieldDescription }}
-            </p>
-          {% endif %}
-
-          <div class="vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row">
-            <div class="vads-u-display--flex vads-u-flex-direction--column vads-u-flex--1">
-              <!-- When -->
-              <div class="vads-u-display--flex vads-u-flex-direction--row vads-u-margin-bottom--1">
+            <!-- Cost -->
+            {% if fieldEventCost %}
+              <div class="vads-u-display--flex vads-u-flex-direction--row vads-u-margin-top--1 vads-u-margin-bottom--2">
                 <p class="vads-u-margin--0 vads-u-margin-right--0p5">
-                  <strong>When:</strong>
+                  <strong>Cost:</strong>
                 </p>
 
-                <div class="vads-u-display--flex vads-u-flex-direction--column">
-                  <!-- Derive most recent date -->
-                  {% assign now = '' | currentTime %}
-                  {% assign mostRecentDate = fieldDatetimeRangeTimezone | deriveMostRecentDate: now %}
-
-                  <!-- Starts at + ends at -->
-                  <p class="vads-u-margin--0">
-                    {{ mostRecentDate | deriveFormattedTimestamp }}
-                  </p>
-
-                  {% if fieldDatetimeRangeTimezone.length > 1 %}
-                    <!-- Repeats -->
-                    <p class="vads-u-margin--0">
-                      <i aria-hidden="true" class="fa fa-sync vads-u-font-size--sm vads-u-margin-right--0p5"></i> Repeats
-                    </p>
-                  {% endif %}
-                </div>
+                <p class="vads-u-margin--0">
+                  {{ fieldEventCost }}
+                </p>
               </div>
-
-              <!-- Where -->
-              {% if fieldFacilityLocation or fieldAddress.addressLine1 %}
-                <div class="vads-u-display--flex vads-u-flex-direction--row vads-u-margin-top--1">
-                  <p class="vads-u-margin--0 vads-u-margin-right--0p5">
-                    <strong>Where:</strong>
-                  </p>
-
-                  {% if facility %}
-                    <p class="vads-u-margin--0">
-                      <a href="{{ facility.entityUrl.path }}">{{ facility.title }}</a>
-                    </p>
-
-                    <p class="vads-u-margin--0">{{ fieldLocationHumanreadable }}</p>
-                  {% else %}
-                  <div class="vads-u-display--flex vads-u-flex-direction--column">
-                    {% if fieldAddress.addressLine1 %}
-                      <p class="vads-u-margin--0">{{ fieldAddress.addressLine1 }}</p>
-                    {% endif %}
-
-                    {% if fieldAddress.addressLine2 %}
-                      <p class="vads-u-margin--0">{{ fieldAddress.addressLine2 }}</p>
-                    {% endif %}
-
-                    <p class="vads-u-margin--0">
-                      {% if fieldAddress.locality %}
-                        {{ fieldAddress.locality }}
-                      {% endif %}
-
-                      {% if fieldAddress.administrativeArea %}
-                        , {{ fieldAddress.administrativeArea }}
-                      {% endif %}
-                    </p>
-                  </div>
-                  {% endif %}
-                </div>
-              {% endif %}
-
-              <!-- Cost -->
-              {% if fieldEventCost %}
-                <div class="vads-u-display--flex vads-u-flex-direction--row vads-u-margin-top--1 vads-u-margin-bottom--2">
-                  <p class="vads-u-margin--0 vads-u-margin-right--0p5">
-                    <strong>Cost:</strong>
-                  </p>
-
-                  <p class="vads-u-margin--0">
-                    {{ fieldEventCost }}
-                  </p>
-                </div>
-              {% endif %}
-            </div>
-
-            <!-- Social links -->
-            <div class="vads-u-display--flex vads-u-flex-direction--column vads-u-flex--1">
-              {% include "src/site/includes/social-share.drupal.liquid" %}
-            </div>
+            {% endif %}
           </div>
 
-          <!-- CTA -->
-          {% if fieldLink or fieldEventCta or fieldAdditionalInformationAbo %}
-            <div class="registration vads-u-margin-top--4 vads-u-margin-bottom--1">
-              {% if start_timestamp < current_timestamp %}
-                <p class="vads-u-margin--0 vads-u-color--secondary vads-u-font-weight--bold">This event already happened.</p>
-              {% else %}
-                {% if fieldLink %}
-                  <p class="vads-u-margin--0">
-                    <a class="vads-c-action-link--green" href="{{ fieldLink.url.path }}">
-                      {% if fieldEventCta %}
-                        {{ fieldEventCta | removeUnderscores | capitalize }}
-                      {% else %}
-                        More details
-                      {% endif %}
-                    </a>
-                  </p>
-                {% endif %}
-
-                {% if fieldAdditionalInformationAbo %}
-                  <p class="vads-u-margin--0">{{ fieldAdditionalInformationAbo.processed | phoneLinks }}</p>
-                {% endif %}
-              {% endif %}
-            </div>
-          {% endif %}
-
-          <!-- Description -->
-          {% if fieldBody.processed %}
-            {{ fieldBody.processed }}
-          {% endif %}
-
-          <!-- Repeating event instances -->
-          {% if fieldDatetimeRangeTimezone.length > 1 %}
-            <button
-              class="vads-u-background-color--gray-lightest vads-u-color--primary-darkest vads-u-font-weight--bold vads-u-display--flex vads-u-align-items--center vads-u-justify-content--space-between vads-u-height--full vads-u-padding--2 vads-u-margin--0 vads-u-margin-top--1"
-              id="expand-recurring-events"
-              style="z-index: 1;"
-              type="button"
-            >
-              View other times for this event <i aria-hidden="true" class="fa fa-plus" id="expand-recurring-events-icon"></i>
-            </button>
-            <div
-              class="vads-u-display--none vads-u-flex-direction--column vads-u-background-color--white vads-u-border--2px vads-u-border-color--gray-lightest vads-u-padding--2"
-              id="recurring-events"
-            >
-              <!-- Recurring events list. -->
-              {% for recurringEventDatetimeRangeTimezone in fieldDatetimeRangeTimezone %}
-              <div class="recurring-event {% if forloop.index > 6 %}vads-u-display--none{% endif %} vads-u-margin-bottom--2">
-                  <p class="vads-u-margin--0">
-                    {{ recurringEventDatetimeRangeTimezone | deriveFormattedTimestamp }}
-                  </p>
-                  <a
-                    class="recurring-event "
-                    data-description="{{ fieldDescription }}"
-                    data-end="{{ recurringEventDatetimeRangeTimezone.endValue }}"
-                    data-location="{{ fieldAddress.addressLine1 }} {{ fieldAddress.locality }}, {{ fieldAddress.administrativeArea }}"
-                    data-start="{{ recurringEventDatetimeRangeTimezone.value }}"
-                    data-subject="{{ title }}"
-                    href="{{ entityUrl.path }}"
-                    rel="noreferrer noopener"
-                    style="max-width: 140px;"
-                  >
-                    <i aria-hidden="true" class="va-c-social-icon fas fa-calendar-check vads-u-margin-right--0p5" role="presentation"></i>
-                    Add to Calendar
-                  </a>
-                </div>
-              {% endfor %}
-
-              <!-- Show all recurring events. -->
-              {% if fieldDatetimeRangeTimezone.length > 6 %}
-                <div class="vads-u-display--flex vads-u-flex-direction--row vads-u-justify-content--flex-end vads-u-width--full medium-screen:vads-u-width--auto">
-                  <button
-                    class="usa-button-secondary vads-u-width--full medium-screen:vads-u-width--auto"
-                    id="show-all-recurring-events"
-                    type="button"
-                  >
-                    Show all times
-                  </button>
-                </div>
-              {% endif %}
-            </div>
-          {% endif %}
-
-          <!-- See more events. -->
-          {% assign index = entityUrl.breadcrumb.length | minus: 2 %}
-          <a
-            class="vads-u-padding-bottom--3 vads-u-margin-top--1 vads-u-font-weight--bold"
-            href="{{ entityUrl.breadcrumb | getValueFromArrayObjPath: index, 'url.path' }}"
-            onclick="recordEvent({ event: 'nav-secondary-button-click' });"
-          >
-            See more events
-            <i aria-hidden="true" class='vads-u-font-size--sm vads-u-margin-left--1 fa fa-chevron-right' role="presentation"></i>
-          </a>
-          <!-- Last updated & feedback button-->
-          {% include "src/site/includes/above-footer-elements.drupal.liquid" %}
+          <!-- Social links -->
+          <div class="vads-u-display--flex vads-u-flex-direction--column vads-u-flex--1">
+            {% include "src/site/includes/social-share.drupal.liquid" %}
+          </div>
         </div>
-      {% endif %}
+
+        <!-- CTA -->
+        {% if fieldLink or fieldEventCta or fieldAdditionalInformationAbo %}
+          <div class="registration vads-u-margin-top--4 vads-u-margin-bottom--1">
+            {% if start_timestamp < current_timestamp %}
+              <p class="vads-u-margin--0 vads-u-color--secondary vads-u-font-weight--bold">This event already happened.</p>
+            {% else %}
+              {% if fieldLink %}
+                <p class="vads-u-margin--0">
+                  <a class="vads-c-action-link--green" href="{{ fieldLink.url.path }}">
+                    {% if fieldEventCta %}
+                      {{ fieldEventCta | removeUnderscores | capitalize }}
+                    {% else %}
+                      More details
+                    {% endif %}
+                  </a>
+                </p>
+              {% endif %}
+
+              {% if fieldAdditionalInformationAbo %}
+                <p class="vads-u-margin--0">{{ fieldAdditionalInformationAbo.processed | phoneLinks }}</p>
+              {% endif %}
+            {% endif %}
+          </div>
+        {% endif %}
+
+        <!-- Description -->
+        {% if fieldBody.processed %}
+          {{ fieldBody.processed }}
+        {% endif %}
+
+        <!-- Repeating event instances -->
+        {% if fieldDatetimeRangeTimezone.length > 1 %}
+          <button
+            class="vads-u-background-color--gray-lightest vads-u-color--primary-darkest vads-u-font-weight--bold vads-u-display--flex vads-u-align-items--center vads-u-justify-content--space-between vads-u-height--full vads-u-padding--2 vads-u-margin--0 vads-u-margin-top--1"
+            id="expand-recurring-events"
+            style="z-index: 1;"
+            type="button"
+          >
+            View other times for this event <i aria-hidden="true" class="fa fa-plus" id="expand-recurring-events-icon"></i>
+          </button>
+          <div
+            class="vads-u-display--none vads-u-flex-direction--column vads-u-background-color--white vads-u-border--2px vads-u-border-color--gray-lightest vads-u-padding--2"
+            id="recurring-events"
+          >
+            <!-- Recurring events list. -->
+            {% for recurringEventDatetimeRangeTimezone in fieldDatetimeRangeTimezone %}
+            <div class="recurring-event {% if forloop.index > 6 %}vads-u-display--none{% endif %} vads-u-margin-bottom--2">
+                <p class="vads-u-margin--0">
+                  {{ recurringEventDatetimeRangeTimezone | deriveFormattedTimestamp }}
+                </p>
+                <a
+                  class="recurring-event "
+                  data-description="{{ fieldDescription }}"
+                  data-end="{{ recurringEventDatetimeRangeTimezone.endValue }}"
+                  data-location="{{ fieldAddress.addressLine1 }} {{ fieldAddress.locality }}, {{ fieldAddress.administrativeArea }}"
+                  data-start="{{ recurringEventDatetimeRangeTimezone.value }}"
+                  data-subject="{{ title }}"
+                  href="{{ entityUrl.path }}"
+                  rel="noreferrer noopener"
+                  style="max-width: 140px;"
+                >
+                  <i aria-hidden="true" class="va-c-social-icon fas fa-calendar-check vads-u-margin-right--0p5" role="presentation"></i>
+                  Add to Calendar
+                </a>
+              </div>
+            {% endfor %}
+
+            <!-- Show all recurring events. -->
+            {% if fieldDatetimeRangeTimezone.length > 6 %}
+              <div class="vads-u-display--flex vads-u-flex-direction--row vads-u-justify-content--flex-end vads-u-width--full medium-screen:vads-u-width--auto">
+                <button
+                  class="usa-button-secondary vads-u-width--full medium-screen:vads-u-width--auto"
+                  id="show-all-recurring-events"
+                  type="button"
+                >
+                  Show all times
+                </button>
+              </div>
+            {% endif %}
+          </div>
+        {% endif %}
+
+        <!-- See more events. -->
+        {% assign index = entityUrl.breadcrumb.length | minus: 2 %}
+        <a
+          class="vads-u-padding-bottom--3 vads-u-margin-top--1 vads-u-font-weight--bold"
+          href="{{ entityUrl.breadcrumb | getValueFromArrayObjPath: index, 'url.path' }}"
+          onclick="recordEvent({ event: 'nav-secondary-button-click' });"
+        >
+          See more events
+          <i aria-hidden="true" class='vads-u-font-size--sm vads-u-margin-left--1 fa fa-chevron-right' role="presentation"></i>
+        </a>
+        <!-- Last updated & feedback button-->
+        {% include "src/site/includes/above-footer-elements.drupal.liquid" %}
+      </div>
     </div>
   </main>
 </div>


### PR DESCRIPTION
## Description

The Events Detail page isn't showing the icon for recurring events since it's still using the old Events V1 template. This PR removes the conditional and always returns the Events V2 template.

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9450

## Testing done

Visual

## Screenshots

<img width="804" alt="Screen Shot 2022-06-15 at 11 45 08 AM" src="https://user-images.githubusercontent.com/10790736/173870207-f2bf7aa3-f3c9-4b00-8f75-2e33ed3ff99b.png">

## Acceptance criteria

- [ ] Recurrence icons appear for recurring events on their Event page.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
