### PR TITLE
Fix js syntax error in GA data on vamc location pages

### DIFF
--- a/src/site/includes/covid-status.drupal.liquid
+++ b/src/site/includes/covid-status.drupal.liquid
@@ -6,7 +6,7 @@ class="vads-u-margin-top--{{topMargin}} vads-u-margin-bottom--{{bottomMargin}} v
 		trigger="{{ fieldSupplementalStatus.entity.name }}"
 		onclick="recordEvent({
 			'event': 'covid-status',
-			'covid-status-entity-id': '{{ entityId }}'
+			'covid-status-entity-id': '{{ entityId }}',
 			'covid-status-heading':  '{{ fieldSupplementalStatus.entity.fieldStatusId }}',
 		});"
 	>


### PR DESCRIPTION
## Description

There was a missing comma in the data being sent to a GA function.

## Testing done

Locally/visual

## Acceptance criteria
- [x] No more console error
- [ ] Events are being captured by GA

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
