### PR TITLE
ami change to fix volume issues

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -52,13 +52,16 @@ jobs:
           ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
           env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
 
+      # - name: Get latest GHA Runner AMI ID # AMI images are rebuilt every 15 days, use the latest one
+      #   run: |
+      #     echo "RUNNER_AMI_ID=$(aws ec2 describe-images \
+      #     --owners 008577686731 \
+      #     --filters "Name=state,Values=available" "Name=name,Values=packer-gha-runner-ubuntu2004*" \
+      #     --query 'sort_by(Images,&CreationDate)[-1].ImageId' \
+      #     --output text)" >> $GITHUB_ENV
       - name: Get latest GHA Runner AMI ID # AMI images are rebuilt every 15 days, use the latest one
         run: |
-          echo "RUNNER_AMI_ID=$(aws ec2 describe-images \
-          --owners 008577686731 \
-          --filters "Name=state,Values=available" "Name=name,Values=packer-gha-runner-ubuntu2004*" \
-          --query 'sort_by(Images,&CreationDate)[-1].ImageId' \
-          --output text)" >> $GITHUB_ENV
+          echo "RUNNER_AMI_ID=ami-09280dcb3b86c4f42" >> $GITHUB_ENV
 
       - name: Get Subnet with the most free IPs # We will run these in the dsva-vagov-utility-2x subnet, so filter for those
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -50,14 +50,17 @@ jobs:
           ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
           env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
 
+      # - name: Get latest GHA Runner AMI ID # AMI images are rebuilt every 15 days, use the latest one
+      #   run: |
+      #     echo "RUNNER_AMI_ID=$(aws ec2 describe-images \
+      #     --owners 008577686731 \
+      #     --filters Name=state,Values=available \
+      #     --filters Name=name,Values=packer-gha-runner-ubuntu2004* \
+      #     --query 'sort_by(Images,&CreationDate)[-1].ImageId' \
+      #     --output text)" >> $GITHUB_ENV
       - name: Get latest GHA Runner AMI ID # AMI images are rebuilt every 15 days, use the latest one
         run: |
-          echo "RUNNER_AMI_ID=$(aws ec2 describe-images \
-          --owners 008577686731 \
-          --filters Name=state,Values=available \
-          --filters Name=name,Values=packer-gha-runner-ubuntu2004* \
-          --query 'sort_by(Images,&CreationDate)[-1].ImageId' \
-          --output text)" >> $GITHUB_ENV
+          echo "RUNNER_AMI_ID=ami-09280dcb3b86c4f42" >> $GITHUB_ENV
 
       - name: Get Subnet with the most free IPs # We will run these in the dsva-vagov-utility-2x subnet, so filter for those
         run: |


### PR DESCRIPTION
## Description
as part of interim fix with the volumes, this ami as hardcoded value should pick up the volume snapshot that has the 110G disk that has more availability.
Please note that this PR can be reverted (or not needed) - if the devops side of packer build with the 200G against a new AMI is run as a new workflow and new ami build.
https://github.com/department-of-veterans-affairs/devops/blob/master/packer/gha-runner/ubuntu2004.json
https://github.com/department-of-veterans-affairs/devops/actions/workflows/packer-build-runner.yml

## Testing done
yes

## Screenshots


## Acceptance criteria
- [X] - all the workflows/actions will go after the AMI that has the volume with more disk space (it is an interim fix)

## Definition of done
- [X] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
