### PR TITLE
Reapply "Build prototype for new focus styles"

### DIFF
--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -41,7 +41,24 @@
   </script>
 
   <!-- Add web components. -->
-  {% if entityId != 11463 or buildtype != "vagovdev") %}
+  {% comment %} TODO: Remove this block once the focus styling changes have been tested {% endcomment %}
+  {% if entityId == 11463 and buildtype == "vagovdev" %}
+    <link rel="stylesheet" href="https://unpkg.com/@department-of-veterans-affairs/formation@8.0.1-0/dist/formation.min.css">
+    <script type="module">
+      import { defineCustomElements } from "https://unpkg.com/@department-of-veterans-affairs/web-components@4.10.2-1/loader/index.es2017.js";
+      defineCustomElements();
+    </script>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://unpkg.com/@department-of-veterans-affairs/component-library@11.3.2-1/dist/main.css"
+    />
+    <style>
+      .usa-accordion-button:focus {
+        border: none !important;
+      }
+    </style>
+  {% else %}
     <link rel="stylesheet" data-entry-name="web-components.css">
     <script nonce="**CSP_NONCE**" defer data-entry-name="web-components.js"></script>
   {% endif %}
@@ -107,25 +124,6 @@
   </script>
 
   {% include "src/site/includes/survey-tools.html" %}
-
-  {% comment %} TODO: Remove this block once the focus styling changes have been tested {% endcomment %}
-  {% if entityId == 11463 and buildtype == "vagovdev" %}
-    <link rel="stylesheet" href="https://unpkg.com/@department-of-veterans-affairs/formation@8.0.1-0/dist/formation.min.css">
-    <script type="module">
-      import { defineCustomElements } from "https://unpkg.com/@department-of-veterans-affairs/web-components@4.10.2-1/loader/index.es2017.js";
-      defineCustomElements();
-    </script>
-    <link
-      rel="stylesheet"
-      type="text/css"
-      href="https://unpkg.com/@department-of-veterans-affairs/component-library@11.3.2-1/dist/main.css"
-    />
-    <style>
-      .usa-accordion-button:focus {
-        border: none !important;
-      }
-    </style>
-  {% endif %}
 
 </head>
 

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -41,7 +41,7 @@
   </script>
 
   <!-- Add web components. -->
-  {% if !(entityId == 11463 and buildtype == "vagovdev") %}
+  {% if entityId != 11463 or buildtype != "vagovdev") %}
     <link rel="stylesheet" data-entry-name="web-components.css">
     <script nonce="**CSP_NONCE**" defer data-entry-name="web-components.js"></script>
   {% endif %}

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -41,7 +41,7 @@
   </script>
 
   <!-- Add web components. -->
-  {% if entityId == 11463 or buildtype != "vagovdev") %}
+  {% if entityId != 11463 or buildtype != "vagovdev") %}
     <link rel="stylesheet" data-entry-name="web-components.css">
     <script nonce="**CSP_NONCE**" defer data-entry-name="web-components.js"></script>
   {% endif %}

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -41,7 +41,7 @@
   </script>
 
   <!-- Add web components. -->
-  {% if entityId != 11463 or buildtype != "vagovdev") %}
+  {% if entityId == 11463 or buildtype != "vagovdev") %}
     <link rel="stylesheet" data-entry-name="web-components.css">
     <script nonce="**CSP_NONCE**" defer data-entry-name="web-components.js"></script>
   {% endif %}

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -41,24 +41,7 @@
   </script>
 
   <!-- Add web components. -->
-  {% comment %} TODO: Remove this block once the focus styling changes have been tested {% endcomment %}
-  {% if entityId == 11463 and buildtype == "vagovdev" %}
-    <link rel="stylesheet" href="https://unpkg.com/@department-of-veterans-affairs/formation@8.0.1-0/dist/formation.min.css">
-    <script type="module">
-      import { defineCustomElements } from "https://unpkg.com/@department-of-veterans-affairs/web-components@4.10.2-1/loader/index.es2017.js";
-      defineCustomElements();
-    </script>
-    <link
-      rel="stylesheet"
-      type="text/css"
-      href="https://unpkg.com/@department-of-veterans-affairs/component-library@11.3.2-1/dist/main.css"
-    />
-    <style>
-      .usa-accordion-button:focus {
-        border: none !important;
-      }
-    </style>
-  {% else %}
+  {% if entityId != 11463 or buildtype != "vagovdev") %}
     <link rel="stylesheet" data-entry-name="web-components.css">
     <script nonce="**CSP_NONCE**" defer data-entry-name="web-components.js"></script>
   {% endif %}
