### PR TITLE
removed white space from fullwidth banner alerts

### DIFF
--- a/src/site/components/fullwidth_banner_alerts.drupal.liquid
+++ b/src/site/components/fullwidth_banner_alerts.drupal.liquid
@@ -1,26 +1,19 @@
 {% for entity in bannerAlert.entities %}
   {% assign hideOnSubpages = entity.fieldAlertInheritanceSubpages %}
   {% assign alertType = entity.fieldAlertType %}
-
   {% if alertType == "information" %}
     {% assign alertType = "info" %}
   {% endif %}
-
   {% if entityUrl.path %}
     {% assign region = entityUrl.path | regionBasePath | prepend: "/" %}
     {% assign lastArg = entityUrl.path | split: "/" | last | prepend: "/" %}
   {% endif %}
-
   {% assign outputStatus = false %}
   {% assign emailUpdates = "" %}
   {% assign statusUrl = "" %}
-
   {% for vamc in entity.fieldBannerAlertVamcs %}
-
     {% if region == vamc.entity.fieldOffice.entity.entityUrl.path %}
-
       {% assign outputStatus = true %}
-
       {% if hideOnSubpages == true and lastArg != region and lastArg != "/operating-status" %}
         {% assign outputStatus = false %}
       {% endif %}
@@ -28,7 +21,6 @@
       {% assign statusUrl = vamc.entity.entityUrl.path %}
     {% endif %}
   {% endfor %}
-
   {% if outputStatus == true %}
     <div data-template="components/fullwidth_banner_alerts" data-entity-id="{{ entity.entityId }}"
          aria-labelledby="usa-alert-header-text-{{ entity.entityId }}"
@@ -59,7 +51,6 @@
               }
             {% endcapture %}
             {{ entity.fieldBody.processed | trackLinks: eventData }}
-
             {% if entity.fieldAlertOperatingStatusCta == true and statusUrl.length %}
               <p>
                 <a href="{{ statusUrl }}" onclick="recordEvent({
@@ -68,14 +59,12 @@
                     });">Get updates on affected services and facilities</a>
               </p>
             {% endif %}
-
             {% if entity.fieldAlertEmailUpdatesButton == true and emailUpdates.length %}
               <p>
                 <a href="{{ emailUpdates }}">Subscribe
                   to email updates</a>
               </p>
             {% endif %}
-
             {% if entity.fieldAlertFindFacilitiesCta == true %}
               <p>
                 <a href="/find-locations">Find other VA facilities near you</a>
@@ -86,5 +75,4 @@
       </div>
     </div>
   {% endif %}
-
 {% endfor %}


### PR DESCRIPTION
## Description


## Testing done
Rebuilt content-build with new changes, view page source on http://localhost:3002/resources/how-to-download-and-open-a-vagov-pdf-form/,  observe the lack of white space

## Screenshots
<img width="811" alt="image" src="https://user-images.githubusercontent.com/61624970/192860326-4000cd62-a61a-4145-b7a7-caf92153918a.png">


## Acceptance criteria
- [ ]  There should be no unnecessary line breaks in the banner section of the web pages.


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
