### PR TITLE
VACMS-10375: Removes staged_content from production build.

### DIFF
--- a/src/site/stages/build/drupal/graphql/entityQueue.graphql.js
+++ b/src/site/stages/build/drupal/graphql/entityQueue.graphql.js
@@ -1,0 +1,25 @@
+const { pascalize } = require('../../../../utilities/stringHelpers');
+
+const getEntityQueueByName = entityQueueName => {
+  const pascalCaseName = pascalize(entityQueueName);
+  return `
+    query GetEntityQueue${pascalCaseName} {
+      entityQueue${pascalCaseName}: entitySubqueueQuery(filter:{
+        conditions: [{field: "name", value: "${entityQueueName}"}]
+      }) {
+        entities {
+          ...on EntitySubqueue {
+            name
+            items {
+              targetId
+            }
+          }
+        }
+      }
+    }
+  `;
+};
+
+module.exports = {
+  getEntityQueueByName,
+};

--- a/src/site/stages/build/drupal/individual-queries.js
+++ b/src/site/stages/build/drupal/individual-queries.js
@@ -149,6 +149,9 @@ function nonNodeQueries() {
   // Get current feature flags
   const { cmsFeatureFlags } = global;
 
+  const { getEntityQueueByName } = require('./graphql/entityQueue.graphql');
+  const GetEntityQueueStagedContent = getEntityQueueByName('staged_content');
+
   const { GetIcsFiles } = require('./graphql/file-fragments/ics.file.graphql');
 
   const {
@@ -179,6 +182,7 @@ function nonNodeQueries() {
   } = require('./graphql/taxonomy-fragments/GetTaxonomies.graphql');
 
   const componentQueries = {
+    GetEntityQueueStagedContent,
     GetLocationsOperatingStatus,
     GetIcsFiles,
     GetSidebars,

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -190,6 +190,37 @@ function writeGraphQLCacheFile(cacheFilePath, graphQLData) {
 }
 
 /**
+ * If buildtype is production, removes pages that are set as "staged content" (via EntityQueue)
+ *
+ * @param {Object} buildOptions
+ * @param {Object} drupalPages - Array of page objects (GraphQL query results) pulled from Drupal
+ */
+function removeStagedContentFromProd(buildOptions, drupalPages) {
+  // If not production build, keep all pages
+  if (buildOptions.buildtype !== ENVIRONMENTS.VAGOVPROD) {
+    return drupalPages;
+  }
+
+  const stagedContent = drupalPages?.data?.entityQueueStagedContent?.entities[0]?.items?.map(
+    item => item.targetId,
+  );
+  if (!stagedContent || stagedContent.length === 0) {
+    return drupalPages;
+  }
+
+  if (!drupalPages?.data?.nodeQuery?.entities) {
+    return drupalPages;
+  }
+
+  const modifiedPages = drupalPages;
+  modifiedPages.data.nodeQuery.entities = drupalPages.data.nodeQuery.entities.filter(
+    page => !stagedContent.includes(page?.entityId),
+  );
+
+  return modifiedPages;
+}
+
+/**
  * Uses Drupal content via a new GraphQL query or the cached result of a
  * previous query. This is where the cache is saved.
  *
@@ -218,6 +249,8 @@ async function getContentViaGraphQL(buildOptions) {
     drupalPages = await contentApi.getAllPagesViaIndividualGraphQlQueries();
 
     console.timeEnd(drupalTimer);
+
+    drupalPages = removeStagedContentFromProd(buildOptions, drupalPages);
 
     // Error handling
     if (drupalPages.errors && drupalPages.errors.length) {

--- a/src/site/utilities/stringHelpers.js
+++ b/src/site/utilities/stringHelpers.js
@@ -26,6 +26,12 @@ function camelize(str) {
   return camelCase(str);
 }
 
+// Pascalcase a string
+function pascalize(str) {
+  const camelized = camelize(str);
+  return camelized[0].toUpperCase() + camelized.substring(1);
+}
+
 // Remove all underscores from body of string and then prepend an underscore if string starts with number
 function updateQueryString(matchedString) {
   const findUnderscores = new RegExp('_', 'g');
@@ -39,4 +45,5 @@ module.exports = {
   updateQueryString,
   queryParamToBeChanged,
   camelize,
+  pascalize,
 };


### PR DESCRIPTION
## Description
See: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/10375

Implements a way to "dark launch" CMS pages. If a node is added to the `staged_content` Entityqueue, that page will be excluded from the production build.

## Testing done
Built with data from [this Tugboat](https://cms-h3msowyrt1vq41aexyonavht3xohk2mr.demo.cms.va.gov/admin/structure/entityqueue/staged_content/staged_content?destination=/admin/structure/entityqueue).

- Built locally with `buildtype=vagovprod`.
   - `staged_content` **does not** build. 
- Built locally with `buildtype=vagovstaging`.
   - `staged_content` **does** build. 
- Additionally, built on Tugboat with removed logic that limits feature to production.
   - `staged_content` does not build.