### PR TITLE
Limit number of broken links that can report for a single page.

### DIFF
--- a/script/github-actions/check-broken-links-blocks.js
+++ b/script/github-actions/check-broken-links-blocks.js
@@ -8,7 +8,7 @@ const reportPath = `./logs/${envName}-broken-links.json`;
 const SERVER_URL = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
 const BRANCH_NAME = process.env.GITHUB_REF;
 const IS_PROD_BRANCH = BRANCH_NAME.replace('refs/heads/', '') === 'main';
-const GITHUB_WORKFLOW = process.env.GITHUB_WORKFLOW;
+const { GITHUB_WORKFLOW } = process.env;
 const maxBrokenLinks = 5000;
 
 // broken links detected
@@ -34,13 +34,18 @@ if (fs.existsSync(reportPath)) {
     },
   });
   const linkBlocks = brokenLinks.brokenPages.map((page, idx) => {
-    const problemMarkup = page.linkErrors.map(error => {
+    let problemMarkup = page.linkErrors.map(error => {
       const destination =
         error.target.substring(0, 1) === '/'
           ? `https://va.gov${error.target}`
           : error.target;
       return `*Broken link:* ${destination} \`\`\`${error.html}\`\`\``;
     });
+    if (problemMarkup.length > 5) {
+      problemMarkup = problemMarkup.slice(0, 5);
+      problemMarkup[5] =
+        'There are too many broken links to display. Please view the source page.';
+    }
     const destination = `https://prod.cms.va.gov/${page.path}`;
     return {
       type: 'section',

--- a/script/github-actions/check-broken-links-blocks.js
+++ b/script/github-actions/check-broken-links-blocks.js
@@ -41,19 +41,27 @@ if (fs.existsSync(reportPath)) {
           : error.target;
       return `*Broken link:* ${destination} \`\`\`${error.html}\`\`\``;
     });
+    // If there are more than 5, print 5 and a generic message.
     if (problemMarkup.length > 5) {
       problemMarkup = problemMarkup.slice(0, 5);
       problemMarkup[5] =
         'There are too many broken links to display. Please view the source page.';
     }
     const destination = `https://prod.cms.va.gov/${page.path}`;
+    let message = `*Source ${idx + 1}: ${destination} *\n${problemMarkup.join(
+      '\n',
+    )}\n\n`;
+    // If the message is still too long to safely pass, replace the message with a generic.
+    // Truncating may break HTML structures or Markdown blocks.
+    if (message.length > 2950) {
+      message = `*Source ${idx +
+        1}: ${destination} *\nThere are too many broken links to display. Please correct the source page.`;
+    }
     return {
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `*Source ${idx + 1}: ${destination} *\n${problemMarkup.join(
-          '\n',
-        )}\n\n`,
+        text: message,
       },
     };
   });


### PR DESCRIPTION
## Description
In response to this Slack thread: https://dsva.slack.com/archives/C030F5WV2TF/p1661534521227879

Slack's API will fail if too much information is passed in one 'block' i.e. chunk of information. If a single page has so many broken links on it that it passes this threshold (3000 chars), then the message will fail to post to Slack.

This just limits the number of links that is allowed to post. 

