### PR TITLE
[VA-9947] Add VA/Tricare switch links

### DIFF
--- a/src/site/facilities/health_care_region_detail_content.drupal.liquid
+++ b/src/site/facilities/health_care_region_detail_content.drupal.liquid
@@ -1,4 +1,8 @@
 <article aria-labelledby="article-heading" role="region" class="usa-content" data-template="health_care_region_detail_content.drupal.liquid">
+  {% include "src/site/includes/lovell-switch-link.drupal.liquid" with
+    entityUrl = entityUrl
+  %}
+
   <h1 id="article-heading">{{ title }}</h1>
   <div class="va-introtext">
     <p>{{ fieldIntroText }}</p>

--- a/src/site/includes/lovell-switch-link.drupal.liquid
+++ b/src/site/includes/lovell-switch-link.drupal.liquid
@@ -1,0 +1,15 @@
+{% if entityUrl.switchPath %}
+  {% if entityUrl.switchPath contains "tricare" %}
+    {% assign currentPageVariation = "VA" %}
+    {% assign switchPageVariation = "TRICARE" %}
+  {% else %}
+    {% assign currentPageVariation = "TRICARE" %}
+    {% assign switchPageVariation = "VA" %}
+  {% endif %}
+
+  <va-alert status="info" class="vads-u-margin-bottom--2" id="va-info-alert">
+    <div class="vads-u-margin-top--0">
+      <strong>You are viewing this page as a {{ currentPageVariation }} beneficiary.</strong> <a href="{{ entityUrl.switchPath }}">View this page as a {{ switchPageVariation }} beneficiary <i aria-hidden="true" class="fas fa-angle-right"></i></a>
+    </div>
+  </va-alert>
+{% endif %}

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -10,6 +10,10 @@
       {% endunless %}
 
       <div class="usa-width-three-fourths vads-u-display--flex vads-u-flex-direction--column vads-u-padding-x--1p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--2">
+        {% include "src/site/includes/lovell-switch-link.drupal.liquid" with
+          entityUrl = entityUrl
+        %}
+
         <!-- Title -->
         <h1>{{ title }}</h1>
 
@@ -82,7 +86,7 @@
                   <div class="vads-u-display--flex vads-u-flex-direction--column">
                     {% if fieldLocationHumanreadable != empty %}
                       <p class="vads-u-margin--0">{{ fieldLocationHumanreadable }}</p>
-                    {% endif %} 
+                    {% endif %}
                     {% if fieldAddress.addressLine1 %}
                       <p class="vads-u-margin--0">{{ fieldAddress.addressLine1 }}</p>
                     {% endif %}

--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -10,6 +10,10 @@
 			{% endunless %}
 
 			<div class="events vads-u-display--flex vads-u-flex-direction--column vads-u-padding-x--1p5 medium-screen:vads-u-padding-x--0 vads-u-padding-bottom--2">
+				{% include "src/site/includes/lovell-switch-link.drupal.liquid" with
+					entityUrl = entityUrl
+				%}
+
 				<h1 id="article-heading">{{ title }}</h1>
 				<div class="va-introtext">
 					{% if fieldIntroText %}

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -8,6 +8,10 @@
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
       <div class="usa-width-three-fourths">
         <article class="usa-content va-l-facility-detail">
+          {% include "src/site/includes/lovell-switch-link.drupal.liquid" with
+            entityUrl = entityUrl
+          %}
+
           {% if title != empty %}
             <h1>{{ title }}</h1>
           {% endif %}

--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -8,6 +8,10 @@
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
       <div class="usa-width-three-fourths">
         <article class="usa-content">
+          {% include "src/site/includes/lovell-switch-link.drupal.liquid" with
+            entityUrl = entityUrl
+          %}
+
           <h1>{{ title }}</h1>
           {% assign image = fieldMedia.entity.image %}
 

--- a/src/site/layouts/health_services_listing.drupal.liquid
+++ b/src/site/layouts/health_services_listing.drupal.liquid
@@ -7,6 +7,10 @@
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
       <div class="usa-width-three-fourths">
         <article class="usa-content">
