### PR TITLE
Assert all web component tags are defined

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@babel/preset-react": "^7.14.5",
     "@babel/register": "^7.15.3",
     "@department-of-veterans-affairs/eslint-plugin": "^1.1.0",
-    "@department-of-veterans-affairs/web-components": "^4.11.0",
+    "@department-of-veterans-affairs/web-components": "~4.9.6",
     "@octokit/rest": "^18.10.0",
     "@sentry/browser": "^6.13.1",
     "@testing-library/cypress": "^8.0.2",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "@babel/preset-react": "^7.14.5",
     "@babel/register": "^7.15.3",
     "@department-of-veterans-affairs/eslint-plugin": "^1.1.0",
+    "@department-of-veterans-affairs/web-components": "^4.11.0",
     "@octokit/rest": "^18.10.0",
     "@sentry/browser": "^6.13.1",
     "@testing-library/cypress": "^8.0.2",

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -42,7 +42,6 @@
 
   <!-- Add web components. -->
   <link rel="stylesheet" data-entry-name="web-components.css">
-  <script nonce="**CSP_NONCE**" defer data-entry-name="web-components.js"></script>
 
   <!-- Render GA template. -->
   {% include 'src/site/includes/google-analytics.liquid' %}

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -42,6 +42,7 @@
 
   <!-- Add web components. -->
   <link rel="stylesheet" data-entry-name="web-components.css">
+  <script nonce="**CSP_NONCE**" defer data-entry-name="web-components.js"></script>
 
   <!-- Render GA template. -->
   {% include 'src/site/includes/google-analytics.liquid' %}

--- a/src/site/tests/home/custom-elements.cypress.spec.js
+++ b/src/site/tests/home/custom-elements.cypress.spec.js
@@ -1,0 +1,15 @@
+const webComponentDocs = require('@department-of-veterans-affairs/web-components/component-docs.json');
+
+const webComponentTags = webComponentDocs.components.map(comp => comp.tag);
+
+describe('Web Components', () => {
+  it('browser has VADS web components defined in its registry', () => {
+    cy.visit('/');
+    cy.window().then(window => {
+      webComponentTags.forEach(tag => {
+        const customElement = window.customElements.get(tag);
+        assert.isFunction(customElement);
+      });
+    });
+  });
+});

