### PR TITLE
[VA-11363] Fix directions link for 508 compliance

### DIFF
--- a/src/site/includes/facilityListing.drupal.liquid
+++ b/src/site/includes/facilityListing.drupal.liquid
@@ -30,10 +30,8 @@
           </div>
         </address>
         <directions>
-          <a
-              href="https://maps.google.com?saddr=Current+Location&amp;daddr={{ entity.fieldAddress.addressLine1 }}, {{ entity.fieldAddress.locality }}, {{ entity.fieldAddress.administrativeArea }} {{ entity.fieldAddress.postalCode }}"
-              target="_blank" rel="noopener noreferrer">
-            Directions
+          <a href="https://maps.google.com?saddr=Current+Location&amp;daddr={{ entity.fieldAddress.addressLine1 }}, {{ entity.fieldAddress.locality }}, {{ entity.fieldAddress.administrativeArea }} {{ entity.fieldAddress.postalCode }}">
+            Directions (Google Maps)
           </a>
         </directions>
       </div>

--- a/src/site/includes/vet_centers/address_phone_image.liquid
+++ b/src/site/includes/vet_centers/address_phone_image.liquid
@@ -39,7 +39,7 @@
           <a onclick="recordEvent({ event: 'directions-link-click', 'vet-center-facility-name': '{{ vetCenter.title }}'})"
              href="https://maps.google.com?saddr=Current+Location&amp;daddr={{ vetCenter.fieldAddress.addressLine1 }}, {{ vetCenter.fieldAddress.locality }}, {{ vetCenter.fieldAddress.administrativeArea }} {{ vetCenter.fieldAddress.postalCode }}"
              aria-label="Directions to {{ vetCenter.title }} on Google Maps">
-            Directions on Google Maps
+            Directions (Google Maps)
           </a>
         </div>
       </div>

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -91,10 +91,10 @@
                       {{ fieldAddress.locality }},
                       {{ fieldAddress.administrativeArea }}
                       {{ fieldAddress.postalCode }}
-                      <div><a
-                            href="https://maps.google.com?saddr=Current+Location&daddr={{ fieldAddress.addressLine1 }}, {{ fieldAddress.locality }}, {{ fieldAddress.postalCode }}"
-                            target="_blank"
-                            rel="noopener noreferrer">Directions</a>
+                      <div>
+                        <a href="https://maps.google.com?saddr=Current+Location&daddr={{ fieldAddress.addressLine1 }}, {{ fieldAddress.locality }}, {{ fieldAddress.postalCode }}">
+                          Directions (Google Maps)
+                        </a>
                       </div>
                     </div>
                     <h3

--- a/src/site/layouts/vet_center.drupal.liquid
+++ b/src/site/layouts/vet_center.drupal.liquid
@@ -93,7 +93,7 @@
                            href="https://maps.google.com?saddr=Current+Location&daddr={{ fieldAddress.addressLine1 }}, {{ fieldAddress.locality }}, {{ fieldAddress.postalCode }}"
                            aria-label="Directions to {{ entityLabel }} on Google Maps"
                         >
-                          Directions on Google Maps
+                          Directions (Google Maps)
                         </a>
                       </div>
                     </div>


### PR DESCRIPTION
## Description

The "Directions" link for Facilities pages needs to not open in a new tab, and identify itself as using Google maps. This makes this less disorienting and more clear to users, especially ones using screen readers

Closes [#11363](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11363)

## Testing done

Visual [(this URL).](http://localhost:3002/pittsburgh-health-care/locations/h-john-heinz-iii-department-of-veterans-affairs-medical-center/)

## Screenshots

<img width="726" alt="Screen Shot 2022-10-28 at 10 47 06 AM" src="https://user-images.githubusercontent.com/10790736/198656910-887630ab-f0ad-4486-a494-d85f5c4ac011.png">

## Acceptance criteria

- [ ] Facility directions links clarify they use Google Maps
- [ ] Facility Google Maps links don't open in a new tab

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
