### PR TITLE
10177 adds plugin to specify page language on main element of all pages.

### DIFF
--- a/src/site/stages/build/plugins/modify-dom/add-lang-to-main.js
+++ b/src/site/stages/build/plugins/modify-dom/add-lang-to-main.js
@@ -1,0 +1,36 @@
+/* eslint-disable no-param-reassign */
+
+/**
+ * Adds the language derived from the fileName to the `main` element of each page.
+ */
+
+function getLanguageFromFileName(fileName) {
+  let pageLang = 'en';
+  if (fileName.includes('-esp/') || fileName.includes('-espanol/')) {
+    pageLang = 'es';
+  } else if (fileName.includes('-tag/') || fileName.includes('-tagalog/')) {
+    pageLang = 'tl';
+  }
+  return pageLang;
+}
+
+module.exports = {
+  modifyFile(fileName, file) {
+    let langAdded = false;
+
+    if (fileName.endsWith('html')) {
+      const pageLang = getLanguageFromFileName(fileName);
+      const { dom } = file;
+      const nodes = dom('main');
+      nodes.each((index, el) => {
+        const main = dom(el);
+        main.attr('lang', pageLang);
+        langAdded = true;
+      });
+
+      if (langAdded) {
+        file.modified = true;
+      }
+    }
+  },
+};

--- a/src/site/stages/build/plugins/modify-dom/index.js
+++ b/src/site/stages/build/plugins/modify-dom/index.js
@@ -8,6 +8,7 @@ const updateExternalLinks = require('./update-external-links');
 const addSubheadingsIds = require('./add-id-to-subheadings');
 const checkBrokenLinks = require('./check-broken-links');
 const injectAxeCore = require('./inject-axe-core');
+const addLangToMain = require('./add-lang-to-main');
 
 const getDomModifiers = BUILD_OPTIONS => {
   if (BUILD_OPTIONS.liquidUnitTestingFramework) {
@@ -16,6 +17,7 @@ const getDomModifiers = BUILD_OPTIONS => {
       updateExternalLinks,
       addSubheadingsIds,
       injectAxeCore,
+      addLangToMain,
     ];
   }
 
@@ -26,6 +28,7 @@ const getDomModifiers = BUILD_OPTIONS => {
     addSubheadingsIds,
     checkBrokenLinks,
     injectAxeCore,
+    addLangToMain,
   ];
 };
 


### PR DESCRIPTION
## Description
Implements a plugin to modify the DOM in each template to indicate the page contents language via the `lang` attribute on the `main` element. This enables proper functionality of the `va-on-this-page` component. It derived the language based on the page name, accepting pages ending in `-esp' or `-espanol` as Spanish and pages ending in `-tag or `-tagalog` as Tagalog, while defaulting to English for all other pages.

## Testing done
Several rounds of manual testing to assure that all Spanish and Tagalog pages were accounted for.

## Screenshots
<img width="1517" alt="Screen Shot 2022-10-19 at 9 48 14 AM" src="https://user-images.githubusercontent.com/732460/196725265-5bf4a852-7616-4502-b9e1-58efe3435d27.png">
<img width="1610" alt="Screen Shot 2022-10-19 at 9 49 03 AM" src="https://user-images.githubusercontent.com/732460/196725295-35f5fe27-df42-43a1-a3cd-b72f41d19088.png">
<img width="1560" alt="Screen Shot 2022-10-19 at 9 49 26 AM" src="https://user-images.githubusercontent.com/732460/196725306-835a5730-e697-4773-89d2-4ca9173d8018.png">


## Acceptance Criteria
- [x] "On this page" appears in English on English pages
- [x] "On this page" appears in the appropriate non-English language
  - [x] Spanish pages = En esta página
  - [x] Tagalog = Sa pahinang ito


## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