+          {% include "src/site/includes/lovell-switch-link.drupal.liquid" with
+            entityUrl = entityUrl
+          %}
+
           <h1 class="vads-u-margin-bottom--1 medium-screen:vads-u-margin-bottom--2">
             {{title}}</h1>
           <div class="va-introtext">

--- a/src/site/layouts/leadership_listing.drupal.liquid
+++ b/src/site/layouts/leadership_listing.drupal.liquid
@@ -9,6 +9,10 @@
 
             <div class="usa-width-three-fourths">
                 <article class="usa-content">
+                    {% include "src/site/includes/lovell-switch-link.drupal.liquid" with
+                        entityUrl = entityUrl
+                    %}
+
                     <h1 class="vads-u-margin-bottom--3">{{ title }}</h1>
                     {% if fieldIntroText %}
                         <div class="va-introtext vads-u-padding-bottom--2p5">

--- a/src/site/layouts/locations_listing.drupal.liquid
+++ b/src/site/layouts/locations_listing.drupal.liquid
@@ -14,6 +14,10 @@
       <div class="usa-width-three-fourths">
 
         <article class="usa-content">
+          {% include "src/site/includes/lovell-switch-link.drupal.liquid" with
+            entityUrl = entityUrl
+          %}
+
           <h1 class="vads-u-margin-bottom--2">Locations</h1>
           <div class="usa-grid usa-grid-full vads-u-margin-y--1p5">
             {% assign basePath = entityUrl.path | regionBasePath %}

