### PR TITLE
Add clean up steps to weekly accessibility heading order scan

### DIFF
--- a/.github/workflows/a11y-heading-order.yml
+++ b/.github/workflows/a11y-heading-order.yml
@@ -111,6 +111,9 @@ jobs:
           path: content-build/test-build.tar.bz2
           retention-days: 1
 
+      - name: Runner clean up
+        run: rm -rf ../content-build
+
   a11y:
     name: Accessibility Tests
     needs: build
@@ -194,6 +197,11 @@ jobs:
           name: a11y_failures
           path: a11y_failures-${{ matrix.ci_node_index }}.csv
           retention-days: 30
+
+      - name: Runner clean up
+        run: |
+          rm -rf build
+          rm /__w/content-build/content-build/test-build.tar.bz2
 
   slack:
     name: Notify Slack


### PR DESCRIPTION
## Description
This PR adds clean up steps to the weekly accessibility heading order scan in order to minimize the risk of self-hosted runners running out of disk space.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/43420