### PR TITLE
added logic for including building info on non va facilities

### DIFF
--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -74,7 +74,11 @@
                     <p class="vads-u-margin--0">{{ fieldLocationHumanreadable }}</p>
                   </div>
                 {% else %}
+
                   <div class="vads-u-display--flex vads-u-flex-direction--column">
+                    {% if fieldLocationHumanreadable %}
+                      <p class="vads-u-margin--0">{{ fieldLocationHumanreadable }}</p>
+                    {% endif %} 
                     {% if fieldAddress.addressLine1 %}
                       <p class="vads-u-margin--0">{{ fieldAddress.addressLine1 }}</p>
                     {% endif %}


### PR DESCRIPTION
## Description
Included building / room information on event address for all facilities when present

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9719

## Testing done
Visual confirmation

## Screenshots
<img width="657" alt="image" src="https://user-images.githubusercontent.com/61624970/178515092-6c3056b0-9769-4d5f-aea6-9fdeff702a05.png">


## Acceptance criteria
- [ ] Room/building is displayed on event page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
