### PR TITLE
VACMS-11967 update manage health block for lovell system pages

### DIFF
--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -52,9 +52,9 @@
 
           <!-- "Manage your health online" section -->
           {% comment %} Hide this section for Lovell TRICARE {% endcomment %}
-          {% if title != 'Lovell Federal TRICARE health care' %}
+          {% if fieldAdministration.entity.entityId != '1039' %}
           <section>
-            {% if title == 'Lovell Federal VA health care' %}
+            {% if fieldAdministration.entity.entityId == '1040' %}
               <h3>Manage your VA health online</h3>
             {% else %}
               <h3>Manage your health online</h3>

--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -51,8 +51,14 @@
           </section>
 
           <!-- "Manage your health online" section -->
+          {% comment %} Hide this section for Lovell TRICARE {% endcomment %}
+          {% if title != 'Lovell Federal TRICARE health care' %}
           <section>
-            <h3>Manage your health online</h3>
+            {% if title == 'Lovell Federal VA health care' %}
+              <h3>Manage your VA health online</h3>
+            {% else %}
+              <h3>Manage your health online</h3>
+            {% endif %}
             <div
               class="vads-u-display--flex medium-screen:vads-u-flex-direction--row vads-u-flex-direction--column">
               <div
@@ -128,6 +134,7 @@
               </div>
             </div>
           </section>
+          {% endif %}
 
 
           <!-- List of links section -->


### PR DESCRIPTION
## Description

closes [#11967](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11967).

Removes "manage health block" for Lovell TRICARE system. Updates title of "manage healthy block" for Lovell VA system. Unchanged for other VA system pages.

## Testing done & Screenshots
Lovell TRICARE system, no block
![Screen Shot 2022-12-22 at 9 04 15 AM](https://user-images.githubusercontent.com/11279744/209188530-4098c11f-a0ca-431a-82f7-f1b2174a9331.png)

Lovell VA system, updated title ("Manage your VA health online")
![Screen Shot 2022-12-22 at 9 04 25 AM](https://user-images.githubusercontent.com/11279744/209188531-57d1155b-9334-4ce6-8b73-8ddee24bdf8e.png)

Non-Lovell VA system, no change to title
![Screen Shot 2022-12-22 at 9 04 08 AM](https://user-images.githubusercontent.com/11279744/209188523-a11d20a1-4b8c-4397-b26c-9eed98158913.png)


## QA steps

**What needs to be checked to prove this works?**  
- View Lovell system pages for TRICARE and VA.
- http://localhost:3002/lovell-federal-tricare-health-care/
- http://localhost:3002/lovell-federal-va-health-care/
**What needs to be checked to prove it didn't break any related things?**  
- View a system page for a non-Lovell VA system
- http://localhost:3002/new-mexico-health-care/


## Acceptance criteria
- [x] When viewing the Lovell TRICARE system page the Manage your health online block should not be present
- [x] When viewing the Lovell VA system page the heading for this block should read as Manage your VA health online
- [x] When viewing any other system page the heading and block should still be present and unchanged

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
