### PR TITLE
Add dynamic string for region or office value

### DIFF
--- a/src/site/layouts/health_care_facility_status.drupal.liquid
+++ b/src/site/layouts/health_care_facility_status.drupal.liquid
@@ -10,8 +10,7 @@
                     <h1 class="vads-u-margin-bottom--2">Operating status</h1>
                     <div class="va-introtext vads-u-margin-bottom--0">
                         Check the latest operating status of services and
-                        facility hours for VA
-                        Pittsburgh health care.
+                        facility hours for {{ regionOrOffice }}.
                     </div>
                     <section class="locations clearfix">
                         {% for office in mainFacilities.entities %}


### PR DESCRIPTION
## Description

Fix hard coded Pittsburgh value in operating status template.

## Testing done

Visual

## Screenshots

![Screen Shot 2022-08-19 at 9 52 05 AM](https://user-images.githubusercontent.com/2982977/185634301-772853cb-57a8-4a8a-ac93-a9aed2f558ee.png)


## Acceptance criteria
- [ ] Value matches the name of the facilities region or office

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
