### PR TITLE
Use either on-demand or GHA runners.

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -442,10 +442,8 @@ jobs:
 
   deploy:
     name: Deploy
-    runs-on:
-      - self-hosted
-      - linux
-      - x64
+    runs-on: ${{ needs.start-runner.outputs.label }}
+
     needs:
       - validate-build-status
       - build

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -127,10 +127,7 @@ jobs:
 
   notify-start:
     name: Notify Start
-    runs-on:
-      - self-hosted
-      - linux
-      - x64
+    runs-on: ubuntu-latest
     needs: validate-build-status
     steps:
       - name: Checkout
@@ -395,7 +392,6 @@ jobs:
         run: echo ::set-output name=BUILD_END_TIME::$(date +"%s")
         working-directory: ${{ github.workspace }}
 
-
   archive:
     name: Archive
     runs-on: ${{ needs.start-runner.outputs.label }}
@@ -516,10 +512,7 @@ jobs:
 
   notify-success:
     name: Notify Success
-    runs-on:
-      - self-hosted
-      - linux
-      - x64
+    runs-on: ubuntu-latest
     needs:
       - validate-build-status
       - deploy
@@ -547,10 +540,7 @@ jobs:
 
   notify-failure:
     name: Notify Failure
-    runs-on:
-      - self-hosted
-      - linux
-      - x64
+    runs-on: ubuntu-latest
     if: |
       (failure() && needs.deploy.result != 'success')
     needs: deploy
@@ -601,10 +591,7 @@ jobs:
 
   record-metrics:
     name: Record metrics in Datadog
-    runs-on:
-      - self-hosted
-      - linux
-      - x64
+    runs-on: ${{ needs.start-runner.outputs.label }}
     needs:
       - start-runner
       - build


### PR DESCRIPTION
## Description
In Content Release, we sometimes experience problems with self-hosted runners from the general pool of runners. This PR moves some jobs to Github Action runners and others to the on-demand runner we spin up at the beginning of the workflow.

Note that the initial job which spins up the on-demand runner itself runs in our self-hosted runner pool. This is OK. We specifically have issue with runners from the self-hosted runner pool when they perform the repo checkout action or when they install node. The start runner job does not do either of those. 

Context: https://dsva.slack.com/archives/CBU0KDSB1/p1669044715948929

