### PR TITLE
9946 fe pages in both lovells get canonical added to make lovell va the canon

### DIFF
--- a/src/site/includes/metatags.drupal.liquid
+++ b/src/site/includes/metatags.drupal.liquid
@@ -1,5 +1,7 @@
 <!-- Canonical URL -->
-{% if entityUrl.path %}
+{% if canonicalLink %}
+  <link rel="canonical" href="{{ hostUrl }}{{ canonicalLink }}/" />
+{% elsif entityUrl.path %}
   <link rel="canonical" href="{{ hostUrl }}{{ entityUrl.path }}/" />
 {% elsif path %}
   <link rel="canonical" href="{{ hostUrl }}/{{ path }}/" />

--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -37,6 +37,14 @@ function getModifiedLovellPage(page, variant) {
   const linkVar =
     variant === 'va' ? LOVELL_VA_LINK_VARIAION : LOVELL_TRICARE_LINK_VARIATION;
 
+  // Add a field for canonical if it has a clone and it's a tricare variant
+  if (variant === 'tricare' && isLovellFederalPage) {
+    page.canonicalLink = page.entityUrl.path.replace(
+      '/lovell-federal-health-care',
+      `/lovell-federal-va-health-care`,
+    );
+  }
+
   // Modify the path
   page.entityUrl.path = page.entityUrl.path.replace(
     '/lovell-federal-health-care',


### PR DESCRIPTION
## Description

Adds a canonical link to the data for the static build for pages in the Lovell system that are TRICARE clones with VA counterparts. The canonical link in the head should point to the VA counterpart when on a tricare page. All other pages within the system should point to themselves.


## Testing done

Visual

## Screenshots

![Screen Shot 2022-09-02 at 11 17 44 AM](https://user-images.githubusercontent.com/2982977/188181265-301b556a-a5e7-4425-910c-21872e3c45af.png)

## Acceptance criteria
- [ ] All pages that have TRICARE in their URL that are not unique to TRICARE should have a canonical that points to the VA version of the page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
