### PR TITLE
Switch to m6i instances.

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -17,7 +17,7 @@ env:
   BUILDTYPE: vagovprod
   DEPLOY_BUCKET: content.www.va.gov
   DRUPAL_ADDRESS: https://prod.cms.va.gov
-  INSTANCE_TYPE: c5d.4xlarge
+  INSTANCE_TYPE: m6i.4xlarge
   MAXIMUM_HEAP: 5000
 
 jobs:


### PR DESCRIPTION
## Description

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11309

Switching to m6i instances, as part of researching instances that are better optimized for Content Release.