### PR TITLE
VACMS-10166 Add lovell menu bifurcation

### DIFF
--- a/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
+++ b/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
@@ -170,42 +170,17 @@ const FACILITY_SIDEBAR_QUERY = `
   name
   description
   links {
-    label
-    expanded
-    description
-    url {
-      path
-    }
+    ...MenuItem
     links {
-      label
-      expanded
-      description
-      url {
-        path
-      }
+      ...MenuItem
       links {
-        label
-        expanded
-        description
-        url {
-          path
-        }
+        ...MenuItem
         links {
           ...MenuItem
           links {
-            label
-            expanded
-            description
-            url {
-              path
-            }
+            ...MenuItem
             links {
-              label
-              expanded
-              description
-              url {
-                path
-              }
+              ...MenuItem
             }
           }
         }
@@ -228,24 +203,27 @@ FACILITY_MENU_NAMES.forEach(facilityMenuName => {
   compiledQuery += nextSidebar;
 
   VaFacilitySidebars[`GetFacilitySidebar__${operationName}`] = `
-  fragment MenuItem on MenuLink {
-    expanded
-    description
-    label
-    url {
-      path
-    }
-    entity {
-      ... on MenuLinkContent {
-        linkedEntity(language_fallback: true, bypass_access_check: true) {
-          ... on Node {
-            entityPublished
-            moderationState
+    fragment MenuItem on MenuLink {
+      expanded
+      description
+      label
+      url {
+        path
+      }
+      entity {
+        ... on MenuLinkContent {
+          linkedEntity(language_fallback: true, bypass_access_check: true) {
+            ... on Node {
+              entityPublished
+              moderationState
+            }
           }
+        }
+        ... on MenuLinkContentLovellFederalHealthCare {
+          fieldMenuSection
         }
       }
     }
-  }
     query {
       ${nextSidebar}
     }

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -356,24 +356,15 @@ function lovellPageModify(page, variant) {
   return page;
 }
 
-function appendDrupalDataWithLovellPages(
-  drupalData,
-  lovellClonePages,
-  variant,
-) {
+function cloneLovellPages(lovellClonePages, variant) {
   // Deep clone with lodash
   const clonedPages = cloneDeep(lovellClonePages);
 
   // Modify the clones
-  const modifiedLovellPages = clonedPages.map(page => {
+  return clonedPages.map(page => {
     page = lovellPageModify(page, variant);
     return page;
   });
-
-  // Add the cloned pages to the drupal data
-  drupalData.data.nodeQuery.entities.push(...modifiedLovellPages);
-
-  return drupalData;
 }
 
 function lovellMenusModifyLinks(links, variation) {
@@ -493,19 +484,18 @@ function getDrupalContent(buildOptions) {
         },
       );
 
-      // Deep clone the lovell pages to create tricare
-      drupalData = appendDrupalDataWithLovellPages(
-        drupalData,
-        lovellVaClonePages,
-        'va',
-      );
-
       // Deep clone the lovell pages to create va pages
-      drupalData = appendDrupalDataWithLovellPages(
-        drupalData,
+      const vaClones = cloneLovellPages(lovellVaClonePages, 'va');
+      // Add the cloned pages to the drupal data
+      drupalData.data.nodeQuery.entities.push(...vaClones);
+
+      // Deep clone the lovell pages to create tricare pages
+      const tricareClones = cloneLovellPages(
         lovellTricareClonePages,
         'tricare',
       );
+      // Add the cloned pages to the drupal data
+      drupalData.data.nodeQuery.entities.push(...tricareClones);
 
       // Delete originals
       lovellClonePageIndexes.forEach(index => {

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -307,22 +307,18 @@ async function loadCachedDrupalFiles(buildOptions, files) {
   }
 }
 
-function isLovellClonePage(page) {
-  // Pages that should be cloned have the value of 347
-  if (page.fieldAdministration) {
-    return page.fieldAdministration.entity.entityId === '347';
-  }
-  return false;
-}
+// Pages that should be cloned have the value of 347
+const isLovellClonePage = page =>
+  page.fieldAdministration &&
+  page.fieldAdministration.entity.entityId === '347';
 
 function lovellPageModify(page, variant) {
-  const linkMod = variant;
   const fieldOfficeMod = variant === 'tricare' ? 'Tricare' : 'VA';
 
   // Modify the path
   page.entityUrl.path = page.entityUrl.path.replace(
     '/lovell-federal-health-care',
-    `/lovell-federal-${linkMod}-health-care`,
+    `/lovell-federal-${variant}-health-care`,
   );
 
   // Modify the title used for querying the menus
@@ -350,7 +346,12 @@ function lovellPageModify(page, variant) {
   return page;
 }
 
-function appendDrupalDataWithLovellTricarePages(drupalData, lovellClonePages) {
+function appendDrupalDataWithLovellTricarePages(drupalData) {
+  // Get lovell 'clone' pages
+  const lovellClonePages = drupalData.data.nodeQuery.entities.filter(
+    isLovellClonePage,
+  );
+
   // Deep clone with lodash
   const clonedPages = cloneDeep(lovellClonePages);
 
@@ -463,16 +464,8 @@ function getDrupalContent(buildOptions) {
 
       await loadCachedDrupalFiles(buildOptions, files);
 
-      // Get lovell 'clone' pages
-      const lovellClonePages = drupalData.data.nodeQuery.entities.filter(
-        isLovellClonePage,
-      );
-
       // clone and modify pages
-      drupalData = appendDrupalDataWithLovellTricarePages(
-        drupalData,
-        lovellClonePages,
-      );
+      drupalData = appendDrupalDataWithLovellTricarePages(drupalData);
 
       // clone and modify menu
       drupalData = appendDrupalDataWithLovellTricareMenus(drupalData);

--- a/src/site/stages/build/drupal/page.js
+++ b/src/site/stages/build/drupal/page.js
@@ -226,21 +226,9 @@ function getFacilitySidebar(page, contentData) {
     }
 
     // set the correct menuName based on the page
-    let facilityNavName = facilityPage
+    const facilityNavName = facilityPage
       ? page.fieldOffice.entity.entityLabel
       : pageTitle;
-
-    // if part of lovell set facilityNavName to 'Lovell Federal health care'
-    // This is here mostly so we can change title without breaking the build
-    // This isn't working as expected no sidebars are showing on any of the tricare pages
-    // TODO: Remove this if metalsmith-drupal getDrupalContent bifurcates menus
-    if (
-      page.fieldAdministration &&
-      page.fieldAdministration.entity.entityId === '347'
-    ) {
-      console.log(page.title, facilityNavName, page.fieldRegionPage);
-      facilityNavName = 'Lovell Federal health care';
-    }
 
     // choose the correct menu name to retrieve the object from contentData
     const facilitySidebarNavName = Object.keys(

--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -1,0 +1,186 @@
+/* eslint-disable no-param-reassign */
+const cloneDeep = require('lodash/cloneDeep');
+
+const { camelize } = require('../../../utilities/stringHelpers');
+
+const LOVELL_TITLE_STRING = 'Lovell Federal';
+const LOVELL_FEDERAL_ENTITY_ID = '347';
+const LOVELL_TRICARE_ENTITY_ID = '1039';
+const LOVELL_VA_ENTITY_ID = '1040';
+const LOVELL_MENU_KEY = 'lovellFederalHealthCareFacilitySidebarQuery';
+
+function isLovellFederalPage(page) {
+  return (
+    page?.fieldAdministration?.entity?.entityId === LOVELL_FEDERAL_ENTITY_ID
+  );
+}
+
+function isLovellTricarePage(page) {
+  return (
+    page?.fieldAdministration?.entity?.entityId === LOVELL_TRICARE_ENTITY_ID
+  );
+}
+
+function isLovellVaPage(page) {
+  return page?.fieldAdministration?.entity?.entityId === LOVELL_VA_ENTITY_ID;
+}
+
+function getModifiedLovellPage(page, variant) {
+  const fieldOfficeMod = variant === 'tricare' ? 'Tricare' : 'VA';
+
+  // Modify the path
+  page.entityUrl.path = page.entityUrl.path.replace(
+    '/lovell-federal-health-care',
+    `/lovell-federal-${variant}-health-care`,
+  );
+
+  // Modify the title used for querying the menus
+  if (page.fieldOffice) {
+    page.fieldOffice.entity.entityLabel = page.fieldOffice.entity.entityLabel.replace(
+      LOVELL_TITLE_STRING,
+      `${LOVELL_TITLE_STRING} ${fieldOfficeMod}`,
+    );
+  }
+  if (page.fieldRegionPage) {
+    page.fieldRegionPage.entity.title = page.fieldRegionPage.entity.title.replace(
+      LOVELL_TITLE_STRING,
+      `${LOVELL_TITLE_STRING} ${fieldOfficeMod}`,
+    );
+  }
+
+  // Modify the title this will become more complex to handle specific cases
+  page.title = page.title.replace(
+    LOVELL_TITLE_STRING,
+    `${LOVELL_TITLE_STRING} ${fieldOfficeMod}`,
+  );
+
+  return page;
+}
+
+function lovellMenusModifyLinks(link) {
+  const { variant } = this;
+  const titleVar = variant === 'va' ? 'VA' : 'Tricare';
+  const linkVar = variant === 'va' ? 'va' : 'tricare';
+
+  link.label = link.label.replace(
+    LOVELL_TITLE_STRING,
+    `${LOVELL_TITLE_STRING} ${titleVar}`,
+  );
+
+  link.url.path = link.url.path.replace(
+    '/lovell-federal-health-care',
+    `/lovell-federal-${linkVar}-health-care`,
+  );
+
+  // Use recursion to modify nested links
+  if (link && link.links.length > 0) {
+    // Remove the links that don't belong in either the va or tricare menus
+    link.links = link.links.filter(menuItem => {
+      if (menuItem.entity.fieldMenuSection === 'va' && variant === 'tricare') {
+        return false;
+      }
+      if (menuItem.entity.fieldMenuSection === 'tricare' && variant === 'va') {
+        return false;
+      }
+      return true;
+    });
+    link.links.map(lovellMenusModifyLinks, { variant });
+  }
+
+  return link;
+}
+
+function getLovellCloneMenu(drupalData, lovellMenuKey, variant) {
+  const titleVar = variant === 'va' ? 'VA' : 'Tricare';
+
+  // Clone the original menu
+  const lovellCloneMenu = cloneDeep(drupalData.data[lovellMenuKey]);
+
+  // Rename the name so our new cloned pages can find the cloned menu
+  lovellCloneMenu.name = lovellCloneMenu.name.replace(
+    LOVELL_TITLE_STRING,
+    `${LOVELL_TITLE_STRING} ${titleVar}`,
+  );
+
+  // Modify labels and paths of the cloned menu links
+  lovellCloneMenu.links = lovellCloneMenu.links.map(lovellMenusModifyLinks, {
+    variant,
+  });
+
+  // create a key for the new menus
+  const lovellCloneMenuKey = camelize(
+    `va${lovellCloneMenu.name}FacilitySidebarQuery`,
+  );
+
+  return {
+    [lovellCloneMenuKey]: lovellCloneMenu,
+  };
+}
+
+function processLovellPages(drupalData) {
+  // Note: this `reduce()` function allows us to categorize all the pages with a single pass over the array.
+  // We could accomplish this same outcome with a few `filter()` calls, but that would require multiple passes over the array.
+  const {
+    lovellFederalPages,
+    lovellVaPages,
+    lovellTricarePages,
+    otherPages,
+  } = drupalData.data.nodeQuery.entities.reduce(
+    (acc, page) => {
+      if (isLovellFederalPage(page)) {
+        acc.lovellFederalPages.push(page);
+      } else if (isLovellTricarePage(page)) {
+        acc.lovellTricarePages.push(page);
+      } else if (isLovellVaPage(page)) {
+        acc.lovellVaPages.push(page);
+      } else {
+        acc.otherPages.push(page);
+      }
+
+      return acc;
+    },
+    {
+      lovellFederalPages: [],
+      lovellTricarePages: [],
+      lovellVaPages: [],
+      otherPages: [],
+    },
+  );
+
+  // modify tricare pages
+  const modifiedLovellTricarePages = lovellTricarePages.map(page =>
+    getModifiedLovellPage(page, 'tricare'),
+  );
+  // modify va pages
+  const modifiedLovellVaPages = lovellVaPages.map(page =>
+    getModifiedLovellPage(page, 'va'),
+  );
+  // Each federal page needs to be duplicated and modified once each for tricare/va
+  const lovellFederalPagesClonedTricare = lovellFederalPages.map(page =>
+    getModifiedLovellPage(cloneDeep(page), 'tricare'),
+  );
+  const lovellFederalPagesClonedVa = lovellFederalPages.map(page =>
+    getModifiedLovellPage(cloneDeep(page), 'va'),
+  );
+
+  drupalData.data.nodeQuery.entities = [
+    ...modifiedLovellTricarePages,
+    ...modifiedLovellVaPages,
+    ...lovellFederalPagesClonedTricare,
+    ...lovellFederalPagesClonedVa,
+    ...otherPages,
+  ];
+
+  // Clone and modify the menu
+  drupalData.data = {
+    ...drupalData.data,
+    ...getLovellCloneMenu(drupalData, LOVELL_MENU_KEY, 'va'),
+    ...getLovellCloneMenu(drupalData, LOVELL_MENU_KEY, 'tricare'),
+  };
+  // Remove the original menu
+  delete drupalData.data[LOVELL_MENU_KEY];
+}
+
+module.exports = {
+  processLovellPages,
+};

--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -8,6 +8,10 @@ const LOVELL_FEDERAL_ENTITY_ID = '347';
 const LOVELL_TRICARE_ENTITY_ID = '1039';
 const LOVELL_VA_ENTITY_ID = '1040';
 const LOVELL_MENU_KEY = 'lovellFederalHealthCareFacilitySidebarQuery';
+const LOVELL_VA_TITLE_VARIATION = 'VA';
+const LOVELL_TRICARE_TITLE_VARIATION = 'TRICARE';
+const LOVELL_VA_LINK_VARIAION = 'va';
+const LOVELL_TRICARE_LINK_VARIATION = 'tricare';
 
 function isLovellFederalPage(page) {
   return (
@@ -26,12 +30,17 @@ function isLovellVaPage(page) {
 }
 
 function getModifiedLovellPage(page, variant) {
-  const fieldOfficeMod = variant === 'tricare' ? 'Tricare' : 'VA';
+  const fieldOfficeMod =
+    variant === 'va'
+      ? LOVELL_VA_TITLE_VARIATION
+      : LOVELL_TRICARE_TITLE_VARIATION;
+  const linkVar =
+    variant === 'va' ? LOVELL_VA_LINK_VARIAION : LOVELL_TRICARE_LINK_VARIATION;
 
   // Modify the path
   page.entityUrl.path = page.entityUrl.path.replace(
     '/lovell-federal-health-care',
-    `/lovell-federal-${variant}-health-care`,
+    `/lovell-federal-${linkVar}-health-care`,
   );
 
   // Modify the title used for querying the menus
@@ -59,8 +68,12 @@ function getModifiedLovellPage(page, variant) {
 
 function lovellMenusModifyLinks(link) {
   const { variant } = this;
-  const titleVar = variant === 'va' ? 'VA' : 'Tricare';
-  const linkVar = variant === 'va' ? 'va' : 'tricare';
+  const titleVar =
+    variant === 'va'
+      ? LOVELL_VA_TITLE_VARIATION
+      : LOVELL_TRICARE_TITLE_VARIATION;
+  const linkVar =
+    variant === 'va' ? LOVELL_VA_LINK_VARIAION : LOVELL_TRICARE_LINK_VARIATION;
 
   link.label = link.label.replace(
     LOVELL_TITLE_STRING,
@@ -91,7 +104,10 @@ function lovellMenusModifyLinks(link) {
 }
 
 function getLovellCloneMenu(drupalData, lovellMenuKey, variant) {
-  const titleVar = variant === 'va' ? 'VA' : 'Tricare';
+  const titleVar =
+    variant === 'va'
+      ? LOVELL_VA_TITLE_VARIATION
+      : LOVELL_TRICARE_TITLE_VARIATION;
 
   // Clone the original menu
   const lovellCloneMenu = cloneDeep(drupalData.data[lovellMenuKey]);


### PR DESCRIPTION
## Description
Bifurcates menus for Lovell pages.


## Testing done

Visual


## Screenshots
![Screen Shot 2022-08-22 at 5 09 08 PM](https://user-images.githubusercontent.com/2982977/186019569-772b5f8f-9ae3-4813-a8be-0e425628a19f.png)

![Screen Shot 2022-08-22 at 5 08 48 PM](https://user-images.githubusercontent.com/2982977/186019587-5f1230b7-f73e-4a07-87fe-e5fc7a00cd6f.png)

## Acceptance criteria
- [ ] Remove Lovell federal health care from the array of sidebar menus to build.
   - [ ] Modify menu query to get Lovell federal health care menu with the additional field of field_menu_section 
- [ ] When on pages that are identified Lovell VA (both Lovell Federal Health Care and Lovell VA) they include a menu that only includes menu items labelled both or Lovell VA.
- [ ] When on pages that are identified Lovell TRICARE (both Lovell Federal Health Care and Lovell TRICARE) they include a menu that only includes menu items labelled both or Lovell TRICARE.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
