### PR TITLE
Add JSON-LD to vet center template

### DIFF
--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -62,13 +62,13 @@
                         },
                         "name": "{{ title }}",
                         "telephone": "{{ fieldPhoneNumber }}",
-                        "openingHours": [
+                        "openingHoursSpecification": [
                           {% for hours in fieldOfficeHours %}
                             {
                               "@type": "OpeningHoursSpecification",
-                              "closes": "{{ hours.endhours | deriveTimeForJSONLD: 'endhours', hours.comment }}",
                               "dayOfWeek": "https://schema.org/{{ hours.day | officeHoursDayFormatter: false }}",
-                              "opens": "{{ hours.starthours | deriveTimeForJSONLD: 'starthours', hours.comment }}"
+                              "opens": "{{ hours.starthours | deriveTimeForJSONLD: 'starthours', hours.comment }}",
+                              "closes": "{{ hours.endhours | deriveTimeForJSONLD: 'endhours', hours.comment }}"
                             }{% if !forloop.last %},{% endif %}
                           {% endfor %}
                         ],

--- a/src/site/layouts/vet_center.drupal.liquid
+++ b/src/site/layouts/vet_center.drupal.liquid
@@ -39,6 +39,39 @@
               <div>
                 <div class="vads-c-facility-detail">
                   <section class="vads-facility-detail">
+                    <script type="application/ld+json">
+                      {
+                        "@context": "https://schema.org",
+                        "@type": "Place",
+                        "address": {
+                          "@type": "PostalAddress",
+                          "streetAddress": "{{ fieldAddress.addressLine1 }}",
+                          "addressLocality": "{{ fieldAddress.locality }}",
+                          "addressRegion": "{{ fieldAddress.administrativeArea }}",
+                          "postalCode": "{{ fieldAddress.postalCode }}"
+                        },
+                        "name": "{{ title }}",
+                        "telephone": "{{ fieldPhoneNumber }}",
+                        "openingHoursSpecification": [
+                          {% for hours in fieldOfficeHours %}
+                            {
+                              "@type": "OpeningHoursSpecification",
+                              "dayOfWeek": "https://schema.org/{{ hours.day | officeHoursDayFormatter: false }}",
+                              "opens": "{{ hours.starthours | deriveTimeForJSONLD: 'starthours', hours.comment }}",
+                              "closes": "{{ hours.endhours | deriveTimeForJSONLD: 'endhours', hours.comment }}"
+                            }{% if !forloop.last %},{% endif %}
+                          {% endfor %}
+                        ],
+                        "hasMap": "https://maps.google.com?saddr=Current+Location&daddr={{ fieldAddress.addressLine1 }}, {{ fieldAddress.locality }}, {{ fieldAddress.postalCode }}",
+                        "image": ["{{ fieldMedia.entity.image.derivative.url }}"],
+                        "branchCode": "{{ fieldFacilityLocatorApiId }}",
+                        "geo": {
+                          "@type": "GeoCoordinates",
+                          "latitude": "{{ fieldGeolocation.lat }}",
+                          "longitude": "{{ fieldGeolocation.lon }}"
+                        }
+                      }
+                    </script>
                     <h3 class="vads-u-font-size--lg vads-u-margin-top--0 vads-u-line-height--1 vads-u-margin-bottom--1">
                       Main Location</h3>
                     <div data-widget-type="expandable-operating-status-{{ fieldFacilityLocatorApiId }}"

--- a/src/site/stages/build/drupal/graphql/vetCenter.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vetCenter.graphql.js
@@ -76,7 +76,11 @@ const vetCenterFragment = `
          administrativeArea
          addressLine1
          addressLine2
-        }   
+        }
+        fieldGeolocation {
+          lat
+          lon
+        }
         fieldOfficeHours {
           day
           starthours


### PR DESCRIPTION
## Description

Adds JSON-LD to Vet Center Template. Brings in geolocation data from GraphQL

## Testing done

- [validator.schema.org](https://validator.schema.org/)
- visual [http/preview?nodeId=3627](http://localhost:3002/preview?nodeId=3627)

## Screenshots

![Screen Shot 2022-08-02 at 11 17 27 AM](https://user-images.githubusercontent.com/2982977/182410510-97101f36-e421-4de6-a5a9-f91a7000de9c.png)

![Screen Shot 2022-08-02 at 11 15 33 AM](https://user-images.githubusercontent.com/2982977/182410534-464380b1-1b3d-42a1-b119-064aafc0a75c.png)

## Acceptance criteria
- [x] Vet Center Pages should have place JSON-LD 
- [x] JSON-LD should have geolocation data


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
