### PR TITLE
Add find and replace for breadcrumb

### DIFF
--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -52,6 +52,8 @@ function getModifiedLovellPage(page, variant) {
     `/lovell-federal-${linkVar}-health-care`,
   );
 
+  // Add a switchPath field
+  // These get modified later in the processLovellPages function
   page.entityUrl.switchPath = originalPath.replace(
     '/lovell-federal-health-care',
     `/lovell-federal-${
@@ -60,6 +62,22 @@ function getModifiedLovellPage(page, variant) {
         : LOVELL_VA_LINK_VARIATION
     }-health-care`,
   );
+
+  // Modify Breadcrumb
+  if (page.entityUrl.breadcrumb) {
+    page.entityUrl.breadcrumb = page.entityUrl.breadcrumb.map(crumb => {
+      crumb.text = crumb.text.replace(
+        /Lovell Federal (VA )?health care/,
+        `${LOVELL_TITLE_STRING} ${fieldOfficeMod} health care`,
+      );
+      crumb.url.path = crumb.url.path.replace(
+        /\/lovell-federal-(va-)?health-care/,
+        `/lovell-federal-${linkVar}-health-care`,
+      );
+      console.log(crumb);
+      return crumb;
+    });
+  }
 
   // Modify the title used for querying the menus
   const variantName = variant === 'tricare' ? 'TRICARE' : 'VA';

--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -74,7 +74,6 @@ function getModifiedLovellPage(page, variant) {
         /\/lovell-federal-(va-)?health-care/,
         `/lovell-federal-${linkVar}-health-care`,
       );
-      console.log(crumb);
       return crumb;
     });
   }


### PR DESCRIPTION
## Description

Adds a find a replace for the breadcrumbs so that they link to the proper locations and remain in the new VA and TRICARE sections.

## Testing done

Visual

## Acceptance criteria
 - [ ] When a page is in lovell federal health care it should have a breadcrumb of Lovell Federal VA health care /lovell-federal-va-health-care
 - [ ] When a page is in lovell tricare, it should have a breadcrumb of Lovell Federal TRICARE health care /lovell-federal-tricare-health-care

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
