### PR TITLE
VACMS-11373 Lovell Giving Wrong Switch Paths

### DIFF
--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -47,7 +47,6 @@ function getModifiedLovellPage(page, variant) {
       : LOVELL_TRICARE_TITLE_VARIATION;
   const linkVar =
     variant === 'va' ? LOVELL_VA_LINK_VARIATION : LOVELL_TRICARE_LINK_VARIATION;
-  const originalPath = `${page.entityUrl.path}`;
 
   // Add a field for canonical if it has a clone and it's a tricare variant
   if (variant === 'tricare' && isLovellFederalPage(page)) {
@@ -58,10 +57,11 @@ function getModifiedLovellPage(page, variant) {
   }
 
   // Modify the path
-  page.entityUrl.path = `${originalPath}`.replace(
+  const modifiedPath = page.entityUrl.path.replace(
     '/lovell-federal-health-care',
     `/lovell-federal-${linkVar}-health-care`,
   );
+  page.entityUrl.path = modifiedPath;
 
   // Add a switchPath field
   // These get modified later in the processLovellPages function
@@ -73,7 +73,7 @@ function getModifiedLovellPage(page, variant) {
       `/lovell-federal-${LOVELL_VA_LINK_VARIATION}-health-care`,
     )
   ) {
-    page.entityUrl.switchPath = `${page.entityUrl.path}`.replace(
+    page.entityUrl.switchPath = page.entityUrl.path.replace(
       variant === 'va'
         ? LOVELL_VA_LINK_VARIATION
         : LOVELL_TRICARE_LINK_VARIATION,
@@ -82,7 +82,7 @@ function getModifiedLovellPage(page, variant) {
         : LOVELL_VA_LINK_VARIATION,
     );
   } else {
-    page.entityUrl.switchPath = `${page.entityUrl.path}`.replace(
+    page.entityUrl.switchPath = page.entityUrl.path.replace(
       '/lovell-federal-health-care',
       `/lovell-federal-${
         variant === 'va'

--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -73,7 +73,7 @@ function getModifiedLovellPage(page, variant) {
       `/lovell-federal-${LOVELL_VA_LINK_VARIATION}-health-care`,
     )
   ) {
-    page.entityUrl.switchPath = originalPath.replace(
+    page.entityUrl.switchPath = `${page.entityUrl.path}`.replace(
       variant === 'va'
         ? LOVELL_VA_LINK_VARIATION
         : LOVELL_TRICARE_LINK_VARIATION,
@@ -82,7 +82,7 @@ function getModifiedLovellPage(page, variant) {
         : LOVELL_VA_LINK_VARIATION,
     );
   } else {
-    page.entityUrl.switchPath = originalPath.replace(
+    page.entityUrl.switchPath = `${page.entityUrl.path}`.replace(
       '/lovell-federal-health-care',
       `/lovell-federal-${
         variant === 'va'

--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -47,7 +47,7 @@ function getModifiedLovellPage(page, variant) {
       : LOVELL_TRICARE_TITLE_VARIATION;
   const linkVar =
     variant === 'va' ? LOVELL_VA_LINK_VARIATION : LOVELL_TRICARE_LINK_VARIATION;
-  const originalPath = page.entityUrl.path;
+  const originalPath = `${page.entityUrl.path}`;
 
   // Add a field for canonical if it has a clone and it's a tricare variant
   if (variant === 'tricare' && isLovellFederalPage(page)) {
@@ -58,7 +58,7 @@ function getModifiedLovellPage(page, variant) {
   }
 
   // Modify the path
-  page.entityUrl.path = originalPath.replace(
+  page.entityUrl.path = `${originalPath}`.replace(
     '/lovell-federal-health-care',
     `/lovell-federal-${linkVar}-health-care`,
   );


### PR DESCRIPTION
## Description

Two tickets show how several Lovell pages have incorrect switch links and/or switch link banners. The cause was modifying the Lovell page path was inadvertently changing the `originalPath` variable, which rippled into how the switch links were being set. This is because the `entityUrl.path` was being checked for making switch links, but the change was being done off of `originalPath`. So it lead to some data inconsistencies among pages.

Closes [#11373](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11373) and likely [#11374](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11374)

## Testing done

Debugging, see below screenshots.

## Screenshots

These are the pages that had incorrect switch links. Both pointed to `lovell-federal-health-care` instead of the Tricare/VA inversions. Debugging confirmed they now have the correct switch link URLs.

![Screen Shot 2022-11-15 at 2 34 39 PM](https://user-images.githubusercontent.com/10790736/202012493-f7aa1003-ad8c-49de-942e-efaabcd4fce2.png)
![Screen Shot 2022-11-15 at 2 35 15 PM](https://user-images.githubusercontent.com/10790736/202012495-4c46f37e-6fa2-403f-a0f9-0db01d0776b0.png)


## Acceptance criteria
- [ ] Lovell pages have correct switch links when visible at the top banner
- [ ] Pages without switch links have no banner

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
