### PR TITLE
Remove unused matrix variable in accessibility scans

### DIFF
--- a/.github/workflows/a11y-heading-order.yml
+++ b/.github/workflows/a11y-heading-order.yml
@@ -130,7 +130,6 @@ jobs:
       fail-fast: false
       max-parallel: 32
       matrix:
-        ci_node_total: [32]
         ci_node_index: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]
 
     env:

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -163,7 +163,6 @@ jobs:
       fail-fast: false
       max-parallel: 32
       matrix:
-        ci_node_total: [32]
         ci_node_index: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]
 
     env:


### PR DESCRIPTION
## Description
The `ci_node_total` variable in these workflows is not being used, so it can be removed.