### PR TITLE
[VA-11691] Keep Switch links for pages with missing breadcrumbs

### DIFF
--- a/src/site/stages/build/drupal/page.js
+++ b/src/site/stages/build/drupal/page.js
@@ -353,7 +353,10 @@ function compilePage(page, contentData) {
   const pageId = { pid: pageIdRaw };
 
   if (!('breadcrumb' in entityUrl)) {
-    page.entityUrl = generateBreadCrumbs(entityUrl.path);
+    page.entityUrl = {
+      ...entityUrl,
+      ...generateBreadCrumbs(entityUrl.path),
+    };
   }
 
   let pageCompiled;


### PR DESCRIPTION
## Description

The Lovell VA Policies page was missing its switch link. This was due to some page logic where it adds in a breadcrumb path if it's missing, which inadvertently removed any properties that were `breadcrumb` or `url`. This change keeps any other properties already there to preserve that data, including switch links.

closes [#11691](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11691)

## Testing done & Screenshots

Visually, see below.

<img width="1190" alt="Screen Shot 2022-12-08 at 1 16 45 PM" src="https://user-images.githubusercontent.com/10790736/206533964-9201be01-88df-4676-b426-404634a889a6.png">

## QA steps

What needs to be checked to prove this works?

Build Lovell locally and check the [Lovell VA Policies page.](http://localhost:3002/lovell-federal-va-health-care/policies/) The switch link should be at the top of the page.

What needs to be checked to prove it didn't break any related things?

Check the Lovell Tricare Policies page (the switch link) and other Lovell pages to ensure those links still work as well.

What variations of circumstances (users, actions, values) need to be checked?  

1. Go to the Lovell VA Policies page
   - [ ] The switch link is there
2. Then go to the other Lovell pages
   - [ ] Their switch links still work as expected
3. Then validate Acceptance Criteria from issue

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
