### PR TITLE
VA-9442: Update Event page location variables

### DIFF
--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -63,32 +63,36 @@
                   <strong>Where:</strong>
                 </p>
 
-                {% if facility %}
-                  <p class="vads-u-margin--0">
-                    <a href="{{ facility.entityUrl.path }}">{{ facility.title }}</a>
-                  </p>
+                {% if fieldFacilityLocation %}
+                  <div class="vads-u-display--flex vads-u-flex-direction--column">
+                    <p class="vads-u-margin--0">
+                      <a href="{{ fieldFacilityLocation.entity.entityUrl.path }}">
+                        {{ fieldFacilityLocation.entity.title }}
+                      </a>
+                    </p>
 
-                  <p class="vads-u-margin--0">{{ fieldLocationHumanreadable }}</p>
+                    <p class="vads-u-margin--0">{{ fieldLocationHumanreadable }}</p>
+                  </div>
                 {% else %}
-                <div class="vads-u-display--flex vads-u-flex-direction--column">
-                  {% if fieldAddress.addressLine1 %}
-                    <p class="vads-u-margin--0">{{ fieldAddress.addressLine1 }}</p>
-                  {% endif %}
-
-                  {% if fieldAddress.addressLine2 %}
-                    <p class="vads-u-margin--0">{{ fieldAddress.addressLine2 }}</p>
-                  {% endif %}
-
-                  <p class="vads-u-margin--0">
-                    {% if fieldAddress.locality %}
-                      {{ fieldAddress.locality }}
+                  <div class="vads-u-display--flex vads-u-flex-direction--column">
+                    {% if fieldAddress.addressLine1 %}
+                      <p class="vads-u-margin--0">{{ fieldAddress.addressLine1 }}</p>
                     {% endif %}
 
-                    {% if fieldAddress.administrativeArea %}
-                      , {{ fieldAddress.administrativeArea }}
+                    {% if fieldAddress.addressLine2 %}
+                      <p class="vads-u-margin--0">{{ fieldAddress.addressLine2 }}</p>
                     {% endif %}
-                  </p>
-                </div>
+
+                    <p class="vads-u-margin--0">
+                      {% if fieldAddress.locality %}
+                        {{ fieldAddress.locality }}
+                      {% endif %}
+
+                      {% if fieldAddress.administrativeArea %}
+                        , {{ fieldAddress.administrativeArea }}
+                      {% endif %}
+                    </p>
+                  </div>
                 {% endif %}
               </div>
             {% endif %}


### PR DESCRIPTION
## Description

Event pages have recently not shown their locations. It looks like removing an outdated template caused the bug, so updating the location variables to only the most recent ones looks to have fixed it.

Closes [#9442](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9442).

## Testing done

Visual ([confirm locally here](http://localhost:3002/preview?nodeId=47378)).

## Screenshots

<img width="835" alt="Screen Shot 2022-06-30 at 4 15 23 PM" src="https://user-images.githubusercontent.com/10790736/176770744-622d03ba-01cb-45e9-aa45-e070288b1181.png">

## Acceptance criteria
- [ ] Events with a location should show the location details, and link to the facility page.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
