### PR TITLE
widget added to translated page types

### DIFF
--- a/src/site/layouts/support_resources_detail_page.drupal.liquid
+++ b/src/site/layouts/support_resources_detail_page.drupal.liquid
@@ -7,6 +7,7 @@
     <div class="usa-grid usa-grid-full">
       <div class="usa-width-three-fourths">
         <div class="usa-content">
+          <div data-widget-type="i18-select"></div>
           <!-- Search bar -->
           <div class="medium-screen:vads-u-border-bottom--2px vads-u-border-color--gray-light medium-screen:vads-u-margin-bottom--3">
             {% include "src/site/includes/support_resources_search_bar.drupal.liquid" %}


### PR DESCRIPTION
## Description
The PACT pages when translated are built from a different template than the English version.  This adds the language toggle widget to the support-resources-detail-page template so that the toggle renders for all language types.

## Testing done


## Screenshots


## Acceptance criteria
- [ ] language toggle appears on Esp page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
