### PR TITLE
[VA-10060] Fix heading structures for Care (and Billing) Templates

### DIFF
--- a/src/site/components/phone-number.drupal.liquid
+++ b/src/site/components/phone-number.drupal.liquid
@@ -5,9 +5,9 @@
   {% assign phoneLabel = 'Phone' %}
 {% endif %}
 {% if haveLocationName != empty %}
-  <h5>{{ phoneLabel }}</h5>
+  <h4>{{ phoneLabel }}</h4>
 {% else %}
-  <h4 class="force-small-header">{{ phoneLabel }}</h4>
+  <h3 class="force-small-header">{{ phoneLabel }}</h3>
 {% endif %}
 <a class="vads-u-margin-bottom--1" aria-label="{{ number.fieldPhoneNumber | accessibleNumber }}{% if number.fieldPhoneExtension %} extension: {{ number.fieldPhoneExtension | accessibleNumber }}{% endif %}"
    href="tel:{{ number.fieldPhoneNumber }}{% if number.fieldPhoneExtension %}p{{ number.fieldPhoneExtension }}{% endif %}">

--- a/src/site/facilities/vha_facility_nonclinical_services.drupal.liquid
+++ b/src/site/facilities/vha_facility_nonclinical_services.drupal.liquid
@@ -1,34 +1,38 @@
 {% if facilities %}
-{% for facility in facilities %}
-  <h4><a href="{{ facility.entityUrl.path }}">{{ facility.entityLabel }}</a></h4>
+  {% for facility in facilities %}
+    <h3>
+      <a href="{{ facility.entityUrl.path }}">
+        {{ facility.entityLabel }}
+      </a>
+    </h3>
 
-  {% comment %}
-    Facility Address
-    Note: this is temporary; service_address.liquid.js should be refactored to be more reusable.
-  {% endcomment %}
-  {% if facility.fieldAddress %}
-    {% assign facilityAddress = facility.fieldAddress %}
-    <div class="vads-u-display--flex vads-u-flex-direction--column">
-      {% if facilityAddress.addressLine1 %}
-        <span class="vads-u-margin-bottom--0">
-          {{ facilityAddress.addressLine1 }}
-        </span>
-      {% endif %}
-      {% if facilityAddress.addressLine2 %}
-        <span class="vads-u-margin-bottom--0">
-          {{ facilityAddress.addressLine2 }}
-        </span>
-      {% endif %}
-      {% if facilityAddress.locality and facilityAddress.administrativeArea and facilityAddress.postalCode %}
-        <span class="vads-u-margin-bottom--0">
-          {{ facilityAddress.locality }}, {{ facilityAddress.administrativeArea}} {{ facilityAddress.postalCode }}
-        </span>
-      {% endif %}
-    </div>
-  {% endif %}
+    {% comment %}
+      Facility Address
+      Note: this is temporary; service_address.liquid.js should be refactored to be more reusable.
+    {% endcomment %}
+    {% if facility.fieldAddress %}
+      {% assign facilityAddress = facility.fieldAddress %}
+      <div class="vads-u-display--flex vads-u-flex-direction--column">
+        {% if facilityAddress.addressLine1 %}
+          <span class="vads-u-margin-bottom--0">
+            {{ facilityAddress.addressLine1 }}
+          </span>
+        {% endif %}
+        {% if facilityAddress.addressLine2 %}
+          <span class="vads-u-margin-bottom--0">
+            {{ facilityAddress.addressLine2 }}
+          </span>
+        {% endif %}
+        {% if facilityAddress.locality and facilityAddress.administrativeArea and facilityAddress.postalCode %}
+          <span class="vads-u-margin-bottom--0">
+            {{ facilityAddress.locality }}, {{ facilityAddress.administrativeArea}} {{ facilityAddress.postalCode }}
+          </span>
+        {% endif %}
+      </div>
+    {% endif %}
 
-  {% include "src/site/facilities/vha_facility_nonclinical_service.drupal.liquid" with
-    facility = facility
-  %}
-{% endfor %}
+    {% include "src/site/facilities/vha_facility_nonclinical_service.drupal.liquid" with
+      facility = facility
+    %}
+  {% endfor %}
 {% endif %}

