### PR TITLE
10982 - fix incorrect url in search tools links in homepage prototype

### DIFF
--- a/src/site/stages/build/drupal/home.js
+++ b/src/site/stages/build/drupal/home.js
@@ -168,7 +168,7 @@ function addHomeContent(contentData, files, metalsmith, buildOptions) {
         commonTasks: {
           searchLinks: [
             {
-              link: 'https://www.va.gov/find-a-location/',
+              link: 'https://www.va.gov/find-locations/',
               linkText: 'Find a VA facility',
             },
             {


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/10982#issuecomment-1276623250
Updated the Find a VA Facility link to point to /find-locations.

(The top two items in the issue comment were taken care of in a previous PR. the bottom two remain TBD)

## Testing done
Manual local testing

## Acceptance criteria
- [x] Other search tools > Find a VA facility > https://staging.va.gov/find-a-location change to https://staging.va.gov/find-locations

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
