### PR TITLE
- Enable MEB url in production in preparation for 08/20 release

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1154,7 +1154,7 @@
     "entryName": "1990ez-edu-benefits",
     "rootUrl": "/education/apply-for-benefits-form-22-1990",
     "template": {
-      "vagovprod": false,
+      "vagovprod": true,
       "layout": "page-react.html"
     }
   },


### PR DESCRIPTION
## Description
Enable vagovprod flag so URL is visible on production in preparation for MEB release on 08/20. This only enables the URL for access in preparation of deployment of services.

Next step will be limited testing on production with UAT testers when DGIB services become only on 08/20.

After that, we'll enable feature flag for full access to everyone so the link becomes accessible from the Education wizard.


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
