### PR TITLE
VACMS-10289: fixes missing lang attribute on non-English content (Resources & Support detail pages only)

### DIFF
--- a/src/site/layouts/support_resources_detail_page.drupal.liquid
+++ b/src/site/layouts/support_resources_detail_page.drupal.liquid
@@ -13,7 +13,7 @@
             {% include "src/site/includes/support_resources_search_bar.drupal.liquid" %}
           </div>
 
-          <article class="vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
+          <article class="usa-content vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
             <!-- Title -->
             <h1>{{ title }}</h1>
 


### PR DESCRIPTION
## Description
This PR adds `.usa-content` class to the `article` element so that non-English content on R&S detail pages will get a `lang` attribute.

Note: this will apply for both Spanish and Tagalog

Issue and more context: [department-of-veterans-affairs/va.gov-cms/issues/10289](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/10289)

## Testing done
- [x] locally

## Screenshots
![Screen Shot 2022-08-18 at 3 54 36 PM](https://user-images.githubusercontent.com/8542413/185483288-81a448b6-eeba-4a55-be4f-ce65e3f0ab61.png)

## Acceptance criteria
- [x] `lang=es` attribute has been added to indicate which section of the page content is in Spanish

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
