### PR TITLE
entity ids of exception accordions added

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -138,6 +138,23 @@ module.exports = function registerFilters() {
     return replaced;
   };
 
+  liquid.filters.filterCollapsibleHeaderLevels = id => {
+    const targetH3IDs = [
+      '111299',
+      '112708',
+      '112719',
+      '112728',
+      '112732',
+      '113302',
+      '113309',
+      '113323',
+      '113332',
+      '7153',
+      '37238',
+    ];
+    return targetH3IDs.includes(id);
+  };
+
   liquid.filters.dateFromUnix = (dt, format, tz = 'America/New_York') => {
     if (!dt) {
       return null;

--- a/src/site/paragraphs/collapsible_panel.drupal.liquid
+++ b/src/site/paragraphs/collapsible_panel.drupal.liquid
@@ -32,15 +32,25 @@
             bordered
         {% endif %}
     >
+    {% assign collapsibleHeaderH3 = entity.entityId | filterCollapsibleHeaderLevels %}
+
+    {% if collapsibleHeaderH3 %}
+        {% assign panelHeaderLevel = 'h3' %}
+    {% else %}
+        {% assign panelHeaderLevel = 'h4' %}
+    {% endif %}
+
         {% for accordionItem in entity.fieldVaParagraphs %}
             {% assign item = accordionItem.entity %}
             {% assign id = item.entityId %}
             <va-accordion-item
               id="{{item.fieldTitle | hashReference: 30 }}-{{id}}"
             >
-            <h4 slot="headline">
-                {{ item.fieldTitle | encode }}
-            </h4>
+
+                <{{ panelHeaderLevel }} slot="headline">
+                    {{ item.fieldTitle | encode }} 
+                </{{ panelHeaderLevel }}>
+
                 <div
                     id={{id}}
                     data-template="paragraphs/collapsible_panel__panel"


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11205

There are a number of accordions that use the collapsible_panel template, that don't conform with page header level hierarchy.  This PR addresses that by manually identifying those components entityIds and adjusting their header levels accordingly

## Testing done
Local visual testing.

Sample URLs for QA: 
http://localhost:3002/preview?nodeId=488
http://localhost:3002/preview?nodeId=48613
http://localhost:3002/preview?nodeId=866
http://localhost:3002/preview?nodeId=3014

## Screenshots
<img width="678" alt="Screen Shot 2022-11-07 at 4 16 25 PM" src="https://user-images.githubusercontent.com/61624970/200417416-553a62a6-c8af-4006-aa8f-a18c863fa4b6.png">
<img width="678" alt="Screen Shot 2022-11-07 at 4 16 14 PM" src="https://user-images.githubusercontent.com/61624970/200417417-a7aaffca-11d7-4dfe-9883-7f7764a0f613.png">


## Acceptance criteria
- [ ] Determine if other pages may have been missed from the audit
- [ ] Update heading levels for necessary pages
- [ ] Review with accessibility lead

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
