### PR TITLE
11467 Adds Google Analytics events for new Homepage

### DIFF
--- a/src/site/includes/common-tasks.drupal.liquid
+++ b/src/site/includes/common-tasks.drupal.liquid
@@ -55,7 +55,7 @@
                 {% if link.url.path and link.label %}
                   <li>
                     <a
-                      onclick="recordEvent({ event: 'homepage-popular-links-click', action: 'Popular on VA.gov - {{link.label}}' })"
+                      onclick="recordEvent({ event: 'homepage-popular-links-click', action: 'Top Pages - {{link.label}}' })"
                       href="{{ link.url.path }}">{{ link.label }}</a>
                   </li>
                 {% endif %}

--- a/src/site/includes/common-tasks.drupal.liquid
+++ b/src/site/includes/common-tasks.drupal.liquid
@@ -30,7 +30,9 @@
                   {% if link.url.path and link.label %}
                     <li>
                       <i role="presentation" class="fas fa-arrow-right vads-u-color--link-default vads-u-margin-right--1"></i>
-                      <a href="{{ link.url.path }}">{{ link.label }}</a>
+                      <a
+                        onclick="recordEvent({ event: 'homepage-search-tools-click', action: 'Other search tools - {{link.label}}' })"
+                        href="{{ link.url.path }}">{{ link.label }}</a>
                     </li>
                   {% endif %}
                 {% endfor %}
@@ -52,7 +54,9 @@
               {% for link in popularLinks%}
                 {% if link.url.path and link.label %}
                   <li>
-                    <a href="{{ link.url.path }}">{{ link.label }}</a>
+                    <a
+                      onclick="recordEvent({ event: 'homepage-popular-links-click', action: 'Popular on VA.gov - {{link.label}}' })"
+                      href="{{ link.url.path }}">{{ link.label }}</a>
                   </li>
                 {% endif %}
               {% endfor %}

--- a/src/site/includes/hero.drupal.liquid
+++ b/src/site/includes/hero.drupal.liquid
@@ -32,7 +32,8 @@
           </p>
 
           {% if fieldPromoCta.entity.fieldButtonLabel and fieldPromoCta.entity.fieldButtonLink.url.path %}
-            <a class="vads-c-action-link--white" href="{{ fieldPromoCta.entity.fieldButtonLink.url.path }}">
+            <a onclick="recordEvent({ event: 'homepage-benefit-link-click', action: 'Homepage benefit promo - {{fieldPromoCta.entity.fieldButtonLabel}}' })"
+               class="vads-c-action-link--white" href="{{ fieldPromoCta.entity.fieldButtonLink.url.path }}">
                 {{fieldPromoCta.entity.fieldButtonLabel}}
             </a>
           {% endif %}
