### PR TITLE
Add services json-ld to vet center template

### DIFF
--- a/src/site/layouts/vet_center.drupal.liquid
+++ b/src/site/layouts/vet_center.drupal.liquid
@@ -178,7 +178,7 @@
                   "@context": "https://schema.org",
                   "@type": "GovernmentService",
                   "name": "{{ healthService.entity.fieldServiceNameAndDescripti.entity.name }}",
-                  "alternateName": "{{ healthService.entity.fieldServiceNameAndDescripti.entity.fieldVetCenterFriendlyName }}"
+                  "alternateName": "{{ healthService.entity.fieldServiceNameAndDescripti.entity.fieldVetCenterFriendlyName }}",
                   "serviceType": "{{ healthService.entity.fieldServiceNameAndDescripti.entity.fieldVetCenterTypeOfCare }}",
                   "serviceOperator": {
                     "@type": "GovernmentOrganization",

--- a/src/site/layouts/vet_center.drupal.liquid
+++ b/src/site/layouts/vet_center.drupal.liquid
@@ -45,7 +45,7 @@
                         "@type": "Place",
                         "address": {
                           "@type": "PostalAddress",
-                          "streetAddress": "{{ fieldAddress.addressLine1 }}",
+                          "streetAddress": "{{ fieldAddress.addressLine1 }}{% if fieldAddress.addressLine2 %}, {{ fieldAddress.addressLine2 }}{% endif %}",
                           "addressLocality": "{{ fieldAddress.locality }}",
                           "addressRegion": "{{ fieldAddress.administrativeArea }}",
                           "postalCode": "{{ fieldAddress.postalCode }}"
@@ -205,7 +205,7 @@
                       "name": "{{ title }}",
                       "address": {
                         "@type": "PostalAddress",
-                        "streetAddress": "{{ fieldAddress.addressLine1 }}",
+                        "streetAddress": "{{ fieldAddress.addressLine1 }}{% if fieldAddress.addressLine2 %}, {{ fieldAddress.addressLine2 }}{% endif %}",
                         "addressLocality": "{{ fieldAddress.locality }}",
                         "addressRegion": "{{ fieldAddress.administrativeArea }}",
                         "postalCode": "{{ fieldAddress.postalCode }}"

--- a/src/site/layouts/vet_center.drupal.liquid
+++ b/src/site/layouts/vet_center.drupal.liquid
@@ -201,7 +201,7 @@
                       "alternateName": "en"
                     },
                     "serviceLocation": {
-                      "@type": "Place",
+                      "@type": "GovernmentOffice",
                       "name": "{{ title }}",
                       "address": {
                         "@type": "PostalAddress",

--- a/src/site/layouts/vet_center.drupal.liquid
+++ b/src/site/layouts/vet_center.drupal.liquid
@@ -172,6 +172,48 @@
                 %}
               {% endfor %}
             </div>
+            {% for healthService in fieldHealthServices %}
+              <script type="application/ld+json">
+                {
+                  "@context": "https://schema.org",
+                  "@type": "GovernmentService",
+                  "name": "{{ healthService.entity.fieldServiceNameAndDescripti.entity.name }}",
+                  "serviceType": "{{ healthService.entity.fieldServiceNameAndDescripti.entity.fieldVetCenterTypeOfCare }}",
+                  "serviceOperator": {
+                    "@type": "GovernmentOrganization",
+                    "name": "US Department of Veterans Affairs"
+                  },
+                  "areaServed": {
+                    "@type": "AdministrativeArea",
+                    "name": "{{ fieldAddress.administrativeArea }}"
+                  },
+                  "audience": {
+                    "@type": "Audience",
+                    "name": "Veterans"
+                  },
+                  "availableChannel": {
+                    "@type": "ServiceChannel",
+                    "name": "Vet Center",
+                    "availableLanguage": {
+                      "@type": "Language",
+                      "name": "Spanish",
+                      "alternateName": "es"
+                    },
+                    "serviceLocation": {
+                      "@type": "Hospital",
+                      "name": "{{ title }}",
+                      "address": {
+                        "@type": "PostalAddress",
+                        "streetAddress": "{{ fieldAddress.addressLine1 }}",
+                        "addressLocality": "{{ fieldAddress.locality }}",
+                        "addressRegion": "{{ fieldAddress.administrativeArea }}",
+                        "postalCode": "{{ fieldAddress.postalCode }}"
+                      }
+                    }
+                  }
+                }
+              </script>
+            {% endfor %}
 
           {% include "src/site/includes/vet_centers/health_services.liquid" with
               fieldHealthServices

--- a/src/site/layouts/vet_center.drupal.liquid
+++ b/src/site/layouts/vet_center.drupal.liquid
@@ -178,6 +178,7 @@
                   "@context": "https://schema.org",
                   "@type": "GovernmentService",
                   "name": "{{ healthService.entity.fieldServiceNameAndDescripti.entity.name }}",
+                  "alternateName": "{{ healthService.entity.fieldServiceNameAndDescripti.entity.fieldVetCenterFriendlyName }}"
                   "serviceType": "{{ healthService.entity.fieldServiceNameAndDescripti.entity.fieldVetCenterTypeOfCare }}",
                   "serviceOperator": {
                     "@type": "GovernmentOrganization",
@@ -196,11 +197,11 @@
                     "name": "Vet Center",
                     "availableLanguage": {
                       "@type": "Language",
-                      "name": "Spanish",
-                      "alternateName": "es"
+                      "name": "English",
+                      "alternateName": "en"
                     },
                     "serviceLocation": {
-                      "@type": "Hospital",
+                      "@type": "Place",
                       "name": "{{ title }}",
                       "address": {
                         "@type": "PostalAddress",


### PR DESCRIPTION
## Description

Adds services json-ld to vet center template.

https://app.mural.co/t/vagov6717/m/vagov6717/1657548339031/75fd9c37c635478edcbc7d5179d95b6d53d9c339?sender=dfafbb7c-1fe6-468b-880a-a3e3fa8ff9c2

## Testing done

https://validator.schema.org

## Screenshots
![Screen Shot 2022-08-05 at 2 39 49 PM](https://user-images.githubusercontent.com/2982977/183140921-3502cb2c-7097-405f-bdc8-4415e7de156d.png)

![Screen Shot 2022-08-05 at 2 39 30 PM](https://user-images.githubusercontent.com/2982977/183140930-24aef4db-81a8-4554-a705-6d19c0b7cd10.png)


## Acceptance criteria
- [x] Services JSON-LD is present in page source
- [x] Services JSON-LD validates at validate.schema.org

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
