### PR TITLE
VACMS-10312: Fixes defect with missing Outreach Materials

### DIFF
--- a/src/site/stages/build/drupal/graphql/file-fragments/outreachAssets.graphql.js
+++ b/src/site/stages/build/drupal/graphql/file-fragments/outreachAssets.graphql.js
@@ -1,5 +1,8 @@
 const outreachAssets = `
-  outreachAssets: nodeQuery(filter: {conditions: [{field: "type", value: "outreach_asset", field: "status", value: ["1"], enabled: $onlyPublishedContent}]}, limit: 10000) {
+  outreachAssets: nodeQuery(filter: {conditions: [
+    { field: "type", value: "outreach_asset" },
+    { field: "status", value: ["1"], enabled: $onlyPublishedContent }
+  ]}, limit: 10000) {
     entities {
       ... on NodeOutreachAsset {
         entityId


### PR DESCRIPTION
## Description

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/10312

Outreach materials (`outreach_assets`) query was broken in a non-obvious way. It was still returning results, but not limited to the `outreach_assets` type. So, it was returning all nodes, and the 10000 limit was insufficient. This corrects the filter.

## Testing done
Testing done in GraphQL explorer.