### PR TITLE
Conditionally use the expandable alert component

### DIFF
--- a/src/site/blocks/alert.drupal.liquid
+++ b/src/site/blocks/alert.drupal.liquid
@@ -5,29 +5,16 @@
 {% endif %}
 
 {% if isPreview or alert.entityPublished %}
-  <va-alert data-template="blocks/alert" data-entity-id="{{ alert.entityId }}" status="{{ alertType }}" class="vads-u-margin-top--3" role="alert">
-    <h2 slot="headline" class="vads-u-font-size--h3">
-      {{ alert.fieldAlertTitle }}
-    </h2>
-
-    {% if alert.fieldAlertContent.entity.fieldTextExpander == empty %}
-      {{ alert.fieldAlertContent.entity.fieldWysiwyg.processed }}
-    {% endif %}
-
     {% if alert.fieldAlertContent.entity.fieldTextExpander %}
-      {% comment %}
-        NOTE: .additional-info-container is a class utilized by
-        createAdditionalInfoWidget.js to add toggle functionality to info alerts
-      {% endcomment %}
-      <div data-alert-box-title="{{ alert.fieldAlertTitle }}" data-label="{{ alert.fieldAlertContent.entity.fieldTextExpander }}" class="form-expanding-group borderless-alert additional-info-container">
-        <div class="additional-info-title">
-          {{ alert.fieldAlertContent.entity.fieldTextExpander }}
-        </div>
-
-        {% if alert.fieldAlertContent.entity.fieldWysiwyg %}
-          <div class="additional-info-content usa-alert-text" hidden>{{ alert.fieldAlertContent.entity.fieldWysiwyg.processed }}</div>
-        {% endif %}
-      </div>
+      <va-alert-expandable status="{{ alertType }}" trigger="{{alert.fieldAlertTitle }}" data-template="blocks/alert" data-entity-id="{{ alert.entityId }}" class="vads-u-margin-top--3" role="alert">
+        {{ alert.fieldAlertContent.entity.fieldWysiwyg.processed }}
+      </va-alert-expandable>
+    {% elsif alert.fieldAlertContent.entity.fieldTextExpander == empty %}
+      <va-alert data-template="blocks/alert" data-entity-id="{{ alert.entityId }}" status="{{ alertType }}" class="vads-u-margin-top--3" role="alert">
+        <h2 slot="headline" class="vads-u-font-size--h3">
+          {{ alert.fieldAlertTitle }}
+        </h2>
+        {{ alert.fieldAlertContent.entity.fieldWysiwyg.processed }}
+      </va-alert>
     {% endif %}
-  </va-alert>
 {% endif %}

--- a/src/site/blocks/alert.drupal.liquid
+++ b/src/site/blocks/alert.drupal.liquid
@@ -10,7 +10,7 @@
         {{ alert.fieldAlertContent.entity.fieldWysiwyg.processed }}
       </va-alert-expandable>
     {% elsif alert.fieldAlertContent.entity.fieldTextExpander == empty %}
-      <va-alert data-template="blocks/alert" data-entity-id="{{ alert.entityId }}" status="{{ alertType }}" class="vads-u-margin-top--3" role="alert">
+      <va-alert status="{{ alertType }}" data-template="blocks/alert" data-entity-id="{{ alert.entityId }}" class="vads-u-margin-top--3" role="alert">
         <h2 slot="headline" class="vads-u-font-size--h3">
           {{ alert.fieldAlertTitle }}
         </h2>


### PR DESCRIPTION
## Description

This updates a template to follow [Design System guidance on the Additional Info component](https://design.va.gov/components/additional-info#when-to-consider-something-else):

> Do not use this component inside an [Alert](https://design.va.gov/components/alert). Try the [Alert - Expandable](https://design.va.gov/components/alert-expandable) component instead, especially when the Alert is within the page content and not at the top of the page.

## Testing done

Local build :eyes: 

## Screenshots

The `/cincinnati-health-care/health-services/suicide-prevention` page:

### Before

![Screenshot of the page on staging with the "How do I talk to someone right now" alert in the viewport and the "Find out how to get support anytime, day or night" additional info component inside the alert expanded.](https://user-images.githubusercontent.com/2008881/183200928-c04b1697-cc2d-4fb4-8d7c-d8dde81c4e9f.png)


### After

![Screenshot of a browser page showing `<va-expandable-alert>` with `data-template="blocks/alert"`](https://user-images.githubusercontent.com/2008881/180097157-35dc28df-1f7a-49d9-937b-87de6478e5d4.png)

A regular alert on the `careers-employment/vocational-rehabilitation/how-to-apply` page:

![Screenshot of a browser page showing a regular alert with the `data-template="blocks/alert"`](https://user-images.githubusercontent.com/2008881/180097295-2ac9321a-3656-40a9-bc8a-d9a74082d6bd.png)

However, the changes here still don't address content structures like this which would still give us an additional-info lookalike inside of an alert component:
 (on page `/resources/choosing-between-urgent-and-emergency-care/`)
 
![Screenshot of a page showing an alert `date-template="paragraphs/alert"` with a `data-template="paragraphs/expandable_text"` inside which looks like an additional info component.](https://user-images.githubusercontent.com/2008881/180102091-03f759ca-4189-4e78-b3c5-a25fb6789ae1.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