--- a/src/site/layouts/news_story.drupal.liquid
+++ b/src/site/layouts/news_story.drupal.liquid
@@ -11,6 +11,10 @@
             {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
             <div class="usa-width-three-fourths">
                 <article class="usa-content">
+                    {% include "src/site/includes/lovell-switch-link.drupal.liquid" with
+                        entityUrl = entityUrl
+                    %}
+
                     <h1>{{ title }}</h1>
                     {% assign image = fieldMedia.entity.image %}
                     {% capture imageClass %}

--- a/src/site/layouts/person_profile.drupal.liquid
+++ b/src/site/layouts/person_profile.drupal.liquid
@@ -13,6 +13,10 @@
             {%  endif %}
             <div class="usa-width-three-fourths">
                 <article class="usa-content">
+                    {% include "src/site/includes/lovell-switch-link.drupal.liquid" with
+                        entityUrl = entityUrl
+                    %}
+
                     <div class="usa-grid usa-grid-full vads-u-margin-bottom--2 vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row">
                         {% if fieldMedia.thumbnail.image != empty %}
                             <div class="vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0 vads-u-margin-right--3">

--- a/src/site/layouts/press_release.drupal.liquid
+++ b/src/site/layouts/press_release.drupal.liquid
@@ -9,6 +9,10 @@
 
             <div class="usa-width-three-fourths">
                 <article class="usa-content">
+                    {% include "src/site/includes/lovell-switch-link.drupal.liquid" with
+                        entityUrl = entityUrl
+                    %}
+
                     <section class="vads-u-margin-bottom--5">
                         <h1 class="vads-u-margin-bottom--2p5">{{ title }}</h1>
                         <p class="vads-u-margin-bottom--0p5">PRESS RELEASE</p>

--- a/src/site/layouts/press_releases_listing.drupal.liquid
+++ b/src/site/layouts/press_releases_listing.drupal.liquid
@@ -58,6 +58,10 @@ larger space in the Fayette Plaza at 627 Pittsburgh Road, Suite 2, Uniontown,
 
       <div class="usa-width-three-fourths">
         <article class="usa-content">
+          {% include "src/site/includes/lovell-switch-link.drupal.liquid" with
+            entityUrl = entityUrl
+          %}
+
           <h1 id="article-heading">{{ title }}</h1>
           <div class="vads-l-grid-container--full">
             <div class="va-introtext">

--- a/src/site/layouts/story_listing.drupal.liquid
+++ b/src/site/layouts/story_listing.drupal.liquid
@@ -8,6 +8,10 @@
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
       <div class="usa-width-three-fourths">
         <article class="usa-content">
+            {% include "src/site/includes/lovell-switch-link.drupal.liquid" with
+              entityUrl = entityUrl
+            %}
+
             <h1 id="article-heading">{{ title }}</h1>
             <div class="vads-l-grid-container--full">
               <div class="va-introtext">

--- a/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
+++ b/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
@@ -12,6 +12,10 @@
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
       <div class="usa-width-three-fourths">
         <article class="usa-content">
+          {% include "src/site/includes/lovell-switch-link.drupal.liquid" with
+            entityUrl = entityUrl
+          %}
+
           <h1 class="vads-u-margin-bottom--2">Operating status</h1>
           <div class="va-introtext vads-u-margin-bottom--0">
             {{ facilitySidebar.name }}

--- a/src/site/layouts/vamc_system_billing_insurance.drupal.liquid
+++ b/src/site/layouts/vamc_system_billing_insurance.drupal.liquid
@@ -8,8 +8,11 @@
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
       <div class="usa-width-three-fourths">
-        <article aria-labelledby="article-heading" role="region"
-          class="usa-content">
+        <article aria-labelledby="article-heading" role="region" class="usa-content">
+          {% include "src/site/includes/lovell-switch-link.drupal.liquid" with
+            entityUrl = entityUrl
+          %}
+
           <h1 id="article-heading">{{ title }}</h1>
           <div class="va-introtext">
             <p>

--- a/src/site/layouts/vamc_system_medical_records_offi.drupal.liquid
+++ b/src/site/layouts/vamc_system_medical_records_offi.drupal.liquid
@@ -9,6 +9,10 @@
 			{% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
 			<div class="usa-width-three-fourths">
 				<article aria-labelledby="article-heading" role="region" class="usa-content">
+					{% include "src/site/includes/lovell-switch-link.drupal.liquid" with
+            entityUrl = entityUrl
+          %}
+
 					<h1 id="article-heading">{{ title }}</h1>
 					<div class="va-introtext">
 						<p>

--- a/src/site/layouts/vamc_system_policies_page.drupal.liquid
+++ b/src/site/layouts/vamc_system_policies_page.drupal.liquid
@@ -8,6 +8,10 @@
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
       <div class="usa-width-three-fourths">
         <article aria-labelledby="article-heading" role="region" class="usa-content">
+          {% include "src/site/includes/lovell-switch-link.drupal.liquid" with
+            entityUrl = entityUrl
+          %}
+
           <h1 id="article-heading">{{ title }}</h1>
           <div class="va-introtext">
             {% include "src/site/includes/centralized-content.drupal.liquid" with

--- a/src/site/layouts/vamc_system_register_for_care.drupal.liquid
+++ b/src/site/layouts/vamc_system_register_for_care.drupal.liquid
@@ -8,6 +8,10 @@
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
       <div class="usa-width-three-fourths">
         <article aria-labelledby="article-heading" role="region" class="usa-content">
+          {% include "src/site/includes/lovell-switch-link.drupal.liquid" with
+            entityUrl = entityUrl
+          %}
+
           <h1 id="article-heading">{{ title }}</h1>
           <div class="va-introtext">
             <p>


### PR DESCRIPTION
## Description

After "Phase XVII Bifurcation Of Love and Thunder," many pages can be viewed as a veteran or DoD employee. This PR creates the "switch links" for switching between these two views and adds a widget to the top of layouts that shows them when available.

Closes [#9947](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9947).

## Testing done

Visual, checked affected pages.

You'll need to run `yarn build --pull-drupal --drupal-address=https://main-h9pcctlewcire4bsv6mokzmlxgji68i8.demo.cms.va.gov` to generate the pages (around 20 minutes) before running `yarn preview`.

## Screenshots

See the below pages' URLs and the respective changes to the alert. Clicking the link on one will go to the other page, respectively.

<img width="1343" alt="Screen Shot 2022-09-06 at 1 37 52 PM" src="https://user-images.githubusercontent.com/10790736/188706367-8aee3322-9f08-475e-9ee2-6dff766751fd.png">

<img width="1297" alt="Screen Shot 2022-09-06 at 1 37 37 PM" src="https://user-images.githubusercontent.com/10790736/188706370-20c6c649-0639-4fa9-939b-6bbab01e32ba.png">

## Acceptance criteria

- [ ] Lovell pages with switch links have the callout to switch them
- [ ] The switch links go to the expected page, VA to Tricare and vice versa.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
