### PR TITLE
VACMS-9899: Correct format of revision date in find-forms detail page…

### DIFF
--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -60,9 +60,9 @@
                 <dfn class="vads-u-font-weight--bold vads-u-display--inline">Form last updated:</dfn>
                 {% assign revisionDateIsLatestUpdate = fieldVaFormRevisionDate.value | isLaterThan: fieldVaFormIssueDate.value %}
                 {% if revisionDateIsLatestUpdate %}
-                  {{ fieldVaFormRevisionDate.value | humanizeDate }}
+                  {{ fieldVaFormRevisionDate.value | formatDate: 'MMMM YYYY' }}
                 {% else %}
-                  {{ fieldVaFormIssueDate.value | humanizeDate }}
+                  {{ fieldVaFormIssueDate.value | formatDate: 'MMMM YYYY' }}
                 {% endif %}
               </dd>
             </div>


### PR DESCRIPTION
## Description
Corrects format of revision date/last modified date in find-forms detail page.

Resolves: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9899

## Screenshots
<img width="619" alt="Screen Shot 2022-07-27 at 9 13 11 AM" src="https://user-images.githubusercontent.com/221539/181298860-781ddda8-8922-4f72-bb11-0b155667a204.png">

## Acceptance criteria
- Visit /find-forms/about-form-10-10ez/
- [ ] Verify 'Form last updated' date format is MMMM YYYY (eg: March 2022)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
