### PR TITLE
Fix Supplemental Claim breadcrumbs

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1253,22 +1253,23 @@
     "productId": "05712241-0f46-4e84-8d3e-70a6cf412a5e",
     "template": {
       "vagovprod": false,
-      "layout": "page-react.html"
-    },
-    "breadcrumbs_override": [
-      {
-        "name": "Decision reviews and appeals",
-        "path": "decision-reviews"
-      },
-      {
-        "name": "Supplemental Claims",
-        "path": "decision-reviews/supplemental-claim"
-      },
-      {
-        "name": "Request a Supplemental Claim",
-        "path": "decision-reviews/supplemental-claim/request-supplemental-claim-form-20-0995"
-      }
-    ]
+      "layout": "page-react.html",
+      "includeBreadcrumbs": true,
+      "breadcrumbs_override": [
+        {
+          "name": "Decision reviews and appeals",
+          "path": "decision-reviews"
+        },
+        {
+          "name": "Supplemental Claims",
+          "path": "decision-reviews/supplemental-claim"
+        },
+        {
+          "name": "Request a Supplemental Claim",
+          "path": "decision-reviews/supplemental-claim/request-supplemental-claim-form-20-0995"
+        }
+      ]
+    }
   },
   {
     "appName": "'Fry/DEA — VA Education Benefits For Survivors And Dependents'",


### PR DESCRIPTION
## Description

Fix Supplemental Claims breadcrumbs:
- Add missing `includeBreadcrumbs` setting
- Move `breadcrumbs_override` inside `template`

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/43928

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [x] Breadcrumbs working

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
