### PR TITLE
VACMS-11995 Add Lovell switch link Cypress tests

### DIFF
--- a/src/site/tests/lovell/switch-links.cypress.spec.js
+++ b/src/site/tests/lovell/switch-links.cypress.spec.js
@@ -1,0 +1,56 @@
+const lovellSwitchLinkPages = [
+  {
+    title: 'System Health Care Page',
+    path: '',
+  },
+  {
+    title: 'Locations',
+    path: '/locations',
+  },
+  {
+    title: 'Health Services',
+    path: '/health-services',
+  },
+  {
+    title: 'Listings (Events)',
+    path: '/events',
+  },
+  {
+    title: 'Listings (News Releases)',
+    path: '/news-releases',
+  },
+  {
+    title: 'Listings (Stories)',
+    path: '/stories',
+  },
+];
+
+const getLovellUrl = (path, variation) =>
+  `${`/lovell-federal-${variation}-health-care`}${path}`;
+
+const lovellVariations = ['va', 'tricare'];
+
+lovellSwitchLinkPages.forEach(page => {
+  lovellVariations.forEach(variation => {
+    const oppositeVariation = variation === 'va' ? 'tricare' : 'va';
+
+    describe(`Lovell ${variation.toUpperCase()} ${page.title} page`, () => {
+      it('has the proper switch link', () => {
+        cy.visit(getLovellUrl(`${page.path}/`, variation));
+        cy.injectAxeThenAxeCheck();
+
+        cy.get('va-alert').should('have.length', 1);
+
+        cy.get('va-alert').contains(
+          `View this page as a ${oppositeVariation.toUpperCase()} beneficiary`,
+        );
+
+        cy.get('va-alert a').should(
+          'have.attr',
+          'href',
+          getLovellUrl(page.path, oppositeVariation),
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description

Lovell switch links are important to test, both as a feature and a quick health check of Lovell's structure. This adds Cypress tests to some of the key Lovell pages.

closes [#11995](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11995)
relates to [#11026](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11026)

## Testing done & Screenshots

Visual, Cypress, see local results below.

![Screen Shot 2022-12-22 at 9 17 03 AM](https://user-images.githubusercontent.com/10790736/209154426-23d9ce16-b382-435d-b54a-46d01d7e45bd.png)

## QA steps

**What needs to be checked to prove this works?** Do a local Lovell build with `yarn build --pull-drupal --drupal-address=https://main-liqqgmzl7tsyfbwyulbkuborufuuttav.demo.cms.va.gov/`, then run cypress tests locally with `yarn cy:run`.
**What needs to be checked to prove it didn't break any related things?** Click through a few other Lovell pages to ensure they're still working normally.
**What variations of circumstances (users, actions, values) need to be checked?** None.

## Acceptance criteria

- [ ] Lovell switch links are properly checked, so the tests pass when the pages work and fail when they don't.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
