### PR TITLE
Start daily accessibility scan one hour earlier

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -3,7 +3,7 @@ name: Accessibility Tests
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 13 * * 1-5'
+    - cron: '0 12 * * 1-5'
 
 env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver


### PR DESCRIPTION
## Description
The daily accessibility scan now takes about an hour longer than it did when it was first created. This PR modifies the start time of the scan to be one hour earlier.