### PR TITLE
11153 lc category support

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -125,6 +125,14 @@ module.exports = function registerFilters() {
     }, []);
   };
 
+  liquid.filters.buildTopicsString = topics => {
+    if (!topics) return null;
+    const fieldTopicIdArray = topics.map(topic => {
+      return topic.entity.fieldTopicId;
+    });
+    return fieldTopicIdArray.join(' ');
+  };
+
   liquid.filters.alphabetizeList = items => {
     return _.orderBy(items, [item => item?.name?.toLowerCase()], ['asc']);
   };

--- a/src/site/layouts/publication_listing.drupal.liquid
+++ b/src/site/layouts/publication_listing.drupal.liquid
@@ -106,7 +106,8 @@
                 large-screen:vads-l-col--12
                   {{entity.fieldMedia.entity.entityBundle}}-asset-wrap">
                     {% if entity.fieldMedia.entity.entityBundle == 'document' %}
-                    {% case entity.fieldLcCategories[0].entity.fieldTopicId %}
+                    {% assign firstTopicCategory = entity.fieldLcCategories | first %}
+                    {% case firstTopicCategory.entity.fieldTopicId %}
                     {% when 'general' %}
                     <img alt="{{entity.title | truncate: 36}}"
                       src="/img/hub-illustrations/records.png" />

--- a/src/site/layouts/publication_listing.drupal.liquid
+++ b/src/site/layouts/publication_listing.drupal.liquid
@@ -180,7 +180,7 @@
                   medium-screen:vads-l-col--8
                   medium-body-utility
                   large-screen:vads-l-col--12">
-                    <i>{{entity.fieldBenefits | benefitTerms}}</i>
+                    <i>{{firstTopicCategory.entity.name}}</i>
                     <h2 class="asset-body-header
                     vads-u-margin-y--1
                     vads-u-font-size--lg">

--- a/src/site/layouts/publication_listing.drupal.liquid
+++ b/src/site/layouts/publication_listing.drupal.liquid
@@ -39,7 +39,7 @@
                       {% assign topicList = outreachAssetsDataArray.entities | buildTopicList %}
                       {% assign sortedTopics = topicList | alphabetizeList %}
                       <option value="select">- All topics -</option>    
-                      {% for topic in topicList %}
+                      {% for topic in sortedTopics %}
                         <option value={{topic.fieldTopicId}}>{{ topic.name }}</option>
                       {% endfor %}
                     </select>
@@ -87,9 +87,8 @@
               {% assign even = true %}
               {% for entity in outreachAssetsDataArray.entities %}
               {% if entity.fieldListing.targetId == entityId %}
-
-              <div data-topic="{{entity.fieldBenefits}}"
-                {{entity.fieldBenefits | breakIntoSingles}}
+              {% assign topicsString = entity.fieldLcCategories | buildTopicsString %}
+              <div data-topic="{{topicsString}}"
                 data-type="{{entity.fieldFormat}}" data-number={{forloop.index}}
                 class="vads-l-col--12
                 vads-l-row
@@ -107,7 +106,7 @@
                 large-screen:vads-l-col--12
                   {{entity.fieldMedia.entity.entityBundle}}-asset-wrap">
                     {% if entity.fieldMedia.entity.entityBundle == 'document' %}
-                    {% case entity.fieldBenefits %}
+                    {% case entity.fieldLcCategories[0].entity.fieldTopicId %}
                     {% when 'general' %}
                     <img alt="{{entity.title | truncate: 36}}"
                       src="/img/hub-illustrations/records.png" />


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11153

## Testing done
Local visual testing
QA steps:
- may require content-build rebuild in order to see changes if tested locally
- navigate to http://localhost:3002/outreach-and-events/outreach-materials/
- Observe that topic filters are present, functional, and alpha sorted

## Screenshots
<img width="825" alt="image" src="https://user-images.githubusercontent.com/61624970/201765965-f8d03a09-cc66-45c9-89c7-1d9025d2f855.png">


## Acceptance criteria
- [ ] The topic filter options are powered by field_lc_categories from the data items on the page (this is a new field and will need to be added to the graphql.)
- [ ] ~~The file type filter options are powered by field_format  (this is not a new field)~~
- [ ] Topic filter and type filter select lists are alpha sorted
- [ ] A veteran should never be able to select a topic option that has no data. (example: Disability should not appear as a filter if there are no data items of topic Disability.)
- [ ] The field field_benefits is no longer referenced on the template and no longer in the graphQL 
- [x] Create future issue -  The two filters are aware of each other and self restrict the other's limits.  (example: If I select format = video, I should not see types in the filter that contain no videos. This would prevent from selecting a filter combination that has no results. – #11476 
 - [ ] Accessibility review - receives 508 approval 
 - [ ] PM/DM review

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
