### PR TITLE
11652 remove environment conditional for building new homepage in prod

### DIFF
--- a/src/site/stages/build/drupal/home.js
+++ b/src/site/stages/build/drupal/home.js
@@ -3,7 +3,6 @@ const fs = require('fs-extra');
 const path = require('path');
 const yaml = require('js-yaml');
 const { createEntityUrlObj, createFileObj } = require('./page');
-const ENVIRONMENTS = require('../../../constants/environments');
 
 function divideHubRows(hubs) {
   return hubs.map((hub, i) => {
@@ -65,48 +64,45 @@ function addHomeContent(contentData, files, metalsmith, buildOptions) {
     files[`./index.html`] = createFileObj(homeEntityObj, 'home.drupal.liquid');
 
     /**
-     * The Below is meant to represent potentially dynamic content for the Home Page Prototype
-     * This page is only built on non-prod environments
+     * Below is the code responsible for generating the new Homepage experience.
      * */
-    if (buildOptions.buildtype !== ENVIRONMENTS.VAGOVPROD) {
-      const {
-        data: {
-          homePageHeroQuery,
-          homePageNewsSpotlightQuery,
-          homePagePopularOnVaGovMenuQuery,
-          homePageOtherSearchToolsMenuQuery,
-        },
-      } = contentData;
+    const {
+      data: {
+        homePageHeroQuery,
+        homePageNewsSpotlightQuery,
+        homePagePopularOnVaGovMenuQuery,
+        homePageOtherSearchToolsMenuQuery,
+      },
+    } = contentData;
 
-      const homePreviewPath = '/new-home-page';
+    const homePreviewPath = '/new-home-page';
 
-      const hero =
-        homePageHeroQuery?.itemsOfEntitySubqueueHomePageHero?.[0]?.entity || {};
-      const searchLinks = homePageOtherSearchToolsMenuQuery?.links || [];
-      const popularLinks = homePagePopularOnVaGovMenuQuery?.links || [];
-      const newsSpotlight =
-        homePageNewsSpotlightQuery
-          ?.itemsOfEntitySubqueueHomePageNewsSpotlight?.[0]?.entity || {};
+    const hero =
+      homePageHeroQuery?.itemsOfEntitySubqueueHomePageHero?.[0]?.entity || {};
+    const searchLinks = homePageOtherSearchToolsMenuQuery?.links || [];
+    const popularLinks = homePagePopularOnVaGovMenuQuery?.links || [];
+    const newsSpotlight =
+      homePageNewsSpotlightQuery
+        ?.itemsOfEntitySubqueueHomePageNewsSpotlight?.[0]?.entity || {};
 
-      const homePreviewEntityObj = {
-        ...homeEntityObj,
-        hero,
-        commonTasks: {
-          searchLinks,
-          popularLinks,
-        },
-        newsSpotlight,
+    const homePreviewEntityObj = {
+      ...homeEntityObj,
+      hero,
+      commonTasks: {
+        searchLinks,
+        popularLinks,
+      },
+      newsSpotlight,
+      path: homePreviewPath,
+      entityUrl: {
         path: homePreviewPath,
-        entityUrl: {
-          path: homePreviewPath,
-        },
-      };
+      },
+    };
 
-      files[`.${homePreviewPath}.html`] = createFileObj(
-        homePreviewEntityObj,
-        'home-preview.drupal.liquid',
-      );
-    }
+    files[`.${homePreviewPath}.html`] = createFileObj(
+      homePreviewEntityObj,
+      'home-preview.drupal.liquid',
+    );
   }
 }
 

--- a/src/site/stages/build/drupal/home.js
+++ b/src/site/stages/build/drupal/home.js
@@ -87,6 +87,7 @@ function addHomeContent(contentData, files, metalsmith, buildOptions) {
 
     const homePreviewEntityObj = {
       ...homeEntityObj,
+      canonicalLink: '/', // Match current homepage to avoid 'duplicate content' SEO demerit
       hero,
       commonTasks: {
         searchLinks,


### PR DESCRIPTION
~~BLOCKED:  do not merge until~~ Dave provided Chris J signoff: https://dsva.slack.com/archives/C03NSH4SLQY/p1671475928807869

## Description

closes department-of-veterans-affairs/va.gov-cms/issues/11652

Blocked by merge of https://github.com/department-of-veterans-affairs/content-build/pull/1406

## Testing done & Screenshots

Manual testing via building content-build locally and seeing the page builds as expected still. 
Will need to be verified in production to be 100% sure.

## QA steps

What needs to be checked to prove this works?  
 - Build content-build locally and seeing the page builds as expected still. 
 -Will need to be verified in production to be 100% sure.

What needs to be checked to prove it didn't break any related things?  
- This change has little to no risk of effecting other things.

What variations of circumstance thes (users, actions, values) need to be checked?  
- This change should only affect *production environment*


## Acceptance Criteria

- [x] new version of homepage should load at `/new-home-page`
- [ ] Page should publish to prod - Needs to be verified in Production 
- [x] the new page uses the existing homepage URL as the canonical URL (from [#48789](https://github.com/department-of-veterans-affairs/va.gov-team/issues/48789)), e.g. `<link rel="canonical" href="https://www.va.gov">` rather than `<link rel="canonical" href="https://va.gov/new-home-page">`.  (This prevents the new page from drawing off SEO power from the live homepage.)

## Definition of done
- [n/a] Events are logged appropriately
- [n/a] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
