### PR TITLE
9761 - Removed IE Deprecation banner from top-nav

### DIFF
--- a/src/site/includes/top-nav.html
+++ b/src/site/includes/top-nav.html
@@ -42,23 +42,4 @@
       <div class="mega-menu" id="mega-menu"></div>
     </div>
   {% endunless %}
-  <!-- Hidden for modern browsers. -->
-  <va-banner
-    class="ie-deprecation-warning"
-    headline="You'll need to use a different web browser"
-    show-close
-    type="warning"
-    visible="false"
-  >
-    You're using Internet Explorer right now to access VA.gov. Microsoft stopped supporting all versions of this browser on June 15, 2022. This means that you'll need to switch to another browser, like Microsoft Edge, Google Chrome, Mozilla Firefox, or Apple Safari.
-  </va-banner>
-  <!-- Solutioned for: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9075 -->
-  <script type="text/javascript">
-    const isIE = /(?:MSIE)|(?:Trident\/[0-7]\.[0-9])/i.test(window.navigator.userAgent);
-
-    if (isIE) {
-      const ieMessageEl = document.body.querySelector('.ie-deprecation-warning');
-      ieMessageEl.setAttribute('visible', '');
-    }
-  </script>
 </div>


### PR DESCRIPTION
## Description
Removes all code written for the IE Deprecation banner including the useOnLoaded custom hook.

## Original issue(s)
department-of-veterans-affairs/va.gov-cms/issues/9761

## Testing done
- [x] Test in IE or mimicked IE (easiest way to do: CAG > MSEdge > IE mode, or CAG > IE from review instance) to make sure banner doesn't appear
- [x] Verify it doesn't show in injected header

## Screenshots
N/A as this is removing a feature. Nothing to show.

## Acceptance Criteria
- [x] Remove the IE11 banner, and any code that is not reusable / valuable for future. 
- [x] Test in IE or mimicked IE (easiest way to do: CAG > MSEdge > IE mode, or CAG > IE from review instance) to make sure banner doesn't appear
- [x] Injected Header: verify it doesn't show in injected header
- [x] Ensure  `useOnLoaded` custom hook is removed

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs