### PR TITLE
9901-graphql updated for new Q&A content on support resource detail pages

### DIFF
--- a/src/site/stages/build/drupal/graphql/fragments.graphql.js
+++ b/src/site/stages/build/drupal/graphql/fragments.graphql.js
@@ -15,6 +15,7 @@ const numberCallout = require('./paragraph-fragments/numberCallout.paragraph.gra
 const phoneNumber = require('./paragraph-fragments/phoneNumber.paragraph.graphql');
 const process = require('./paragraph-fragments/process.paragraph.graphql');
 const qa = require('./paragraph-fragments/qa.paragraph.graphql');
+const qaGroup = require('./paragraph-fragments/qaGroup.paragraph.graphql');
 const qaSection = require('./paragraph-fragments/qaSection.paragraph.graphql');
 const reactWidget = require('./paragraph-fragments/reactWidget.paragraph.graphql');
 const richTextCharLimit1000 = require('./paragraph-fragments/richTextCharLimit1000.paragraph.graphql');
@@ -53,6 +54,7 @@ const ALL_FRAGMENTS = `
   ${promo}
   ${qaSection}
   ${qa}
+  ${qaGroup}
   ${reactWidget}
   ${richTextCharLimit1000}
   ${spanishSummary}
@@ -87,6 +89,7 @@ module.exports = {
   promo,
   qaSection,
   qa,
+  qaGroup,
   reactWidget,
   richTextCharLimit1000,
   spanishSummary,

--- a/src/site/stages/build/drupal/graphql/nodeSupportResourcesDetailPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeSupportResourcesDetailPage.graphql.js
@@ -25,34 +25,7 @@ fragment nodeSupportResourcesDetailPage on NodeSupportResourcesDetailPage {
       ... downloadableFile
       ... embeddedImage
       ... numberCallout
-      ... on ParagraphQAGroup {
-        fieldSectionHeader
-        fieldRichWysiwyg {
-          value
-          format
-          processed
-        }
-        queryFieldQAs {
-          entities {
-            entityId
-            entityLabel
-            moderationState
-            ... on NodeQA {
-              fieldAnswer {
-                targetId
-                targetRevisionId
-                ... on FieldNodeQAFieldAnswer {
-                  entity {
-                    entityId
-                    entityLabel
-                    
-                  }
-                }
-              }
-            }
-          } 
-        }
-      }
+      ... qaGroup 
     }
   }
   fieldTableOfContentsBoolean
@@ -154,7 +127,7 @@ const GetNodeSupportResourcesDetailPage = `
       ]
     }) {
       entities {
-				... nodeSupportResourcesDetailPage 
+        ... nodeSupportResourcesDetailPage 
       }
     }
   }

