### PR TITLE
[CDP] Update to new URL

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1239,7 +1239,7 @@
   {
     "appName": "Combined Debt Portal",
     "entryName": "combined-debt-portal",
-    "rootUrl": "/manage-debt-and-bills/summary",
+    "rootUrl": "/manage-va-debt/summary",
     "template": {
       "vagovprod": true,
       "vagovstaging": true,


### PR DESCRIPTION
## Description
Updating combined-debt-portal with new URL
Moving from ~~`/manage-debt-and-bills/summary`~~ to `/manage-va-debt/summary`
[vets-website matching url update](https://github.com/department-of-veterans-affairs/vets-website/pull/21590)

## Acceptance criteria
- [ ] URL has been updated in registry 

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
