### PR TITLE
11324 Updates to GA Event Labels

### DIFF
--- a/src/site/components/banners.drupal.liquid
+++ b/src/site/components/banners.drupal.liquid
@@ -30,6 +30,7 @@
 <!-- Promo Banners -->
 {% for promoBanner in visiblePromoBanners %}
   <va-promo-banner
+    onclick="recordEvent({ event: 'promo-banner-event', 'promo-banner-action': 'Footer alert - {{promoBanner.title}}'})"
     aria-label="{{ promoBanner.title }}"
     role="region"
     data-template="components/banners.drupal.liquid"

--- a/src/site/layouts/home.drupal.liquid
+++ b/src/site/layouts/home.drupal.liquid
@@ -65,7 +65,9 @@
     <section id="homepage-popular">
       <div class="usa-grid usa-grid-full">
         <div class="usa-width-one-third">
-          <a href="/find-locations/" onclick="recordEvent({ event: 'nav-main-health' });" class="homepage-button">
+          <a href="/find-locations/"
+            onclick="recordEvent({ event: 'nav-main-health', 'homepage-cta-action': 'Homepage CTA - Find a location' });"
+            class="homepage-button">
             <div class="icon-wrapper">
               <i class="fa fa-map-marker-alt homepage-button-icon"></i>
             </div>
@@ -77,7 +79,8 @@
         </div>
 
         <div class="usa-width-one-third">
-          <button onclick="recordEvent({ event: 'nav-main-vcl' });" class="homepage-button vcl va-overlay-trigger" data-show="#modal-crisisline">
+          <button onclick="recordEvent({ event: 'nav-main-vcl', 'homepage-cta-action': 'Homepage CTA - Crisis Line' });"
+            class="homepage-button vcl va-overlay-trigger" data-show="#modal-crisisline">
             <div class="icon-wrapper vcl"></div>
             <div class="button-inner">
               <span>Talk to a Veterans Crisis Line responder now</span>
@@ -86,7 +89,8 @@
         </div>
 
         <div class="usa-width-one-third" id="myva-login">
-          <button onclick="recordEvent({ event: 'nav-main-sign-in' });" class="homepage-button signin-signup-modal-trigger">
+          <button onclick="recordEvent({ event: 'nav-main-sign-in', 'homepage-cta-action': 'Homepage CTA - Sign In' });"
+            class="homepage-button signin-signup-modal-trigger">
             <div class="icon-wrapper">
               <i class="fas fa-user-circle homepage-button-icon"></i>
             </div>


### PR DESCRIPTION
## Description
Adds new, unique action labels to homepage CTAs, OPIA Promos and Promo Banner

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11324

Has sibling PR in vets-website: https://github.com/department-of-veterans-affairs/vets-website/pull/22652

## Testing done
Manually testing via Chrome Analytics Debugger extension


## Acceptance criteria
- [x] Mega menu events identify the benefit program from which it was clicked
   - [x] Header - Disability - Check your claim or appeal status
   - [x] Header - Life insurance - Check your appeal status
   - [x] Header - Housing - Check your appeal status
   - [x] Header - Disability - View your payment history
   - [x] Header - Education - View your payment history
   - [x] Header - Records - View your payment history
   - [x] Header - Records - Request your military records
   - [x] Header - Burials and memorials - Request your military records
Events on boxes at far right of mega menu are tracked and identified distinctly from other mega menu events
   - [x] Header - Education - GI Bill comparison tool
   - [x] Header - Records - Confirm your VA benefit status
- [x] CTAs below benefit hub are tracked and identifiable as interactions occurring on the CTAs, rather than elsewhere on the page
   - [x] Homepage CTA - Find a location
   - [x] Homepage CTA - Crisis Line
   - [x] Homepage CTA - Sign In
- [x] Sign in events on the header are uniquely identified as occurring in the header
   - [x] Header - Sign in
- [x] Events on OPIA promo spots are tracked and identifiable as interactions occurring on the promo spots, rather than elsewhere on the page
   - [x] Homepage - [title] promo - for any OPIA promo above the footer on current homepage
- [x] Events on PACT Act banner alert are tracked and identified as initiated on alert banner, rather than from a promo block or elsewhere
  - [x] Footer alert - [title]

## QA Notes
To help make QA easier, I recommen filtering by the following action names to confirm action/event is being logged to Google Anayltics via [this extension](https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna)
- For  Megamenu Link Click, you'll be looking for an action called 'nav-header-action'
- For Megamenu 3rd Column Promo clicks, you'll be looking for an action called 'nav-hub-action'
- For Homepage CTA clicks, action name is 'homepage-cta-action'
- For Header Sign In button clicks, action name is 'header-sign-in-action'
- For OPIA Homepage Promo clicks, action name is 'homepage-promo-action'
- For Promo Banner clicks, action name is 'promo-banner-action'

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
