### PR TITLE
Allow apps to opt out of global web-components definition script & site-wide styleshet

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1116,7 +1116,8 @@
     "template": {
       "vagovprod": true,
       "layout": "page-react.html"
-    }
+    },
+    "defineWebComponentsLocally": true
   },
   {
     "appName": "My Education Benefits",

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1117,7 +1117,7 @@
       "vagovprod": true,
       "layout": "page-react.html"
     },
-    "defineWebComponentsLocally": true
+    "useLocalStylesAndComponents": true
   },
   {
     "appName": "My Education Benefits",

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -76,7 +76,7 @@
     Apps that opt out of the site-wide stylesheet must include a smaller subset of styles
     in their application bundle
   {% endcomment %}
-  {% if !useLocalStylesAndComponents %}
+  {% if buildtype == 'vagovprod' or !useLocalStylesAndComponents %}
     <link rel="stylesheet" data-entry-name="style.css">
   {% endif %}
   <link rel="stylesheet" data-entry-content="content-build.css">

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -47,7 +47,7 @@
       this global file which will define all web components. Instead, they will manually
       define a subset of web components which are used in their application
     {% endcomment %}
-    {% if !defineWebComponentsLocally %}
+    {% if buildtype == 'vagovprod' or !defineWebComponentsLocally %}
       <script nonce="**CSP_NONCE**" defer data-entry-name="web-components.js"></script>
     {% endif %}
   {% endif %}

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -42,7 +42,14 @@
   <!-- Add web components. -->
   {% if entityId != 11463 or buildtype != "vagovdev") %}
     <link rel="stylesheet" data-entry-name="web-components.css">
-    <script nonce="**CSP_NONCE**" defer data-entry-name="web-components.js"></script>
+    {% comment %}
+      The `defineWebComponentsLocally` registry value allows apps to opt-out of
+      this global file which will define all web components. Instead, they will manually
+      define a subset of web components which are used in their application
+    {% endcomment %}
+    {% if !defineWebComponentsLocally %}
+      <script nonce="**CSP_NONCE**" defer data-entry-name="web-components.js"></script>
+    {% endif %}
   {% endif %}
 
   <!-- Render GA template. -->

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -72,7 +72,13 @@
   <link rel="preload" href="/generated/fa-solid-900.woff2" as="font" type="font/woff2" crossorigin>
 
   <!-- CSS -->
-  <link rel="stylesheet" data-entry-name="style.css">
+  {% comment %}
+    Apps that opt out of the site-wide stylesheet must include a smaller subset of styles
+    in their application bundle
+  {% endcomment %}
+  {% if !useLocalStylesAndComponents %}
+    <link rel="stylesheet" data-entry-name="style.css">
+  {% endif %}
   <link rel="stylesheet" data-entry-content="content-build.css">
   <link rel="stylesheet" data-entry-name="{{ entryname | default: 'static-pages' }}.css">
 

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -43,11 +43,11 @@
   {% if entityId != 11463 or buildtype != "vagovdev") %}
     <link rel="stylesheet" data-entry-name="web-components.css">
     {% comment %}
-      The `defineWebComponentsLocally` registry value allows apps to opt-out of
+      The `useLocalStylesAndComponents` registry value allows apps to opt-out of
       this global file which will define all web components. Instead, they will manually
       define a subset of web components which are used in their application
     {% endcomment %}
-    {% if buildtype == 'vagovprod' or !defineWebComponentsLocally %}
+    {% if buildtype == 'vagovprod' or !useLocalStylesAndComponents%}
       <script nonce="**CSP_NONCE**" defer data-entry-name="web-components.js"></script>
     {% endif %}
   {% endif %}

--- a/src/site/stages/build/plugins/create-react-pages.js
+++ b/src/site/stages/build/plugins/create-react-pages.js
@@ -13,32 +13,35 @@ function createReactPages(files, drupalData = { data: {} }, done) {
   } = drupalData;
   const alertItems = { alert: alertsItem };
 
