### PR TITLE
VACMS-10168 Add Lovell categorized event listings

### DIFF
--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -29,7 +29,7 @@ function isLovellVaPage(page) {
   return page?.fieldAdministration?.entity?.entityId === LOVELL_VA_ENTITY_ID;
 }
 
-function isLovellListingPage(page) {
+function isListingPage(page) {
   const listingPageTypes = [
     'event_listing',
     'press_releases_listing',
@@ -351,19 +351,19 @@ function processLovellPages(drupalData) {
   } = drupalData.data.nodeQuery.entities.reduce(
     (acc, page) => {
       if (isLovellFederalPage(page)) {
-        if (isLovellListingPage(page)) {
+        if (isListingPage(page)) {
           acc.lovellFederalListingPages.push(page);
         } else {
           acc.lovellFederalNonListingPages.push(page);
         }
       } else if (isLovellTricarePage(page)) {
-        if (isLovellListingPage(page)) {
+        if (isListingPage(page)) {
           acc.lovellTricareListingPages.push(page);
         } else {
           acc.lovellTricareNonListingPages.push(page);
         }
       } else if (isLovellVaPage(page)) {
-        if (isLovellListingPage(page)) {
+        if (isListingPage(page)) {
           acc.lovellVaListingPages.push(page);
         } else {
           acc.lovellVaNonListingPages.push(page);

--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 /* eslint-disable no-param-reassign, no-console */
 const cloneDeep = require('lodash/cloneDeep');
 
@@ -282,18 +283,12 @@ function updateLovellSwitchLinks(page, pages) {
  */
 function combineLovellListingPages(tricareOrVaPages, federalPages) {
   return tricareOrVaPages.map(listingPage => {
-    let pastObjectLabel;
-    switch (listingPage.entityBundle) {
-      case 'press_release_listing':
-        pastObjectLabel = 'pastPressReleases';
-        break;
-      case 'story_listing':
-        pastObjectLabel = 'pastNewsStories';
-        break;
-      default:
-        pastObjectLabel = 'pastEvents';
-        break;
-    }
+    const typePastMap = {
+      event_listing: 'pastEvents',
+      press_releases_listing: 'pastPressReleases',
+      story_listing: 'pastNewsStories',
+    };
+    const pastObjectLabel = typePastMap[listingPage.entityBundle];
     const {
       entityBundle,
       [pastObjectLabel]: pastListItems,

--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -294,17 +294,23 @@ function combineLovellListingPages(tricareOrVaPages, federalPages) {
       [pastObjectLabel]: pastListItems,
       reverseFieldListingNode,
     } = listingPage;
+
     const listingPageToCombine = federalPages.find(
       page => page.entityBundle === entityBundle,
     );
+
+    const {
+      [pastObjectLabel]: pastListItemsToCombine,
+      reverseFieldListingNode: reverseFieldListingNodeToCombine,
+    } = listingPageToCombine;
 
     const pastListItemEntities = pastListItems?.entities || [];
     const allListItemEntities = reverseFieldListingNode?.entities || [];
 
     const pastListItemEntitiesToCombine =
-      listingPageToCombine[pastObjectLabel]?.entities || [];
+      pastListItemsToCombine?.entities || [];
     const allListItemEntitiesToCombine =
-      listingPageToCombine?.reverseFieldListingNode?.entities || [];
+      reverseFieldListingNodeToCombine?.entities || [];
 
     const combinedPastListItemEntities = [
       ...pastListItemEntities,
@@ -315,20 +321,17 @@ function combineLovellListingPages(tricareOrVaPages, federalPages) {
       ...allListItemEntitiesToCombine,
     ];
 
-    const finalListingPage = {
+    return {
       ...listingPage,
       reverseFieldListingNode: {
         ...reverseFieldListingNode,
         entities: combinedAllListItemEntities,
       },
+      [pastObjectLabel]: {
+        ...pastListItems,
+        entities: combinedPastListItemEntities,
+      },
     };
-
-    finalListingPage[pastObjectLabel] = {
-      ...pastListItems,
-      entities: combinedPastListItemEntities,
-    };
-
-    return finalListingPage;
   });
 }
 

--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -64,14 +64,32 @@ function getModifiedLovellPage(page, variant) {
 
   // Add a switchPath field
   // These get modified later in the processLovellPages function
-  page.entityUrl.switchPath = originalPath.replace(
-    '/lovell-federal-health-care',
-    `/lovell-federal-${
+  if (
+    page.entityUrl.path.includes(
+      `/lovell-federal-${LOVELL_TRICARE_LINK_VARIATION}-health-care`,
+    ) ||
+    page.entityUrl.path.includes(
+      `/lovell-federal-${LOVELL_VA_LINK_VARIATION}-health-care`,
+    )
+  ) {
+    page.entityUrl.switchPath = originalPath.replace(
+      variant === 'va'
+        ? LOVELL_VA_LINK_VARIATION
+        : LOVELL_TRICARE_LINK_VARIATION,
       variant === 'va'
         ? LOVELL_TRICARE_LINK_VARIATION
-        : LOVELL_VA_LINK_VARIATION
-    }-health-care`,
-  );
+        : LOVELL_VA_LINK_VARIATION,
+    );
+  } else {
+    page.entityUrl.switchPath = originalPath.replace(
+      '/lovell-federal-health-care',
+      `/lovell-federal-${
+        variant === 'va'
+          ? LOVELL_TRICARE_LINK_VARIATION
+          : LOVELL_VA_LINK_VARIATION
+      }-health-care`,
+    );
+  }
 
   // Modify Breadcrumb
   if (page.entityUrl.breadcrumb) {


### PR DESCRIPTION
## Description

The event listing pages on Lovell Tricare and VA only have federal events, but not events specific to Tricare or the VA. This takes the Tricare or VA specific events and adds them to their respective listings.

UPDATE on 10/12: Thanks to @ryguyk for helping me get this ticket on the right track. This PR now updates the listings for events, press releases, and stories. Screenshots have been updated. The broken menus are a separate issue and will be addressed later.

## Testing done

Visual, see below screenshots

## Screenshots

<img width="893" alt="Screen Shot 2022-10-12 at 12 05 56 PM" src="https://user-images.githubusercontent.com/10790736/195397383-b827f2c8-fa4f-4748-9597-fead639e2f37.png">

<img width="853" alt="Screen Shot 2022-10-12 at 12 06 05 PM" src="https://user-images.githubusercontent.com/10790736/195397389-39d2e343-a8af-4d05-8fdf-2f0ce7b49fd6.png">

<img width="1055" alt="Screen Shot 2022-10-12 at 12 06 16 PM" src="https://user-images.githubusercontent.com/10790736/195397392-774af667-3bda-4c96-a61f-2d178e2322f9.png">

<img width="1042" alt="Screen Shot 2022-10-12 at 12 06 23 PM" src="https://user-images.githubusercontent.com/10790736/195397394-1d824cd3-2bde-49bd-bcb0-6372f241ae2b.png">

<img width="988" alt="Screen Shot 2022-10-12 at 12 06 41 PM" src="https://user-images.githubusercontent.com/10790736/195397396-aed957b9-7840-4829-9a4c-d8476968c38e.png">

<img width="1042" alt="Screen Shot 2022-10-12 at 12 06 32 PM" src="https://user-images.githubusercontent.com/10790736/195397400-5da13292-12ab-4177-b5a7-f7aa1ffe0e9f.png">

## Acceptance criteria
- [ ] The Lovell Tricare event listing page has federal and Tricare events, but not VA events
- [ ] The Lovell VA event listing page has federal and VA events, but not Tricare events
- [ ] The event listings still sort and filter events as expected

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
