### PR TITLE
VACMS-11309: switch to c5.4xlarge instances.

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -17,7 +17,7 @@ env:
   BUILDTYPE: vagovprod
   DEPLOY_BUCKET: content.www.va.gov
   DRUPAL_ADDRESS: https://prod.cms.va.gov
-  INSTANCE_TYPE: m5.4xlarge
+  INSTANCE_TYPE: c5.4xlarge
   MAXIMUM_HEAP: 5000
 
 jobs:


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11309

The ultimate aim here is to speed up content build. The build process timing is pushed to Datadog, so we will be able to see the impact of any metrics changes.

## Testing done
We tested different instance types here: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11130#issuecomment-1284493502

We saw speed improvements with different instance types than what we currently use. 
