### PR TITLE
Point `content-release` action to new owner.

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Get latest release
         id: get-latest-release
-        uses: thebritican/fetch-latest-release@v2.0.0
+        uses: gregziegan/fetch-latest-release@v2.0.0
 
       - name: Validate build status
         run: node ./script/github-actions/validate-build-status.js ${{ steps.get-latest-release.outputs.target_commitish }}


### PR DESCRIPTION
## Description
Security issue, see [thread](https://dsva.slack.com/archives/C02HX4AQZ33/p1662126073997009).

>On September 1, CSOC received notification from DHS Cybersecurity & Infrastructure Security Agency (CISA) of vulnerable code posted to the VA’s public-facing GitHub repository. Below are details on the vulnerability and recommended remediation. The code should be remediated as soon as possible. Please confirm with CSOC as soon as the remediation is in place, and contact us 24x7 with questions.
Vulnerability Background:

>The vulnerability stems from a known issue with GitHub Action Workflows (AW). Calls to third-party AWs reference the AW author’s username. If the AW author changes their username, an attacker could create an account with the AW author’s old username and publish a malicious AW with the old name. Any GitHub code calling that AW with reference to the old username could then execute the malicious code.

>CISA identified one workflow hosted within the VA-managed, public-facing GitHub repository that is vulnerable to this attack. The VA workflow calls a third-party AW authored by a user that had recently changed their username (from `thebritican` to `gregziegan`).
