### PR TITLE
[VA-11537] Add feedback button to redesigned homepage

### DIFF
--- a/src/site/layouts/home-preview.drupal.liquid
+++ b/src/site/layouts/home-preview.drupal.liquid
@@ -9,6 +9,19 @@
   {% include "src/site/includes/email-update-signup.drupal.liquid" %}
   {% endcomment %}
 
+  <!-- Medallia feedback button-->
+  <div class="usa-grid usa-grid-full">
+    <div class="last-updated vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
+      <div class="vads-u-display--flex above-footer-elements-container">
+        <div class="vads-u-flex--1 vads-u-text-align--right">
+          <span class="vads-u-text-align--right">
+              {% include "src/site/includes/medallia-feedback-button.drupal.liquid" %}
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- Email Updates Signup -->
   <div class="homepage-email-updates-signup">
     <div class="homepage-email-updates-signup__wrapper vads-u-background-color--primary-alt-lightest">


### PR DESCRIPTION
## Description

The redesigned homepage needs the feedback button to be implemented the same way as the current homepage and stay accessible.

closes [#11537](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11537)
relates to [#11570](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11570)

## Testing done & Screenshots

Visual testing

<img width="1115" alt="Screen Shot 2022-11-30 at 9 59 57 AM" src="https://user-images.githubusercontent.com/10790736/204842364-6f37176e-c4c2-4103-ab37-f63541e0d562.png">

## QA steps

What needs to be checked to prove this works?  

1. Check out this branch and do a local PR build
2. Go to `http://localhost:3002/new-home-page/`
3. Confirm that the feedback button is present, working, and accessible

What needs to be checked to prove it didn't break any related things?

1. Check that all other links and functionality on the new homepage still work
2. Check that the current homepage still works

What variations of circumstances (users, actions, values) need to be checked?  

1. Different screen sizes
    - [ ] View the page on small and big screen sizes to confirm the button is still there and reachable
2. Screen reader usage
    - [ ] Access the button with a screen reader and confirm its functionality is still understandable and it can be used
3. Screen zooming in and out
    - [ ] Zoom in up to 400% and see the button can still be reached

## Acceptance criteria

- [ ] The new homepage has the same feedback button as the existing one
- [ ] The new homepage feedback button is properly styled like the mockups
- [ ] The new homepage button is accessible

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
