### PR TITLE
11425 New URL for new Homepage

### DIFF
--- a/src/site/includes/common-tasks.drupal.liquid
+++ b/src/site/includes/common-tasks.drupal.liquid
@@ -1,10 +1,4 @@
-<!--
-  Search and Common tasks hub on home page
-
-  Homepage redesign iteration (/homepage-test)
-  Date: April 2022
-  Author: allison@cityfriends.tech
--->
+<!-- Search and Common tasks hub on home page -->
 
 <!-- Hub Content -->
 <div class="homepage-common-tasks__wrapper">

--- a/src/site/includes/hero.drupal.liquid
+++ b/src/site/includes/hero.drupal.liquid
@@ -1,10 +1,4 @@
-<!--
-  Hero section on home page
-
-  Homepage redesign iteration (/homepage-test)
-  Date: September 2022
-  Author: bryan@kindsys.us
--->
+<!-- Hero section on home page -->
 
 <!-- Hero Content -->
 <div class="homepage-hero__wrapper">

--- a/src/site/layouts/home-preview.drupal.liquid
+++ b/src/site/layouts/home-preview.drupal.liquid
@@ -1,12 +1,6 @@
 {% include "src/site/includes/header.html" %}
 <main data-template="layouts/home" id="content">
 
-  <!--
-    Homepage redesign iteration (/homepage-test)
-    Date: September 2022
-    Author:  bryan@kindsys.us
-  -->
-
   {% include "src/site/includes/hero.drupal.liquid" with hero %}
   {% include "src/site/includes/common-tasks.drupal.liquid" with commonTasks %}
   {% include "src/site/includes/news-spotlight.drupal.liquid" with newsSpotlight %}

--- a/src/site/stages/build/drupal/home.js
+++ b/src/site/stages/build/drupal/home.js
@@ -78,7 +78,7 @@ function addHomeContent(contentData, files, metalsmith, buildOptions) {
         },
       } = contentData;
 
-      const homePreviewPath = '/homepage-test';
+      const homePreviewPath = '/new-home-page';
 
       const hero =
         homePageHeroQuery?.itemsOfEntitySubqueueHomePageHero?.[0]?.entity || {};
@@ -102,7 +102,7 @@ function addHomeContent(contentData, files, metalsmith, buildOptions) {
         },
       };
 
-      files[`./homepage-test.html`] = createFileObj(
+      files[`./new-home-page.html`] = createFileObj(
         homePreviewEntityObj,
         'home-preview.drupal.liquid',
       );

--- a/src/site/stages/build/drupal/home.js
+++ b/src/site/stages/build/drupal/home.js
@@ -102,7 +102,7 @@ function addHomeContent(contentData, files, metalsmith, buildOptions) {
         },
       };
 
-      files[`./new-home-page.html`] = createFileObj(
+      files[`.${homePreviewPath}.html`] = createFileObj(
         homePreviewEntityObj,
         'home-preview.drupal.liquid',
       );


### PR DESCRIPTION
## Description

closes department-of-veterans-affairs/va.gov-cms/issues/11425


## QA steps

What needs to be checked to prove this works?  
- Rerun content build and check /new-home-page and see that it points to the new homepage
What needs to be checked to prove it didn't break any related things?  
- Rerun content build and check /homepage-test and see it no longer points to the new homepage


## Acceptance Criteria
- [x] Nothing at `/homepage-test` on either Staging or Prod
- [x] New homepage available at `/new-home-page` on Staging and (on launch day) on Prod

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
