### PR TITLE
Url link added to online events when present

### DIFF
--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -75,8 +75,15 @@
                   </div>
 
                 {% elsif fieldLocationType == "online" %}
-                  <p class="vads-u-margin--0 vads-u-margin-bottom--2">This is an online event.</p>
-
+                  {% if fieldUrlOfAnOnlineEvent %}
+                  <p class="vads-u-margin--0 vads-u-margin-bottom--2">
+                    <a href="{{ fieldUrlOfAnOnlineEvent.uri }}">
+                      This is an online event.
+                    </a>
+                  </p>
+                  {% else %}
+                    <p class="vads-u-margin--0 vads-u-margin-bottom--2">This is an online event.</p>
+                  {% endif %}
                 {% else %}
 
                   <div class="vads-u-display--flex vads-u-flex-direction--column">

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -75,15 +75,11 @@
                   </div>
 
                 {% elsif fieldLocationType == "online" %}
-                  {% if fieldUrlOfAnOnlineEvent %}
                   <p class="vads-u-margin--0 vads-u-margin-bottom--2">
-                    <a href="{{ fieldUrlOfAnOnlineEvent.uri }}">
+                    {% if fieldUrlOfAnOnlineEvent %}<a href="{{ fieldUrlOfAnOnlineEvent.uri }}">{% endif %}
                       This is an online event.
-                    </a>
+                    {% if fieldUrlOfAnOnlineEvent %}</a>{% endif %}
                   </p>
-                  {% else %}
-                    <p class="vads-u-margin--0 vads-u-margin-bottom--2">This is an online event.</p>
-                  {% endif %}
                 {% else %}
 
                   <div class="vads-u-display--flex vads-u-flex-direction--column">


### PR DESCRIPTION
## Description
Adds the URL to an online event as a link when it is provided
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11346

## Testing done
Local visual testing.  URLs to QA:
http://localhost:3002/preview?nodeId=33511
http://localhost:3002/outreach-and-events/events/50078/

## Screenshots
<img width="1098" alt="Screen Shot 2022-10-26 at 8 22 40 AM" src="https://user-images.githubusercontent.com/61624970/198045653-ee9ace05-093e-4ea2-8495-20e6f1654503.png">
<img width="1098" alt="Screen Shot 2022-10-26 at 8 23 11 AM" src="https://user-images.githubusercontent.com/61624970/198045661-3a7a9eef-9298-42b7-9d44-c00cd8657679.png">


## Acceptance criteria
- [ ]Events with Location: Online and a URL entered should show the "This is an online event" text in the front-end wrapped by the specified URL.
- [ ]  Registration link, when present, should continue to be displayed as it does currently


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
