### PR TITLE
12012 change footer rail accessibility link

### DIFF
--- a/src/platform/static-data/footer-links.json
+++ b/src/platform/static-data/footer-links.json
@@ -248,7 +248,7 @@
   },
   {
     "column": "bottom_rail",
-    "href": "https://www.section508.va.gov",
+    "href": "https://www.va.gov/accessibility-at-va/",
     "order": 1,
     "target": null,
     "title": "Accessibility",


### PR DESCRIPTION
## Description

closes  https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12012

## Testing done & Screenshots
Manual testing locally

## QA steps

Confirm bottom rail of footer link is changed in production to va.gov/accessibility-at-va/


## Acceptance criteria

- [ ] Confirm bottom rail of footer link is changed in production to va.gov/accessibility-at-va/


## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
