### PR TITLE
Revert to older output setting syntax for broken link checking.

### DIFF
--- a/script/github-actions/check-broken-links-blocks.js
+++ b/script/github-actions/check-broken-links-blocks.js
@@ -91,7 +91,7 @@ if (fs.existsSync(reportPath)) {
   console.log(
     `${brokenLinks.brokenLinksCount} broken links found. \n ${brokenLinks.summary}`,
   );
-  console.log(`SLACK_BLOCKS=${JSON.stringify(payload)} >> $GITHUB_OUTPUT`);
+  console.log(`::set-output name=SLACK_BLOCKS::${JSON.stringify(payload)}`);
 
   if (!IS_PROD_BRANCH && !contentOnlyBuild) {
     // Ignore the results of the broken link checker unless
@@ -106,12 +106,12 @@ if (fs.existsSync(reportPath)) {
    * Only emit this variable if ran against main branch or during Content Release.
    * Meets the following condition: blocks & attachments & IS_PROD_BRANCH
    */
-  console.log(`UPLOAD_AND_NOTIFY=1 >> $GITHUB_OUTPUT`);
+  console.log(`::set-output name=UPLOAD_AND_NOTIFY::1`);
 
   if (shouldFail) {
     throw new Error('Broken links found');
   }
 } else {
   console.log('No broken links found!');
-  console.log(`UPLOAD_AND_NOTIFY=0 >> $GITHUB_OUTPUT`);
+  console.log(`::set-output name=UPLOAD_AND_NOTIFY::0`);
 }

--- a/script/github-actions/check-broken-links.js
+++ b/script/github-actions/check-broken-links.js
@@ -28,7 +28,7 @@ if (fs.existsSync(reportPath)) {
   console.log(
     `${brokenLinks.brokenLinksCount} broken links found. \n ${brokenLinks.summary}`,
   );
-  console.log(`SLACK_ATTACHMENTS=${slackAttachments} >> $GITHUB_OUTPUT`);
+  console.log(`::set-output name=SLACK_ATTACHMENTS::${slackAttachments}`);
 
   if (!IS_PROD_BRANCH && !contentOnlyBuild) {
     // Ignore the results of the broken link checker unless
@@ -43,12 +43,12 @@ if (fs.existsSync(reportPath)) {
    * Only emit this variable if ran against main branch or during Content Release.
    * Meets the following condition: blocks & attachments & IS_PROD_BRANCH
    */
-  console.log(`UPLOAD_AND_NOTIFY=1 >> $GITHUB_OUTPUT`);
+  console.log(`::set-output name=UPLOAD_AND_NOTIFY::1`);
 
   if (shouldFail) {
     throw new Error('Broken links found');
   }
 } else {
   console.log('No broken links found!');
-  console.log(`UPLOAD_AND_NOTIFY=0 >> $GITHUB_OUTPUT`);
+  console.log(`::set-output name=UPLOAD_AND_NOTIFY::0`);
 }


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12040

This reverts these scripts back to older, deprecated syntax to restore broken link checking. A follow-up ticket will be made to migrate the scripts to become proper custom actions.