### PR TITLE
Build prototype for new focus styles

### DIFF
--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -41,8 +41,10 @@
   </script>
 
   <!-- Add web components. -->
-  <link rel="stylesheet" data-entry-name="web-components.css">
-  <script nonce="**CSP_NONCE**" defer data-entry-name="web-components.js"></script>
+  {% if !(entityId == 11463 and buildtype != "vagovprod") %}
+    <link rel="stylesheet" data-entry-name="web-components.css">
+    <script nonce="**CSP_NONCE**" defer data-entry-name="web-components.js"></script>
+  {% endif %}
 
   <!-- Render GA template. -->
   {% include 'src/site/includes/google-analytics.liquid' %}
@@ -110,7 +112,7 @@
   {% if entityId == 11463 and buildtype != "vagovprod" %}
     <link rel="stylesheet" href="https://unpkg.com/@department-of-veterans-affairs/formation@8.0.1-0/dist/formation.min.css">
     <script type="module">
-      import { defineCustomElements } from "https://unpkg.com/@department-of-veterans-affairs/web-components@4.10.2-0/loader/index.es2017.js";
+      import { defineCustomElements } from "https://unpkg.com/@department-of-veterans-affairs/web-components@4.10.2-1/loader/index.es2017.js";
       defineCustomElements();
     </script>
     <link

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -118,6 +118,11 @@
       type="text/css"
       href="https://unpkg.com/@department-of-veterans-affairs/component-library/dist/main.css"
     />
+    <style>
+      .usa-accordion-button:focus {
+        border: none !important;
+      }
+    </style>
   {% endif %}
 
 </head>

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -106,6 +106,7 @@
 
   {% include "src/site/includes/survey-tools.html" %}
 
+  {% comment %} TODO: Remove this block once the focus styling changes have been tested {% endcomment %}
   {% if entityId == 11463 and buildtype != "vagovprod" %}
     <link rel="stylesheet" href="https://unpkg.com/@department-of-veterans-affairs/formation@8.0.1-0/dist/formation.min.css">
     <script type="module">

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -106,6 +106,19 @@
 
   {% include "src/site/includes/survey-tools.html" %}
 
+  {% if entityId == 11463 and buildtype != "vagovprod" %}
+    <link rel="stylesheet" href="https://unpkg.com/@department-of-veterans-affairs/formation@8.0.1-0/dist/formation.min.css">
+    <script type="module">
+      import { defineCustomElements } from "https://unpkg.com/@department-of-veterans-affairs/web-components@4.10.2-0/loader/index.es2017.js";
+      defineCustomElements();
+    </script>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://unpkg.com/@department-of-veterans-affairs/component-library/dist/main.css"
+    />
+  {% endif %}
+
 </head>
 
 <body class="{{ body_class }} merger">

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -118,7 +118,7 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="https://unpkg.com/@department-of-veterans-affairs/component-library/dist/main.css"
+      href="https://unpkg.com/@department-of-veterans-affairs/component-library@11.3.2-1/dist/main.css"
     />
     <style>
       .usa-accordion-button:focus {


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1058

Related PRs:

- https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/857
- https://github.com/department-of-veterans-affairs/component-library/pull/433

This adds pre-release packages of `formation` and `component-library` to the Covid-19 healthcare page in order to test the new double box-shadow focus styles. They are designed to be easily removed.

The prototype will live [here on staging](https://staging.va.gov/health-care/covid-19-vaccine/).

## Testing done

Local build :eyes: 


## Screenshots

### Header

![Screenshot of the header on a localhost build, with the new focus style on the "Contact us" button](https://user-images.githubusercontent.com/2008881/183475119-7ec80bfb-f957-492c-ac7e-645ae8c994cf.png)

### On this page

![Screenshot of the "On this page" component on a localhost build, with one of the links having the new focus style.](https://user-images.githubusercontent.com/2008881/183475263-984903b1-b915-4b0f-88c9-baa6980057bc.png)

### Pages not part of the prototype

![Screenshot of a page that isn't the Covid-19 page. An item in the header is focused, and it retains the original focus styling.](https://user-images.githubusercontent.com/2008881/183476365-12dcc5bd-6206-4fae-9e92-f94a3b5d8200.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
