### PR TITLE
[VA-9738] Include "Converting to Cerner" logic in topTaskUrl link filter

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1302,27 +1302,33 @@ module.exports = function registerFilters() {
     return sidebarData;
   };
 
-  liquid.filters.topTaskUrl = (flag, path) => {
-    if (flag === 'cerner' && path === 'refill-track-prescriptions/') {
-      return 'https://patientportal.myhealth.va.gov/pages/medications/current';
+  liquid.filters.topTaskUrl = (flag, path, buildtype) => {
+    const isNotProd = buildtype !== 'vagovprod';
+
+    // If cerner, or if cerner-staged in a non-prod environment
+    if (flag === 'cerner' || (flag === 'cerner_staged' && isNotProd)) {
+      if (path === 'refill-track-prescriptions/') {
+        return 'https://patientportal.myhealth.va.gov/pages/medications/current';
+      }
+
+      if (path === 'secure-messaging/') {
+        return 'https://patientportal.myhealth.va.gov/pages/messaging/inbox';
+      }
+
+      if (path === 'schedule-view-va-appointments/') {
+        return 'https://patientportal.myhealth.va.gov/pages/scheduling/upcoming';
+      }
+
+      if (path === 'get-medical-records/') {
+        return 'https://patientportal.myhealth.va.gov/pages/health_record/clinical_documents/open_notes?pagelet=https%3A%2F%2Fportal.myhealth.va.gov%2Fperson%2F1056308125V679416%2Fhealth-record%2Fopen-notes';
+      }
+
+      if (path === 'view-test-and-lab-results/') {
+        return 'https://patientportal.myhealth.va.gov/pages/health_record/results';
+      }
     }
 
-    if (flag === 'cerner' && path === 'secure-messaging/') {
-      return 'https://patientportal.myhealth.va.gov/pages/messaging/inbox';
-    }
-
-    if (flag === 'cerner' && path === 'schedule-view-va-appointments/') {
-      return 'https://patientportal.myhealth.va.gov/pages/scheduling/upcoming';
-    }
-
-    if (flag === 'cerner' && path === 'get-medical-records/') {
-      return 'https://patientportal.myhealth.va.gov/pages/health_record/clinical_documents/open_notes?pagelet=https%3A%2F%2Fportal.myhealth.va.gov%2Fperson%2F1056308125V679416%2Fhealth-record%2Fopen-notes';
-    }
-
-    if (flag === 'cerner' && path === 'view-test-and-lab-results/') {
-      return 'https://patientportal.myhealth.va.gov/pages/health_record/results';
-    }
-
+    // Vista equivalent
     return `/health-care/${path}`;
   };
 

--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -55,7 +55,7 @@
                 class="vads-u-margin-right--0 medium-screen:vads-u-margin-right--3">
                 <div class="vads-facility-hub-cta">
                   <a onClick="recordEvent({ event: 'cta-hub-link-click' });"
-                    href="{{ fieldVamcEhrSystem | topTaskUrl: "refill-track-prescriptions/" }}"
+                    href="{{ fieldVamcEhrSystem | topTaskUrl: "refill-track-prescriptions/", buildtype }}"
                     class="top-task-link vads-u-height--full vads-u-width--full">
                     <i
                       class=" fa fa-prescription-bottle vads-facility-hub-cta-circle">&nbsp;</i>
@@ -66,7 +66,7 @@
                 </div>
                 <div class="vads-facility-hub-cta">
                   <a onClick="recordEvent({ event: 'cta-hub-link-click' });"
-                    href="{{ fieldVamcEhrSystem | topTaskUrl: "secure-messaging/" }}"
+                    href="{{ fieldVamcEhrSystem | topTaskUrl: "secure-messaging/", buildtype }}"
                     class="top-task-link vads-u-height--full vads-u-width--full">
                     <i
                       class="far fa-comments vads-facility-hub-cta-circle">&nbsp;</i>
@@ -78,7 +78,7 @@
                 <div
                   class="vads-facility-hub-cta vads-u-border-color--primary-alt-light medium-screen:vads-u-border-bottom--1px">
                   <a onClick="recordEvent({ event: 'cta-hub-link-click' });"
-                    href="{{ fieldVamcEhrSystem | topTaskUrl: "schedule-view-va-appointments/", title }}"
+                    href="{{ fieldVamcEhrSystem | topTaskUrl: "schedule-view-va-appointments/", buildtype }}"
                     class="top-task-link vads-u-height--full vads-u-width--full">
                     <i
                       class="far fa-calendar-check vads-facility-hub-cta-circle">&nbsp;</i>
@@ -91,7 +91,7 @@
               <div>
                 <div class="vads-facility-hub-cta">
                   <a onClick="recordEvent({ event: 'cta-hub-link-click' });"
-                    href="{{ fieldVamcEhrSystem | topTaskUrl: "get-medical-records/" }}"
+                    href="{{ fieldVamcEhrSystem | topTaskUrl: "get-medical-records/", buildtype }}"
                     class="top-task-link vads-u-height--full vads-u-width--full">
                     <i
                       class="fa fa-file-medical vads-facility-hub-cta-circle">&nbsp;</i>
@@ -102,7 +102,7 @@
                 </div>
                 <div class="vads-facility-hub-cta">
                   <a onClick="recordEvent({ event: 'cta-hub-link-click' });"
-                    href="{{ fieldVamcEhrSystem | topTaskUrl: "view-test-and-lab-results/" }}"
+                    href="{{ fieldVamcEhrSystem | topTaskUrl: "view-test-and-lab-results/", buildtype }}"
                     class="top-task-link vads-u-height--full vads-u-width--full">
                     <i
                       class="fa fa-clipboard-list vads-facility-hub-cta-circle">&nbsp;</i>
@@ -190,7 +190,7 @@
 
         </article>
             <!-- Last updated & feedback button-->
-        {% include "src/site/includes/above-footer-elements.drupal.liquid" %}           
+        {% include "src/site/includes/above-footer-elements.drupal.liquid" %}
       </div>
     </div>
   </main>


### PR DESCRIPTION
## Description

The links for managing online health need to include logic for "converting to cerner," or `cerner_staged`. The logic for which URLs are chosen is explained in the ticket.

Closes [#9738.](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9738)

## Testing done

Visual on [this localhost page.](http://localhost:3002/preview?nodeId=8127)

## Screenshots

<img width="1064" alt="Screen Shot 2022-07-19 at 12 57 54 PM" src="https://user-images.githubusercontent.com/10790736/179807281-10430458-d16c-47fa-9219-a51b2f0bd8df.png">

## Acceptance criteria

- [ ] When `cerner_staged` is selected and it's not production, it shows the cerner portal links
- [ ] When `cerner_staged` is selected and it is production, it shows the vista links that go to other va.gov **pages**

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
