### PR TITLE
Revert "VACMS-11309: switch to c5d instances."

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -17,7 +17,7 @@ env:
   BUILDTYPE: vagovprod
   DEPLOY_BUCKET: content.www.va.gov
   DRUPAL_ADDRESS: https://prod.cms.va.gov
-  INSTANCE_TYPE: c5d.4xlarge
+  INSTANCE_TYPE: c5.4xlarge
   MAXIMUM_HEAP: 5000
 
 jobs:


### PR DESCRIPTION
Reverts department-of-veterans-affairs/content-build#1378

Back pocket PR, in the event we need it.