### PR TITLE
VACMS-11422: add tricare fallback to Lovell Service descriptions

### DIFF
--- a/src/site/facilities/facility_health_service.drupal.liquid
+++ b/src/site/facilities/facility_health_service.drupal.liquid
@@ -20,7 +20,9 @@
           </div>
         {% endif %}
 
-        {% if serviceTaxonomy.description.processed %}
+        {% if serviceSection.name == "Lovell - TRICARE" and serviceTaxonomy.fieldTricareDescription %}
+          <div>{{ serviceTaxonomy.fieldTricareDescription }}</div>
+        {% elsif serviceTaxonomy.description.processed %}
           <div>{{ serviceTaxonomy.description.processed }}</div>
         {% endif %}
 

--- a/src/site/facilities/health_service.drupal.liquid
+++ b/src/site/facilities/health_service.drupal.liquid
@@ -16,7 +16,9 @@
                         <span class="vads-u-font-style--italic">Common conditions: </span>{{ serviceTaxonomy.fieldCommonlyTreatedCondition }}
                     </div>
                 {% endif %}
-                {% if serviceTaxonomy.description.processed  %}
+                {% if section.name == "Lovell - TRICARE" and serviceTaxonomy.fieldTricareDescription %}
+                    <description>{{ serviceTaxonomy.fieldTricareDescription | phoneLinks }}</description>
+                {% elsif serviceTaxonomy.description.processed  %}
                     <description>{{ serviceTaxonomy.description.processed | phoneLinks }}</description>
                 {% endif %}
 

--- a/src/site/includes/health_services_listing_services.liquid
+++ b/src/site/includes/health_services_listing_services.liquid
@@ -8,6 +8,7 @@
       <va-accordion bordered>
       {% for service in servicesListOrderedByName %}
         {% include "src/site/facilities/health_service.drupal.liquid" with
+          section
           healthService = service
           sectionName = typeOfCare
         %}

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -190,10 +190,12 @@
 
               <va-accordion bordered>
               {% for localService in localHealthServices %}
+                {% assign serviceSection = localService.entity.fieldAdministration.entity %}
                 {% assign localHealthService = localService.entity | featureFieldRegionalHealthService %}
                 {% if localHealthService != empty and localService.entity.status == true %}
 
                   {% include "src/site/facilities/facility_health_service.drupal.liquid" with
+                      serviceSection
                       healthService = localHealthService
                       locationEntity = localService.entity
                       locations = localService.entity.fieldServiceLocation

--- a/src/site/layouts/health_services_listing.drupal.liquid
+++ b/src/site/layouts/health_services_listing.drupal.liquid
@@ -42,29 +42,35 @@
           </section>
           {% endif %}
 
+          {% assign section = fieldAdministration.entity %}
           {% assign clinicalHealthServices = fieldOffice.entity.reverseFieldRegionPageNode.entities %}
 
           {% include "src/site/includes/health_services_listing_services.liquid" with
+            section
             clinicalHealthServices
             typeOfCare = "Primary care"
           %}
 
           {% include "src/site/includes/health_services_listing_services.liquid" with
+            section
             clinicalHealthServices
             typeOfCare = "Mental health care"
           %}
 
           {% include "src/site/includes/health_services_listing_services.liquid" with
+            section
             clinicalHealthServices
             typeOfCare = "Specialty care"
           %}
 
           {% include "src/site/includes/health_services_listing_services.liquid" with
+            section
             clinicalHealthServices
             typeOfCare = "Social programs and services"
           %}
 
           {% include "src/site/includes/health_services_listing_services.liquid" with
+            section
             clinicalHealthServices
             typeOfCare = "Other services"
           %}

--- a/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
@@ -105,6 +105,11 @@ const healthCareLocalFacilityPageFragment = `
           status
           ${serviceLocation}
           ${appointmentItems}
+          fieldAdministration {
+            entity {
+              name
+            }
+          }
           fieldRegionalHealthService
           {
             entity {
@@ -125,6 +130,7 @@ const healthCareLocalFacilityPageFragment = `
                       description {
                         processed
                       }
+                      fieldTricareDescription
                       parent {
                         entity {
                           ...on TaxonomyTermHealthCareServiceTaxonomy {

--- a/src/site/stages/build/drupal/graphql/healthServicesListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthServicesListingPage.graphql.js
@@ -86,6 +86,7 @@ const healthServicesListingPage = `
                     description {
                       processed
                     }
+                    fieldTricareDescription
                     fieldServiceTypeOfCare
                   }
                 }
@@ -108,6 +109,7 @@ const healthServicesListingPage = `
       entity{
         ... on TaxonomyTermAdministration {
           entityId
+          name
         }
       }
     }


### PR DESCRIPTION
## Description

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11422

Display the tricare service description for a service listed on either a VAMC Facility page or a Health Service List page when the following criteria are satisfied:

**VAMC Facility Page**

- The field_administration (section) field for the facility = Lovell - TRICARE
- The field_tricare_description field for the VA Services term referenced by the VAMC Facility Health Service is not empty

**Health Service List Page**

- The field_administration (section) field for the health service list page = Lovell - TRICARE
- The field_tricare_description field for the VA Services term referenced by the VAMC System Health Service is not empty

## Testing done

Manual testing

## Screenshots

**VAMC Facility - USS Red Rover**
<img width="722" alt="Screen Shot 2022-11-17 at 5 47 11 PM" src="https://user-images.githubusercontent.com/21045418/202581891-00af1430-4547-44b0-a0e8-9fa2135e1f89.png">

**Health Services for Lovell VA compared to Lovell Tricare**
<img width="1769" alt="Screen Shot 2022-11-17 at 5 46 54 PM" src="https://user-images.githubusercontent.com/21045418/202581869-e86bc58b-3489-4bf7-aca4-c3e386516098.png">

## Acceptance criteria

Data for testing currently resides here: https://cms-liqqgmzl7tsyfbwyulbkuborufuuttav.demo.cms.va.gov/

Placeholder tricare descriptions have been provided for:

- Audiology and Speech
- Dental/oral Surgery

- [ ] On /lovell-federal-va-health-care/health-services/ the descriptions for these two services shouldn't mention tricare
- [ ] On /lovell-federal-tricare-health-care/health-services/ these two services should mention tricare
- [ ] On /lovell-federal-tricare-health-care/locations/uss-red-rover/ these two services should mention tricare
