### PR TITLE
10726 fe page bifurcation fix for new content

### DIFF
--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -194,8 +194,8 @@ function getLovellCloneMenu(drupalData, lovellMenuKey, variant) {
   const lovellCloneMenuKey = camelize(
     `va${lovellCloneMenu.name}FacilitySidebarQuery`,
   );
-  console.log(lovellCloneMenuKey);
-  console.dir(lovellCloneMenu, { depth: 7 });
+  // console.log(lovellCloneMenuKey);
+  // console.dir(lovellCloneMenu, { depth: 9 });
 
   return {
     [lovellCloneMenuKey]: lovellCloneMenu,

--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -62,19 +62,19 @@ function getModifiedLovellPage(page, variant) {
   );
 
   // Modify the title used for querying the menus
-  const variantFind = variant === 'tricare' ? 'TRICARE' : 'VA';
-  const findString = `${LOVELL_TITLE_STRING} ${variantFind}`;
-  const regexFind = new RegExp(findString, 'gi');
+  const variantName = variant === 'tricare' ? 'TRICARE' : 'VA';
+  const titleNeedle = `${LOVELL_TITLE_STRING} ${variantName}`;
+  const regexNeedle = new RegExp(titleNeedle, 'gi');
 
   if (page.fieldOffice) {
     // services, facilites
     if (
       page.fieldOffice.entity.entityLabel
         .toLowerCase()
-        .includes(`${LOVELL_TITLE_STRING} ${variantFind}`.toLowerCase())
+        .includes(`${LOVELL_TITLE_STRING} ${variantName}`.toLowerCase())
     ) {
       page.fieldOffice.entity.entityLabel = page.fieldOffice.entity.entityLabel.replace(
-        regexFind,
+        regexNeedle,
         `${LOVELL_TITLE_STRING} ${fieldOfficeMod}`,
       );
     } else {
@@ -88,10 +88,10 @@ function getModifiedLovellPage(page, variant) {
     if (
       page.fieldRegionPage.entity.title
         .toLowerCase()
-        .includes(`${LOVELL_TITLE_STRING} ${variantFind}`.toLowerCase())
+        .includes(`${LOVELL_TITLE_STRING} ${variantName}`.toLowerCase())
     ) {
       page.fieldRegionPage.entity.title = page.fieldRegionPage.entity.title.replace(
-        regexFind,
+        regexNeedle,
         `${LOVELL_TITLE_STRING} ${fieldOfficeMod}`,
       );
     } else {
@@ -106,10 +106,10 @@ function getModifiedLovellPage(page, variant) {
   if (
     page.title
       .toLowerCase()
-      .includes(`${LOVELL_TITLE_STRING} ${variantFind}`.toLowerCase())
+      .includes(`${LOVELL_TITLE_STRING} ${variantName}`.toLowerCase())
   ) {
     page.title = page.title.replace(
-      regexFind,
+      regexNeedle,
       `${LOVELL_TITLE_STRING} ${fieldOfficeMod}`,
     );
   } else {
@@ -194,8 +194,6 @@ function getLovellCloneMenu(drupalData, lovellMenuKey, variant) {
   const lovellCloneMenuKey = camelize(
     `va${lovellCloneMenu.name}FacilitySidebarQuery`,
   );
-  // console.log(lovellCloneMenuKey);
-  // console.dir(lovellCloneMenu, { depth: 9 });
 
   return {
     [lovellCloneMenuKey]: lovellCloneMenu,

--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -152,10 +152,21 @@ function lovellMenusModifyLinks(link) {
     );
   }
 
-  link.url.path = link.url.path.replace(
-    '/lovell-federal-health-care',
-    `/lovell-federal-${linkVar}-health-care`,
-  );
+  // Handle the special case for the first one
+  if (
+    variant === 'tricare' &&
+    link.url.path === '/lovell-federal-va-health-care'
+  ) {
+    link.url.path = link.url.path.replace(
+      '/lovell-federal-va-health-care',
+      `/lovell-federal-tricare-health-care`,
+    );
+  } else {
+    link.url.path = link.url.path.replace(
+      '/lovell-federal-health-care',
+      `/lovell-federal-${linkVar}-health-care`,
+    );
+  }
 
   // Use recursion to modify nested links
   if (link && link.links.length > 0) {
@@ -200,6 +211,7 @@ function getLovellCloneMenu(drupalData, lovellMenuKey, variant) {
   const findString = `${LOVELL_TITLE_STRING} ${variantFind}`;
   const regexFind = new RegExp(findString, 'gi');
 
+  // Rename the name so our new cloned pages can find the cloned menu
   if (
     lovellCloneMenu.name
       .toLowerCase()
@@ -210,7 +222,6 @@ function getLovellCloneMenu(drupalData, lovellMenuKey, variant) {
       `${LOVELL_TITLE_STRING} ${titleVar}`,
     );
   } else {
-    // Rename the name so our new cloned pages can find the cloned menu
     lovellCloneMenu.name = lovellCloneMenu.name.replace(
       LOVELL_TITLE_STRING,
       `${LOVELL_TITLE_STRING} ${titleVar}`,


### PR DESCRIPTION
When the pages are built for Lovell the process to assign menus is broken due to the code not properly handling the new TRICARE and VA titles and labels. 

## Testing Done
-visual

## ACs
 - [ ] The build should be successful
 - [ ] The proper menus should be showing up for Lovell pages