### PR TITLE
11771 adds account info link to new homepage

### DIFF
--- a/src/site/includes/hero.drupal.liquid
+++ b/src/site/includes/hero.drupal.liquid
@@ -55,7 +55,7 @@
             <button class="vads-u-padding-x--4 vads-u-margin-bottom--3" onclick="openLoginModal()">
               Create account
             </button>
-            <a href="#">
+            <a href="/resources/creating-an-account-for-vagov">
               Learn how an account helps you
             </a>
           </div>


### PR DESCRIPTION
## Description
Adds new link to “Learn how an account helps you” link in the hero section of `/new-home-page`

closes department-of-veterans-affairs/va.gov-cms/issues/11771  
 
## Testing done & Screenshots
Manually verified URL of link. Page is not yet published. (see Preview: http://preview-prod.vfs.va.gov/preview?nodeId=51915)
  * https://prod.cms.va.gov/resources/creating-an-account-for-vagov

## QA steps

Mouse over link or check page source. Observe that the href attribute value of link is: "/resources/creating-an-account-for-vagov"

## Acceptance criteria

- [x] "Learn how an account helps you" links to approved URL:  /resources/creating-an-account-for-vagov
- [x] target = open in same window

## Definition of done
- [ ] Events are logged appropriately –> Does not currently trigger GA event.
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
