### PR TITLE
VACMS-11271 Update alt text for main header logo

### DIFF
--- a/src/site/includes/top-nav.html
+++ b/src/site/includes/top-nav.html
@@ -22,7 +22,7 @@
   <div class="row va-flex usa-grid usa-grid-full" id="va-header-logo-menu">
     <div class="va-header-logo-wrapper">
       <a href="/" class="va-header-logo">
-        <img src="/img/header-logo.png" alt="Go to VA.gov" height="59" width="264" />
+        <img src="/img/header-logo.png" alt="VA logo and seal" height="59" width="264" />
       </a>
     </div>
     {% if !noNavOrLogin %}

--- a/src/site/paragraphs/table.drupal.liquid
+++ b/src/site/paragraphs/table.drupal.liquid
@@ -51,7 +51,7 @@
                                 >
                                     <dfn> {{colLabels | getValueFromObjPath: forloop.index0}}      </dfn>
                                 </th>
-                                <th class="column-value"  role="rowheader" scope="row">
+                                <th class="column-value table-row-header-responsive"  role="rowheader" scope="row">
                                     <dfn class="vads-u-display--block"> {{ column }} </dfn>
                                 </th>
                             {% else %}

--- a/src/site/paragraphs/table.drupal.liquid
+++ b/src/site/paragraphs/table.drupal.liquid
@@ -51,7 +51,7 @@
                                 >
                                     <dfn> {{colLabels | getValueFromObjPath: forloop.index0}}      </dfn>
                                 </th>
-                                <th class="column-value table-row-header-responsive"  role="rowheader" scope="row">
+                                <th class="column-value"  role="rowheader" scope="row">
                                     <dfn class="vads-u-display--block"> {{ column }} </dfn>
                                 </th>
                             {% else %}


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11271

updated alt text in header logo

## Testing done
local testing in chrome

## Screenshots

<img width="731" alt="Screen Shot 2022-10-24 at 2 55 55 PM" src="https://user-images.githubusercontent.com/61624970/197603842-17bd06a8-9e8c-4e8d-8ebe-af989dee412c.png">


## Acceptance criteria
- [ ] Alt text is updated on main header

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
