### PR TITLE
VAntage blog link and press link updated

### DIFF
--- a/src/platform/static-data/footer-links.json
+++ b/src/platform/static-data/footer-links.json
@@ -133,7 +133,7 @@
   },
   {
     "column": 3,
-    "href": "http://www.news.va.gov/",
+    "href": "https://www.news.va.gov/",
     "order": 1,
     "target": "_blank",
     "title": "VA news",

--- a/src/platform/static-data/footer-links.json
+++ b/src/platform/static-data/footer-links.json
@@ -133,10 +133,10 @@
   },
   {
     "column": 3,
-    "href": "https://www.blogs.va.gov/VAntage/",
+    "href": "http://www.news.va.gov/",
     "order": 1,
     "target": "_blank",
-    "title": "VAntage Point blog",
+    "title": "VA news",
     "rel": "noopener noreferrer"
   },
   {
@@ -144,7 +144,7 @@
     "href": "https://www.va.gov/opa/pressrel",
     "order": 2,
     "target": null,
-    "title": "News releases"
+    "title": "Press releases"
   },
   {
     "column": 3,


### PR DESCRIPTION
## Description
Issue: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/10666

Updated VAntage blog link and text, and VA news text.

## Testing done
Visual, local testing

## Screenshots
<img width="466" alt="Screen Shot 2022-09-20 at 10 14 19 AM" src="https://user-images.githubusercontent.com/61624970/191282815-36e10c09-c4d4-4028-8438-60545ff7ac9d.png">
<img width="788" alt="Screen Shot 2022-09-20 at 10 14 47 AM" src="https://user-images.githubusercontent.com/61624970/191282819-7be586b8-4a30-42c1-9db2-bdf6adca204e.png">


## Acceptance criteria
- [ ] VAntage blog link and text updated
- [ ] VA news text updated

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
