### PR TITLE
Fix URLs for Lovell federal pages with 'va'

### DIFF
--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -48,6 +48,22 @@ function getModifiedLovellPage(page, variant) {
   const linkVar =
     variant === 'va' ? LOVELL_VA_LINK_VARIATION : LOVELL_TRICARE_LINK_VARIATION;
 
+  // Fix any incorrect URLs based on the variant
+  if (isLovellFederalPage(page)) {
+    const oppositeVariant =
+      variant === 'va'
+        ? LOVELL_TRICARE_LINK_VARIATION
+        : LOVELL_VA_LINK_VARIATION;
+    const reverseUrl = `/lovell-federal-${oppositeVariant}-health-care`;
+
+    if (page.entityUrl.path.includes(reverseUrl)) {
+      page.entityUrl.path = page.entityUrl.path.replace(
+        reverseUrl,
+        `/lovell-federal-health-care`,
+      );
+    }
+  }
+
   // Add a field for canonical if it has a clone and it's a tricare variant
   if (variant === 'tricare' && isLovellFederalPage(page)) {
     page.canonicalLink = page.entityUrl.path.replace(


### PR DESCRIPTION
## Description

Lovell federal pages should be checked if they have `va` in the CMS URL. This could potentially be creating a bug where federal pages aren't being properly cloned for the Tricare side, hence why so many of those pages have correct menu links but no actual pages.

This PR checks if a page is a Federal page, and if the URL is already the opposite of the page variation being built (for example, the Tricare variation of a federal page but it already has `va` in the URL). This resets the URL to remove the variation so it can have the proper URL set and go through the rest of the page build steps without issue.

relates to [#11026](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11026)

## Testing done & Screenshots

Confirmed it locally.

## QA steps

Rebuild Lovell locally with `yarn build --pull-drupal --drupal-address=https://main-liqqgmzl7tsyfbwyulbkuborufuuttav.demo.cms.va.gov/` and check the Lovell pages. Make sure that all the Tricare versions of them exist and can be clicked on in both the VA switch links and the Tricare side menu.

## Acceptance criteria

- [ ] All federal pages have proper variations built for both `va` and `tricare`.
- [ ] All Tricare pages can be accessed correctly in the menu and switch links.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
