### PR TITLE
Change hub h2 to h3

### DIFF
--- a/src/site/layouts/home-preview.drupal.liquid
+++ b/src/site/layouts/home-preview.drupal.liquid
@@ -17,7 +17,7 @@
     <h2 class="vads-u-color--gray-dark vads-u-font-family--sans usa-width-two-thirds">Learn about and apply for VA benefits and health care</h2>
     {% for hub in hubs %}
       <div class="usa-width-one-third" data-e2e="hub" data-entity-id="{{ hub.entity.entityId }}">
-        <h2 class="heading-level-4"><a href="{{ hub.entity.entityUrl.path }}" onclick="recordEvent({ event: 'nav-linkslist' });"><i class="icon-small icon-heading hub-icon-{{ hub.entity.fieldTitleIcon }} hub-background-{{ hub.entity.fieldTitleIcon }} white vads-u-margin-right--0p5"></i>{{ hub.entity.fieldHomePageHubLabel }}</a></h2>
+        <h3 class="heading-level-4"><a href="{{ hub.entity.entityUrl.path }}" onclick="recordEvent({ event: 'nav-linkslist' });"><i class="icon-small icon-heading hub-icon-{{ hub.entity.fieldTitleIcon }} hub-background-{{ hub.entity.fieldTitleIcon }} white vads-u-margin-right--0p5"></i>{{ hub.entity.fieldHomePageHubLabel }}</a></h3>
         <p class="vads-u-margin-top--0">{{ hub.entity.fieldTeaserText }}</p>
       </div>
       {% comment %} Close this row and open a new one when needed. {% endcomment %}


### PR DESCRIPTION
## Description

Changed h2s to h3s under the heading 'Learn about and apply for VA benefits and health care'

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9722

## Testing done

Visual

## Acceptance criteria
- [x] Sub-categories listed after the `h2` text "Learn about and apply for VA benefits and health care" are `h3` elements.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
