### PR TITLE
VACMS-8932: replaced old CTA arrow implementation with the one from the VA design system

### DIFF
--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -115,19 +115,13 @@
         {% if fieldVaFormToolUrl %}
           <h3 data-testid="va_form--online-tool">Online tool</h3>
           <p>{{ fieldVaFormToolIntro }}</p>
-            <div class="vads-u-display--inline-block">
-              <a
-                class="vads-u-text-decoration--none vads-u-display--flex vads-u-align-items--center"
-                href="{{ fieldVaFormToolUrl.uri }}"
-                onclick="recordEvent({ event: 'cta-primary-button-click' });">
-                <i
-                  aria-hidden="true"
-                  class="fas fa-chevron-circle-right fa-2x vads-u-margin-right--1 va-form-layout--remove-pointer-events"
-                  role="presentation"
-                ></i>
-                <span class="vads-u-text-decoration--underline vads-u-font-weight--bold">Go to the online tool</span>
-              </a>
-            </div>
+          <a 
+            class="vads-c-action-link--blue" 
+            href="{{ fieldVaFormToolUrl.uri }}" 
+            onclick="recordEvent({ event: 'cta-primary-button-click' });"
+          >
+            Go to the online tool
+          </a>
         {% endif %}
 
 


### PR DESCRIPTION
## Description
This PR updates an old implementation of a CTA arrow link with a reusable one from the VA design system. The visited state of the link will now have a blue arrow, instead of purple.

## Testing done


## Screenshots
Old:
![Screen Shot 2022-06-16 at 2 39 11 PM](https://user-images.githubusercontent.com/8542413/174142201-e06e7a06-b9d6-4780-b3c4-9796ae9d6ba3.png)

New:
![Screen Shot 2022-06-16 at 2 39 29 PM](https://user-images.githubusercontent.com/8542413/174142210-a3de263a-38de-4907-8bda-8508a7feb7f6.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
