### PR TITLE
First row modified to be headers

### DIFF
--- a/src/site/paragraphs/table.drupal.liquid
+++ b/src/site/paragraphs/table.drupal.liquid
@@ -70,12 +70,3 @@
             {% endif %}
         {% endfor %}
 </table>
-
-<style>
-    /* 768px = $medium-screen */
-    @media (max-width: 768px) {
-        .table-row-header-responsive {
-        padding: 0;
-        }
-    }
-  </style>

--- a/src/site/paragraphs/table.drupal.liquid
+++ b/src/site/paragraphs/table.drupal.liquid
@@ -45,12 +45,23 @@
             {% else %}
                     <tr class="vads-u-padding-top--5" role="row">
                         {% for column in value %}
+                            {% if forloop.first == true %}
+                                <th 
+                                    class="vads-u-padding-bottom--0 column-label vads-u-font-weight--bold medium-screen:vads-u-display--none table-row-header-responsive" role="rowheader" scope="row"
+                                >
+                                    <dfn> {{colLabels | getValueFromObjPath: forloop.index0}}      </dfn>
+                                </th>
+                                <th class="column-value table-row-header-responsive"  role="rowheader" scope="row">
+                                    <dfn class="vads-u-display--block"> {{ column }} </dfn>
+                                </th>
+                            {% else %}
                                 <td class="vads-u-padding-bottom--0 column-label vads-u-font-weight--bold medium-screen:vads-u-display--none" role="cell">
                                     <dfn> {{colLabels | getValueFromObjPath: forloop.index0}}      </dfn>
                                 </td>
                                 <td class="column-value"  role="cell">
                                     <dfn class="vads-u-display--block"> {{ column }}  </dfn>
                                 </td>
+                            {% endif %}
                         {% endfor %}
                     </tr>
             {% endif %}
@@ -59,3 +70,12 @@
             {% endif %}
         {% endfor %}
 </table>
+
+<style>
+    /* 768px = $medium-screen */
+    @media (max-width: 768px) {
+        .table-row-header-responsive {
+        padding: 0;
+        }
+    }
+  </style>

--- a/src/site/paragraphs/table.drupal.liquid
+++ b/src/site/paragraphs/table.drupal.liquid
@@ -47,7 +47,7 @@
                         {% for column in value %}
                             {% if forloop.first == true %}
                                 <th 
-                                    class="vads-u-padding-bottom--0 column-label vads-u-font-weight--bold medium-screen:vads-u-display--none table-row-header-responsive" role="rowheader" scope="row"
+                                    class="vads-u-padding-bottom--0 column-label vads-u-font-weight--bold medium-screen:vads-u-display--none" role="rowheader" scope="row"
                                 >
                                     <dfn> {{colLabels | getValueFromObjPath: forloop.index0}}      </dfn>
                                 </th>


### PR DESCRIPTION
## Description
Make the first element in each row a table header, with scope and role type appropriate for a row

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/10983
## Testing done
Local visual testing.  accordions tested at this url '/disability/compensation-rates/veteran-rates/'

## Screenshots
<img width="1296" alt="Screen Shot 2022-10-17 at 2 15 56 PM" src="https://user-images.githubusercontent.com/61624970/196252818-4802a7c2-7f86-4d12-b580-43489438f32c.png">
<img width="1296" alt="Screen Shot 2022-10-17 at 2 16 05 PM" src="https://user-images.githubusercontent.com/61624970/196252823-ed360add-e037-4131-93a2-ef0f8fc359ec.png">


## Acceptance criteria
- [ ] The first element of every row in `<tbody>` will be `<th>` elements (instead of `<td>`) with `scope="row"` and `role="rowheader"` attributes
- [ ] All tables on [this Benefit Detail page](https://prod.cms.va.gov/node/986/edit) render correctly
- [ ] Confirm that the mobile view of table continues to look as intended
- [ ] Confirm that the visual layout of table _is not affected_ by change
- [ ] Requires Accessibility review

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
