### PR TITLE
9721 screenreader no h1 heading on page

### DIFF
--- a/src/site/includes/hero.html
+++ b/src/site/includes/hero.html
@@ -14,7 +14,7 @@
         <!-- start first column-->
         <div class="vads-l-col--12 medium-screen:vads-l-col--5">
           <div class="vads-u-padding-x--7">
-            <h2 class="vads-u-color--white">Access and manage your VA benefits and health care</h2>
+            <h1 class="vads-u-color--white heading-level-2 vads-u-margin-top--5">Access and manage your VA benefits and health care</h1>
 
             <div id="myva-login--hero">
               <button onclick="recordEvent({ event: 'nav-main-sign-in' });" class="usa-button homepage-hero__button signin-signup-modal-trigger">

--- a/src/site/includes/hero.html
+++ b/src/site/includes/hero.html
@@ -13,7 +13,7 @@
 
         <!-- start first column-->
         <div class="vads-l-col--12 medium-screen:vads-l-col--5">
-          <div class="vads-u-padding-x--7">
+          <div class="vads-u-padding-x--7 vads-u-padding-bottom--2">
             <h1 class="vads-u-color--white heading-level-2 vads-u-margin-top--5">Access and manage your VA benefits and health care</h1>
 
             <div id="myva-login--hero">


### PR DESCRIPTION
## Description

Changed heading 'Access and manage your VA benefits and health care' to a H1 so that the page would have at least one H1.

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9721


## Testing done

- Visual
- Axe Dev Tools to confirm that the heading error went away


## Screenshots

![Screen Shot 2022-07-13 at 10 23 28 AM](https://user-images.githubusercontent.com/2982977/178757576-df8a219b-2936-43c7-9941-6438d4955d6c.png)


## Acceptance criteria
- [ ] There is a H1 on the page
- [ ] It looks the same

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
