### PR TITLE
new id for search header

### DIFF
--- a/src/site/includes/common-tasks.drupal.liquid
+++ b/src/site/includes/common-tasks.drupal.liquid
@@ -8,7 +8,7 @@
       <div class="vads-l-col--12 medium-screen:vads-l-col--6">
         <div
           class="vads-u-margin-x--2p5 small-desktop-screen:vads-u-margin-x--0 small-desktop-screen:vads-u-padding-right--9 vads-u-padding-bottom--5">
-          <h2 class="vads-u-color--gray-dark vads-u-font-family--serif">
+          <h2 class="vads-u-color--gray-dark vads-u-font-family--serif" id="search-tools-header">
             Search
           </h2>
 


### PR DESCRIPTION
## Description

closes 11747
relates to 11747

## Testing done & Screenshots
<img width="1099" alt="image" src="https://user-images.githubusercontent.com/61624970/206003655-2f4f9696-32ea-407e-8316-1bb3a286efe7.png">



## QA steps

1. Navigate to /new-home-page/
   - [ ] verify that the new id is reflected in dev tools


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
