### PR TITLE
[VA-1294] Add Schemas to FAQ Pages

### DIFF
--- a/src/site/includes/faq-schema.liquid
+++ b/src/site/includes/faq-schema.liquid
@@ -1,0 +1,18 @@
+<script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {% for faq in FAQs.fetched.fieldQuestions %}
+        {
+          "@type": "Question",
+          "name": "{% for question in faq.entity.fieldQuestion %}{{ question.value }}{% endfor %}",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "{% for answer in faq.entity.fieldAnswer %}{% for answerContent in answer.entity.fieldWysiwyg %}{{ answerContent.value | strip_newlines | replace: "\"", "'" | replace: "&nbsp;", " " }}{% endfor %}{% endfor %}"
+          }
+        }{% if forloop.last != true %},{% endif %}
+      {% endfor %}
+    ]
+  }
+</script>

--- a/src/site/layouts/faq_multiple_q_a.drupal.liquid
+++ b/src/site/layouts/faq_multiple_q_a.drupal.liquid
@@ -1,3 +1,23 @@
+{% for faqGroup in fieldQAGroups %}
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {% for fieldQA in faqGroup.entity.fieldQAs %}
+          {
+            "@type": "Question",
+            "name": "{{ fieldQA.entity.title }}",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "{{ fieldQA.entity.fieldAnswer.entity.fieldWysiwyg.processed | strip_newlines | replace: "\"", "'" | replace: "&nbsp;", " " }}"
+          }{% if forloop.last != true %},{% endif %}
+        {% endfor %}
+      ]
+    }
+  </script>
+{% endfor %}
+
 {% include "src/site/includes/header.html" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" with constructLcBreadcrumbs = true titleInclude = true %}

--- a/src/site/layouts/vamc_system_medical_records_offi.drupal.liquid
+++ b/src/site/layouts/vamc_system_medical_records_offi.drupal.liquid
@@ -1,3 +1,4 @@
+{% include "src/site/includes/faq-schema.liquid" with FAQs = fieldCcFaqs %}
 {% include "src/site/includes/header.html" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}

--- a/src/site/layouts/vet_center.drupal.liquid
+++ b/src/site/layouts/vet_center.drupal.liquid
@@ -1,3 +1,4 @@
+{% include "src/site/includes/faq-schema.liquid" with FAQs = fieldCcVetCenterFaqs %}
 {% include "src/site/includes/header.html" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" with

--- a/src/site/paragraphs/q_a_section.drupal.liquid
+++ b/src/site/paragraphs/q_a_section.drupal.liquid
@@ -11,6 +11,25 @@
     ]
   }
 {% endcomment %}
+
+<script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {% for fieldQuestion in entity.fieldQuestions %}
+        {
+          "@type": "Question",
+          "name": "{{ fieldQuestion.entity.fieldQuestion }}",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "{% for answer in fieldQuestion.entity.fieldAnswer %}{{ answer.entity.fieldWysiwyg.processed | strip_newlines | replace: "\"", "'" | replace: "&nbsp;", " " }}{% endfor %}"
+        }{% if forloop.last != true %},{% endif %}
+      {% endfor %}
+    ]
+  }
+</script>
+
 <div data-template="paragraphs/q_a_section" data-entity-id="{{ entity.entityId }}">
   {% if entity.fieldSectionHeader != empty %}
     <h2>{{ entity.fieldSectionHeader }}</h2>


### PR DESCRIPTION
## Description

Several FAQ pages and components don't have the Google Schema code included in the page so the questions and answers will show up in search results. This adds the schema code to the HTML for the needed code in three layouts and one component.

I went through all the listed pages in the original ticket and added the schemas to all the pages where the FAQ data was present in the page's MetalSmith object. It couldn't be added to pages where the questions and answers were added in plain text inputs.

Closes [#1294](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/1294).

## Testing done

Visual, code inspection

## Screenshots

### Schemas on Facility Pages

<a href="http://localhost:3002/preview?nodeId=3676">Norristown Vet Center</a>

<img width="603" alt="faq-vet-center" src="https://user-images.githubusercontent.com/10790736/180312687-a66e7123-c998-44cb-b878-8633bcc64f9f.png">

<a href="http://localhost:3002/preview?nodeId=45727">Medical Records Office</a>

<img width="541" alt="faq-medical-records-office" src="https://user-images.githubusercontent.com/10790736/180312698-22c878dc-48ae-466a-9417-e6d426da1efd.png">

<a href="http://localhost:3002/preview?nodeId=33833">FAQ Multiple QA Page 1</a>

<img width="582" alt="faq-multiple-QA-1" src="https://user-images.githubusercontent.com/10790736/180312694-c44a2ef2-1a89-4dae-9430-b4fb88697fdc.png">

<a href="http://localhost:3002/preview?nodeId=15594">FAQ Multiple QA Page 2</a>

<img width="537" alt="faq-multiple-QA-2" src="https://user-images.githubusercontent.com/10790736/180312690-cc9f5850-5945-4857-b7c3-56ef8aa27551.png">

<a href="http://localhost:3002/preview?nodeId=905">QA Section Component (Filing a VA Disability Claim)</a>

<img width="514" alt="faq-qa-section-component" src="https://user-images.githubusercontent.com/10790736/180312688-4d9b7ce2-fbbe-4f60-aa54-c3b5fd53d4bb.png">

## Acceptance criteria
- [ ] On all the above pages:
  - [ ] The schemas are valid JSON
  - [ ] The schema question and answer content accurately reflect the page's content
  - [ ] The pages pass the validation at https://validator.schema.org/

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
