### PR TITLE
Increase build timeout from 30m to 45m

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -259,7 +259,7 @@ jobs:
 
       - name: Build
         run: yarn build --buildtype=${{ env.BUILDTYPE }} --asset-source=local --drupal-address=${{ env.DRUPAL_ADDRESS }} --drupal-user=${{ env.DRUPAL_USERNAME }} --drupal-password="${{ env.DRUPAL_PASSWORD }}" --pull-drupal --drupal-max-parallel-requests=15 --no-drupal-proxy --verbose | tee build-output.txt
-        timeout-minutes: 30
+        timeout-minutes: 45
         env:
           NODE_ENV: production
 


### PR DESCRIPTION
Jobs are timing out and failing. Sometimes that step takes 22m but a couple runs lately have timeout at 30m:

![image](https://user-images.githubusercontent.com/1504756/184249551-0a9b2e64-bedc-4437-a87a-a225b1d237c3.png)

https://github.com/department-of-veterans-affairs/content-build/runs/7795882449?check_suite_focus=true

![image](https://user-images.githubusercontent.com/1504756/184249670-38377991-c746-4cf5-bc7e-a835bf8ebf8e.png)



## Description
e.g. second failure from a timeout here > https://github.com/department-of-veterans-affairs/content-build/runs/7795882449?check_suite_focus=true


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
