### PR TITLE
VACMS-12011 Fix Lovell Tricare Menu links

### DIFF
--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -200,6 +200,19 @@ function lovellMenusModifyLinks(link) {
       `${LOVELL_TITLE_STRING} ${titleVar}`,
     );
 
+    const oppositeVariant =
+      variant === 'va'
+        ? LOVELL_TRICARE_LINK_VARIATION
+        : LOVELL_VA_LINK_VARIATION;
+    const reverseUrl = `/lovell-federal-${oppositeVariant}-health-care`;
+
+    if (link.url.path.includes(reverseUrl)) {
+      link.url.path = link.url.path.replace(
+        reverseUrl,
+        `/lovell-federal-health-care`,
+      );
+    }
+
     link.url.path = link.url.path.replace(
       '/lovell-federal-health-care',
       `/lovell-federal-${linkVar}-health-care`,

--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -40,6 +40,18 @@ function isListingPage(page) {
   return listingPageTypes.includes(page.entityBundle);
 }
 
+function resetToFederalUrlIfNeeded(path, variant) {
+  const oppositeVariant =
+    variant === 'va' ? LOVELL_TRICARE_LINK_VARIATION : LOVELL_VA_LINK_VARIATION;
+  const reverseUrl = `/lovell-federal-${oppositeVariant}-health-care`;
+
+  if (path.includes(reverseUrl)) {
+    return path.replace(reverseUrl, `/lovell-federal-health-care`);
+  }
+
+  return path;
+}
+
 function getModifiedLovellPage(page, variant) {
   const fieldOfficeMod =
     variant === 'va'
@@ -50,18 +62,10 @@ function getModifiedLovellPage(page, variant) {
 
   // Fix any incorrect URLs based on the variant
   if (isLovellFederalPage(page)) {
-    const oppositeVariant =
-      variant === 'va'
-        ? LOVELL_TRICARE_LINK_VARIATION
-        : LOVELL_VA_LINK_VARIATION;
-    const reverseUrl = `/lovell-federal-${oppositeVariant}-health-care`;
-
-    if (page.entityUrl.path.includes(reverseUrl)) {
-      page.entityUrl.path = page.entityUrl.path.replace(
-        reverseUrl,
-        `/lovell-federal-health-care`,
-      );
-    }
+    page.entityUrl.path = resetToFederalUrlIfNeeded(
+      page.entityUrl.path,
+      variant,
+    );
   }
 
   // Add a field for canonical if it has a clone and it's a tricare variant
@@ -200,18 +204,7 @@ function lovellMenusModifyLinks(link) {
       `${LOVELL_TITLE_STRING} ${titleVar}`,
     );
 
-    const oppositeVariant =
-      variant === 'va'
-        ? LOVELL_TRICARE_LINK_VARIATION
-        : LOVELL_VA_LINK_VARIATION;
-    const reverseUrl = `/lovell-federal-${oppositeVariant}-health-care`;
-
-    if (link.url.path.includes(reverseUrl)) {
-      link.url.path = link.url.path.replace(
-        reverseUrl,
-        `/lovell-federal-health-care`,
-      );
-    }
+    link.url.path = resetToFederalUrlIfNeeded(link.url.path, variant);
 
     link.url.path = link.url.path.replace(
       '/lovell-federal-health-care',


### PR DESCRIPTION
## Description

The "opposite variant" URL checks need to be applied to menu links as well as page links. This change puts that logic into a function that can be applied to both and fix the broken Tricare links that would otherwise bring links back to the VA pages.

closes [#12011](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12011)
relates to [#11026](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11026)

## Testing done & Screenshots

Visual testing. See URLs from the highlighted menu links in the bottom left of each screenshot.

<img width="1179" alt="Screen Shot 2022-12-20 at 3 28 47 PM" src="https://user-images.githubusercontent.com/10790736/208760439-7e669af9-6325-4b26-bfae-6ade8daaaee3.png">
<img width="1179" alt="Screen Shot 2022-12-20 at 3 28 52 PM" src="https://user-images.githubusercontent.com/10790736/208760444-f76dd45d-d3ac-4b94-91ae-fa34c5264754.png">

## QA steps

What needs to be checked to prove this works?  

Tricare menu links, and they link to other Tricare pages.

What needs to be checked to prove it didn't break any related things?  

The menu links on VA pages still link to VA pages, and the switch links still work properly.

## Acceptance criteria

- [ ] The side menu on Tricare pages link to other Tricare pages, not VA pages
- [ ] VA pages still link to other VA pages

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
