### PR TITLE
[CDP] Updating vagovprod for UAT testing

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1241,7 +1241,7 @@
     "entryName": "combined-debt-portal",
     "rootUrl": "/manage-debt-and-bills/summary",
     "template": {
-      "vagovprod": false,
+      "vagovprod": true,
       "vagovstaging": true,
       "layout": "page-react.html"
     }


### PR DESCRIPTION
## Description
Updating `vagovprod` flag to true for Combined Debt Portal for UAT testing. There is a feature flag that will redirect unauth/non-whitelisted users to va.gov home page. 

## Acceptance criteria
- [x] vagovprod flag true

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
