### PR TITLE
VACMS-11658: Phase 2 of static-data-file caching

### DIFF
--- a/src/site/stages/build/drupal/static-data-files/generate.js
+++ b/src/site/stages/build/drupal/static-data-files/generate.js
@@ -5,7 +5,7 @@ const getApiClient = require('../api');
 const { logDrupal } = require('../utilities-drupal');
 const { DATA_FILE_PATH, DATA_FILES } = require('./config');
 const {
-  // shouldPullDrupal,
+  shouldPullDrupal,
   PULL_DRUPAL_BUILD_ARG,
   getDrupalCachePath,
 } = require('../metalsmith-drupal');
@@ -255,17 +255,7 @@ const generateStaticDataFilesFromDrupal = async (
   let processedJsonDataFiles = [];
 
   // Pull static-data-file content from Drupal
-
-  // Until this is merged to prod and a build is run, the cache directory will not be present.
-  // We cannot use `shouldPullDrupal` - which checks for the existence of the cache directory - until it exists.
-  // So, we'll implement this change in two phases:
-  //  1. First, we'll push a change that pulls from Drupal only with an explicit `--pull-drupal`.
-  //     When this is merged and a build is run, the resulting files will be saved in the newly created cache directory.
-  //  2. After the cache is created, we'll change the check to `shouldPullDrupal`, which considers the existence of
-  //     the cache directory in determing whether to pull from Drupal or read from cache.
-
-  // if (shouldPullDrupal(buildOptions, DRUPAL_CACHE_STATIC_DATA_FILEPATH)) {
-  if (buildOptions[PULL_DRUPAL_BUILD_ARG]) {
+  if (shouldPullDrupal(buildOptions, DRUPAL_CACHE_STATIC_DATA_FILEPATH)) {
     logDrupal(
       `Generating static data files from Drupal at ${buildOptions['drupal-address']}.`,
     );


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11658

This PR is a follow-on to [a previous PR](https://github.com/department-of-veterans-affairs/content-build/pull/1363) that implemented essentially the entirety of the heavy lifting regarding the caching of static data files.

The logic we ultimately needed (not implemented by previous PR but implemented by this PR) is to pull from Drupal in either of these situations:
1. `--pull-drupal` flag is present
2. The cached data found

Because the cache never previously existed for these static data files, the second condition above would have always been true, and the build would have attempted to pull from Drupal. Since review instances cannot pull from Drupal (no SOCKS access), we cannot have this situation. Therefore, the previous PR left things in such a state where pulling from Drupal would only happen under the first condition.

Once the previous PR went live and the cache file was created for the first time, review instances would then have something to pull from cache. Since that is now the case, this PR updates the logic to come in line with the two conditions listed above.


## Testing done
Tested locally and on Review Instance as described in QA steps below.

## QA steps
### Local QA
The work we need to QA boils down to ensuring that data is pulled from Drupal when at least one of the conditions mentioned above is met, and that data is pulled from cache otherwise. We can test this locally:

1. In terminal ensure you are at the root of the content-build repo.
1. `rm -rf ./.cache/localhost/drupal/static-data-files`
1. `yarn build` (you can kill the build after step 2 completes)
   - [ ] Validate that the static data files are generated _from Drupal_:
![image](https://user-images.githubusercontent.com/6863534/206593048-afbf75e4-fa56-4216-9083-ef12399494bb.png)
1. `yarn build` (yes, again; and you can kill the build after step 2 again)
   - [ ] Validate that the static data files are generated _from cache_:
![image](https://user-images.githubusercontent.com/6863534/206593394-fb4a6527-f557-460b-8f43-cd41777dc5ce.png)
1. `yarn build --pull-drupal` (again, you can kill the build after step 2)
   - [ ] Validate that the static data files are generated _from Drupal_:
![image](https://user-images.githubusercontent.com/6863534/206593621-72357f22-d56a-47cd-abb9-b0cbffb2557c.png)

### Review-instance QA
The practical implication of the change in this PR is that it makes static data files available on review instances. So, we can also QA that piece of the puzzle:
1. Find the "view deployment" button on this PR.
1. Once the homepage opens in the browser, navigate to `/data/cms/vamc-ehr.json`.
   - [ ] Validate that the path resolves to a resource
   - [ ] Validate that the json file begins with:
    ```
    {
      "data": {
        "nodeQuery": {
          "count": 
    ```
