### PR TITLE
10718 accordion heading fixes

### DIFF
--- a/src/site/facilities/health_service.drupal.liquid
+++ b/src/site/facilities/health_service.drupal.liquid
@@ -1,6 +1,7 @@
         {% assign serviceTaxonomy = healthService.fieldServiceNameAndDescripti.entity %}
         <va-accordion-item
             header="{{ serviceTaxonomy.name }}"
+            level=3
             {% if serviceTaxonomy.fieldAlsoKnownAs %}
                 subheader="{{ serviceTaxonomy.fieldAlsoKnownAs }}"
                 data-childlabel="{{ serviceTaxonomy.fieldAlsoKnownAs }}"

--- a/src/site/facilities/health_service.drupal.liquid
+++ b/src/site/facilities/health_service.drupal.liquid
@@ -1,7 +1,5 @@
         {% assign serviceTaxonomy = healthService.fieldServiceNameAndDescripti.entity %}
         <va-accordion-item
-            header="{{ serviceTaxonomy.name }}"
-            level=3
             {% if serviceTaxonomy.fieldAlsoKnownAs %}
                 subheader="{{ serviceTaxonomy.fieldAlsoKnownAs }}"
                 data-childlabel="{{ serviceTaxonomy.fieldAlsoKnownAs }}"
@@ -9,6 +7,9 @@
             data-label="{{ serviceTaxonomy.name }}"
             data-template="facilities/health_service"
         >
+            <h3 slot="headline">
+                {{ serviceTaxonomy.name }}
+            </h3>
             <div id="{{ serviceTaxonomy.entityBundle }}-{{ serviceTaxonomy.entityId }}">
                 {% if serviceTaxonomy.fieldCommonlyTreatedCondition %}
                     <div class="vads-u-margin-bottom--2">

--- a/src/site/layouts/faq_multiple_q_a.drupal.liquid
+++ b/src/site/layouts/faq_multiple_q_a.drupal.liquid
@@ -75,9 +75,11 @@
                   {% for fieldQA in fieldQAGroup.entity.fieldQAs %}
                     {% if fieldQA.entity %}
                       <va-accordion-item
-                        header="{{ fieldQA.entity.title }}"
                         data-faq-entity-id="{{ fieldQA.entity.entityId }}"
                       >
+                      <h3 slot="headline">
+                        {{ fieldQA.entity.title }}
+                    </h3>
                         <div id="{{ fieldQA.entity.entityBundle }}-{{ fieldQA.entity.entityId }}">
                           {% assign fieldAnswer = fieldQA.entity.fieldAnswer %}
                           {% assign bundleComponent = "src/site/paragraphs/" | append: fieldAnswer.entity.entityBundle %}

--- a/src/site/layouts/faq_multiple_q_a.drupal.liquid
+++ b/src/site/layouts/faq_multiple_q_a.drupal.liquid
@@ -141,7 +141,6 @@
     {% include "src/site/paragraphs/contact_information.drupal.liquid" with entity = fieldContactInformation.entity %}
 
     <!-- Back to top -->
-
     <div class="usa-grid usa-grid-full">
       <div class="usa-width-three-fourths">
         <div class="usa-content">

--- a/src/site/paragraphs/collapsible_panel.drupal.liquid
+++ b/src/site/paragraphs/collapsible_panel.drupal.liquid
@@ -36,10 +36,11 @@
             {% assign item = accordionItem.entity %}
             {% assign id = item.entityId %}
             <va-accordion-item
-              header="{{ item.fieldTitle | encode }}"
-              level=4
               id="{{item.fieldTitle | hashReference: 30 }}-{{id}}"
             >
+            <h4 slot="headline">
+                {{ item.fieldTitle | encode }}
+            </h4>
                 <div
                     id={{id}}
                     data-template="paragraphs/collapsible_panel__panel"

--- a/src/site/paragraphs/collapsible_panel.drupal.liquid
+++ b/src/site/paragraphs/collapsible_panel.drupal.liquid
@@ -37,6 +37,7 @@
             {% assign id = item.entityId %}
             <va-accordion-item
               header="{{ item.fieldTitle | encode }}"
+              level=4
               id="{{item.fieldTitle | hashReference: 30 }}-{{id}}"
             >
                 <div

--- a/src/site/paragraphs/q_a.collapsible_panel.drupal.liquid
+++ b/src/site/paragraphs/q_a.collapsible_panel.drupal.liquid
@@ -9,9 +9,12 @@
 
       <va-accordion-item
         header="{{ item.fieldQuestion }}"
+        level=3
         {% if level %}
           level="{{ level }}"
         {% endif %}
+
+
       >
         <div
           id={{ id }}

--- a/src/site/paragraphs/q_a.collapsible_panel.drupal.liquid
+++ b/src/site/paragraphs/q_a.collapsible_panel.drupal.liquid
@@ -6,16 +6,13 @@
     {% for accordionItem in questions %}
       {% assign item = accordionItem.entity %}
       {% assign id = item.entityId %}
+      {% assign fieldSectionHeaderTag = 'h3 slot="headline"' %}
+      {% if level %}
+        {% assign fieldSectionHeaderTag = {{ level 'slot="headline"'}} %}
+      {% endif %}
 
-      <va-accordion-item
-        header="{{ item.fieldQuestion }}"
-        level=3
-        {% if level %}
-          level="{{ level }}"
-        {% endif %}
-
-
-      >
+      <va-accordion-item>
+      <{{ fieldSectionHeaderTag }}>{{ item.fieldQuestion }}</{{ fieldSectionHeaderTag }}>
         <div
           id={{ id }}
           data-template="paragraphs/q_a.collapsible_panel__qa"


### PR DESCRIPTION
## Description
Adjusted accordion heading levels in content build to make them fit page hierarchy for accessibility 
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/10718

## Testing done
Visual, local testing. Examples of pages with corresponding templates:
/tennessee-valley-health-care/health-services/
/health-care/covid-19-vaccine/
/health-care/eligibility/

## Screenshots

<img width="1217" alt="Screen Shot 2022-10-04 at 9 42 19 AM" src="https://user-images.githubusercontent.com/61624970/193835667-6a8e9bf6-bd4a-48f5-9aff-89c926b70107.png">
<img width="1217" alt="Screen Shot 2022-10-04 at 9 41 34 AM" src="https://user-images.githubusercontent.com/61624970/193835673-90f95b47-ad87-4a83-ad4f-9081aa04e660.png">
<img width="1217" alt="Screen Shot 2022-10-04 at 9 41 46 AM" src="https://user-images.githubusercontent.com/61624970/193835678-f7be0f58-f57e-4bbc-9cc5-76ecfc036c1e.png">

## Acceptance criteria
- [ ] Headers in QA collapsable panel, Collapsable panel, and Health Services now reflect the appropriate header level

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
