### PR TITLE
[VA-11654] Update hard-coded H2 to 'Top Pages'

### DIFF
--- a/src/site/includes/common-tasks.drupal.liquid
+++ b/src/site/includes/common-tasks.drupal.liquid
@@ -45,7 +45,7 @@
       <div class="vads-l-col--12 medium-screen:vads-l-col--6 vads-u-background-color--white">
         <div class="vads-u-padding-left--2p5 medium-screen:vads-u-padding-left--6 vads-u-padding-bottom--5">
           <h2 class="vads-u-color--gray-dark vads-u-font-family--serif">
-            Popular on VA.gov
+            Top Pages
           </h2>
           <ul class="homepage-common-tasks__list vads-u-padding-left--0 ">
             {% if popularLinks %}


### PR DESCRIPTION
## Description

The `h2` header that reads "Popular on VA.gov" is being changed to "Top Pages." This sets it up for being dynamically changed for the CMS menu title.

## Testing done

Visual

## Screenshots

<img width="1036" alt="Screen Shot 2022-11-22 at 10 28 51 AM" src="https://user-images.githubusercontent.com/10790736/203354099-77f3002e-9ed7-47df-9e04-a72630c10b4c.png">

## Acceptance criteria
- [ ] "Popular on VA.gov" is changed to "Top Pages" for the menus

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
