### PR TITLE
VACMS-10094 fe cleaning up duplicate faq schema implementation

### DIFF
--- a/src/site/includes/faq-schema.liquid
+++ b/src/site/includes/faq-schema.liquid
@@ -3,10 +3,10 @@
     "@context": "https://schema.org",
     "@type": "FAQPage",
     "mainEntity": [
-      {% for faq in FAQs.fetched.fieldQuestions %}
+      {% for faq in faqs %}
         {
           "@type": "Question",
-          "name": "{% for question in faq.entity.fieldQuestion %}{{ question.value }}{% endfor %}",
+          "name": "{{ faq.entity.fieldQuestion }}",
           "acceptedAnswer": {
             "@type": "Answer",
             "text": "{% for answer in faq.entity.fieldAnswer %}{% for answerContent in answer.entity.fieldWysiwyg %}{{ answerContent.value | strip_newlines | replace: "\"", "'" | replace: "&nbsp;", " " }}{% endfor %}{% endfor %}"

--- a/src/site/layouts/vet_center.drupal.liquid
+++ b/src/site/layouts/vet_center.drupal.liquid
@@ -1,4 +1,3 @@
-{% include "src/site/includes/faq-schema.liquid" with FAQs = fieldCcVetCenterFaqs %}
 {% include "src/site/includes/header.html" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" with

--- a/src/site/paragraphs/q_a.collapsible_panel.drupal.liquid
+++ b/src/site/paragraphs/q_a.collapsible_panel.drupal.liquid
@@ -21,12 +21,10 @@
           data-analytics-faq-text="{{ item.fieldQuestion | escape }}"
         >
           <div id="{{ item.entityBundle }}-{{ id }}">
-            <div itemprop="acceptedAnswer" itemscope="" itemtype="http://schema.org/Answer">
-              {% for answer in item.fieldAnswer %}
-                {% assign bundleComponent = "src/site/paragraphs/" | append: answer.entity.entityBundle | append: ".drupal.liquid" %}
-                {% include {{ bundleComponent }} with entity = answer.entity %}
-              {% endfor %}
-            </div>
+            {% for answer in item.fieldAnswer %}
+              {% assign bundleComponent = "src/site/paragraphs/" | append: answer.entity.entityBundle | append: ".drupal.liquid" %}
+              {% include {{ bundleComponent }} with entity = answer.entity %}
+            {% endfor %}
           </div>
         </div>
       </va-accordion-item>

--- a/src/site/paragraphs/q_a.drupal.liquid
+++ b/src/site/paragraphs/q_a.drupal.liquid
@@ -1,12 +1,12 @@
 <div data-template="paragraphs/q_a" data-entity-id="{{ entity.entityId }}" data-analytics-faq-section="{{ sectionHeader | escape }}" data-analytics-faq-text="{{ entity.fieldQuestion | escape }}">
-  <div itemscope itemprop="mainEntity" itemtype="https://schema.org/Question" id="{{ entity.entityId }}">
+  <div id="{{ entity.entityId }}">
     <div class="vads-u-display--flex">
-      <h2 itemprop="name">
+      <h2>
         {{ entity.fieldQuestion }}
       </h2>
     </div>
 
-    <div itemprop="acceptedAnswer" itemscope="" itemtype="http://schema.org/Answer" data-entity-id="{{ entity.entityId }}">
+    <div data-entity-id="{{ entity.entityId }}">
       {% for answer in entity.fieldAnswer %}
         {% assign bundleComponent = "src/site/paragraphs/" | append: answer.entity.entityBundle | append: ".drupal.liquid" %}
         {% include {{ bundleComponent }} with entity = answer.entity %}

--- a/src/site/paragraphs/q_a_section.drupal.liquid
+++ b/src/site/paragraphs/q_a_section.drupal.liquid
@@ -12,23 +12,7 @@
   }
 {% endcomment %}
 
-<script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {% for fieldQuestion in entity.fieldQuestions %}
-        {
-          "@type": "Question",
-          "name": "{{ fieldQuestion.entity.fieldQuestion }}",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "{% for answer in fieldQuestion.entity.fieldAnswer %}{{ answer.entity.fieldWysiwyg.processed | strip_newlines | replace: "\"", "'" | replace: "&nbsp;", " " }}{% endfor %}"
-        }{% if forloop.last != true %},{% endif %}
-      {% endfor %}
-    ]
-  }
-</script>
+{% include "src/site/includes/faq-schema.liquid" with faqs = entity.fieldQuestions %}
 
 <div data-template="paragraphs/q_a_section" data-entity-id="{{ entity.entityId }}">
   {% if entity.fieldSectionHeader != empty %}


### PR DESCRIPTION
## Description
 closes: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/10094
Fix validation issues on faq schema.

## Testing done

https://validator.schema.org/

## Screenshots


## Acceptance criteria
- [x] Remove microdata attributes
- [x] Use only one faq block

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
