### PR TITLE
VACMS-9840: Works around a Drupal bug with updating alt text in image media.

### DIFF
--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -248,7 +248,7 @@
                   <div class="vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-margin-bottom--4">
                     {% if storyTeaser.entity.fieldMedia.entity.thumbnail.derivative.url %}
                       <img
-                        alt="{{ storyTeaser.entity.fieldMedia.entity.thumbnail.alt }}"
+                        alt="{{ storyTeaser.entity.fieldMedia.entity.image.alt }}"
                         class="story-image vads-u-height--full medium-screen:vads-u-margin-right--2"
                         height="{{ storyTeaser.entity.fieldMedia.entity.thumbnail.derivative.height }}"
                         src="{{ storyTeaser.entity.fieldMedia.entity.thumbnail.derivative.url }}"

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -106,7 +106,7 @@
           <div class="vads-l-col--12 medium-screen:vads-l-col--4 vads-u-align-content--stretch vads-u-margin-y--1 ">
             <div class="vads-u-background-color--gray-light-alt vads-u-height--full medium-screen:vads-u-margin-x--1 medium-screen:vads-u-margin-y--0">
               <img
-                alt="{{ promo.entity.fieldImage.entity.thumbnail.alt }}"
+                alt="{{ promo.entity.fieldImage.entity.image.alt }}"
                 height="{{ promo.entity.fieldImage.entity.thumbnail.derivative.height }}"
                 src="{{ promo.entity.fieldImage.entity.thumbnail.derivative.url }}"
                 width="{{ promo.entity.fieldImage.entity.thumbnail.derivative.width }}"

--- a/src/site/layouts/step_by_step.drupal.liquid
+++ b/src/site/layouts/step_by_step.drupal.liquid
@@ -59,7 +59,7 @@
                                 <div class="vads-u-margin--1p5">
                                 {% include "src/site/paragraphs/alert_single.drupal.liquid" with entity = fieldStep.entity.fieldAlert.entity %}
                                 </div>
-                                <img alt="{{ fieldStep.entity.fieldMedia.entity.thumbnail.alt }}"
+                                <img alt="{{ fieldStep.entity.fieldMedia.entity.image.alt }}"
                                 src="{{ fieldStep.entity.fieldMedia.entity.thumbnail.url }}" />
                             </div>
                           </span>
@@ -75,7 +75,7 @@
                       {% endif %}
                     <!-- Step image -->
                     {% if fieldStep.entity.fieldMedia.entity != empty %}
-                      <img alt="{{ fieldStep.entity.fieldMedia.entity.thumbnail.alt }}"
+                      <img alt="{{ fieldStep.entity.fieldMedia.entity.image.alt }}"
                         src="{{ fieldStep.entity.fieldMedia.entity.thumbnail.url }}" />
                     {% endif %}
                   </span>

--- a/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
@@ -162,8 +162,12 @@ const nodeCampaignLandingPage = `
                     height
                   }
                   targetId
-                  alt
                   title
+                }
+              }
+              ... on MediaImage {
+                image {
+                  alt
                 }
               }
             }
@@ -200,8 +204,12 @@ const nodeCampaignLandingPage = `
                     height
                   }
                   targetId
-                  alt
                   title
+                }
+              }
+              ... on MediaImage {
+                image {
+                  alt
                 }
               }
             }
@@ -238,8 +246,12 @@ const nodeCampaignLandingPage = `
               width
             }
             targetId
-            alt
             title
+          }
+        }
+        ... on MediaImage {
+          image {
+            alt
           }
         }
       }

--- a/src/site/stages/build/drupal/graphql/nodeStepByStep.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeStepByStep.graphql.js
@@ -41,8 +41,12 @@ fragment nodeStepByStep on NodeStepByStep {
                 entity {
                   ... on Media {
                     thumbnail {
-                      alt
                       url
+                    }
+                  }
+                  ... on MediaImage {
+                    image {
+                      alt
                     }
                   }
                 }


### PR DESCRIPTION
## Description
See department-of-veterans-affairs/va.gov-cms#9840.

If you update the alt text of a Media Image in Drupal, the alt text is not actually changed; see this core issue: https://www.drupal.org/project/drupal/issues/3232414 (which I've yet to chime in on)

I've changed the GraphQL queries referring to thumbnail.alt and the liquid templates so that the content build will reflect the latest alt text, rather than the original alt text.

I made the simplest and probably dumbest changes possible because I don't really speak GraphQL and I'm an idiot even when I'm fluent in the thing in question, so apologies if I'm missing something obvious.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
