### PR TITLE
Fix spotlight section header for lovell region pages

### DIFF
--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -132,7 +132,10 @@
 
           <!-- List of links section -->
           <div class="vads-u-margin-top--5">
-            {% include "src/site/paragraphs/facilities/list_of_link_teasers_facility.drupal.liquid" with paragraph = fieldRelatedLinks.entity %}
+            {% include "src/site/paragraphs/facilities/list_of_link_teasers_facility.drupal.liquid"
+                    with paragraph = fieldRelatedLinks.entity
+                         regionNickname = title
+            %}
           </div>
 
           {% assign header = "h3" %}


### PR DESCRIPTION
## Description

closes [#11940](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11940)
## Testing done & Screenshots

Lovell TRICARE region page: http://localhost:3002/lovell-federal-tricare-health-care/
![Screen Shot 2022-12-21 at 10 14 11 AM](https://user-images.githubusercontent.com/11279744/208975463-b6c51ee5-cb51-4add-9e4d-54cf5b55c782.png)

Lovell TRICARE Facility Page
http://localhost:3002/lovell-federal-tricare-health-care/locations/captain-james-a-lovell-federal-health-care-center/
![Screen Shot 2022-12-21 at 10 16 01 AM](https://user-images.githubusercontent.com/11279744/208979288-4d3bba88-47c5-417e-9319-68abe8e29faa.png)

Lovell VA region page
http://localhost:3002/lovell-federal-va-health-care/
![Screen Shot 2022-12-21 at 10 40 00 AM](https://user-images.githubusercontent.com/11279744/208979638-703e6b87-b9f0-4e6c-a2d4-6f31cbcee514.png)

Lovell VA facility page
http://localhost:3002/lovell-federal-va-health-care/locations/captain-james-a-lovell-federal-health-care-center/
![Screen Shot 2022-12-21 at 10 41 00 AM](https://user-images.githubusercontent.com/11279744/208979688-e4b3cc43-4778-4094-ab37-52230529877f.png)

Non-Lovell region page
http://localhost:3002/new-mexico-health-care/
![Screen Shot 2022-12-21 at 10 14 16 AM](https://user-images.githubusercontent.com/11279744/208979846-ffa90ffc-e94d-45e7-b3bd-24b2aa16114b.png)

Non-Lovell facility page
http://localhost:3002/new-mexico-health-care/locations/raymond-g-murphy-department-of-veterans-affairs-medical-center/
![Screen Shot 2022-12-21 at 10 14 23 AM](https://user-images.githubusercontent.com/11279744/208979882-2c404b7e-4974-4b38-ac25-f3b57d28bc8f.png)


## QA steps

What needs to be checked to prove this works?  
- Lovell TRICARE and VA region pages, as well as a related facility under those regions. All should correctly display `"in the spotlight at ..."` in the light blue box of related links.

What needs to be checked to prove it didn't break any related things?  
- Non Lovell pages should still correctly display their region titles in the same box (new mexico in my example)

## Acceptance criteria

- [ ] Lovell VA system page shows 'In the spotlight at Lovell Federal VA Health Care"
- [ ] Lovell Tricare system page shows 'In the spotlight at Lovell Federal Tricare Health Care"

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