--- a/src/site/tests/home/custom-elements.cypress.spec.js
+++ b/src/site/tests/home/custom-elements.cypress.spec.js
@@ -7,7 +7,10 @@ describe('Web Components', () => {
     cy.visit('/');
     cy.window().then(window => {
       webComponentTags.forEach(tag => {
+        // This will be the constructor the browser uses when it sees a
+        // Design System web component in the document.
         const customElement = window.customElements.get(tag);
+
         assert.isFunction(customElement);
       });
     });

--- a/src/site/tests/home/custom-elements.cypress.spec.js
+++ b/src/site/tests/home/custom-elements.cypress.spec.js
@@ -11,7 +11,7 @@ describe('Web Components', () => {
         // Design System web component in the document.
         const customElement = window.customElements.get(tag);
 
-        assert.isFunction(customElement);
+        assert.isFunction(customElement, `${tag} is defined`);
       });
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1088,6 +1088,17 @@
   dependencies:
     minimist "^1.2.6"
 
+"@department-of-veterans-affairs/web-components@^4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-4.11.0.tgz#94486e70e3ac7640820c0ddda4dce6c055710ab3"
+  integrity sha512-6egB77pWbf3FIMnirIrWfm/QqoKblgYWsiYxEq3UNDlYWMzCpA/82+5614gguXq58kLXLWHdDVY/BOINACiuqw==
+  dependencies:
+    "@stencil/core" "^2.10.0"
+    aria-hidden "^1.1.3"
+    body-scroll-lock "^4.0.0-beta.0"
+    classnames "^2.3.1"
+    intersection-observer "^0.12.0"
+
 "@discoveryjs/json-ext@^0.5.0":
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.5.tgz#9283c9ce5b289a3c4f61c12757469e59377f81f3"
@@ -1366,6 +1377,11 @@
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
+
+"@stencil/core@^2.10.0":
+  version "2.17.3"
+  resolved "https://registry.yarnpkg.com/@stencil/core/-/core-2.17.3.tgz#b86cb76eb57231ce1f04014c2a51d1690c64325d"
+  integrity sha512-qw2DZzOpyaltLLEfYRTj3n+XbvRtkmv4QQimYDJubC6jMY0NXK9r6H2+VyszdbbVmvK1D9GqZtyvY0NmOrztsg==
 
 "@testing-library/cypress@^8.0.2":
   version "8.0.2"
@@ -2049,6 +2065,13 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+aria-hidden@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.1.3.tgz#bb48de18dc84787a3c6eee113709c473c64ec254"
+  integrity sha512-RhVWFtKH5BiGMycI72q2RAFMLQi8JP9bLuQXgR5a8Znp7P5KOIADSJeyfI8PCVxLEp067B2HbP5JIiI/PXIZeA==
+  dependencies:
+    tslib "^1.0.0"
+
 aria-query@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
@@ -2461,6 +2484,11 @@ body-parser@1.19.0, body-parser@^1.19.0:
     raw-body "2.4.0"
     type-is "~1.6.17"
 
+body-scroll-lock@^4.0.0-beta.0:
+  version "4.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/body-scroll-lock/-/body-scroll-lock-4.0.0-beta.0.tgz#4f78789d10e6388115c0460cd6d7d4dd2bbc4f7e"
+  integrity sha512-a7tP5+0Mw3YlUJcGAKUqIBkYYGlYxk2fnCasq/FUph1hadxlTRjF+gAcZksxANnaMnALjxEddmSi/H3OR8ugcQ==
+
 bonjour@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bonjour/-/bonjour-3.5.0.tgz#8e890a183d8ee9a2393b3844c691a42bcf7bc9f5"
@@ -2842,6 +2870,11 @@ circular-json@^0.3.1:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
   integrity sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==
+
+classnames@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
+  integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
 
 clean-regexp@^1.0.0:
   version "1.0.0"
@@ -6011,6 +6044,11 @@ interpret@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
+
+intersection-observer@^0.12.0:
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.12.2.tgz#4a45349cc0cd91916682b1f44c28d7ec737dc375"
+  integrity sha512-7m1vEcPCxXYI8HqnL8CKI6siDyD+eIWSwgB3DZA+ZTogxk9I4CDnj4wilt9x/+/QbHI4YG5YZNmC6458/e9Ktg==
 
 ip-regex@^2.1.0:
   version "2.1.0"
@@ -11113,7 +11151,7 @@ tsconfig-paths@^3.11.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.0.0, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1088,10 +1088,10 @@
   dependencies:
     minimist "^1.2.6"
 
-"@department-of-veterans-affairs/web-components@^4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-4.11.0.tgz#94486e70e3ac7640820c0ddda4dce6c055710ab3"
-  integrity sha512-6egB77pWbf3FIMnirIrWfm/QqoKblgYWsiYxEq3UNDlYWMzCpA/82+5614gguXq58kLXLWHdDVY/BOINACiuqw==
+"@department-of-veterans-affairs/web-components@~4.9.6":
+  version "4.9.6"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-4.9.6.tgz#16e9f057c0dbef33aa4342fc4d6ea94cdfd07c41"
+  integrity sha512-VJQq4VY8OQ0ZD32BacCjnnBeHyrJ9OoRmlBKZ7bR4LTLQwUWBDNYgSnLh8LQMO1h2gLnXdeeuMOz8xKEqT/Jig==
   dependencies:
     "@stencil/core" "^2.10.0"
     aria-hidden "^1.1.3"


### PR DESCRIPTION
## Description

Related to #1262 

After accidentally deploying a prod build which didn't include the script that defines the web component tags in the browser, it seemed like a good idea to try to prevent that in the future with a test.

cc @department-of-veterans-affairs/platform-design-system-fe 

## Testing done

E2E tests. In [this commit](https://github.com/department-of-veterans-affairs/content-build/pull/1266/commits/4fdd01e23c364d664a54bdce437b35a41ae404f4) we can see that [this new test will fail](https://github.com/department-of-veterans-affairs/content-build/runs/7902604966?check_suite_focus=true#step:9:117) when the script responsible for defining web components isn't on the page.

![A screenshot of the GitHub Action link above showing the Cypress failure when `va-accordion` isn't defined.](https://user-images.githubusercontent.com/2008881/185475247-002bdaad-ef24-4b3f-8455-eb87de53aed7.png)


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
