### PR TITLE
9997 fe queries for vamc content types need field administration

### DIFF
--- a/src/site/stages/build/drupal/graphql/bannerAlerts.graphql.js
+++ b/src/site/stages/build/drupal/graphql/bannerAlerts.graphql.js
@@ -50,6 +50,13 @@ const bannerAlerts = `
             }
           }
         }
+        fieldAdministration {
+          entity{
+            ... on TaxonomyTermAdministration {
+              entityId
+            }
+          }
+        }
       }
     }
   }

--- a/src/site/stages/build/drupal/graphql/bioPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/bioPage.graphql.js
@@ -6,61 +6,68 @@ const entityElementsFromPages = require('./entityElementsForPages.graphql');
 const { generatePaginatedQueries } = require('../individual-queries-helpers');
 
 const personProfileFragment = `
- fragment bioPage on NodePersonProfile {
-  ${entityElementsFromPages}
-  fieldNameFirst
-  fieldLastName
-  fieldSuffix
-  fieldDescription
-  fieldEmailAddress
-  fieldPhoneNumber
-  fieldCompleteBiographyCreate
-  fieldCompleteBiography { entity { url } }
-  fieldOffice {
-      entity {
-        entityLabel
-        entityType
-        ...on NodeHealthCareRegionPage {
-          ${entityElementsFromPages}
-          title
+  fragment bioPage on NodePersonProfile {
+    ${entityElementsFromPages}
+    fieldNameFirst
+    fieldLastName
+    fieldSuffix
+    fieldDescription
+    fieldEmailAddress
+    fieldPhoneNumber
+    fieldCompleteBiographyCreate
+    fieldCompleteBiography { entity { url } }
+    fieldOffice {
+        entity {
+          entityLabel
+          entityType
+          ...on NodeHealthCareRegionPage {
+            ${entityElementsFromPages}
+            title
+          }
         }
       }
-    }
-  fieldIntroText
-  fieldPhotoAllowHiresDownload
-  fieldMedia {
-    thumbnail: entity {
-      ... on MediaImage {
-        image {
-          alt
-          title
-          derivative(style: _23MEDIUMTHUMBNAIL) {
-            url
-            width
-            height
+    fieldIntroText
+    fieldPhotoAllowHiresDownload
+    fieldMedia {
+      thumbnail: entity {
+        ... on MediaImage {
+          image {
+            alt
+            title
+            derivative(style: _23MEDIUMTHUMBNAIL) {
+              url
+              width
+              height
+            }
+          }
+        }
+      }
+      hiRes: entity {
+        ... on MediaImage {
+          image {
+            alt
+            title
+            derivative(style: ORIGINAL) {
+              url
+              width
+              height
+            }
           }
         }
       }
     }
-    hiRes: entity {
-      ... on MediaImage {
-        image {
-          alt
-          title
-          derivative(style: ORIGINAL) {
-            url
-            width
-            height
-          }
+    fieldBody {
+      processed
+    }
+    changed
+    fieldAdministration {
+      entity{
+        ... on TaxonomyTermAdministration {
+          entityId
         }
       }
     }
   }
-  fieldBody {
-    processed
-  }
-  changed
- }
 `;
 
 function getNodePersonProfilesSlice(operationName, offset, limit) {

--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionHealthServices.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionHealthServices.node.graphql.js
@@ -26,6 +26,13 @@ const HEALTH_SERVICES_RESULTS = `
                 }
               }
             }
+            fieldAdministration {
+              entity{
+                ... on TaxonomyTermAdministration {
+                  entityId
+                }
+              }
+            }
           }
         }
       }

--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionNonClinicialServices.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionNonClinicialServices.node.graphql.js
@@ -93,6 +93,13 @@ module.exports = `
                     }
                   }
                 }
+                fieldAdministration {
+                  entity{
+                    ... on TaxonomyTermAdministration {
+                      entityId
+                    }
+                  }
+                }
               }
             }
           }

--- a/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
@@ -142,6 +142,13 @@ const healthCareLocalFacilityPageFragment = `
         }
       }
     }
+    fieldAdministration {
+      entity{
+        ... on TaxonomyTermAdministration {
+          entityId
+        }
+      }
+    }
   }
 `;
 

--- a/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
@@ -139,6 +139,13 @@ const healthCareLocalFacilityPageFragment = `
               }
             }
           }
