### PR TITLE
VACMS-11829: hide Other nearby VA locations for tricare listing page

### DIFF
--- a/src/site/layouts/locations_listing.drupal.liquid
+++ b/src/site/layouts/locations_listing.drupal.liquid
@@ -6,6 +6,7 @@
 {% assign otherFacilities = fieldOffice.entity.otherFacilities %}
 {% assign mobileFacilities = fieldOffice.entity.mobileFacilities %}
 {% assign fieldOtherVaLocations = fieldOffice.entity.fieldOtherVaLocations %}
+{% assign section = fieldAdministration.entity %}
 
 <div class="interior" id="content">
   <main class="va-l-detail-page va-facility-page">
@@ -59,7 +60,7 @@
                 {% include 'src/site/includes/facilityListing.drupal.liquid' with entity = mobile type = 'mobile' %}
               {% endfor %}
             {% endif %}
-            {% if fieldOtherVaLocations != empty and fieldOtherVaLocations.length %}
+            {% if fieldOtherVaLocations != empty and fieldOtherVaLocations.length and section.name != "Lovell - TRICARE" %}
               <h2 class="medium-screen:vads-u-margin-bottom--4" id="other-nearby-va-locations">
                 Other nearby VA locations
               </h2>

--- a/src/site/stages/build/drupal/graphql/locationsListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/locationsListingPage.graphql.js
@@ -52,6 +52,7 @@ const locationListingPage = `
       entity{
         ... on TaxonomyTermAdministration {
           entityId
+          name
         }
       }
     }


### PR DESCRIPTION
## Description

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11829

## Testing done & Screenshots

Manual/visual testing

https://web-liqqgmzl7tsyfbwyulbkuborufuuttav.demo.cms.va.gov/lovell-federal-tricare-health-care/locations/

<img width="1780" alt="Screenshot 2022-12-15 at 1 16 27 PM" src="https://user-images.githubusercontent.com/21045418/207937014-cb741f70-02c0-4f6d-b2cb-4f3e334ebe3d.png">

## QA steps

- [ ] Visit: https://web-liqqgmzl7tsyfbwyulbkuborufuuttav.demo.cms.va.gov/lovell-federal-tricare-health-care/locations/
- [ ] Verify that the Other nearby VA locations block is not displayed
- [ ] Visit https://web-liqqgmzl7tsyfbwyulbkuborufuuttav.demo.cms.va.gov/lovell-federal-va-health-care/locations/
- [ ] Verify that the Other nearby VA locations block is displayed
- [ ] Verify that other systems still display this block (example: https://web-liqqgmzl7tsyfbwyulbkuborufuuttav.demo.cms.va.gov/columbia-missouri-health-care/locations/)