### PR TITLE
Outreach filteres added and sorted

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -109,6 +109,30 @@ module.exports = function registerFilters() {
 
   liquid.filters.formatDate = (dt, format) => prettyTimeFormatted(dt, format);
 
+  liquid.filters.buildTopicList = topics => {
+    if (!topics) return null;
+    const topicArray = [];
+
+    // Add unique topics to topic array
+    for (let i = 0; i < topics.length; i++) {
+      const fieldObjects = topics[i].fieldLcCategories;
+      if (fieldObjects[0]) {
+        const { entity } = fieldObjects[0];
+        const index = topicArray.findIndex(
+          object => object.name === entity.name,
+        );
+        if (index === -1) {
+          topicArray.push(entity);
+        }
+      }
+    }
+    return topicArray;
+  };
+
+  liquid.filters.alphabetizeList = items => {
+    return _.orderBy(items, [item => item?.name?.toLowerCase()], ['asc']);
+  };
+
   liquid.filters.drupalToVaPath = content => {
     let replaced = content;
     if (content) {

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -111,22 +111,18 @@ module.exports = function registerFilters() {
 
   liquid.filters.buildTopicList = topics => {
     if (!topics) return null;
-    const topicArray = [];
-
-    // Add unique topics to topic array
-    for (let i = 0; i < topics.length; i++) {
-      const fieldObjects = topics[i].fieldLcCategories;
-      if (fieldObjects[0]) {
-        const { entity } = fieldObjects[0];
-        const index = topicArray.findIndex(
-          object => object.name === entity.name,
-        );
-        if (index === -1) {
-          topicArray.push(entity);
+    return topics.reduce((topicArray, current) => {
+      current.fieldLcCategories.forEach(passedEntity => {
+        if (
+          !topicArray.some(
+            givenEntity => givenEntity.name === passedEntity.entity?.name,
+          )
+        ) {
+          topicArray.push(passedEntity.entity);
         }
-      }
-    }
-    return topicArray;
+      });
+      return topicArray;
+    }, []);
   };
 
   liquid.filters.alphabetizeList = items => {

--- a/src/site/layouts/publication_listing.drupal.liquid
+++ b/src/site/layouts/publication_listing.drupal.liquid
@@ -36,23 +36,12 @@
                       for="outreach-topic">Select a topic</label>
                     <select class="vads-u-max-width--100 usa-select"
                       name="outreach-topic" id="outreach-topic">
-                      <option value="select">- All topics -</option>
-                      <option value="healthcare">Health care</option>
-                      <option value="disability">Disability
-                      </option>
-                      <option value="education">Education and training
-                      </option>
-                      <option value="careers">Careers and employment</option>
-                      <option value="pension">Pension</option>
-                      <option value="housing">Housing assistance</option>
-                      <option value="insurance">Life insurance</option>
-                      <option value="burial">Burials and memorials
-                      </option>
-                      <option value="records">Records</option>
-                      <option value="service">Service member benefits</option>
-                      <option value="family">Family member benefits</option>
-                      <option value="general">General benefits information
-                      </option>
+                      {% assign topicList = outreachAssetsDataArray.entities | buildTopicList %}
+                      {% assign sortedTopics = topicList | alphabetizeList %}
+                      <option value="select">- All topics -</option>    
+                      {% for topic in topicList %}
+                        <option value={{topic.fieldTopicId}}>{{ topic.name }}</option>
+                      {% endfor %}
                     </select>
                   </div>
                   <div class="vads-l-col--12
@@ -66,14 +55,13 @@
                     <select class="vads-u-max-width--100 usa-select"
                       name="outreach-type" id="outreach-type">
                       <option value="select">- All types -</option>
-                      <option value="video">Videos</option>
-                      <option value="social_share">Social share images, text,
-                        and badges</option>
                       <option value="newsletter_content">Newsletter content
                       </option>
                       <option value="document">Poster, Flyer, brochure and
                         fact sheets</option>
-
+                      <option value="social_share">Social share images, text,
+                        and badges</option>
+                      <option value="video">Videos</option>
                     </select>
                   </div>
                 </div>

--- a/src/site/stages/build/drupal/graphql/file-fragments/outreachAssets.graphql.js
+++ b/src/site/stages/build/drupal/graphql/file-fragments/outreachAssets.graphql.js
@@ -15,6 +15,14 @@ const outreachAssets = `
         fieldListing {
           targetId
         }
+        fieldLcCategories {
+          entity {
+            ... on TaxonomyTermLcCategories {
+              name
+              fieldTopicId
+            }
+          }
+        }
         fieldMedia {
           entity {
             ... on MediaImage {


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11153

Adjusted graphql query to allow outreach filters to be added dynamically

## Testing done
Local testing with backend tugboat instance

## Screenshots
<img width="284" alt="Screen Shot 2022-11-02 at 9 45 32 AM" src="https://user-images.githubusercontent.com/61624970/200036755-c2be002b-4c4d-4820-8913-50b0c6abeb88.png">
<img width="678" alt="Screen Shot 2022-11-04 at 1 14 48 PM" src="https://user-images.githubusercontent.com/61624970/200036761-d228df87-6a96-40e6-b0b4-1d2fc09152c8.png">


## Acceptance criteria
- [ ] The topic filter options are powered by field_lc_categories from the data items on the page (this is a new field and will need to be added to the graphql.)
- [ ] ~~The file type filter options are powered by field_format  (this is not a new field)~~
- [ ] Topic filter and type filter select lists are alpha sorted
- [ ] A veteran should never be able to select a topic option that has no data. (example: Disability should not appear as a filter if there are no data items of topic Disability.)
- [ ] The field field_benefits is no longer referenced on the template and no longer in the graphQL 
- [ ] Accessibility review - receives 508 approval 
- [ ] Create future issue -  The two filters are aware of each other and self restrict the other's limits.  (example: If I select format = video, I should not see types in the filter that contain no videos. This would prevent from selecting a filter combination that has no results.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
