### PR TITLE
VACMS-9945: Add bifurcation for Lovell build step

### DIFF
--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -327,7 +327,7 @@ function appendDrupalDataWithLovellTricarePages(drupalData) {
     );
 
     // Modify the title
-    lovellPage.title = lovellPage.title.replace('Federal', 'Tricare');
+    lovellPage.title = lovellPage.title.replace('Federal', 'Federal TRICARE');
 
     return lovellPage;
   });

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -310,6 +310,29 @@ function getDrupalContent(buildOptions) {
     return () => {};
   }
 
+  const drupalDataWithBifurcatedLovellPages = drupalData => {
+    // Adjust this if needed to get the fieldAdministration field
+    const lovellPages = drupalData.data.nodeQuery.entities.filter(
+      page => page.fieldOffice.fieldAdministration === 347,
+    );
+    const clonedLovellPages = lovellPages.map(page => {
+      // Change the URL for the tricare pages
+      page.entityUrl.path.replace(
+        '/lovell-federal-health-care/',
+        '/lovell-tricare-health-care/',
+      );
+
+      return page;
+    });
+
+    drupalData.data.nodeQuery.entities = [
+      ...drupalData.data.nodeQuery.entities,
+      ...clonedLovellPages,
+    ];
+
+    return drupalData;
+  };
+
   return async (files, metalsmith, done) => {
     let drupalData = null;
     try {
@@ -317,6 +340,7 @@ function getDrupalContent(buildOptions) {
       drupalData = convertDrupalFilesToLocal(drupalData, files);
 
       await loadCachedDrupalFiles(buildOptions, files);
+      drupalData = drupalDataWithBifurcatedLovellPages(drupalData);
       pipeDrupalPagesIntoMetalsmith(drupalData, files);
       await createReactPages(files, drupalData);
       addHomeContent(drupalData, files, metalsmith, buildOptions);

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -323,7 +323,7 @@ function appendDrupalDataWithLovellTricarePages(drupalData) {
     // Change the URL for the tricare pages
     lovellPage.entityUrl.path = lovellPage.entityUrl.path.replace(
       '/lovell-federal-health-care',
-      '/lovell-tricare-health-care',
+      '/lovell-federal-tricare-health-care',
     );
 
     // Modify the title

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -4,6 +4,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const recursiveRead = require('recursive-readdir');
 const JSONStream = require('JSONStream');
+const cloneDeep = require('lodash/cloneDeep');
 
 const ENVIRONMENTS = require('../../../constants/environments');
 const { ENABLED_ENVIRONMENTS } = require('../../../constants/drupals');
@@ -304,34 +305,43 @@ async function loadCachedDrupalFiles(buildOptions, files) {
   }
 }
 
+function appendDrupalDataWithLovellTricarePages(drupalData) {
+  const isLovellPage = page => {
+    if (page.fieldAdministration) {
+      return page.fieldAdministration.entity.entityId === '347';
+    }
+    return false;
+  };
+
+  // Adjust this if needed to get the fieldAdministration field
+  const lovellPages = drupalData.data.nodeQuery.entities.filter(isLovellPage);
+
+  // Deep clone with lodash
+  const clonedPages = cloneDeep(lovellPages);
+
+  const modifiedLovellPages = clonedPages.map(lovellPage => {
+    // Change the URL for the tricare pages
+    lovellPage.entityUrl.path = lovellPage.entityUrl.path.replace(
+      '/lovell-federal-health-care',
+      '/lovell-tricare-health-care',
+    );
+
+    // Modify the title
+    lovellPage.title = lovellPage.title.replace('Federal', 'Tricare');
+
+    return lovellPage;
+  });
+
+  drupalData.data.nodeQuery.entities.push(...modifiedLovellPages);
+
+  return drupalData;
+}
+
 function getDrupalContent(buildOptions) {
   if (!ENABLED_ENVIRONMENTS.has(buildOptions.buildtype)) {
     log(`Drupal integration disabled for buildtype ${buildOptions.buildtype}`);
     return () => {};
   }
-
-  const drupalDataWithBifurcatedLovellPages = drupalData => {
-    // Adjust this if needed to get the fieldAdministration field
-    const lovellPages = drupalData.data.nodeQuery.entities.filter(
-      page => page.fieldOffice.fieldAdministration === 347,
-    );
-    const clonedLovellPages = lovellPages.map(page => {
-      // Change the URL for the tricare pages
-      page.entityUrl.path.replace(
-        '/lovell-federal-health-care/',
-        '/lovell-tricare-health-care/',
-      );
-
-      return page;
-    });
-
-    drupalData.data.nodeQuery.entities = [
-      ...drupalData.data.nodeQuery.entities,
-      ...clonedLovellPages,
-    ];
-
-    return drupalData;
-  };
 
   return async (files, metalsmith, done) => {
     let drupalData = null;
@@ -340,7 +350,10 @@ function getDrupalContent(buildOptions) {
       drupalData = convertDrupalFilesToLocal(drupalData, files);
 
       await loadCachedDrupalFiles(buildOptions, files);
-      drupalData = drupalDataWithBifurcatedLovellPages(drupalData);
+
+      // clone and modify for lovell tricare pages
+      drupalData = appendDrupalDataWithLovellTricarePages(drupalData);
+
       pipeDrupalPagesIntoMetalsmith(drupalData, files);
       await createReactPages(files, drupalData);
       addHomeContent(drupalData, files, metalsmith, buildOptions);

--- a/src/site/stages/build/drupal/page.js
+++ b/src/site/stages/build/drupal/page.js
@@ -68,7 +68,7 @@ function paginatePages(page, files, field, layout, ariaLabel, perPage) {
     const pagedEntities = _.chunk(page[pageField].entities, perPage);
 
     for (let pageNum = 0; pageNum < pagedEntities.length; pageNum++) {
-      let pagedPage = Object.assign({}, page);
+      let pagedPage = { ...page };
 
       if (pageNum > 0) {
         pagedPage = set(
@@ -141,7 +141,7 @@ function updateEntityUrlObj(page, drupalPagePath, title, pathSuffix) {
       .replace(/\s+/g, '-')
       .toLowerCase();
 
-  let generatedPage = Object.assign({}, page);
+  let generatedPage = { ...page };
   const absolutePath = path.join('/', drupalPagePath, pathSuffix);
 
   generatedPage.entityUrl.breadcrumb = [
@@ -226,9 +226,21 @@ function getFacilitySidebar(page, contentData) {
     }
 
     // set the correct menuName based on the page
-    const facilityNavName = facilityPage
+    let facilityNavName = facilityPage
       ? page.fieldOffice.entity.entityLabel
       : pageTitle;
+
+    // if part of lovell set facilityNavName to 'Lovell Federal health care'
+    // This is here mostly so we can change title without breaking the build
+    // This isn't working as expected no sidebars are showing on any of the tricare pages
+    // TODO: Remove this if metalsmith-drupal getDrupalContent bifurcates menus
+    if (
+      page.fieldAdministration &&
+      page.fieldAdministration.entity.entityId === '347'
+    ) {
+      console.log(page.title, facilityNavName, page.fieldRegionPage);
+      facilityNavName = 'Lovell Federal health care';
+    }
 
     // choose the correct menu name to retrieve the object from contentData
     const facilitySidebarNavName = Object.keys(
@@ -241,33 +253,32 @@ function getFacilitySidebar(page, contentData) {
 
     if (facilitySidebarNavName) {
       return contentData.data[facilitySidebarNavName];
-    } else {
-      const errorMessage = `Failed to find a facility sidebar with a name that matches the VAMC office label "${facilityNavName}".`;
-
-      console.log(chalk.red(errorMessage));
-
-      console.log(
-        chalk.red(
-          'The VAMC office label should match one of the following menu names as returned by the CMS -',
-        ),
-      );
-
-      const sidebarNames = Object.values(contentData.data)
-        .filter(queryData => queryData?.name)
-        .map(queryData => `- ${queryData.name}`);
-
-      console.log(chalk.red(sidebarNames.join('\n')));
-
-      const stringifiedPage = JSON.stringify(page, null, 2);
-
-      console.log(
-        chalk.red(
-          `Here is the entity evaluated when this error was triggered: \n${stringifiedPage}`,
-        ),
-      );
-
-      throw new Error(errorMessage);
     }
+    const errorMessage = `Failed to find a facility sidebar with a name that matches the VAMC office label "${facilityNavName}".`;
+
+    console.log(chalk.red(errorMessage));
+
+    console.log(
+      chalk.red(
+        'The VAMC office label should match one of the following menu names as returned by the CMS -',
+      ),
+    );
+
+    const sidebarNames = Object.values(contentData.data)
+      .filter(queryData => queryData?.name)
+      .map(queryData => `- ${queryData.name}`);
+
+    console.log(chalk.red(sidebarNames.join('\n')));
+
+    const stringifiedPage = JSON.stringify(page, null, 2);
+
+    console.log(
+      chalk.red(
+        `Here is the entity evaluated when this error was triggered: \n${stringifiedPage}`,
+      ),
+    );
+
+    throw new Error(errorMessage);
   }
 
   // return the default and most important of the menu structure
@@ -376,17 +387,16 @@ function compilePage(page, contentData) {
     case 'vamc_system_register_for_care':
     case 'vamc_system_billing_insurance':
     case 'vamc_system_medical_records_offi':
-      pageCompiled = Object.assign(
-        {},
-        page,
-        facilitySidebarNavItems,
-        outreachSidebarNavItems,
-        alertItems,
-        { bannerAlert: bannerAlertsItem },
-        { banners },
-        { promoBanners },
-        pageId,
-      );
+      pageCompiled = {
+        ...page,
+        ...facilitySidebarNavItems,
+        ...outreachSidebarNavItems,
+        ...alertItems,
+        bannerAlert: bannerAlertsItem,
+        banners,
+        promoBanners,
+        ...pageId,
+      };
       break;
     case 'health_care_local_facility':
     case 'vamc_operating_status_and_alerts':
@@ -425,16 +435,15 @@ function compilePage(page, contentData) {
         ...page,
         fieldFacilityOperatingStatus,
       };
-      pageCompiled = Object.assign(
-        {},
-        page,
-        facilitySidebarNavItems,
-        alertItems,
-        { bannerAlert: bannerAlertsItem },
-        { banners },
-        { promoBanners },
-        pageId,
-      );
+      pageCompiled = {
+        ...page,
+        ...facilitySidebarNavItems,
+        ...alertItems,
+        bannerAlert: bannerAlertsItem,
+        banners,
+        promoBanners,
+        ...pageId,
+      };
       break;
     case 'health_care_region_page':
     case 'press_release':
@@ -493,17 +502,16 @@ function compilePage(page, contentData) {
       sidebarNavItems = getHubSidebar(sideNavs, owner);
 
       // Build page with correct sidebar
-      pageCompiled = Object.assign(
-        {},
-        page,
-        sidebarNavItems,
-        outreachSidebarNavItems,
-        alertItems,
-        { bannerAlert: bannerAlertsItem },
-        { banners },
-        { promoBanners },
-        pageId,
-      );
+      pageCompiled = {
+        ...page,
+        ...sidebarNavItems,
+        ...outreachSidebarNavItems,
+        ...alertItems,
+        bannerAlert: bannerAlertsItem,
+        banners,
+        promoBanners,
+        ...pageId,
+      };
       break;
   }
 


### PR DESCRIPTION
## Description

This hooks into the build step, finds pages for Lovell Federal Health Care subsite, and duplicates them with needed changes for the Lovell Tricare subsite.

Currently a WIP, blocked until #1242 is merged. Also being handed off to @wullaski during the sprint.

Closes [#9945.](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9945)

## Testing done

Running `yarn build`  locally and verifying pages get created in a new `lovell-tricare-health-care` directory.

## Screenshots

![Screen Shot 2022-08-10 at 1 02 56 PM](https://user-images.githubusercontent.com/2982977/183976732-47ba6469-b62c-46ea-b5be-d015ed5dc97b.png)


## Acceptance criteria
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9945
These are looser.... than the actual acs on the issue to reflect a slight pivot.
- [x] All pages for Lovell Federal Health Care ~are properly found in the new build step function~ filtered in the get drupal data build step.
- [x] All above pages are duplicated with needed changes to the URL path so they link to the Tricare subsite
  - actual path pattern is not fully defined at this time but the code is clear on where we will put the finalized pattern. Should not prevent this from being merged to an integration branch.
  - Titles can also be altered... pattern not finalized yet.  Should not prevent this from being merged to an integration branch.
- [x] Duplicate pages are created and rendered as part of the site build.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