--- a/src/site/stages/build/drupal/graphql/nodeSupportResourcesDetailPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeSupportResourcesDetailPage.graphql.js
@@ -25,6 +25,31 @@ fragment nodeSupportResourcesDetailPage on NodeSupportResourcesDetailPage {
       ... downloadableFile
       ... embeddedImage
       ... numberCallout
+      fieldQAGroups {
+        entity {
+          ... on ParagraphQAGroup {
+            fieldSectionHeader
+            fieldAccordionDisplay
+            fieldQAs {
+              entity {
+                ... on NodeQA {
+                  title
+                  entityId
+                  entityBundle
+                  fieldAnswer {
+                    entity {
+                      entityType
+                      entityBundle
+                      ... richTextCharLimit1000
+                      ... reactWidget
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
   fieldTableOfContentsBoolean
@@ -48,31 +73,7 @@ fragment nodeSupportResourcesDetailPage on NodeSupportResourcesDetailPage {
       ... contactInformation
     }
   }
-  fieldQAGroups {
-    entity {
-      ... on ParagraphQAGroup {
-        fieldSectionHeader
-        fieldAccordionDisplay
-        fieldQAs {
-          entity {
-            ... on NodeQA {
-              title
-              entityId
-              entityBundle
-              fieldAnswer {
-                entity {
-                  entityType
-                  entityBundle
-                  ... richTextCharLimit1000
-                  ... reactWidget
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
+
   fieldRelatedBenefitHubs {
     entity {
       ... on NodeLandingPage {

--- a/src/site/stages/build/drupal/graphql/nodeSupportResourcesDetailPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeSupportResourcesDetailPage.graphql.js
@@ -108,6 +108,7 @@ const GetNodeSupportResourcesDetailPage = `
   ${fragments.process}
   ${fragments.qaSection}
   ${fragments.qa}
+  ${fragments.qaGroup}
   ${fragments.listOfLinkTeasers}
   ${fragments.reactWidget}
   ${fragments.spanishSummary}

--- a/src/site/stages/build/drupal/graphql/nodeSupportResourcesDetailPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeSupportResourcesDetailPage.graphql.js
@@ -125,7 +125,43 @@ const GetNodeSupportResourcesDetailPage = `
       ]
     }) {
       entities {
-        ... nodeSupportResourcesDetailPage
+				... on NodeSupportResourcesDetailPage {
+					fieldContentBlock {
+					  targetId
+					  targetRevisionId
+            entity {
+              entityId
+              ... on ParagraphQAGroup {
+                fieldSectionHeader
+                fieldRichWysiwyg {
+                  value
+                  format
+                  processed
+                }
+                queryFieldQAs {
+                	entities {
+                    entityId
+                    entityLabel
+                    moderationState
+                    ... on NodeQA {
+                      fieldAnswer {
+                        targetId
+                        targetRevisionId
+                        ... on FieldNodeQAFieldAnswer {
+                          entity {
+                            entityId
+                            entityLabel
+                            
+                          }
+                        }
+                      }
+                    }
+                  } 
+                }
+              }
+            }
+	        }
+        }
       }
     }
   }

--- a/src/site/stages/build/drupal/graphql/nodeSupportResourcesDetailPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeSupportResourcesDetailPage.graphql.js
@@ -150,8 +150,7 @@ const GetNodeSupportResourcesDetailPage = `
       ]
     }) {
       entities {
-				... NodeSupportResourcesDetailPage 
-        
+				... nodeSupportResourcesDetailPage 
       }
     }
   }

--- a/src/site/stages/build/drupal/graphql/nodeSupportResourcesDetailPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeSupportResourcesDetailPage.graphql.js
@@ -48,6 +48,41 @@ fragment nodeSupportResourcesDetailPage on NodeSupportResourcesDetailPage {
       ... contactInformation
     }
   }
+  fieldContentBlock {
+    targetId
+    targetRevisionId
+    entity {
+      entityId
+      ... on ParagraphQAGroup {
+        fieldSectionHeader
+        fieldRichWysiwyg {
+          value
+          format
+          processed
+        }
+        queryFieldQAs {
+          entities {
+            entityId
+            entityLabel
+            moderationState
+            ... on NodeQA {
+              fieldAnswer {
+                targetId
+                targetRevisionId
+                ... on FieldNodeQAFieldAnswer {
+                  entity {
+                    entityId
+                    entityLabel
+                    
+                  }
+                }
+              }
+            }
+          } 
+        }
+      }
+    }
+  }
   fieldRelatedBenefitHubs {
     entity {
       ... on NodeLandingPage {
@@ -125,43 +160,8 @@ const GetNodeSupportResourcesDetailPage = `
       ]
     }) {
       entities {
-				... on NodeSupportResourcesDetailPage {
-					fieldContentBlock {
-					  targetId
-					  targetRevisionId
-            entity {
-              entityId
-              ... on ParagraphQAGroup {
-                fieldSectionHeader
-                fieldRichWysiwyg {
-                  value
-                  format
-                  processed
-                }
-                queryFieldQAs {
-                	entities {
-                    entityId
-                    entityLabel
-                    moderationState
-                    ... on NodeQA {
-                      fieldAnswer {
-                        targetId
-                        targetRevisionId
-                        ... on FieldNodeQAFieldAnswer {
-                          entity {
-                            entityId
-                            entityLabel
-                            
-                          }
-                        }
-                      }
-                    }
-                  } 
-                }
-              }
-            }
-	        }
-        }
+				... NodeSupportResourcesDetailPage 
+        
       }
     }
   }

--- a/src/site/stages/build/drupal/graphql/nodeSupportResourcesDetailPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeSupportResourcesDetailPage.graphql.js
@@ -25,29 +25,32 @@ fragment nodeSupportResourcesDetailPage on NodeSupportResourcesDetailPage {
       ... downloadableFile
       ... embeddedImage
       ... numberCallout
-      fieldQAGroups {
-        entity {
-          ... on ParagraphQAGroup {
-            fieldSectionHeader
-            fieldAccordionDisplay
-            fieldQAs {
-              entity {
-                ... on NodeQA {
-                  title
-                  entityId
-                  entityBundle
-                  fieldAnswer {
-                    entity {
-                      entityType
-                      entityBundle
-                      ... richTextCharLimit1000
-                      ... reactWidget
-                    }
+      ... on ParagraphQAGroup {
+        fieldSectionHeader
+        fieldRichWysiwyg {
+          value
+          format
+          processed
+        }
+        queryFieldQAs {
+          entities {
+            entityId
+            entityLabel
+            moderationState
+            ... on NodeQA {
+              fieldAnswer {
+                targetId
+                targetRevisionId
+                ... on FieldNodeQAFieldAnswer {
+                  entity {
+                    entityId
+                    entityLabel
+                    
                   }
                 }
               }
             }
-          }
+          } 
         }
       }
     }

--- a/src/site/stages/build/drupal/graphql/nodeSupportResourcesDetailPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeSupportResourcesDetailPage.graphql.js
@@ -48,37 +48,27 @@ fragment nodeSupportResourcesDetailPage on NodeSupportResourcesDetailPage {
       ... contactInformation
     }
   }
-  fieldContentBlock {
-    targetId
-    targetRevisionId
+  fieldQAGroups {
     entity {
-      entityId
       ... on ParagraphQAGroup {
         fieldSectionHeader
-        fieldRichWysiwyg {
-          value
-          format
-          processed
-        }
-        queryFieldQAs {
-          entities {
-            entityId
-            entityLabel
-            moderationState
+        fieldAccordionDisplay
+        fieldQAs {
+          entity {
             ... on NodeQA {
+              title
+              entityId
+              entityBundle
               fieldAnswer {
-                targetId
-                targetRevisionId
-                ... on FieldNodeQAFieldAnswer {
-                  entity {
-                    entityId
-                    entityLabel
-                    
-                  }
+                entity {
+                  entityType
+                  entityBundle
+                  ... richTextCharLimit1000
+                  ... reactWidget
                 }
               }
             }
-          } 
+          }
         }
       }
     }

--- a/src/site/stages/build/drupal/graphql/nodeSupportResourcesDetailPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeSupportResourcesDetailPage.graphql.js
@@ -49,7 +49,6 @@ fragment nodeSupportResourcesDetailPage on NodeSupportResourcesDetailPage {
       ... contactInformation
     }
   }
-
   fieldRelatedBenefitHubs {
     entity {
       ... on NodeLandingPage {

--- a/src/site/stages/build/drupal/graphql/paragraph-fragments/qaGroup.paragraph.graphql.js
+++ b/src/site/stages/build/drupal/graphql/paragraph-fragments/qaGroup.paragraph.graphql.js
@@ -1,0 +1,30 @@
+module.exports = `
+fragment qaGroup on ParagraphQAGroup {
+    fieldSectionHeader
+    fieldRichWysiwyg {
+      value
+      format
+      processed
+    }
+    queryFieldQAs {
+      entities {
+        entityId
+        entityLabel
+        moderationState
+        ... on NodeQA {
+          fieldAnswer {
+            targetId
+            targetRevisionId
+            ... on FieldNodeQAFieldAnswer {
+              entity {
+                entityId
+                entityLabel
+                
+              }
+            }
+          }
+        }
+      } 
+    }
+  }
+`;


### PR DESCRIPTION
## Description
updated graphql query to pull new QA content

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9901

## Testing done
Tested in PR tugboat environment: https://tugboat.vfs.va.gov/62c7e70524e7d21f96728554

https://cms-zqis1amj7i3jmmqvydvdxfmptbsn7zzf.ci.cms.va.gov/admin/content/deploy
https://web-zqis1amj7i3jmmqvydvdxfmptbsn7zzf.ci.cms.va.gov/resources/how-to-get-your-medical-records-from-your-va-health-facility/

Trigger content build and release using the frontend from this PR.  Observe that the environment builds without error

## Screenshots
<img width="877" alt="Screen Shot 2022-08-15 at 10 49 54 AM" src="https://user-images.githubusercontent.com/61624970/184659003-50e2a06c-3942-4d9e-82ed-94b748bd9837.png">

<img width="781" alt="Screen Shot 2022-08-15 at 10 48 47 AM" src="https://user-images.githubusercontent.com/61624970/184659022-d9b935a2-9bca-4ebc-a2f4-f5b80a132a99.png">


## Acceptance criteria
- [ ] Query pulls in new Q&A content
- [ ]  Updated content model must be present in main before this can be merged

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
