### PR TITLE
downgrades yarn to 1.19.1

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,7 +9,7 @@ ARG userid=504
 RUN groupadd -g $userid vets-website \
   && useradd -u $userid -r -m -d /application -g vets-website vets-website
 
-ENV YARN_VERSION 1.21.1
+ENV YARN_VERSION 1.19.1
 ENV NODE_ENV production
 
 RUN apt-get update

--- a/.github/workflows/a11y-heading-order.yml
+++ b/.github/workflows/a11y-heading-order.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install Yarn
         shell: bash
-        run: npm i -g yarn@1.21.1
+        run: npm i -g yarn@1.19.1
 
       - name: Install vets-website dependencies
         uses: nick-invision/retry@v2

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Install Yarn
         shell: bash
-        run: npm i -g yarn@1.21.1
+        run: npm i -g yarn@1.19.1
 
       - name: Install vets-website dependencies
         uses: nick-invision/retry@v2

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -197,7 +197,7 @@ jobs:
           node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 
       - name: Setup Yarn
-        run: npm i -g yarn@1.21.1
+        run: npm i -g yarn@1.19.1
 
       - name: Cache dependencies
         id: cache-dependencies

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -72,7 +72,7 @@ jobs:
           node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 
       - name: Setup Yarn
-        run: npm i -g yarn@1.21.1
+        run: npm i -g yarn@1.19.1
 
       - name: Cache dependencies
         id: cache-dependencies

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -34,7 +34,7 @@ runs:
 
     - name: Setup Yarn
       shell: bash
-      run: npm i -g yarn@1.21.1
+      run: npm i -g yarn@1.19.1
 
     - name: Cache dependencies
       id: cache-dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG userid=504
 RUN groupadd -g $userid vets-website \
   && useradd -u $userid -r -m -d /application -g vets-website vets-website
 
-ENV YARN_VERSION 1.21.1
+ENV YARN_VERSION 1.19.1
 ENV NODE_ENV production
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
   "optionalDependencies": {},
   "engines": {
     "node": ">=14.15.0",
-    "yarn": ">=1.21.1"
+    "yarn": "1.19.1"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Description
To downgrade yarn to  1.19.1, matching the downgrade on vets-website, so `yarn add` command works in workspaces

## Testing done
-[x] local build
-[x] unit/e2e
-[x] web testing

## Acceptance criteria
-[x] No change in workflow detected
