### PR TITLE
VACMS-10465-adding-event-location

### DIFF
--- a/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
@@ -71,13 +71,10 @@ const nodeEvent = `
         entityBundle
         entityId
         entityType
-        ... on NodeHealthCareLocalFacility {
-          entityUrl {
-            path
-          }
-          fieldFacilityLocatorApiId
-          title
+        entityUrl {
+          path
         }
+        title
       }
     }
     fieldFeatured
@@ -221,13 +218,10 @@ const nodeEventWithoutBreadcrumbs = `
         entityBundle
         entityId
         entityType
-        ... on NodeHealthCareLocalFacility {
-          entityUrl {
-            path
-          }
-          fieldFacilityLocatorApiId
-          title
+        entityUrl {
+          path
         }
+        title
       }
     }
     fieldFeatured


### PR DESCRIPTION
## Description
Ticket [#10465](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/10465)

## Testing done
Joint testing efforts with Backend. See PR [#10357](https://github.com/department-of-veterans-affairs/va.gov-cms/pull/10357)
- Additional, existing events were checked to make sure they were still functioning as desired.

## Screenshots
<img width="1011" alt="Screen Shot 2022-09-01 at 11 18 44 AM" src="https://user-images.githubusercontent.com/732460/187985267-719a7b6e-992c-4603-949b-4abc978cbcf8.png">

## Acceptance criteria
- [x] Vets Center now appears in "Where" in event view.
- [x] Not Vet Center-held events still function normally in displaying their locations.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