@@ -124,6 +107,25 @@
   </script>
 
   {% include "src/site/includes/survey-tools.html" %}
+
+  {% comment %} TODO: Remove this block once the focus styling changes have been tested {% endcomment %}
+  {% if entityId == 11463 and buildtype == "vagovdev" %}
+    <link rel="stylesheet" href="https://unpkg.com/@department-of-veterans-affairs/formation@8.0.1-0/dist/formation.min.css">
+    <script type="module">
+      import { defineCustomElements } from "https://unpkg.com/@department-of-veterans-affairs/web-components@4.10.2-1/loader/index.es2017.js";
+      defineCustomElements();
+    </script>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://unpkg.com/@department-of-veterans-affairs/component-library@11.3.2-1/dist/main.css"
+    />
+    <style>
+      .usa-accordion-button:focus {
+        border: none !important;
+      }
+    </style>
+  {% endif %}
 
 </head>
 

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -41,7 +41,7 @@
   </script>
 
   <!-- Add web components. -->
-  {% if !(entityId == 11463 and buildtype != "vagovprod") %}
+  {% if !(entityId == 11463 and buildtype == "vagovdev") %}
     <link rel="stylesheet" data-entry-name="web-components.css">
     <script nonce="**CSP_NONCE**" defer data-entry-name="web-components.js"></script>
   {% endif %}
@@ -109,7 +109,7 @@
   {% include "src/site/includes/survey-tools.html" %}
 
   {% comment %} TODO: Remove this block once the focus styling changes have been tested {% endcomment %}
-  {% if entityId == 11463 and buildtype != "vagovprod" %}
+  {% if entityId == 11463 and buildtype == "vagovdev" %}
     <link rel="stylesheet" href="https://unpkg.com/@department-of-veterans-affairs/formation@8.0.1-0/dist/formation.min.css">
     <script type="module">
       import { defineCustomElements } from "https://unpkg.com/@department-of-veterans-affairs/web-components@4.10.2-1/loader/index.es2017.js";

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -41,8 +41,10 @@
   </script>
 
   <!-- Add web components. -->
-  <link rel="stylesheet" data-entry-name="web-components.css">
-  <script nonce="**CSP_NONCE**" defer data-entry-name="web-components.js"></script>
+  {% if !(entityId == 11463 and buildtype != "vagovprod") %}
+    <link rel="stylesheet" data-entry-name="web-components.css">
+    <script nonce="**CSP_NONCE**" defer data-entry-name="web-components.js"></script>
+  {% endif %}
 
   <!-- Render GA template. -->
   {% include 'src/site/includes/google-analytics.liquid' %}
@@ -105,6 +107,25 @@
   </script>
 
   {% include "src/site/includes/survey-tools.html" %}
+
+  {% comment %} TODO: Remove this block once the focus styling changes have been tested {% endcomment %}
+  {% if entityId == 11463 and buildtype != "vagovprod" %}
+    <link rel="stylesheet" href="https://unpkg.com/@department-of-veterans-affairs/formation@8.0.1-0/dist/formation.min.css">
+    <script type="module">
+      import { defineCustomElements } from "https://unpkg.com/@department-of-veterans-affairs/web-components@4.10.2-1/loader/index.es2017.js";
+      defineCustomElements();
+    </script>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://unpkg.com/@department-of-veterans-affairs/component-library@11.3.2-1/dist/main.css"
+    />
+    <style>
+      .usa-accordion-button:focus {
+        border: none !important;
+      }
+    </style>
+  {% endif %}
 
 </head>
 


### PR DESCRIPTION
## Description

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1058

This reverts the revert in department-of-veterans-affairs/content-build#1261 :upside_down_face:. 

