### PR TITLE
Install yarn in accessibility workflows

### DIFF
--- a/.github/workflows/a11y-heading-order.yml
+++ b/.github/workflows/a11y-heading-order.yml
@@ -50,6 +50,10 @@ jobs:
         with:
           node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 
+      - name: Install Yarn
+        shell: bash
+        run: npm i -g yarn@1.21.1
+
       - name: Install vets-website dependencies
         uses: nick-invision/retry@v2
         with:

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -1,9 +1,9 @@
 name: Accessibility Tests
 
-on:
-  workflow_dispatch:
-  schedule:
-    - cron: '0 13 * * 1-5'
+on: [push]
+  # workflow_dispatch:
+  # schedule:
+  #   - cron: '0 13 * * 1-5'
 
 env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
@@ -72,6 +72,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
+
+      - name: Install Yarn
+        shell: bash
+        run: npm i -g yarn@1.21.1
 
       - name: Install vets-website dependencies
         uses: nick-invision/retry@v2

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -1,9 +1,9 @@
 name: Accessibility Tests
 
-on: [push]
-  # workflow_dispatch:
-  # schedule:
-  #   - cron: '0 13 * * 1-5'
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 13 * * 1-5'
 
 env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -4,6 +4,7 @@ on: [push]
   # workflow_dispatch:
   # schedule:
   #   - cron: '0 13 * * 1-5'
+  
 
 env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -4,7 +4,6 @@ on: [push]
   # workflow_dispatch:
   # schedule:
   #   - cron: '0 13 * * 1-5'
-  
 
 env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver


### PR DESCRIPTION
## Description
Due to changes in self-hosted runners used in the two accessibility scans, yarn now needs to be installed in the workflows.

## Testing done
Ran daily accessibility scan.