### PR TITLE
Revert "runners to gha tying back to asg (#1185)"

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -32,7 +32,7 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
       APPROX_WORKFLOW_START_TIME: ${{ steps.export-approx-workflow-start-time.outputs.APPROX_WORKFLOW_START_TIME }}
     env:
-      INSTANCE_TYPE: m5.4xlarge
+      INSTANCE_TYPE: c5.4xlarge
 
     steps:
       - name: Export approximate workflow start time
@@ -80,10 +80,10 @@ jobs:
           max_attempts: 3
           aws-resource-tags: >
             [
-              {"Key": "Name", "Value": "dsva-vagov-content-build-gha-runner"},
+              {"Key": "Name", "Value": "dsva-vagov-content-build-on-demand-runner"},
               {"Key": "project", "Value": "vagov"},
               {"Key": "office", "Value": "dsva"},
-              {"Key": "application", "Value": "gha-runner"},
+              {"Key": "application", "Value": "on-demand-gha-runner"},
               {"Key": "VAECID", "Value": "AWG20180517003"},
               {"Key": "environment", "Value": "utility"}
             ]

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,7 +29,7 @@ jobs:
       vagovstaging-id: ${{ steps.start-ec2-runner-id.outputs.vagovstaging }}
       vagovprod-id: ${{ steps.start-ec2-runner-id.outputs.vagovprod }}
     env:
-      INSTANCE_TYPE: m5.4xlarge
+      INSTANCE_TYPE: c5.4xlarge
 
     strategy:
       fail-fast: true
@@ -79,10 +79,10 @@ jobs:
           max_attempts: 3
           aws-resource-tags: >
             [
-              {"Key": "Name", "Value": "dsva-vagov-content-build-gha-runner"},
+              {"Key": "Name", "Value": "dsva-vagov-content-build-on-demand-runner"},
               {"Key": "project", "Value": "vagov"},
               {"Key": "office", "Value": "dsva"},
-              {"Key": "application", "Value": "gha-runner"},
+              {"Key": "application", "Value": "on-demand-gha-runner"},
               {"Key": "VAECID", "Value": "AWG20180517003"},
               {"Key": "environment", "Value": "utility"}
             ]


### PR DESCRIPTION
## Description
Reverts the self-hosted runners back to `dsva-vagov-content-build-on-demand-runner`.

## Acceptance criteria
- [ ] The `dsva-vagov-content-build-on-demand-runner` runner should be used in the CI and content-release workflows

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