@@ -43,6 +44,7 @@
       <!-- start second column for  bplogin card -->
       <script>
         function openLoginModal() {
+          recordEvent({ event: "homepage-create-account", action: "Homepage Create Account CTA" });
           const params = (new URL(document.location)).searchParams;
           params.set("next", "loginModal")
           document.location = "?" + params.toString();

--- a/src/site/includes/homepage-benefits.drupal.liquid
+++ b/src/site/includes/homepage-benefits.drupal.liquid
@@ -13,7 +13,7 @@
         {% if hub.entity.entityUrl.path and hub.entity.fieldHomePageHubLabel and hub.entity.fieldTeaserText and hub.entity.fieldTitleIcon %}
         <div class="usa-width-one-third" data-e2e="hub" data-entity-id="{{ hub.entity.entityId }}">
           <h3 class="heading-level-4"><a href="{{ hub.entity.entityUrl.path }}"
-              onclick="recordEvent({ event: 'nav-linkslist' });"><i
+              onclick="recordEvent({ event: 'nav-linkslist', action: 'Benefit hub - {{ hub.entity.fieldHomePageHubLabel }}' });"><i
                 class="icon-small icon-heading hub-icon-{{ hub.entity.fieldTitleIcon }} hub-background-{{ hub.entity.fieldTitleIcon }} white vads-u-margin-right--1"></i>{{
               hub.entity.fieldHomePageHubLabel }}</a></h3>
           <p class="vads-u-margin-top--0 ">{{ hub.entity.fieldTeaserText }}</p>

--- a/src/site/includes/news-spotlight.drupal.liquid
+++ b/src/site/includes/news-spotlight.drupal.liquid
@@ -22,7 +22,9 @@
             NEWS</h2>
           {% if fieldPromoHeadline and fieldLink.url.path %}
             <h3 class="vads-u-font-family--serif vads-u-margin-top--0 vads-u-font-size--xl">
-              <a href="{{ fieldLink.url.path }}" class="vads-u-color--white">{{ fieldPromoHeadline }}</a>
+              <a
+                onclick="recordEvent({ event: 'homepage-news-promo-title-click', action: 'Homepage News Promo - {{ fieldPromoHeadline }} - Title' })"
+                href="{{ fieldLink.url.path }}" class="vads-u-color--white">{{ fieldPromoHeadline }}</a>
             </h3>
           {% endif %}
 
@@ -32,14 +34,18 @@
               {{ fieldPromoText }}
             {% endif %}
             {% if fieldLinkLabel and fieldLink.url.path %}
-              <a href="{{ fieldLink.url.path }}" class="vads-u-color--white">
+              <a
+                onclick="recordEvent({ event: 'homepage-news-promo-click', action: 'Homepage news promo - {{  fieldPromoHeadline }} - CTA' })"
+                href="{{ fieldLink.url.path }}" class="vads-u-color--white">
                 {{fieldLinkLabel}}
               </a>
             {% endif %}
           </p>
 
           <div>
-            <a href="https://news.va.gov/" class="vads-u-color--white">More VA news
+            <a
+              onclick="recordEvent({ event: 'homepage-news-promo-more-news-click', action: 'Homepage news promo - More VA News' })"
+              href="https://news.va.gov/" class="vads-u-color--white">More VA news
               <i class="fas fa-chevron-right vads-u-margin-left--1" role="presentation"></i>
             </a>
           </div>

--- a/src/site/layouts/home-preview.drupal.liquid
+++ b/src/site/layouts/home-preview.drupal.liquid
@@ -43,9 +43,9 @@
                            vads-u-display--inline-block
                            medium-screen:vads-u-max-width--none
                            medium-screen:vads-u-width--auto">
-                  {{comment}}
+                  {% comment %}
                    This `recordEvent` was added as a placeholder as this is a temporary implementation of the Email Submit form.
-                  {{endcomment}}
+                  {% endcomment %}
                   <button
                     onclick="recordEvent({ event: 'homepage-email-sign-up', action: 'Homepage email sign up' })"
                     class="email-update-signup-form__button vads-u-width--full medium-screen:vads-u-width--auto vads-u-display--inline-block">Sign

--- a/src/site/layouts/home-preview.drupal.liquid
+++ b/src/site/layouts/home-preview.drupal.liquid
@@ -43,7 +43,11 @@
                            vads-u-display--inline-block
                            medium-screen:vads-u-max-width--none
                            medium-screen:vads-u-width--auto">
+                  {{comment}}
+                   This `recordEvent` was added as a placeholder as this is a temporary implementation of the Email Submit form.
+                  {{endcomment}}
                   <button
+                    onclick="recordEvent({ event: 'homepage-email-sign-up', action: 'Homepage email sign up' })"
                     class="email-update-signup-form__button vads-u-width--full medium-screen:vads-u-width--auto vads-u-display--inline-block">Sign
                     up</button>
                 </div>


### PR DESCRIPTION
## Description
This PR add Google Analytics tracking to the new Homepage.

closes 11467  
Sibling PR: department-of-veterans-affairs/vets-website/compare/11467-ga-for-new-homepage  

## Original issue(s)
department-of-veterans-affairs/va.gov-cms/issues/11467

## Testing done
Local testing with the Google Analytics Chrome extension.


## Acceptance Criteria

- [x] Analytics team can help us test these once they are available in staging
- [x] Create an account events are tracked, distinctly from header sign-in events, such as `Homepage create an account CTA`
- [x] Events on Benefit promo are tracked by title and as initiated on the body of the homepage, such as `Homepage benefit promo > The PACT Act and your VA benefits` 
- [x] Search events are tracked and identifiable as interactions occurring on the body of the page, rather than from the header, such as `Homepage > Search`
- [x] Events on "Other search tools" are tracked by link label, such as `Other search tools  > Find a VA location`
- [x] Events on "Popular links menu" are tracked by link label, such as `Popular on VA.gov  > Check your claim or appeal status`
- [x] Events initiated via the VA news promo title link are tracked by name and as initiated on the body of the homepage, such as `Homepage news promo > title > Pathfinder`
- [x] Events initiated via the VA news promo CTA are tracked by name and as initiated on the body of the homepage, such as `Homepage news promo > CTA > Pathfinder`
- [x] Events on the More VA news link are identified as initiated on the body of the homepage, such as `Homepage news promo > More VA News`
- [x] Events on email signup are tracked, such as `Homepage email sign up`
- [x] Benefit hub events are tracked by Hub title, such a `Benefit hub > VA department`
- [x] Mega menu event tracking should be maintained
- [x] Header event tracking should be maintained
- [x] Footer event tracking should be maintained

## QA Steps
- [ ]  Verify in AdSwerve that the events are firing
- [ ]  Analytics team said they can assist via making sure the new event tagging/data layer works. Let @mmiddaugh know when changes are in PR and she'll ping Analytics for review, or can review herself


## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
