### PR TITLE
10527 office hours on facilities are not showing closed if weekdays are empty

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1510,4 +1510,32 @@ module.exports = function registerFilters() {
     }
     return moment(time, 'Hmm').format('HH:mm:ss');
   };
+
+  liquid.filters.officeHoursDataFormat = data => {
+    const formattedData = [];
+    for (let i = 0; i < 7; i++) {
+      let day = {
+        day: i,
+        starthours: null,
+        endhours: null,
+        comment: 'Closed',
+      };
+      data.forEach(item => {
+        if (item.day === i) {
+          day = {
+            day: item.day,
+            starthours: item.starthours,
+            endhours: item.endhours,
+            comment: item.comment,
+          };
+        }
+      });
+      formattedData.push(day);
+    }
+
+    return [
+      ...formattedData.filter(a => a.day !== 0),
+      ...formattedData.filter(a => a.day === 0),
+    ];
+  };
 };

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -9,6 +9,7 @@ import pressReleasesMockData from '../layouts/tests/vamc/fixtures/pressReleasesM
 import registerFilters from './liquid';
 import sidebarData from './fixtures/sidebarData.json';
 import vetCenterData from '../layouts/tests/vet_center/template/fixtures/vet_center_data.json';
+import vetCenterHoursData from '../layouts/tests/vet_center/template/fixtures/vet_center_hours_data.json';
 import healthCareRegionNonClinicalServicesData from './fixtures/healthCareRegionNonClinicalServicesData.json';
 import stagingSurveys from './medalliaStagingSurveys.json';
 import prodSurveys from './medalliaProdSurveys.json';
@@ -2442,5 +2443,64 @@ describe('deriveTimeForJSONLD', () => {
     expect(
       liquid.filters.deriveTimeForJSONLD(time, timetype, comment),
     ).to.equal('23:59:59');
+  });
+});
+
+describe('officeHoursDataFormat', () => {
+  // The function shifts the order of the array so that monday is first the day order is then 1,2,3,4,5,6,0
+  const defaultDay = index => {
+    return {
+      comment: 'Closed',
+      day: index === 6 ? 0 : index + 1, // because of the shift
+      endhours: null,
+      starthours: null,
+    };
+  };
+
+  it('when given an incomplete week returns a complete week with default days filled in where there were no values', () => {
+    const data = vetCenterHoursData.partialWeek;
+    for (let i = 0; i < 7; i++) {
+      // Check every day is equal to default day except for day provided by the data
+      if (i !== 1) {
+        assert.deepEqual(
+          liquid.filters.officeHoursDataFormat(data)[i],
+          defaultDay(i),
+        );
+      }
+    }
+  });
+
+  it('when given an incomplete week returns a complete week with the given data in the correct place', () => {
+    const data = vetCenterHoursData.partialWeek;
+    for (let i = 0; i < 7; i++) {
+      // Day 2 gets shifted back to 1 check if day 2 is in the right space
+      if (i === 1) {
+        assert.deepEqual(
+          liquid.filters.officeHoursDataFormat(data)[i],
+          data[0],
+        );
+      }
+    }
+  });
+
+  it('when given a complete week returns a complete week with the expected data', () => {
+    const data = vetCenterHoursData.completeWeek;
+    for (let i = 0; i < 7; i++) {
+      // Check to see if the new data equals the original data shifted back one
+      assert.deepEqual(
+        liquid.filters.officeHoursDataFormat(data)[i],
+        data[i === 6 ? 0 : i + 1],
+      );
+    }
+  });
+
+  it('when given a partial week always returns a full week', () => {
+    const data = vetCenterHoursData.partialWeek;
+    expect(liquid.filters.officeHoursDataFormat(data).length, 7);
+  });
+
+  it('when given a full week always returns a full week', () => {
+    const data = vetCenterHoursData.completeWeek;
+    expect(liquid.filters.officeHoursDataFormat(data).length, 7);
   });
 });

