### PR TITLE
VA-12023: Remove white space above facility operating status alerts

### DIFF
--- a/src/site/includes/operatingStatusFlagsLinks.drupal.liquid
+++ b/src/site/includes/operatingStatusFlagsLinks.drupal.liquid
@@ -5,7 +5,7 @@
   'infoBoxText': 'Facility notice'});"
   href="{{ facilitySidebar.links.0.url.path }}/operating-status">
     <span
-      class="operating-status-flag operating-status-flag-notice operating-status usa-alert usa-alert-info background-color-only vads-u-margin-top--1 vads-u-padding-y--2 vads-u-padding-x--1p5">
+      class="operating-status-flag operating-status-flag-notice operating-status usa-alert usa-alert-info background-color-only vads-u-margin-top--0 vads-u-padding-y--2 vads-u-padding-x--1p5">
       <i class="fa fa-info-circle" aria-hidden="true"></i>
         Facility notice
       <i class="fa fa-chevron-right vads-u-padding-left--0p5" aria-hidden="true"></i>
@@ -18,7 +18,7 @@
   'infoBoxText': 'Facility limited'});"
      href="{{ facilitySidebar.links.0.url.path }}/operating-status">
     <span
-      class="operating-status-flag operating-status-flag-warning operating-status usa-alert usa-alert-warning background-color-only vads-u-margin-top--1 vads-u-padding-y--2 vads-u-padding-x--1p5">
+      class="operating-status-flag operating-status-flag-warning operating-status usa-alert usa-alert-warning background-color-only vads-u-margin-top--0 vads-u-padding-y--2 vads-u-padding-x--1p5">
       <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
         Limited services and hours
       <i class="fa fa-chevron-right vads-u-padding-left--0p5" aria-hidden="true"></i>
@@ -31,7 +31,7 @@
   'infoBoxText': 'Facility closed'});"
      href="{{ facilitySidebar.links.0.url.path }}/operating-status">
     <span
-      class="operating-status-flag operating-status-flag-error operating-status usa-alert usa-alert-error background-color-only vads-u-margin-top--1 vads-u-padding-y--2 vads-u-padding-x--1p5">
+      class="operating-status-flag operating-status-flag-error operating-status usa-alert usa-alert-error background-color-only vads-u-margin-top--0 vads-u-padding-y--2 vads-u-padding-x--1p5">
       <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
         Facility Closed
       <i class="fa fa-chevron-right vads-u-padding-left--0p5" aria-hidden="true"></i>


### PR DESCRIPTION
## Description

There's extra white space above the Facility operating status alerts, which is removed by getting rid of the extra top margin. This change is made on all three of the different operating status alerts.

closes [#12023](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12023)

## Testing done & Screenshots

Visual, see below screenshots.

### Before

<img width="757" alt="Screen Shot 2022-12-28 at 9 41 10 AM" src="https://user-images.githubusercontent.com/10790736/209829984-db1b6348-8581-480c-a33b-0a2ffb4d7741.png">

### After

<img width="804" alt="Screen Shot 2022-12-28 at 9 40 53 AM" src="https://user-images.githubusercontent.com/10790736/209829964-e6739695-fca2-44c1-8efe-94ea07ae6d6d.png">

## QA steps

**What needs to be checked to prove this works?** The operating status focus indicator has equal space around all sides. 
**What needs to be checked to prove it didn't break any related things?** No other focus indicators now have unequal spacing.

1. Do a local build and go to a facility page, like [Gainesville](https://www.va.gov/north-florida-health-care/locations/gainesville-twenty-third-avenue-va-clinic/)
   - [ ] Check that the "Facility Notice" alert, when focused with a keyboard, doesn't have any extra white space above it and under the focus indicator.

## Acceptance criteria

- [x] The focus indicator has an equal amount of space on all sides.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
