### PR TITLE
11831 Switch background colors for new homepage search section

### DIFF
--- a/src/site/includes/common-tasks.drupal.liquid
+++ b/src/site/includes/common-tasks.drupal.liquid
@@ -5,7 +5,7 @@
   <div class="vads-l-grid-container vads-u-padding-x--0 homepage-common-tasks">
     <div class="vads-l-row">
       <!-- start first column-->
-      <div class="vads-l-col--12 medium-screen:vads-l-col--6">
+      <div class="vads-l-col--12 medium-screen:vads-l-col--6 vads-u-background-color--white ">
         <div
           class="vads-u-margin-x--2p5 small-desktop-screen:vads-u-margin-x--0 small-desktop-screen:vads-u-padding-right--9 vads-u-padding-bottom--5">
           <h2 class="vads-u-color--gray-dark vads-u-font-family--serif" id="search-tools-header">
@@ -38,7 +38,7 @@
       <!-- end first column -->
 
       <!-- start second column -->
-      <div class="vads-l-col--12 medium-screen:vads-l-col--6 vads-u-background-color--white">
+      <div class="vads-l-col--12 medium-screen:vads-l-col--6">
         <div class="vads-u-padding-left--2p5 medium-screen:vads-u-padding-left--6 vads-u-padding-bottom--5">
           <h2 class="vads-u-color--gray-dark vads-u-font-family--serif">
             Top Pages


### PR DESCRIPTION
## Description
This PR swaps the background colors of the Search / Top links section of the new homepage design.
closes department-of-veterans-affairs/va.gov-cms/issues/11831

Sibling PR:  https://github.com/department-of-veterans-affairs/vets-website/pull/22945

## Testing done & Screenshots
Visually / manually checking again screenshots in ticket. 

<img width="1214" alt="Screenshot 2022-12-14 at 11 58 17 AM" src="https://user-images.githubusercontent.com/732460/207671477-92720e6a-ab46-419a-acf2-9c392c6bab08.png">

<img width="491" alt="Screenshot 2022-12-14 at 11 58 37 AM" src="https://user-images.githubusercontent.com/732460/207671487-261b2cf5-1d58-4e54-9d56-b54dbac87cf7.png">

## QA steps
Navigate to `/new-home-page` and see the Search / Top Links. Search block should have white background. Top Links menu should have light blue background.


## Acceptance criteria
In both mobile and desktop, 
- [x] Search block has white background
- [x] Menu of links has light blue background

## Definition of done
- [n/a] Events are logged appropriately
- [n/a] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
