### PR TITLE
VA-12069: Only show patient satisfaction scores for vha API endpoints

### DIFF
--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -209,9 +209,11 @@
             </section>
           {% endif %}
 
-          <div data-widget-type="facility-patient-satisfaction-scores"
-               data-facility="{{ fieldFacilityLocatorApiId | widgetFacilityDetail | escape }}">
-          </div>
+          {% if fieldFacilityLocatorApiId contains "vha_" %}
+            <div data-widget-type="facility-patient-satisfaction-scores"
+                data-facility="{{ fieldFacilityLocatorApiId | widgetFacilityDetail | escape }}">
+            </div>
+          {% endif %}
 
           <!-- Social Links -->
           {% include "src/site/facilities/facility_social_links.drupal.liquid"


### PR DESCRIPTION
## Description

Patient satisfaction scores aren't available for Tricare pages, but the widget for them is still on the pages. This causes an infinite spinner since it waits for data that will never come.

This pull request puts a conditional around the facility satisfaction scores so they only appear for appropriate endpoints. Tricare pages don't have the widget, and the functional VA ones have the widget (it doesn't load properly on my device only due to a local API issue, it won't affect the overall functionality).

closes [#12069](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12069)

## Testing done & Screenshots

### Tricare Page

<img width="842" alt="Screen Shot 2022-12-28 at 12 31 59 PM" src="https://user-images.githubusercontent.com/10790736/209850553-8a625a83-6099-468b-bd4c-7aaad2cd50ad.png">

### VA Page

<img width="1089" alt="Screen Shot 2022-12-28 at 12 31 23 PM" src="https://user-images.githubusercontent.com/10790736/209850577-7e99cde1-8864-4e8b-8f04-996a3bce9705.png">

## QA steps

**What needs to be checked to prove this works?** Lovell Tricare location pages need not to show the patient satisfaction scores widget.
**What needs to be checked to prove it didn't break any related things?** VA location pages still need to show it properly.
**What variations of circumstances (users, actions, values) need to be checked?** Just checking the Lovell pages.

## Acceptance criteria

- [ ] Lovell Tricare pages no longer show patient satisfaction scores
- [ ] Lovell VA pages still successfully show patient satisfaction scores

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
