### PR TITLE
[VA-43664] Add missing comma to COVID RecordEvent

### DIFF
--- a/src/site/includes/covid-status.drupal.liquid
+++ b/src/site/includes/covid-status.drupal.liquid
@@ -6,7 +6,7 @@ class="vads-u-margin-top--{{topMargin}} vads-u-margin-bottom--{{bottomMargin}} v
 		trigger="{{ fieldSupplementalStatus.entity.name }}"
 		onclick="recordEvent({
 			'event': 'covid-status',
-			'covid-status-entity-id': '{{ entityId }}'
+			'covid-status-entity-id': '{{ entityId }}',
 			'covid-status-heading':  '{{ fieldSupplementalStatus.entity.fieldStatusId }}',
 		});"
 	>


### PR DESCRIPTION
## Description

There's a missing comma for the Covid status record event, creating an error in `recordEvent`. This adds back the comma to fix the error and closes [#43664](https://github.com/department-of-veterans-affairs/va.gov-team/issues/43664).

## Testing done

None

## Screenshots

None

## Acceptance criteria

- [ ] The comma is added back to fix the error

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