+          fieldAdministration {
+            entity{
+              ... on TaxonomyTermAdministration {
+                entityId
+              }
+            }
+          }
         }
       }
     }

--- a/src/site/stages/build/drupal/graphql/healthCareRegionDetailPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionDetailPage.graphql.js
@@ -74,6 +74,13 @@ const healthCareRegionDetailPage = `
         }
       }
     }
+    fieldAdministration {
+      entity{
+        ... on TaxonomyTermAdministration {
+          entityId
+        }
+      }
+    }
   }
 `;
 

--- a/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
@@ -152,6 +152,13 @@ const nodeHealthCareRegionPage = `
         }
       }
     }
+    fieldAdministration {
+      entity{
+        ... on TaxonomyTermAdministration {
+          entityId
+        }
+      }
+    }
   }
 `;
 

--- a/src/site/stages/build/drupal/graphql/healthServicesListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthServicesListingPage.graphql.js
@@ -7,7 +7,7 @@ const entityElementsFromPages = require('./entityElementsForPages.graphql');
 const { generatePaginatedQueries } = require('../individual-queries-helpers');
 
 const healthServicesListingPage = `
- fragment healthServicesListingPage on NodeHealthServicesListing {
+  fragment healthServicesListingPage on NodeHealthServicesListing {
     ${entityElementsFromPages}
     title
     fieldIntroText
@@ -104,7 +104,14 @@ const healthServicesListingPage = `
         }
       }
     }
- }
+    fieldAdministration {
+      entity{
+        ... on TaxonomyTermAdministration {
+          entityId
+        }
+      }
+    }
+  }
 `;
 
 function getNodeHealthServicesListingPages(operationName, offset, limit) {

--- a/src/site/stages/build/drupal/graphql/healthServicesListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthServicesListingPage.graphql.js
@@ -48,7 +48,7 @@ const healthServicesListingPage = `
               fieldLocalHealthCareService {
                 entity {
                   ... on NodeHealthCareLocalHealthService {
-                    status                  
+                    status        
                     entityUrl {
                       path
                     }
@@ -61,6 +61,13 @@ const healthServicesListingPage = `
                             }
                           }
                           title
+                        }
+                      }
+                    }
+                    fieldAdministration {
+                      entity{
+                        ... on TaxonomyTermAdministration {
+                          entityId
                         }
                       }
                     }

--- a/src/site/stages/build/drupal/graphql/leadershipListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/leadershipListingPage.graphql.js
@@ -5,7 +5,7 @@
 const entityElementsFromPages = require('./entityElementsForPages.graphql');
 
 const leadershipListingPage = `
- fragment leadershipListingPage on NodeLeadershipListing {
+  fragment leadershipListingPage on NodeLeadershipListing {
     ${entityElementsFromPages}
     title
     fieldIntroText
@@ -113,7 +113,14 @@ const leadershipListingPage = `
         }
       }
     }
- }
+    fieldAdministration {
+      entity{
+        ... on TaxonomyTermAdministration {
+          entityId
+        }
+      }
+    }
+  }
 `;
 
 const GetNodeLeadershipListingPages = `

--- a/src/site/stages/build/drupal/graphql/locationsListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/locationsListingPage.graphql.js
@@ -6,7 +6,7 @@ const entityElementsFromPages = require('./entityElementsForPages.graphql');
 const healthCareLocalFacilities = require('./facilities-fragments/healthCareLocalFacility.node.graphql');
 
 const locationListingPage = `
- fragment locationListingPage on NodeLocationsListing {
+  fragment locationListingPage on NodeLocationsListing {
     ${entityElementsFromPages}
     title
     entityId
@@ -48,7 +48,14 @@ const locationListingPage = `
         }
       }
     }
- }
+    fieldAdministration {
+      entity{
+        ... on TaxonomyTermAdministration {
+          entityId
+        }
+      }
+    }
+  }
 `;
 
 const GetNodeLocationsListingPages = `

--- a/src/site/stages/build/drupal/graphql/newStoryPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/newStoryPage.graphql.js
@@ -41,6 +41,13 @@ const newsStoryFragment = `
     fieldFullStory {
       processed
     }
+    fieldAdministration {
+      entity{
+        ... on TaxonomyTermAdministration {
+          entityId
+        }
+      }
+    }
   }
 `;
 

--- a/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
@@ -158,6 +158,13 @@ const nodeEvent = `
         }
       }
     }
+    fieldAdministration {
+      entity{
+        ... on TaxonomyTermAdministration {
+          entityId
+        }
+      }
+    }
   }
 `;
 
@@ -305,6 +312,13 @@ const nodeEventWithoutBreadcrumbs = `
         entity {
           name
           timezone
+        }
+      }
+    }
+    fieldAdministration {
+      entity{
+        ... on TaxonomyTermAdministration {
+          entityId
         }
       }
     }

