### PR TITLE
VACMS-10466 add path to next-build broken links, update log color

### DIFF
--- a/src/site/stages/build/plugins/modify-dom/check-broken-links/index.js
+++ b/src/site/stages/build/plugins/modify-dom/check-broken-links/index.js
@@ -46,8 +46,13 @@ module.exports = {
     const linkErrors = getBrokenLinks(file, this.allPaths);
 
     if (linkErrors.length > 0) {
+      // next-build generated files return file.path as undefined, this slices off /index.html to match live link
+      let nextFilePath = '';
+      if (file.path === undefined) {
+        nextFilePath = fileName.slice(0, -11);
+      }
       this.brokenPages.push({
-        path: file.path,
+        path: file.path || nextFilePath,
         linkErrors,
       });
     }

--- a/src/site/stages/build/plugins/run-next-build.js
+++ b/src/site/stages/build/plugins/run-next-build.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-param-reassign */
-/* eslint-disable no-console */
 const { spawn } = require('child_process');
+const { logDrupal } = require('../drupal/utilities-drupal');
 
 const runNextBuild = options => (files, metalsmith, done) => {
-  console.log(
+  logDrupal(
     'Next build: starting build in child process. Metalsmith will continue.',
   );
   const directory = options['next-build-directory'];
@@ -29,7 +29,7 @@ const runNextBuild = options => (files, metalsmith, done) => {
     // If the child process exits abnormally, exit parent with the same code
     child.on('exit', code => {
       if (code) {
-        console.log(scriptOutput);
+        logDrupal(scriptOutput);
         process.exit(code);
       }
     });
@@ -42,7 +42,7 @@ const runNextBuild = options => (files, metalsmith, done) => {
         ...metalsmith.metadata(),
       });
       const exitCodeText = code ? `with code ${code}` : 'successfully';
-      console.log(
+      logDrupal(
         `Next build: build completed ${exitCodeText}. Log output is available in metalsmith.metadata().nextBuildLog.`,
       );
       resolve();


### PR DESCRIPTION
## Description
Relates to https://github.com/department-of-veterans-affairs/va.gov-cms/issues/10466

## Testing done
- Pointed local next-build and content-build repos at my local ddev cms instance
- Ran content build to get baseline # of broken links
- Added dummy broken links to News Story nodes
- Re-ran content build locally, verified new dummy broken links were picked up

command to run: `NODE_OPTIONS='--max-http-header-size=50000' yarn build --nosymlink --run-next-build`

I did the same while facing at the staging instance content-build points at by default, but that content is reset daily during the mirror update, so local testing was the way to go to preserve my bad data.

## Screenshots
```json
        {
            "path": "finger-lakes-health-care/stories/the-new-2022-pact-act",
            "linkErrors": [
                {
                    "html": "<a href=\"/foo-bar\">facilities across the country</a>",
                    "target": "/foo-bar"
                },
                {
                    "html": "<a href=\"/www.va.gov/pact\">www.va.gov/pact</a>",
                    "target": "/www.va.gov/pact"
                }
            ]
        },
        {
            "path": "butler-health-care/stories/prevention-is-the-key-to-health",
            "linkErrors": [
                {
                    "html": "<a href=\"/foo-de-doo-boo\">preventive health services</a>",
                    "target": "/foo-de-doo-boo"
                }
            ]
        },
```

## Acceptance criteria
- [x] Broken links in pages generated by next-build are correctly reported in the broken links json output

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
