### PR TITLE
VACMS-9588 Fix syntax for accordion event tracking

### DIFF
--- a/src/site/facilities/health_service.drupal.liquid
+++ b/src/site/facilities/health_service.drupal.liquid
@@ -26,14 +26,14 @@
                             {% if location.entity.status and facility != empty %}
                                 <li class="vads-u-margin-bottom--2">
                                     <a
-                                        onclick="recordEvent(
+                                        onclick='recordEvent(
                                             {
-                                                'event': 'nav-accordion-link-click',
-                                                'accordion-parent-label': '{{ serviceTaxonomy.name }}',
-                                                'accordion-child-label': '{{ serviceTaxonomy.fieldAlsoKnownAs }}',
-                                                'accordion-section-label': '{{ sectionName }}'
+                                                "event": "nav-accordion-link-click",
+                                                "accordion-parent-label": "{{ serviceTaxonomy.name | escape }}",
+                                                "accordion-child-label": "{{ serviceTaxonomy.fieldAlsoKnownAs | escape }}",
+                                                "accordion-section-label": "{{ sectionName | escape }}"
 
-                                            })"
+                                            })'
                                         href="{{ facility.entityUrl.path }}"
                                     >
                                         {{ facility.title }}


### PR DESCRIPTION
## Description

The event tracking in the accordions is causing JS syntax errors that affect other interactions, like showing the feedback modal. This PR makes two changes to avoid this:

1. Use double quotes around the event tracking values so they don't cancel out the single quotes used as apostrophes in the value.
2. Add `escape` filters to the variables for any special characters

Closes [#9588](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9588).

## Testing done

Visual, although I hit some obstacles in fully reproducing it.

## Screenshots

N/A

## Acceptance criteria
- [ ] Feedback modals on pages like [West Los Angeles VA Medical Center](https://www.va.gov/greater-los-angeles-health-care/locations/west-los-angeles-va-medical-center/) work, and the apostrophes in the accordions don't break the functionality.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