--- a/src/site/includes/hours.liquid
+++ b/src/site/includes/hours.liquid
@@ -14,41 +14,10 @@
 			{% endif %}
 			<div class="vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row vads-u-margin-bottom--0">
 				<ul class="vads-u-flex--1 va-c-facility-hours-list vads-u-margin-top--0 vads-u-margin-bottom--1 small-screen:vads-u-margin-bottom--0 vads-u-margin-right--3">
-					{% assign saturday = false %}
-					{% assign sunday = false %}
+					{% assign allHours = allHours | officeHoursDataFormat%}
 					{% for hours in allHours %}
-						{% if hours.day == 6 %}
-							{% assign saturday = hours %}
-						{% elsif hours.day == 0 %}
-							{% assign sunday = hours %}
-						{% else %}
-							{% include "src/site/includes/hours-item.liquid" with hours = hours %}
-						{% endif %}
+						{% include "src/site/includes/hours-item.liquid" with hours = hours %}
 					{% endfor %}
-					{% if saturday %}
-						{% include "src/site/includes/hours-item.liquid" with hours = saturday %}
-					{% else %}
-                        <li>
-                            {% if headerType == 'clinical' %}
-                                <b class="abbrv-day">Sat:</b>
-                            {% else %}
-                                <span class="abbrv-day">Sat.</span>
-                            {% endif %}
-							Closed
-                        </li>
-                    {% endif %}
-                    {% if sunday %}
-                        {% include "src/site/includes/hours-item.liquid" with hours = sunday %}
-                    {% else %}
-                        <li>
-                            {% if headerType == 'clinical' %}
-                                <b class="abbrv-day">Sun:</b>
-                            {% else %}
-                                <span class="abbrv-day">Sun.</span>
-                            {% endif %}
-                            Closed
-                        </li>
-					{% endif %}
 				</ul>
 			</div>
 		</div>

--- a/src/site/layouts/tests/vet_center/template/fixtures/vet_center_hours_data.json
+++ b/src/site/layouts/tests/vet_center/template/fixtures/vet_center_hours_data.json
@@ -1,0 +1,54 @@
+{
+  "completeWeek": [
+    {
+      "day": 0,
+      "starthours": -1,
+      "endhours": -1,
+      "comment": "Closed"
+    },
+    {
+      "day": 1,
+      "starthours": 700,
+      "endhours": 1730,
+      "comment": "Test Comment"
+    },
+    {
+      "day": 2,
+      "starthours": 700,
+      "endhours": 1730,
+      "comment": ""
+    },
+    {
+      "day": 3,
+      "starthours": 700,
+      "endhours": 1730,
+      "comment": ""
+    },
+    {
+      "day": 4,
+      "starthours": 700,
+      "endhours": 1730,
+      "comment": ""
+    },
+    {
+      "day": 5,
+      "starthours": 700,
+      "endhours": 1630,
+      "comment": ""
+    },
+    {
+      "day": 6,
+      "starthours": -1,
+      "endhours": -1,
+      "comment": "Closed"
+    }
+  ],
+  "partialWeek": [
+    {
+      "day": 2,
+      "starthours": 700,
+      "endhours": 1730,
+      "comment": "Test Comment"
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Creates a filter for normalizing the hours data coming from the cms so that the data always consists of 7 days. Where there is no data for a day the filter sets default values for that day:

```
let day = {
  day: i,
  starthours: null,
  endhours: null,
  comment: 'Closed',
};
```

## Testing done

- visual
- unit testing

## Screenshots

![Screen Shot 2022-09-07 at 11 17 44 AM](https://user-images.githubusercontent.com/2982977/188915599-481dc9ad-7dfd-4c48-b4c2-7a4c7439ff52.png)

## Acceptance criteria
- [ ] Wherever field_office_hours is used: when From, To, and Comment is all empty, print "Closed" in the template.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
