### PR TITLE
Changed to old way of assigning header level on accordions

### DIFF
--- a/src/site/paragraphs/q_a.collapsible_panel.drupal.liquid
+++ b/src/site/paragraphs/q_a.collapsible_panel.drupal.liquid
@@ -1,18 +1,21 @@
 <div data-template="paragraphs/q_a.collapsible_panel">
   <va-accordion>
+    
     {% assign questions = entity.fieldQuestions %}
     {% assign sectionHeader = entity.fieldSectionHeader %}
 
     {% for accordionItem in questions %}
       {% assign item = accordionItem.entity %}
       {% assign id = item.entityId %}
-      {% assign fieldSectionHeaderTag = 'h3 slot="headline"' %}
-      {% if level %}
-        {% assign fieldSectionHeaderTag = {{ level 'slot="headline"'}} %}
-      {% endif %}
 
-      <va-accordion-item>
-      <{{ fieldSectionHeaderTag }}>{{ item.fieldQuestion }}</{{ fieldSectionHeaderTag }}>
+      <va-accordion-item
+        header="{{ item.fieldQuestion }}"
+        {% if level %}
+          level="{{ level }}"
+          {% else %}
+          level=3
+        {% endif %}
+      >
         <div
           id={{ id }}
           data-template="paragraphs/q_a.collapsible_panel__qa"


### PR DESCRIPTION

## Description
To accommodate  for header levels that are passed from CMS, header levels need to be assigned in <va-accordion-item> props.

## Testing done
Verified that accordion headers are properly rendered locally

## Screenshots
<img width="1329" alt="Screen Shot 2022-10-07 at 9 57 16 AM" src="https://user-images.githubusercontent.com/61624970/194570956-36ef07ca-54d9-492c-ab92-b75bbd7f78f9.png">


## Acceptance criteria
- [ ] headers render properly

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