-  appRegistry.forEach(({ entryName, appName, rootUrl, template }) => {
-    const trimmedUrl = path.join('.', rootUrl);
-    const filePath = path.join(trimmedUrl, 'index.html');
-    if (!files[filePath]) {
-      if (global.verbose) {
-        console.log(
-          `Generating HTML template for application ${appName} at ${rootUrl}`,
-        );
+  appRegistry.forEach(
+    ({ entryName, appName, rootUrl, template, defineWebComponentsLocally }) => {
+      const trimmedUrl = path.join('.', rootUrl);
+      const filePath = path.join(trimmedUrl, 'index.html');
+      if (!files[filePath]) {
+        if (global.verbose) {
+          console.log(
+            `Generating HTML template for application ${appName} at ${rootUrl}`,
+          );
+        }
+        files[filePath] = {
+          title: appName,
+          entryname: entryName,
+          shouldAddDebugInfo: true,
+          defineWebComponentsLocally: !!defineWebComponentsLocally,
+          debug: null,
+          path: trimmedUrl,
+          layout: 'page-react.html',
+          contents: Buffer.from('\n<!-- Generated from manifest.json -->\n'),
+          entityUrl: { path: `/${trimmedUrl}` },
+          alertItems,
+          ...{ bannerAlert: bannerAlertsItem },
+          ...{ banners },
+          ...{ promoBanners },
+          ...template,
+        };
       }
-      files[filePath] = {
-        title: appName,
-        entryname: entryName,
-        shouldAddDebugInfo: true,
-        debug: null,
-        path: trimmedUrl,
-        layout: 'page-react.html',
-        contents: Buffer.from('\n<!-- Generated from manifest.json -->\n'),
-        entityUrl: { path: `/${trimmedUrl}` },
-        alertItems,
-        ...{ bannerAlert: bannerAlertsItem },
-        ...{ banners },
-        ...{ promoBanners },
-        ...template,
-      };
-    }
-  });
+    },
+  );
 
   done?.();
 }

--- a/src/site/stages/build/plugins/create-react-pages.js
+++ b/src/site/stages/build/plugins/create-react-pages.js
@@ -14,7 +14,13 @@ function createReactPages(files, drupalData = { data: {} }, done) {
   const alertItems = { alert: alertsItem };
 
   appRegistry.forEach(
-    ({ entryName, appName, rootUrl, template, defineWebComponentsLocally }) => {
+    ({
+      entryName,
+      appName,
+      rootUrl,
+      template,
+      useLocalStylesAndComponents,
+    }) => {
       const trimmedUrl = path.join('.', rootUrl);
       const filePath = path.join(trimmedUrl, 'index.html');
       if (!files[filePath]) {
@@ -27,7 +33,7 @@ function createReactPages(files, drupalData = { data: {} }, done) {
           title: appName,
           entryname: entryName,
           shouldAddDebugInfo: true,
-          defineWebComponentsLocally: !!defineWebComponentsLocally,
+          useLocalStylesAndComponents: !!useLocalStylesAndComponents,
           debug: null,
           path: trimmedUrl,
           layout: 'page-react.html',


### PR DESCRIPTION
## Description

Part of https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1211

This updates the build to check a `useLocalStylesAndComponents` value in each app's registry when building the page for the app. If the value is true then the script that defines all web components globally along with the site-wide stylesheet won't be included on the page.

This also sets the `useLocalStylesAndComponents` registry value in the `pre-check-in` app to true.


## Testing done

In a localhost build, the `web-components.js` script file and `style.css` stylesheet were present in the `appointment-check-in` app, but not the `appointment-pre-check-in` due to the registry value:

![Screenshot of the terminal using ripgrep to show the above statement](https://user-images.githubusercontent.com/2008881/201803909-9182ebac-30ce-4daf-82f6-220dadfa0b91.png)

And in a production build, the web-component script and site-wide stylesheet are still present in the app despite the `useLocalStylesAndComponents` registry value.

![image](https://user-images.githubusercontent.com/2008881/202018175-d46653c6-cdd6-4e38-a185-170f8b1dd2cb.png)


## Acceptance criteria
- [x] applications can opt out of site-wide script for defining web components
- [x] applications can opt out of site-wide CSS stylesheet