--- a/src/site/stages/build/drupal/graphql/nodeEventListing.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeEventListing.graphql.js
@@ -28,6 +28,13 @@ const nodeEventListing = `
         }
       }
     }
+    fieldAdministration {
+      entity{
+        ... on TaxonomyTermAdministration {
+          entityId
+        }
+      }
+    }
   }
 `;
 

--- a/src/site/stages/build/drupal/graphql/pressReleasePage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/pressReleasePage.graphql.js
@@ -69,6 +69,13 @@ const pressReleaseFragment = `
 
       }
     }
+    fieldAdministration {
+      entity{
+        ... on TaxonomyTermAdministration {
+          entityId
+        }
+      }
+    }
   }
 `;
 

--- a/src/site/stages/build/drupal/graphql/pressReleasesListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/pressReleasesListingPage.graphql.js
@@ -5,7 +5,7 @@
 const entityElementsFromPages = require('./entityElementsForPages.graphql');
 
 const pressReleasesListingPage = `
- fragment pressReleasesListingPage on NodePressReleasesListing {
+  fragment pressReleasesListingPage on NodePressReleasesListing {
     ${entityElementsFromPages}
     fieldIntroText
     reverseFieldListingNode(limit: 500, filter: {conditions: [{field: "type", value: "press_release"}, {field: "status", value: "1", operator: EQUAL}]}) {
@@ -43,7 +43,14 @@ const pressReleasesListingPage = `
         }
       }
     }
- }
+    fieldAdministration {
+      entity{
+        ... on TaxonomyTermAdministration {
+          entityId
+        }
+      }
+    }
+  }
 `;
 
 const GetNodePressReleaseListingPages = `

--- a/src/site/stages/build/drupal/graphql/storyListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/storyListingPage.graphql.js
@@ -5,7 +5,7 @@
 const entityElementsFromPages = require('./entityElementsForPages.graphql');
 
 const storyListingPage = `
- fragment storyListingPage on NodeStoryListing {
+  fragment storyListingPage on NodeStoryListing {
     ${entityElementsFromPages}
     fieldIntroText
     reverseFieldListingNode(limit: 500, filter: {conditions: [{field: "type", value: "news_story"}, {field: "status", value: "1", operator: EQUAL}]}, sort: {field: "created", direction: DESC}) {
@@ -69,7 +69,14 @@ const storyListingPage = `
         }
       }
     }
