### PR TITLE
Update to WCAG 2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ test-results/
 
 # Ignore user's editor/IDE prefs
 .vscode/
+*.code-workspace
 .idea/
 .swp
 .swo

--- a/src/platform/testing/e2e/cypress/support/commands/axeCheck.js
+++ b/src/platform/testing/e2e/cypress/support/commands/axeCheck.js
@@ -107,7 +107,7 @@ Cypress.Commands.add('axeCheck', (context = 'main', tempOptions = {}) => {
     axeBuilder = {
       runOnly: {
         type: 'tag',
-        values: ['section508', 'wcag2a', 'wcag2aa'],
+        values: ['section508', 'wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'],
       },
       rules: {
         'color-contrast': {
@@ -122,7 +122,7 @@ Cypress.Commands.add('axeCheck', (context = 'main', tempOptions = {}) => {
     axeBuilder = {
       runOnly: {
         type: 'tag',
-        values: ['section508', 'wcag2a', 'wcag2aa'],
+        values: ['section508', 'wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'],
       },
       rules: {
         'color-contrast': {

--- a/src/platform/testing/unit/axe-plugin.js
+++ b/src/platform/testing/unit/axe-plugin.js
@@ -1,10 +1,17 @@
 module.exports = function(chai, utils) {
   const axe = require('axe-core');
-  const Assertion = chai.Assertion;
+  const { Assertion } = chai;
 
   utils.addMethod(chai.Assertion.prototype, 'accessible', function(
     rules = {},
-    rulesets = ['section508', 'wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'best-practice'],
+    rulesets = [
+      'section508',
+      'wcag2a',
+      'wcag2aa',
+      'wcag21a',
+      'wcag21aa',
+      'best-practice',
+    ],
   ) {
     const el = this._obj;
     const config = {

--- a/src/platform/testing/unit/axe-plugin.js
+++ b/src/platform/testing/unit/axe-plugin.js
@@ -4,7 +4,7 @@ module.exports = function(chai, utils) {
 
   utils.addMethod(chai.Assertion.prototype, 'accessible', function(
     rules = {},
-    rulesets = ['section508', 'wcag2a', 'wcag2aa', 'best-practice'],
+    rulesets = ['section508', 'wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'best-practice'],
   ) {
     const el = this._obj;
     const config = {

--- a/src/site/assets/js/execute-axe-check.js
+++ b/src/site/assets/js/execute-axe-check.js
@@ -92,7 +92,7 @@ function processAxeCheckResults(error, results) {
       iframes: false,
       runOnly: {
         type: 'tag',
-        values: ['section508', 'wcag2a', 'wcag2aa', 'best-practice'],
+        values: ['section508', 'wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'best-practice'],
         resultTypes: ['violations'],
       },
       rules: {

--- a/src/site/assets/js/execute-axe-check.js
+++ b/src/site/assets/js/execute-axe-check.js
@@ -92,7 +92,14 @@ function processAxeCheckResults(error, results) {
       iframes: false,
       runOnly: {
         type: 'tag',
-        values: ['section508', 'wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'best-practice'],
+        values: [
+          'section508',
+          'wcag2a',
+          'wcag2aa',
+          'wcag21a',
+          'wcag21aa',
+          'best-practice',
+        ],
         resultTypes: ['violations'],
       },
       rules: {

--- a/src/site/tests/support/axe.js
+++ b/src/site/tests/support/axe.js
@@ -27,7 +27,7 @@ const axeCheck = container => {
   const options = {
     runOnly: {
       type: 'tag',
-      values: ['section508', 'wcag2a', 'wcag2aa'],
+      values: ['section508', 'wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'],
     },
     rules: {
       // the 'bypass' check is disabled because it may give a false-positive


### PR DESCRIPTION
## Description

Same update as https://github.com/department-of-veterans-affairs/vets-website/pull/21870 but for this repo.

Update all [WCAG rules from 2.0 to 2.1](https://github.com/dequelabs/axe-core/blob/a3d5cef612013ffe0db5383a4047508654444d3c/doc/API.md#axe-core-tags), as our [current standard is 2.1](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing).

This introduces two new rules:
- [autocomplete-valid](https://dequeuniversity.com/rules/axe/4.4/autocomplete-valid?application=RuleDescription) 
- [avoid-inline-spacing](https://dequeuniversity.com/rules/axe/4.4/avoid-inline-spacing?application=RuleDescription)

## Testing done

- Unit/E2E ran locally, all passed.
- Ran the [full daily scan with this branch](https://github.com/department-of-veterans-affairs/content-build/actions/runs/2848533686), all passed. 

## Screenshots

N/A

## Acceptance criteria
- [x] WCAG 2.1 rules have been enabled

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
