### PR TITLE
[VA-11155] Lovell Menus not showing on front-end

### DIFF
--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -196,6 +196,14 @@ function getLovellCloneMenu(drupalData, lovellMenuKey, variant) {
     `${LOVELL_TITLE_STRING} ${titleVar}`,
   );
 
+  // Move federal health care links to the top of the menu
+  // Otherwise the menu renders as blank
+  const federalLinksIndex = lovellCloneMenu.links
+    .map(menu => menu.label)
+    .indexOf('Lovell Federal health care');
+  const federalLinks = lovellCloneMenu.links.splice(federalLinksIndex, 1);
+  lovellCloneMenu.links = [...federalLinks, ...lovellCloneMenu.links];
+
   // Change the root level item
   // It's coming in from the cms as a va item when it should be both
   lovellCloneMenu.links[0].label = 'Lovell Federal Health Care';


### PR DESCRIPTION
## Description

Lovell pages aren't showing any of their menus. The cause is the Lovell menu structure was changed, and the Federal menu needs to be before the Tricare or VA menus. This fix rearranges the menu as part of the cloning process so the federal one is always placed first, which should help avoid similar bugs in the future.

## Testing done

Visual, see below screenshots.

## Screenshots

<img width="1152" alt="Screen Shot 2022-10-18 at 7 12 32 PM" src="https://user-images.githubusercontent.com/10790736/196562955-94836d0c-56ae-4adb-9d0f-d3b95da94ac4.png">

## Acceptance criteria
- [ ] Lovell pages (federal, Tricare, and VA) all show the side menu.
- [ ] Lovell side menus all have working links

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