- }
+    fieldAdministration {
+      entity{
+        ... on TaxonomyTermAdministration {
+          entityId
+        }
+      }
+    }
+  }
 `;
 
 const GetNodeStoryListingPages = `

--- a/src/site/stages/build/drupal/graphql/vamcBillingAndInsurancePage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vamcBillingAndInsurancePage.graphql.js
@@ -37,6 +37,13 @@ const billingAndInsuranceFragment = `
     fieldOffice {
       ${healthCareRegionNonClinicialServices}
     }
+    fieldAdministration {
+      entity{
+        ... on TaxonomyTermAdministration {
+          entityId
+        }
+      }
+    }
   }
 `;
 

--- a/src/site/stages/build/drupal/graphql/vamcMedicalRecordsOfficePage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vamcMedicalRecordsOfficePage.graphql.js
@@ -55,6 +55,13 @@ const medicalRecordsOfficeFragment = `
     fieldOffice {
       ${healthCareRegionNonClinicialServices}
     }
+    fieldAdministration {
+      entity{
+        ... on TaxonomyTermAdministration {
+          entityId
+        }
+      }
+    }
   }
 `;
 

--- a/src/site/stages/build/drupal/graphql/vamcOperatingStatusAndAlerts.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vamcOperatingStatusAndAlerts.graphql.js
@@ -73,6 +73,13 @@ const vamcOperatingStatusAndAlerts = `
         }
       }
     }
+    fieldAdministration {
+      entity{
+        ... on TaxonomyTermAdministration {
+          entityId
+        }
+      }
+    }
   }
 `;
 

--- a/src/site/stages/build/drupal/graphql/vamcPoliciesPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vamcPoliciesPage.graphql.js
@@ -36,7 +36,14 @@ const policiesPageFragment = `
           title
         }
       }
-    }    
+    }
+    fieldAdministration {
+      entity{
+        ... on TaxonomyTermAdministration {
+          entityId
+        }
+      }
+    } 
   }
 `;
 

--- a/src/site/stages/build/drupal/graphql/vamcRegisterForCarePage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vamcRegisterForCarePage.graphql.js
@@ -26,6 +26,13 @@ const registerForCareFragment = `
     fieldOffice {
       ${healthCareRegionNonClinicialServices}
     }
+    fieldAdministration {
+      entity{
+        ... on TaxonomyTermAdministration {
+          entityId
+        }
+      }
+    }
   }
 `;
 


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9997
All content types that can potentially appear in VAMC Lovell need to have field_administration added to the graphQL query.

## Testing done

Visual developer console

## Screenshots


## Acceptance criteria
- The graphQL queries for the following content types include field_administration 
   - Facility specific pages
      - [x] VAMC Detail Page / health_care_region_detail_page
      - [x] VAMC Facility / health_care_local_facility
      - [x] VAMC Facility Health Service / health_care_local_health_service
      - [x] VAMC System Health Service / regional_health_care_service_des
      - [x] VAMC Facility Non-clinical Service / vha_facility_nonclinical_service
      - [x] VAMC System / health_care_region_page
      - [x] VAMC System Banner Alert with Situation Updates / full_width_banner_alert
      - [x] VAMC System Billing and Insurance / vamc_system_billing_insurance
      - [x] VAMC System Locations List / locations_listing
      - [x] VAMC System Medical Records Office / vamc_system_medical_records_offi
      - [x] VAMC System Operating Status / vamc_operating_status_and_alerts
      - [x] VAMC System Policies Page / vamc_system_policies_page
      - [x] VAMC System Register for Care / vamc_system_register_for_care
      - [x] Health Services List / health_services_listing
   - Spanning all products including facilities.
      - [x] Events List / event_listing
      - [x] Event / event
      - [x] Leadership List / leadership_listing
      - [x] Staff Profile / person_profile
      - [x] News Releases List / press_releases_listing
      - [x] News Release / press_release
      - [x] Stories List / story_listing
      - [x] Story / news_story

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