The goal here is to create a prototype page with the double box-shadow focus styling that can be used in user testing sessions. I have modified the original boolean expression so that our web component script gets loaded on all pages that aren't the prototype. The prototype will be the [COVID-19 page](https://dev.va.gov/health-care/covid-19-vaccine/) in the dev environment.

Just to be safe I'm planning on merging this after the daily deploy, and not on Friday.

## Additional details

The reason why I'm removing the "regular" web component loader script on the prototype page is because the browser will use whichever custom element constructor gets defined in its registry first. The [spec says](https://html.spec.whatwg.org/multipage/custom-elements.html#element-definition):

>  When invoked, the `define(name, constructor, options)` method must run these steps:
> ...
> 3. If this [CustomElementRegistry](https://html.spec.whatwg.org/multipage/custom-elements.html#customelementregistry) contains an entry with [name](https://html.spec.whatwg.org/multipage/custom-elements.html#concept-custom-element-definition-name) `name`, then throw a ["NotSupportedError"](https://webidl.spec.whatwg.org/#notsupportederror) [DOMException](https://webidl.spec.whatwg.org/#dfn-DOMException).

I didn't see a "NotSupportedError" in the console when I was defining different versions of the web components under the same name so it may be getting caught already, but we get undesirable behavior where the web component internals don't have the prototype focus styles but other global elements do:

[Video showing focus styles not matching between global links and links internal to a web component's shadow DOM](https://user-images.githubusercontent.com/2008881/185467559-73da3f3d-7a37-42e6-8f11-f2a5d1c53f6c.webm)


## Screenshots

### Dev build

These screenshots were taken on a site that was built using:

```
yarn build --buildtype vagovdev
```

And served using:

```
yarn serve --buildtype vagovdev
```

<details>

<summary>COVID-19 page on a dev build</summary>

This prototype has the double box-shadow focus styling so that it can be tested with Veterans.

![A screenshot of the header with the "Contact us" link highlighted. It has the proposed double box-shadow focus styling](https://user-images.githubusercontent.com/2008881/185242180-6ae97d21-e274-4dbe-8c99-2b1f467135c3.png)

![A screenshot of the page content. A link in the "On this page" component is highlighted using the box-shadow focus styling](https://user-images.githubusercontent.com/2008881/185242344-d34720ab-f6a8-4fd4-877f-56532ba0f60c.png)

</details>

<details>

<summary>Other page on a dev build</summary>

There are no changes here, and web components still work.

![A screenshot of the header with the "contact us" link highlighted. It has the original yellow outline for focus styling](https://user-images.githubusercontent.com/2008881/185259980-a88624a7-3bae-4744-9991-19b9f258c823.png)

![A screenshot of a different section on the same page. An accordion item is focused and is styled using the gold outline](https://user-images.githubusercontent.com/2008881/185260068-e6933d70-68da-4518-8542-4540f8dec701.png)

</details>

### Staging build

These screenshots were taken on a site that was built using:

```
NODE_ENV=production yarn build --buildtype vagovstaging
``` 

and served using:

```
yarn serve --buildtype vagovstaging
```

In both of these cases the double box-shadow focus styles aren't present and web components work.

**I confirmed with local testing that a staging build behaves the same way as a production build with these changes.**

<details>


<summary>COVID-19 page on a staging build</summary>

![A screenshot of the header with the "contact us" link focused. It is styled using the gold outline.](https://user-images.githubusercontent.com/2008881/185259306-d74d1e10-72a1-4de0-b257-f55826aa6e2e.png)

![A screenshot of a link in the "On this page" component focused. It is styled using the gold outline.](https://user-images.githubusercontent.com/2008881/185259446-4cc989e9-299a-4881-bb60-41e884d4ffc1.png)

</details>

<details>

<summary>Other page on a staging build</summary>

![image](https://user-images.githubusercontent.com/2008881/185259729-9c4577e7-65ca-4e22-b009-e2846b1bbfea.png)

![image](https://user-images.githubusercontent.com/2008881/185259698-32376937-45be-4ab3-b309-3e0e4c36c6ac.png)