### PR TITLE
VACMS-10707: Only show published vet center locations

### DIFF
--- a/src/site/stages/build/drupal/graphql/vetCenterLocations.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vetCenterLocations.graphql.js
@@ -84,7 +84,11 @@ fragment vetCenterLocationsFragment on NodeVetCenterLocationsList {
   fieldOffice {
     entity {
       ... on NodeVetCenter {
-        reverseFieldOfficeNode(limit: 500, filter: {conditions: [{field: "type", value: ["vet_center_outstation", "vet_center_cap", "vet_center_mobile_vet_center"]}]}) {
+        reverseFieldOfficeNode(limit: 500, filter: {
+          conditions: [
+            { field: "type", value: ["vet_center_outstation", "vet_center_cap", "vet_center_mobile_vet_center"] },
+            { field: "status", value: ["1"], enabled: $onlyPublishedContent }
+          ]}) {
           entities {
             ... on NodeVetCenterCap {
               title


### PR DESCRIPTION
## Description

Facility locations can show draft and archived location pages when they should only show published ones. This adjusts the GraphQL query so only published ones are used on the page.

## Testing done

Visual.

## Screenshots

### Before

[Seen on this Tugboat page.](https://web-ersyymdhh8rrzxlevrh1xsmeyx7pzcpv.demo.cms.va.gov/duluth-vet-center/locations/)

<img width="804" alt="Screen Shot 2022-09-30 at 5 13 03 PM" src="https://user-images.githubusercontent.com/10790736/193655222-5d070f9c-3b63-43c2-875c-8e34db5fbcc5.png">

### After

[Seen on this local page pulled from the previous Tugboat instance.](http://localhost:3002/duluth-vet-center/locations/)

<img width="808" alt="Screen Shot 2022-10-03 at 2 40 52 PM" src="https://user-images.githubusercontent.com/10790736/193655252-e1dedb67-f429-4b0b-b08d-cec2fc1b8ebf.png">

## Acceptance criteria
- [ ] Published satellite locations are shown, while Draft and Archived ones are not.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
