### PR TITLE
Use on demand runner for deploy job

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -602,7 +602,7 @@ jobs:
 
   deploy:
     name: Deploy
-    runs-on: [self-hosted, asg]
+    runs-on: self-hosted
     if: ${{ always() && github.ref == 'refs/heads/main' && needs.get-latest-run-number.result == 'success' && needs.get-latest-run-number.outputs.latest_run_number == github.run_number }}
     needs: [build, cypress-tests, get-latest-run-number]
 


### PR DESCRIPTION
## Description
Updates the `Deploy` job to use on demand runners.

## Acceptance criteria
- [x] Deploy job uses on demand runners

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
