### PR TITLE
9718 online location added

### DIFF
--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -74,11 +74,7 @@
                     <p class="vads-u-margin--0">{{ fieldLocationHumanreadable }}</p>
                   </div>
                 {% else %}
-
                   <div class="vads-u-display--flex vads-u-flex-direction--column">
-                    {% if fieldLocationHumanreadable %}
-                      <p class="vads-u-margin--0">{{ fieldLocationHumanreadable }}</p>
-                    {% endif %} 
                     {% if fieldAddress.addressLine1 %}
                       <p class="vads-u-margin--0">{{ fieldAddress.addressLine1 }}</p>
                     {% endif %}

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -74,7 +74,11 @@
                     <p class="vads-u-margin--0">{{ fieldLocationHumanreadable }}</p>
                   </div>
                 {% else %}
+
                   <div class="vads-u-display--flex vads-u-flex-direction--column">
+                    {% if fieldLocationHumanreadable %}
+                      <p class="vads-u-margin--0">{{ fieldLocationHumanreadable }}</p>
+                    {% endif %} 
                     {% if fieldAddress.addressLine1 %}
                       <p class="vads-u-margin--0">{{ fieldAddress.addressLine1 }}</p>
                     {% endif %}

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -101,6 +101,15 @@
               </div>
             {% endif %}
 
+            {% if fieldLocationType == "online" %}
+              <div class="vads-u-display--flex vads-u-flex-direction--row vads-u-margin-top--1 vads-u-margin-bottom--2">
+                <p class="vads-u-margin--0 vads-u-margin-right--0p5">
+                  <strong>Where:</strong>
+                </p>
+                <p class="vads-u-margin--0">This is an online event.</p>
+                </div>
+            {% endif %}
+
             <!-- Cost -->
             {% if fieldEventCost %}
               <div class="vads-u-display--flex vads-u-flex-direction--row vads-u-margin-top--1 vads-u-margin-bottom--2">


### PR DESCRIPTION
## Description
Logic added to include location for online events

## Testing done
Local visual confirmation

## Screenshots
<img width="871" alt="Screen Shot 2022-07-12 at 11 22 13 AM" src="https://user-images.githubusercontent.com/61624970/178526452-3c2d2191-eeb8-46de-86a7-bbd06bc6307e.png">


## Acceptance criteria
- [ ] "This is an online event" displays as the location for online events

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
