### PR TITLE
fix(workflow): Use on-demand Runner for Validation

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -88,10 +88,7 @@ jobs:
 
   validate-build-status:
     name: Validate Build Status
-    runs-on:
-      - self-hosted
-      - linux
-      - x64
+    runs-on: ${{ needs.start-runner.outputs.label }}
     needs: start-runner
     outputs:
       REF: ${{ steps.get-latest-release.outputs.target_commitish }}


### PR DESCRIPTION
- There is a chance of the validation job landing on an instance that cannot perform the operation as expected
- When validation lands on a non-on-demand runner it is failing
- Keeping the validation job on the on-demand runner that gets spun up should resolve this