### PR TITLE
VACMS-11989: disallow new lovell paths from robots.txt

### DIFF
--- a/src/site/assets/robots.txt
+++ b/src/site/assets/robots.txt
@@ -17,7 +17,8 @@ Disallow: /covid19screen
 # to prevent sub-directories from being indexed
 # see https://developers.google.com/search/docs/advanced/robots/create-robots-txt#useful-robots.txt-rules
 
-Disallow: /lovell-fhcc-health-care/
+Disallow: /lovell-federal-va-health-care/
+Disallow: /lovell-federal-tricare-health-care/
 
 # sitemap index
 Sitemap: https://www.va.gov/sitemap.xml


### PR DESCRIPTION
## Description

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11989

## QA steps

- [ ] verify that both root Lovell URLs from the linked issue above have been added to the disallow list in the robots.txt file