--- a/src/site/includes/hours.liquid
+++ b/src/site/includes/hours.liquid
@@ -2,15 +2,15 @@
 	<div class="vads-u-margin-bottom--0" data-template="hours">
 		<div class="clinicalhours">
 			{% if headerType == 'small' %}
-				<h4 class="force-small-header vads-u-margin-top--0 vads-u-line-height--1 vads-u-margin-bottom--1">
-					Hours</h4>
+				<h3 class="force-small-header vads-u-margin-top--0 vads-u-line-height--1 vads-u-margin-bottom--1">
+					Hours</h3>
 			{% elsif headerType == 'standard' %}
-				<h4 class="vads-u-font-size--lg vads-u-margin-top--0 vads-u-line-height--1 vads-u-margin-bottom--1">
-					Hours</h4>
+				<h3 class="vads-u-font-size--lg vads-u-margin-top--0 vads-u-line-height--1 vads-u-margin-bottom--1">
+					Hours</h3>
 			{% elsif headerType == 'clinical' %}
-				<h3 class="vads-u-margin-top--2p5 vads-u-margin-bottom--1">
+				<h2 class="vads-u-margin-top--2p5 vads-u-margin-bottom--1">
 					Clinical hours
-				</h3>
+				</h2>
 			{% endif %}
 			<div class="vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row vads-u-margin-bottom--0">
 				<ul class="vads-u-flex--1 va-c-facility-hours-list vads-u-margin-top--0 vads-u-margin-bottom--1 small-screen:vads-u-margin-bottom--0 vads-u-margin-right--3">

--- a/src/site/layouts/vamc_system_billing_insurance.drupal.liquid
+++ b/src/site/layouts/vamc_system_billing_insurance.drupal.liquid
@@ -37,7 +37,9 @@
               </p>
             {% endif %}
             {% if fieldPhoneNumber %}
-              <b>Phone</b>
+              <h3>
+                Phone
+              </h3>
               <p><a href="tel:{{ fieldPhoneNumber }}">{{ fieldPhoneNumber }}</a>
               </p>
             {% endif %}

--- a/src/site/paragraphs/service_location.drupal.liquid
+++ b/src/site/paragraphs/service_location.drupal.liquid
@@ -16,9 +16,9 @@
 
 {% if single.fieldHours != "1" %}
   {% if haveLocationName %}
-    <h5 data-template="paragraphs/service_location">Hours</h5>
+    <h4 data-template="paragraphs/service_location">Hours</h4>
   {% else %}
-    <h4 class="force-small-header" data-template="paragraphs/service_location">Hours</h4>
+    <h3 class="force-small-header" data-template="paragraphs/service_location">Hours</h3>
   {% endif %}
 {% endif %}
 


### PR DESCRIPTION
## Description

The heading structures used in the "Register for Care" page templates aren't correctly organized for screen readers. They need to descend in a logical order based on the content. This pull request fixes them so screen reader users can properly understand and navigate around them.

This closes [#10060](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/10060), and also closes [#10062](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/10062) due to heavy similarity and code overlap means they both need to be fixed at basically the same time.

## Testing done

Visual

* [Register for Care local page](http://localhost:3002/preview?nodeId=45917)
* [Billing and Insurance local page](http://localhost:3002/preview?nodeId=45663)

## Screenshots

### Register for Care page

<img width="432" alt="Screen Shot 2022-08-15 at 3 52 51 PM" src="https://user-images.githubusercontent.com/10790736/184720422-d437e4b8-6d08-4ee4-bce9-49f5e9f8b26e.png">

### Billing and Insurance page

<img width="411" alt="Screen Shot 2022-08-15 at 5 09 36 PM" src="https://user-images.githubusercontent.com/10790736/184720425-b603fbb1-1e69-4701-ad8a-ebc5a841c66c.png">

## Acceptance criteria

- [ ] All headings are logically organized (`h3`s are only nested inside `h2`s and so on)
- [ ] Headings only appear in descending order (`h3`s only appear if there's an `h2` present and so on)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
