### PR TITLE
VACMS-11996: adds unit tests for Lovell listing pages

### DIFF
--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -460,5 +460,7 @@ function processLovellPages(drupalData) {
 }
 
 module.exports = {
+  isLovellTricarePage,
+  isLovellVaPage,
   processLovellPages,
 };

--- a/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/federal/events.json
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/federal/events.json
@@ -1,0 +1,970 @@
+{
+  "entityBundle": "event_listing",
+  "entityId": "36319",
+  "entityPublished": true,
+  "title": "Events",
+  "vid": 736012,
+  "entityUrl": {
+    "breadcrumb": [
+      {
+        "url": {
+          "path": "/",
+          "routed": true
+        },
+        "text": "Home"
+      },
+      {
+        "url": {
+          "path": "/lovell-federal-health-care",
+          "routed": true
+        },
+        "text": "Lovell Federal health care"
+      },
+      {
+        "url": {
+          "path": "",
+          "routed": true
+        },
+        "text": "NEWS AND EVENTS"
+      },
+      {
+        "url": {
+          "path": "",
+          "routed": true
+        },
+        "text": "Events"
+      }
+    ],
+    "path": "/lovell-federal-health-care/events"
+  },
+  "entityMetatags": [
+    {
+      "__typename": "MetaLink",
+      "key": "image_src",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "title",
+      "value": "Events | Lovell Federal health care | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "description",
+      "value": "Check early and often to see upcoming events at Lovell Federal health care and regional events."
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:site_name",
+      "value": "Veterans Affairs"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:title",
+      "value": "Events | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:description",
+      "value": "Check early and often to see upcoming events at Lovell Federal health care and regional events."
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:image",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:image:alt",
+      "value": "U.S. Department of Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:card",
+      "value": "summary_large_image"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:site",
+      "value": "@DeptVetAffairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:description",
+      "value": "Check early and often to see upcoming events at Lovell Federal health care and regional events."
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:title",
+      "value": "Events | Lovell Federal health care | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:image:alt",
+      "value": "U.S. Department of Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:image",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    }
+  ],
+  "changed": 1671038410,
+  "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care and regional events.",
+  "pastEvents": {
+    "entities": [
+      {
+        "changed": 1671038416,
+        "entityBundle": "event",
+        "entityId": "36405",
+        "entityPublished": true,
+        "entityMetatags": [
+          {
+            "__typename": "MetaLink",
+            "key": "image_src",
+            "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "title",
+            "value": "Lovell Federal health care | Lovell Federal health care Placeholder - Event | Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:site_name",
+            "value": "Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:title",
+            "value": "Lovell Federal health care Placeholder - Event | Lovell Federal health care | Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:image",
+            "value": "/img/styles/3_2_medium_thumbnail/public/2021-03/Placeholder%20image%20-%20VA%20logo.png"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:image:height",
+            "value": "314"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:image:alt",
+            "value": "VA logo"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:card",
+            "value": "summary_large_image"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:site",
+            "value": "@DeptVetAffairs"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:title",
+            "value": "Lovell Federal health care Placeholder - Event | Lovell Federal health care | Veterans Affairs"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:image:alt",
+            "value": "VA logo"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:image",
+            "value": "/img/styles/3_2_medium_thumbnail/public/2021-03/Placeholder%20image%20-%20VA%20logo.png"
+          }
+        ],
+        "entityUrl": {
+          "path": "/lovell-federal-va-health-care/events/36405"
+        },
+        "title": "Lovell Federal health care Placeholder - Event",
+        "vid": 736023,
+        "fieldAdditionalInformationAbo": null,
+        "fieldAddress": null,
+        "fieldBody": null,
+        "fieldDatetimeRangeTimezone": [
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 1633119000,
+            "rrule": null,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/Chicago",
+            "value": 1633115400
+          }
+        ],
+        "fieldDescription": null,
+        "fieldEventCost": null,
+        "fieldEventCta": null,
+        "fieldEventRegistrationrequired": false,
+        "fieldFacilityLocation": null,
+        "fieldFeatured": false,
+        "fieldLink": null,
+        "fieldListing": {
+          "entity": {
+            "entityBundle": "event_listing",
+            "entityId": "36319",
+            "entityType": "node",
+            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal health care and regional events.",
+            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care and regional events.",
+            "fieldOffice": {
+              "entity": {
+                "entityType": "node",
+                "entityBundle": "health_care_region_page",
+                "entityId": "15007"
+              }
+            }
+          }
+        },
+        "fieldLocationHumanreadable": null,
+        "fieldLocationType": "online",
+        "fieldMedia": {
+          "entity": {
+            "entityBundle": "image",
+            "entityId": "2858",
+            "entityType": "media",
+            "image": {
+              "alt": "VA logo",
+              "title": "",
+              "derivative": {
+                "height": 300,
+                "url": "/img/styles/7_2_medium_thumbnail/public/2021-03/Placeholder%20image%20-%20VA%20logo.png",
+                "width": 1050
+              }
+            },
+            "thumbnail": {
+              "alt": "VA logo",
+              "height": 320,
+              "targetId": 3145,
+              "title": null,
+              "url": "/img/2021-03/Placeholder%20image%20-%20VA%20logo.png",
+              "width": 320
+            }
+          }
+        },
+        "fieldMetaTags": null,
+        "fieldOrder": null,
+        "fieldUrlOfAnOnlineEvent": null,
+        "uid": {
+          "targetId": 1282,
+          "entity": {
+            "name": "lisa.trombley@va.gov",
+            "timezone": null
+          }
+        },
+        "fieldAdministration": {
+          "entity": {
+            "entityId": "347"
+          }
+        }
+      },
+      {
+        "changed": 1671038406,
+        "entityBundle": "event",
+        "entityId": "49919",
+        "entityPublished": true,
+        "entityMetatags": [
+          {
+            "__typename": "MetaLink",
+            "key": "image_src",
+            "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "title",
+            "value": "Lovell Federal health care | Test Event 1 Both | Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:site_name",
+            "value": "Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:title",
+            "value": "Test Event 1 Both | Lovell Federal health care | Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:image:height",
+            "value": "314"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:card",
+            "value": "summary_large_image"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:site",
+            "value": "@DeptVetAffairs"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:title",
+            "value": "Test Event 1 Both | Lovell Federal health care | Veterans Affairs"
+          }
+        ],
+        "entityUrl": {
+          "path": "/lovell-federal-va-health-care/events/49919"
+        },
+        "title": "Test Event 1 Both",
+        "vid": 735968,
+        "fieldAdditionalInformationAbo": null,
+        "fieldAddress": {
+          "additionalName": null,
+          "addressLine1": "",
+          "addressLine2": "",
+          "administrativeArea": "",
+          "countryCode": "US",
+          "dependentLocality": null,
+          "familyName": null,
+          "givenName": null,
+          "langcode": null,
+          "locality": "",
+          "organization": null,
+          "postalCode": null,
+          "sortingCode": null
+        },
+        "fieldBody": {
+          "format": "rich_text",
+          "processed": "<html><head></head><body><p>This is an event that should appear in both Lovells.</p></body></html>",
+          "value": "<p>This is an event that should appear in both Lovells.</p>\r\n"
+        },
+        "fieldDatetimeRangeTimezone": [
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 1666402200,
+            "rrule": null,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/New_York",
+            "value": 1666398600
+          }
+        ],
+        "fieldDescription": null,
+        "fieldEventCost": "Free",
+        "fieldEventCta": null,
+        "fieldEventRegistrationrequired": false,
+        "fieldFacilityLocation": {
+          "entity": {
+            "entityBundle": "health_care_local_facility",
+            "entityId": "1480",
+            "entityType": "node",
+            "entityUrl": {
+              "path": "/lovell-federal-va-health-care/locations/captain-james-a-lovell-federal-health-care-center"
+            },
+            "title": "Captain James A. Lovell Federal Health Care Center"
+          }
+        },
+        "fieldFeatured": false,
+        "fieldLink": null,
+        "fieldListing": {
+          "entity": {
+            "entityBundle": "event_listing",
+            "entityId": "36319",
+            "entityType": "node",
+            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal health care and regional events.",
+            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care and regional events.",
+            "fieldOffice": {
+              "entity": {
+                "entityType": "node",
+                "entityBundle": "health_care_region_page",
+                "entityId": "15007"
+              }
+            }
+          }
+        },
+        "fieldLocationHumanreadable": null,
+        "fieldLocationType": "facility",
+        "fieldMedia": null,
+        "fieldMetaTags": null,
+        "fieldOrder": null,
+        "fieldUrlOfAnOnlineEvent": null,
+        "uid": {
+          "targetId": 1215,
+          "entity": {
+            "name": "Steve.Wirt@civicactions.com",
+            "timezone": null
+          }
+        },
+        "fieldAdministration": {
+          "entity": {
+            "entityId": "347"
+          }
+        }
+      },
+      {
+        "changed": 1671038406,
+        "entityBundle": "event",
+        "entityId": "49920",
+        "entityPublished": true,
+        "entityMetatags": [
+          {
+            "__typename": "MetaLink",
+            "key": "image_src",
+            "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "title",
+            "value": "Lovell Federal health care | Test Event 2 Both | Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:site_name",
+            "value": "Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:title",
+            "value": "Test Event 2 Both | Lovell Federal health care | Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:image:height",
+            "value": "314"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:card",
+            "value": "summary_large_image"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:site",
+            "value": "@DeptVetAffairs"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:title",
+            "value": "Test Event 2 Both | Lovell Federal health care | Veterans Affairs"
+          }
+        ],
+        "entityUrl": {
+          "path": "/lovell-federal-va-health-care/events/49920"
+        },
+        "title": "Test Event 2 Both",
+        "vid": 735967,
+        "fieldAdditionalInformationAbo": null,
+        "fieldAddress": {
+          "additionalName": null,
+          "addressLine1": "",
+          "addressLine2": "",
+          "administrativeArea": "",
+          "countryCode": "US",
+          "dependentLocality": null,
+          "familyName": null,
+          "givenName": null,
+          "langcode": null,
+          "locality": "",
+          "organization": null,
+          "postalCode": null,
+          "sortingCode": null
+        },
+        "fieldBody": {
+          "format": "rich_text",
+          "processed": "<html><head></head><body><p>This is another event that should appear in both Lovells.</p></body></html>",
+          "value": "<p>This is another event that should appear in both Lovells.</p>\r\n"
+        },
+        "fieldDatetimeRangeTimezone": [
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 1666589400,
+            "rrule": null,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/New_York",
+            "value": 1666585800
+          }
+        ],
+        "fieldDescription": null,
+        "fieldEventCost": "Free",
+        "fieldEventCta": null,
+        "fieldEventRegistrationrequired": false,
+        "fieldFacilityLocation": null,
+        "fieldFeatured": false,
+        "fieldLink": null,
+        "fieldListing": {
+          "entity": {
+            "entityBundle": "event_listing",
+            "entityId": "36319",
+            "entityType": "node",
+            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal health care and regional events.",
+            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care and regional events.",
+            "fieldOffice": {
+              "entity": {
+                "entityType": "node",
+                "entityBundle": "health_care_region_page",
+                "entityId": "15007"
+              }
+            }
+          }
+        },
+        "fieldLocationHumanreadable": null,
+        "fieldLocationType": "online",
+        "fieldMedia": null,
+        "fieldMetaTags": null,
+        "fieldOrder": null,
+        "fieldUrlOfAnOnlineEvent": {
+          "uri": "https://google.com",
+          "title": ""
+        },
+        "uid": {
+          "targetId": 1215,
+          "entity": {
+            "name": "Steve.Wirt@civicactions.com",
+            "timezone": null
+          }
+        },
+        "fieldAdministration": {
+          "entity": {
+            "entityId": "347"
+          }
+        }
+      }
+    ]
+  },
+  "reverseFieldListingNode": {
+    "entities": [
+      {
+        "changed": 1671038416,
+        "entityBundle": "event",
+        "entityId": "36405",
+        "entityPublished": true,
+        "entityMetatags": [
+          {
+            "__typename": "MetaLink",
+            "key": "image_src",
+            "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "title",
+            "value": "Lovell Federal health care | Lovell Federal health care Placeholder - Event | Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:site_name",
+            "value": "Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:title",
+            "value": "Lovell Federal health care Placeholder - Event | Lovell Federal health care | Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:image",
+            "value": "/img/styles/3_2_medium_thumbnail/public/2021-03/Placeholder%20image%20-%20VA%20logo.png"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:image:height",
+            "value": "314"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:image:alt",
+            "value": "VA logo"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:card",
+            "value": "summary_large_image"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:site",
+            "value": "@DeptVetAffairs"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:title",
+            "value": "Lovell Federal health care Placeholder - Event | Lovell Federal health care | Veterans Affairs"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:image:alt",
+            "value": "VA logo"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:image",
+            "value": "/img/styles/3_2_medium_thumbnail/public/2021-03/Placeholder%20image%20-%20VA%20logo.png"
+          }
+        ],
+        "entityUrl": {
+          "path": "/lovell-federal-va-health-care/events/36405"
+        },
+        "title": "Lovell Federal health care Placeholder - Event",
+        "vid": 736023,
+        "fieldAdditionalInformationAbo": null,
+        "fieldAddress": null,
+        "fieldBody": null,
+        "fieldDatetimeRangeTimezone": [
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 1633119000,
+            "rrule": null,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/Chicago",
+            "value": 1633115400
+          }
+        ],
+        "fieldDescription": null,
+        "fieldEventCost": null,
+        "fieldEventCta": null,
+        "fieldEventRegistrationrequired": false,
+        "fieldFacilityLocation": null,
+        "fieldFeatured": false,
+        "fieldLink": null,
+        "fieldListing": {
+          "entity": {
+            "entityBundle": "event_listing",
+            "entityId": "36319",
+            "entityType": "node",
+            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal health care and regional events.",
+            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care and regional events.",
+            "fieldOffice": {
+              "entity": {
+                "entityType": "node",
+                "entityBundle": "health_care_region_page",
+                "entityId": "15007"
+              }
+            }
+          }
+        },
+        "fieldLocationHumanreadable": null,
+        "fieldLocationType": "online",
+        "fieldMedia": {
+          "entity": {
+            "entityBundle": "image",
+            "entityId": "2858",
+            "entityType": "media",
+            "image": {
+              "alt": "VA logo",
+              "title": "",
+              "derivative": {
+                "height": 300,
+                "url": "/img/styles/7_2_medium_thumbnail/public/2021-03/Placeholder%20image%20-%20VA%20logo.png",
+                "width": 1050
+              }
+            },
+            "thumbnail": {
+              "alt": "VA logo",
+              "height": 320,
+              "targetId": 3145,
+              "title": null,
+              "url": "/img/2021-03/Placeholder%20image%20-%20VA%20logo.png",
+              "width": 320
+            }
+          }
+        },
+        "fieldMetaTags": null,
+        "fieldOrder": null,
+        "fieldUrlOfAnOnlineEvent": null,
+        "uid": {
+          "targetId": 1282,
+          "entity": {
+            "name": "lisa.trombley@va.gov",
+            "timezone": null
+          }
+        },
+        "fieldAdministration": {
+          "entity": {
+            "entityId": "347"
+          }
+        }
+      },
+      {
+        "changed": 1671038406,
+        "entityBundle": "event",
+        "entityId": "49919",
+        "entityPublished": true,
+        "entityMetatags": [
+          {
+            "__typename": "MetaLink",
+            "key": "image_src",
+            "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "title",
+            "value": "Lovell Federal health care | Test Event 1 Both | Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:site_name",
+            "value": "Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:title",
+            "value": "Test Event 1 Both | Lovell Federal health care | Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:image:height",
+            "value": "314"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:card",
+            "value": "summary_large_image"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:site",
+            "value": "@DeptVetAffairs"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:title",
+            "value": "Test Event 1 Both | Lovell Federal health care | Veterans Affairs"
+          }
+        ],
+        "entityUrl": {
+          "path": "/lovell-federal-va-health-care/events/49919"
+        },
+        "title": "Test Event 1 Both",
+        "vid": 735968,
+        "fieldAdditionalInformationAbo": null,
+        "fieldAddress": {
+          "additionalName": null,
+          "addressLine1": "",
+          "addressLine2": "",
+          "administrativeArea": "",
+          "countryCode": "US",
+          "dependentLocality": null,
+          "familyName": null,
+          "givenName": null,
+          "langcode": null,
+          "locality": "",
+          "organization": null,
+          "postalCode": null,
+          "sortingCode": null
+        },
+        "fieldBody": {
+          "format": "rich_text",
+          "processed": "<html><head></head><body><p>This is an event that should appear in both Lovells.</p></body></html>",
+          "value": "<p>This is an event that should appear in both Lovells.</p>\r\n"
+        },
+        "fieldDatetimeRangeTimezone": [
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 1666402200,
+            "rrule": null,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/New_York",
+            "value": 1666398600
+          }
+        ],
+        "fieldDescription": null,
+        "fieldEventCost": "Free",
+        "fieldEventCta": null,
+        "fieldEventRegistrationrequired": false,
+        "fieldFacilityLocation": {
+          "entity": {
+            "entityBundle": "health_care_local_facility",
+            "entityId": "1480",
+            "entityType": "node",
+            "entityUrl": {
+              "path": "/lovell-federal-va-health-care/locations/captain-james-a-lovell-federal-health-care-center"
+            },
+            "title": "Captain James A. Lovell Federal Health Care Center"
+          }
+        },
+        "fieldFeatured": false,
+        "fieldLink": null,
+        "fieldListing": {
+          "entity": {
+            "entityBundle": "event_listing",
+            "entityId": "36319",
+            "entityType": "node",
+            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal health care and regional events.",
+            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care and regional events.",
+            "fieldOffice": {
+              "entity": {
+                "entityType": "node",
+                "entityBundle": "health_care_region_page",
+                "entityId": "15007"
+              }
+            }
+          }
+        },
+        "fieldLocationHumanreadable": null,
+        "fieldLocationType": "facility",
+        "fieldMedia": null,
+        "fieldMetaTags": null,
+        "fieldOrder": null,
+        "fieldUrlOfAnOnlineEvent": null,
+        "uid": {
+          "targetId": 1215,
+          "entity": {
+            "name": "Steve.Wirt@civicactions.com",
+            "timezone": null
+          }
+        },
+        "fieldAdministration": {
+          "entity": {
+            "entityId": "347"
+          }
+        }
+      },
+      {
+        "changed": 1671038406,
+        "entityBundle": "event",
+        "entityId": "49920",
+        "entityPublished": true,
+        "entityMetatags": [
+          {
+            "__typename": "MetaLink",
+            "key": "image_src",
+            "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "title",
+            "value": "Lovell Federal health care | Test Event 2 Both | Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:site_name",
+            "value": "Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:title",
+            "value": "Test Event 2 Both | Lovell Federal health care | Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:image:height",
+            "value": "314"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:card",
+            "value": "summary_large_image"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:site",
+            "value": "@DeptVetAffairs"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:title",
+            "value": "Test Event 2 Both | Lovell Federal health care | Veterans Affairs"
+          }
+        ],
+        "entityUrl": {
+          "path": "/lovell-federal-va-health-care/events/49920"
+        },
+        "title": "Test Event 2 Both",
+        "vid": 735967,
+        "fieldAdditionalInformationAbo": null,
+        "fieldAddress": {
+          "additionalName": null,
+          "addressLine1": "",
+          "addressLine2": "",
+          "administrativeArea": "",
+          "countryCode": "US",
+          "dependentLocality": null,
+          "familyName": null,
+          "givenName": null,
+          "langcode": null,
+          "locality": "",
+          "organization": null,
+          "postalCode": null,
+          "sortingCode": null
+        },
+        "fieldBody": {
+          "format": "rich_text",
+          "processed": "<html><head></head><body><p>This is another event that should appear in both Lovells.</p></body></html>",
+          "value": "<p>This is another event that should appear in both Lovells.</p>\r\n"
+        },
+        "fieldDatetimeRangeTimezone": [
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 1666589400,
+            "rrule": null,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/New_York",
+            "value": 1666585800
+          }
+        ],
+        "fieldDescription": null,
+        "fieldEventCost": "Free",
+        "fieldEventCta": null,
+        "fieldEventRegistrationrequired": false,
+        "fieldFacilityLocation": null,
+        "fieldFeatured": false,
+        "fieldLink": null,
+        "fieldListing": {
+          "entity": {
+            "entityBundle": "event_listing",
+            "entityId": "36319",
+            "entityType": "node",
+            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal health care and regional events.",
+            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care and regional events.",
+            "fieldOffice": {
+              "entity": {
+                "entityType": "node",
+                "entityBundle": "health_care_region_page",
+                "entityId": "15007"
+              }
+            }
+          }
+        },
+        "fieldLocationHumanreadable": null,
+        "fieldLocationType": "online",
+        "fieldMedia": null,
+        "fieldMetaTags": null,
+        "fieldOrder": null,
+        "fieldUrlOfAnOnlineEvent": {
+          "uri": "https://google.com",
+          "title": ""
+        },
+        "uid": {
+          "targetId": 1215,
+          "entity": {
+            "name": "Steve.Wirt@civicactions.com",
+            "timezone": null
+          }
+        },
+        "fieldAdministration": {
+          "entity": {
+            "entityId": "347"
+          }
+        }
+      }
+    ]
+  },
+  "fieldOffice": {
+    "entity": {
+      "entityLabel": "Lovell Federal health care"
+    }
+  },
+  "fieldAdministration": {
+    "entity": {
+      "entityId": "347"
+    }
+  }
+}

--- a/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/federal/news.json
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/federal/news.json
@@ -1,0 +1,149 @@
+{
+  "entityBundle": "press_releases_listing",
+  "entityId": "36320",
+  "entityPublished": true,
+  "title": "News releases",
+  "vid": 736013,
+  "entityUrl": {
+    "breadcrumb": [
+      {
+        "url": {
+          "path": "/",
+          "routed": true
+        },
+        "text": "Home"
+      },
+      {
+        "url": {
+          "path": "/lovell-federal-health-care",
+          "routed": true
+        },
+        "text": "Lovell Federal health care"
+      },
+      {
+        "url": {
+          "path": "",
+          "routed": true
+        },
+        "text": "NEWS AND EVENTS"
+      },
+      {
+        "url": {
+          "path": "",
+          "routed": true
+        },
+        "text": "News releases"
+      }
+    ],
+    "path": "/lovell-federal-health-care/news-releases"
+  },
+  "entityMetatags": [
+    {
+      "__typename": "MetaLink",
+      "key": "image_src",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "title",
+      "value": "News releases | Lovell Federal health care | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "description",
+      "value": "Lovell Federal health care news releases and information for the Veterans, their families, and caregivers"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:site_name",
+      "value": "Veterans Affairs"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:title",
+      "value": "News releases | Lovell Federal health care | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:description",
+      "value": "Lovell Federal health care news releases and information for the Veterans, their families, and caregivers"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:image",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:image:alt",
+      "value": "U.S. Department of Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:card",
+      "value": "summary_large_image"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:site",
+      "value": "@DeptVetAffairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:description",
+      "value": "Lovell Federal health care news releases and information for the Veterans, their families, and caregivers"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:title",
+      "value": "News releases | Lovell Federal health care | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:image:alt",
+      "value": "U.S. Department of Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:image",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    }
+  ],
+  "fieldIntroText": "News releases for Lovell Federal health care.",
+  "reverseFieldListingNode": {
+    "entities": [
+      {
+        "entityId": "49925",
+        "title": "TEST A press release for BOTH LOVELL",
+        "fieldReleaseDate": {
+          "value": "2022-10-02T19:50:12"
+        },
+        "entityUrl": {
+          "path": "/lovell-federal-va-health-care/news-releases/test-a-press-release-for-both-lovell"
+        },
+        "uid": {
+          "targetId": 1215,
+          "entity": {
+            "name": "Steve.Wirt@civicactions.com",
+            "timezone": null
+          }
+        },
+        "promote": false,
+        "created": 1664740679,
+        "fieldIntroText": "This is a press release for both Lovells."
+      }
+    ]
+  },
+  "fieldOffice": {
+    "targetId": 15007,
+    "entity": {
+      "entityLabel": "Lovell Federal health care",
+      "title": "Lovell Federal health care"
+    }
+  },
+  "fieldAdministration": {
+    "entity": {
+      "entityId": "347"
+    }
+  }
+}

--- a/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/federal/stories.json
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/federal/stories.json
@@ -1,0 +1,158 @@
+{
+  "entityBundle": "story_listing",
+  "entityId": "36321",
+  "entityPublished": true,
+  "title": "Stories",
+  "vid": 735972,
+  "entityUrl": {
+    "breadcrumb": [
+      {
+        "url": {
+          "path": "/",
+          "routed": true
+        },
+        "text": "Home"
+      },
+      {
+        "url": {
+          "path": "/lovell-federal-health-care",
+          "routed": true
+        },
+        "text": "Lovell Federal health care"
+      },
+      {
+        "url": {
+          "path": "",
+          "routed": true
+        },
+        "text": "NEWS AND EVENTS"
+      },
+      {
+        "url": {
+          "path": "",
+          "routed": true
+        },
+        "text": "Stories"
+      }
+    ],
+    "path": "/lovell-federal-health-care/stories"
+  },
+  "entityMetatags": [
+    {
+      "__typename": "MetaLink",
+      "key": "image_src",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "title",
+      "value": "Stories | Lovell Federal health care | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "description",
+      "value": "Lovell Federal health care top stories."
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:site_name",
+      "value": "Veterans Affairs"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:title",
+      "value": "Stories | Lovell Federal health care | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:description",
+      "value": "Lovell Federal health care top stories."
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:image",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:image:alt",
+      "value": "U.S. Department of Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:card",
+      "value": "summary_large_image"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:site",
+      "value": "@DeptVetAffairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:description",
+      "value": "Lovell Federal health care top stories."
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:title",
+      "value": "Stories | Lovell Federal health care | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:image:alt",
+      "value": "U.S. Department of Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:image",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    }
+  ],
+  "fieldIntroText": "Lovell Federal health care top stories.",
+  "reverseFieldListingNode": {
+    "entities": [
+      {
+        "entityId": "49929",
+        "title": "TEST story for BOTH Lovell",
+        "fieldFeatured": false,
+        "entityUrl": {
+          "path": "/lovell-federal-va-health-care/stories/test-story-for-both-lovell"
+        },
+        "uid": {
+          "targetId": 1215,
+          "entity": {
+            "name": "Steve.Wirt@civicactions.com",
+            "timezone": null
+          }
+        },
+        "promote": false,
+        "created": 1664741402,
+        "fieldAuthor": {
+          "entity": {
+            "title": "Steven Winslow",
+            "fieldDescription": "Caregiver Support Social Worker (Manhattan Campus)"
+          }
+        },
+        "fieldImageCaption": null,
+        "fieldIntroText": "This is a story for the ages.",
+        "fieldMedia": null,
+        "fieldFullStory": {
+          "processed": "<html><head></head><body><p>The story of this story can not be surpassed.</p></body></html>"
+        }
+      }
+    ]
+  },
+  "fieldOffice": {
+    "targetId": 15007,
+    "entity": {
+      "title": "Lovell Federal health care",
+      "entityLabel": "Lovell Federal health care"
+    }
+  },
+  "fieldAdministration": {
+    "entity": {
+      "entityId": "347"
+    }
+  }
+}

--- a/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/tricare/events.json
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/tricare/events.json
@@ -1,0 +1,666 @@
+{
+  "entityBundle": "event_listing",
+  "entityId": "49454",
+  "entityPublished": true,
+  "title": "Events",
+  "vid": 736022,
+  "entityUrl": {
+    "breadcrumb": [
+      {
+        "url": {
+          "path": "/",
+          "routed": true
+        },
+        "text": "Home"
+      },
+      {
+        "url": {
+          "path": "/lovell-federal-health-care",
+          "routed": true
+        },
+        "text": "Lovell Federal health care"
+      },
+      {
+        "url": {
+          "path": "",
+          "routed": true
+        },
+        "text": "NEWS AND EVENTS"
+      },
+      {
+        "url": {
+          "path": "",
+          "routed": true
+        },
+        "text": "Events"
+      }
+    ],
+    "path": "/lovell-federal-tricare-health-care/events"
+  },
+  "entityMetatags": [
+    {
+      "__typename": "MetaLink",
+      "key": "image_src",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "title",
+      "value": "Events | Lovell Federal TRICARE health care | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "description",
+      "value": "Check early and often to see upcoming events at Lovell Federal TRICARE health care and regional events."
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:site_name",
+      "value": "Veterans Affairs"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:title",
+      "value": "Events | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:description",
+      "value": "Check early and often to see upcoming events at Lovell Federal TRICARE health care and regional events."
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:image",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:image:alt",
+      "value": "U.S. Department of Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:card",
+      "value": "summary_large_image"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:site",
+      "value": "@DeptVetAffairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:description",
+      "value": "Check early and often to see upcoming events at Lovell Federal TRICARE health care and regional events."
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:title",
+      "value": "Events | Lovell Federal TRICARE health care | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:image:alt",
+      "value": "U.S. Department of Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:image",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    }
+  ],
+  "changed": 1671038416,
+  "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal TRICARE health care and regional events.",
+  "pastEvents": {
+    "entities": [
+      {
+        "changed": 1671038406,
+        "entityBundle": "event",
+        "entityId": "49921",
+        "entityPublished": true,
+        "entityMetatags": [
+          {
+            "__typename": "MetaLink",
+            "key": "image_src",
+            "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "title",
+            "value": "Lovell Federal TRICARE health care | Test Event A TRICARE | Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:site_name",
+            "value": "Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:title",
+            "value": "Test Event A TRICARE | Lovell Federal TRICARE health care | Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:image:height",
+            "value": "314"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:card",
+            "value": "summary_large_image"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:site",
+            "value": "@DeptVetAffairs"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:title",
+            "value": "Test Event A TRICARE | Lovell Federal TRICARE health care | Veterans Affairs"
+          }
+        ],
+        "entityUrl": {
+          "path": "/lovell-federal-tricare-health-care/events/49921"
+        },
+        "title": "Test Event A TRICARE",
+        "vid": 735966,
+        "fieldAdditionalInformationAbo": null,
+        "fieldAddress": {
+          "additionalName": null,
+          "addressLine1": "",
+          "addressLine2": "",
+          "administrativeArea": "",
+          "countryCode": "US",
+          "dependentLocality": null,
+          "familyName": null,
+          "givenName": null,
+          "langcode": null,
+          "locality": "",
+          "organization": null,
+          "postalCode": null,
+          "sortingCode": null
+        },
+        "fieldBody": {
+          "format": "rich_text",
+          "processed": "<html><head></head><body><p>This is another event that should appear in TRICARE lovell.</p></body></html>",
+          "value": "<p>This is another event that should appear in TRICARE lovell.</p>\r\n"
+        },
+        "fieldDatetimeRangeTimezone": [
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 1666251000,
+            "rrule": null,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/New_York",
+            "value": 1666247400
+          }
+        ],
+        "fieldDescription": null,
+        "fieldEventCost": "Free",
+        "fieldEventCta": null,
+        "fieldEventRegistrationrequired": false,
+        "fieldFacilityLocation": null,
+        "fieldFeatured": false,
+        "fieldLink": null,
+        "fieldListing": {
+          "entity": {
+            "entityBundle": "event_listing",
+            "entityId": "49454",
+            "entityType": "node",
+            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal TRICARE health care and regional events.",
+            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal TRICARE health care and regional events.",
+            "fieldOffice": {
+              "entity": {
+                "entityType": "node",
+                "entityBundle": "health_care_region_page",
+                "entityId": "49011"
+              }
+            }
+          }
+        },
+        "fieldLocationHumanreadable": null,
+        "fieldLocationType": "online",
+        "fieldMedia": null,
+        "fieldMetaTags": null,
+        "fieldOrder": null,
+        "fieldUrlOfAnOnlineEvent": {
+          "uri": "https://google.com",
+          "title": ""
+        },
+        "uid": {
+          "targetId": 1215,
+          "entity": {
+            "name": "Steve.Wirt@civicactions.com",
+            "timezone": null
+          }
+        },
+        "fieldAdministration": {
+          "entity": {
+            "entityId": "1039"
+          }
+        }
+      },
+      {
+        "changed": 1671038406,
+        "entityBundle": "event",
+        "entityId": "49922",
+        "entityPublished": true,
+        "entityMetatags": [
+          {
+            "__typename": "MetaLink",
+            "key": "image_src",
+            "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "title",
+            "value": "Lovell Federal TRICARE health care | Test Event B TRICARE | Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:site_name",
+            "value": "Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:title",
+            "value": "Test Event B TRICARE | Lovell Federal TRICARE health care | Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:image:height",
+            "value": "314"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:card",
+            "value": "summary_large_image"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:site",
+            "value": "@DeptVetAffairs"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:title",
+            "value": "Test Event B TRICARE | Lovell Federal TRICARE health care | Veterans Affairs"
+          }
+        ],
+        "entityUrl": {
+          "path": "/lovell-federal-tricare-health-care/events/49922"
+        },
+        "title": "Test Event B TRICARE",
+        "vid": 735965,
+        "fieldAdditionalInformationAbo": null,
+        "fieldAddress": {
+          "additionalName": null,
+          "addressLine1": "",
+          "addressLine2": "",
+          "administrativeArea": "",
+          "countryCode": "US",
+          "dependentLocality": null,
+          "familyName": null,
+          "givenName": null,
+          "langcode": null,
+          "locality": "",
+          "organization": null,
+          "postalCode": null,
+          "sortingCode": null
+        },
+        "fieldBody": {
+          "format": "rich_text",
+          "processed": "<html><head></head><body><p>This is another event that should appear in TRICARE lovell.</p></body></html>",
+          "value": "<p>This is another event that should appear in TRICARE lovell.</p>\r\n"
+        },
+        "fieldDatetimeRangeTimezone": [
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 1666269300,
+            "rrule": null,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/New_York",
+            "value": 1666265700
+          }
+        ],
+        "fieldDescription": null,
+        "fieldEventCost": "Free",
+        "fieldEventCta": null,
+        "fieldEventRegistrationrequired": false,
+        "fieldFacilityLocation": {
+          "entity": {
+            "entityBundle": "health_care_local_facility",
+            "entityId": "49055",
+            "entityType": "node",
+            "entityUrl": {
+              "path": "/lovell-federal-tricare-health-care/locations/captain-james-a-lovell-federal-health-care-center"
+            },
+            "title": "Captain James A. Lovell Federal Health Care Center"
+          }
+        },
+        "fieldFeatured": false,
+        "fieldLink": null,
+        "fieldListing": {
+          "entity": {
+            "entityBundle": "event_listing",
+            "entityId": "49454",
+            "entityType": "node",
+            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal TRICARE health care and regional events.",
+            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal TRICARE health care and regional events.",
+            "fieldOffice": {
+              "entity": {
+                "entityType": "node",
+                "entityBundle": "health_care_region_page",
+                "entityId": "49011"
+              }
+            }
+          }
+        },
+        "fieldLocationHumanreadable": null,
+        "fieldLocationType": "facility",
+        "fieldMedia": null,
+        "fieldMetaTags": null,
+        "fieldOrder": null,
+        "fieldUrlOfAnOnlineEvent": null,
+        "uid": {
+          "targetId": 1215,
+          "entity": {
+            "name": "Steve.Wirt@civicactions.com",
+            "timezone": null
+          }
+        },
+        "fieldAdministration": {
+          "entity": {
+            "entityId": "1039"
+          }
+        }
+      }
+    ]
+  },
+  "reverseFieldListingNode": {
+    "entities": [
+      {
+        "changed": 1671038406,
+        "entityBundle": "event",
+        "entityId": "49921",
+        "entityPublished": true,
+        "entityMetatags": [
+          {
+            "__typename": "MetaLink",
+            "key": "image_src",
+            "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "title",
+            "value": "Lovell Federal TRICARE health care | Test Event A TRICARE | Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:site_name",
+            "value": "Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:title",
+            "value": "Test Event A TRICARE | Lovell Federal TRICARE health care | Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:image:height",
+            "value": "314"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:card",
+            "value": "summary_large_image"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:site",
+            "value": "@DeptVetAffairs"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:title",
+            "value": "Test Event A TRICARE | Lovell Federal TRICARE health care | Veterans Affairs"
+          }
+        ],
+        "entityUrl": {
+          "path": "/lovell-federal-tricare-health-care/events/49921"
+        },
+        "title": "Test Event A TRICARE",
+        "vid": 735966,
+        "fieldAdditionalInformationAbo": null,
+        "fieldAddress": {
+          "additionalName": null,
+          "addressLine1": "",
+          "addressLine2": "",
+          "administrativeArea": "",
+          "countryCode": "US",
+          "dependentLocality": null,
+          "familyName": null,
+          "givenName": null,
+          "langcode": null,
+          "locality": "",
+          "organization": null,
+          "postalCode": null,
+          "sortingCode": null
+        },
+        "fieldBody": {
+          "format": "rich_text",
+          "processed": "<html><head></head><body><p>This is another event that should appear in TRICARE lovell.</p></body></html>",
+          "value": "<p>This is another event that should appear in TRICARE lovell.</p>\r\n"
+        },
+        "fieldDatetimeRangeTimezone": [
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 1666251000,
+            "rrule": null,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/New_York",
+            "value": 1666247400
+          }
+        ],
+        "fieldDescription": null,
+        "fieldEventCost": "Free",
+        "fieldEventCta": null,
+        "fieldEventRegistrationrequired": false,
+        "fieldFacilityLocation": null,
+        "fieldFeatured": false,
+        "fieldLink": null,
+        "fieldListing": {
+          "entity": {
+            "entityBundle": "event_listing",
+            "entityId": "49454",
+            "entityType": "node",
+            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal TRICARE health care and regional events.",
+            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal TRICARE health care and regional events.",
+            "fieldOffice": {
+              "entity": {
+                "entityType": "node",
+                "entityBundle": "health_care_region_page",
+                "entityId": "49011"
+              }
+            }
+          }
+        },
+        "fieldLocationHumanreadable": null,
+        "fieldLocationType": "online",
+        "fieldMedia": null,
+        "fieldMetaTags": null,
+        "fieldOrder": null,
+        "fieldUrlOfAnOnlineEvent": {
+          "uri": "https://google.com",
+          "title": ""
+        },
+        "uid": {
+          "targetId": 1215,
+          "entity": {
+            "name": "Steve.Wirt@civicactions.com",
+            "timezone": null
+          }
+        },
+        "fieldAdministration": {
+          "entity": {
+            "entityId": "1039"
+          }
+        }
+      },
+      {
+        "changed": 1671038406,
+        "entityBundle": "event",
+        "entityId": "49922",
+        "entityPublished": true,
+        "entityMetatags": [
+          {
+            "__typename": "MetaLink",
+            "key": "image_src",
+            "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "title",
+            "value": "Lovell Federal TRICARE health care | Test Event B TRICARE | Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:site_name",
+            "value": "Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:title",
+            "value": "Test Event B TRICARE | Lovell Federal TRICARE health care | Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:image:height",
+            "value": "314"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:card",
+            "value": "summary_large_image"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:site",
+            "value": "@DeptVetAffairs"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:title",
+            "value": "Test Event B TRICARE | Lovell Federal TRICARE health care | Veterans Affairs"
+          }
+        ],
+        "entityUrl": {
+          "path": "/lovell-federal-tricare-health-care/events/49922"
+        },
+        "title": "Test Event B TRICARE",
+        "vid": 735965,
+        "fieldAdditionalInformationAbo": null,
+        "fieldAddress": {
+          "additionalName": null,
+          "addressLine1": "",
+          "addressLine2": "",
+          "administrativeArea": "",
+          "countryCode": "US",
+          "dependentLocality": null,
+          "familyName": null,
+          "givenName": null,
+          "langcode": null,
+          "locality": "",
+          "organization": null,
+          "postalCode": null,
+          "sortingCode": null
+        },
+        "fieldBody": {
+          "format": "rich_text",
+          "processed": "<html><head></head><body><p>This is another event that should appear in TRICARE lovell.</p></body></html>",
+          "value": "<p>This is another event that should appear in TRICARE lovell.</p>\r\n"
+        },
+        "fieldDatetimeRangeTimezone": [
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 1666269300,
+            "rrule": null,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/New_York",
+            "value": 1666265700
+          }
+        ],
+        "fieldDescription": null,
+        "fieldEventCost": "Free",
+        "fieldEventCta": null,
+        "fieldEventRegistrationrequired": false,
+        "fieldFacilityLocation": {
+          "entity": {
+            "entityBundle": "health_care_local_facility",
+            "entityId": "49055",
+            "entityType": "node",
+            "entityUrl": {
+              "path": "/lovell-federal-tricare-health-care/locations/captain-james-a-lovell-federal-health-care-center"
+            },
+            "title": "Captain James A. Lovell Federal Health Care Center"
+          }
+        },
+        "fieldFeatured": false,
+        "fieldLink": null,
+        "fieldListing": {
+          "entity": {
+            "entityBundle": "event_listing",
+            "entityId": "49454",
+            "entityType": "node",
+            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal TRICARE health care and regional events.",
+            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal TRICARE health care and regional events.",
+            "fieldOffice": {
+              "entity": {
+                "entityType": "node",
+                "entityBundle": "health_care_region_page",
+                "entityId": "49011"
+              }
+            }
+          }
+        },
+        "fieldLocationHumanreadable": null,
+        "fieldLocationType": "facility",
+        "fieldMedia": null,
+        "fieldMetaTags": null,
+        "fieldOrder": null,
+        "fieldUrlOfAnOnlineEvent": null,
+        "uid": {
+          "targetId": 1215,
+          "entity": {
+            "name": "Steve.Wirt@civicactions.com",
+            "timezone": null
+          }
+        },
+        "fieldAdministration": {
+          "entity": {
+            "entityId": "1039"
+          }
+        }
+      }
+    ]
+  },
+  "fieldOffice": {
+    "entity": {
+      "entityLabel": "Lovell Federal TRICARE health care"
+    }
+  },
+  "fieldAdministration": {
+    "entity": {
+      "entityId": "1039"
+    }
+  }
+}

--- a/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/tricare/news.json
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/tricare/news.json
@@ -1,0 +1,149 @@
+{
+  "entityBundle": "press_releases_listing",
+  "entityId": "49628",
+  "entityPublished": true,
+  "title": "News releases",
+  "vid": 736020,
+  "entityUrl": {
+    "breadcrumb": [
+      {
+        "url": {
+          "path": "/",
+          "routed": true
+        },
+        "text": "Home"
+      },
+      {
+        "url": {
+          "path": "/lovell-federal-health-care",
+          "routed": true
+        },
+        "text": "Lovell Federal health care"
+      },
+      {
+        "url": {
+          "path": "",
+          "routed": true
+        },
+        "text": "NEWS AND EVENTS"
+      },
+      {
+        "url": {
+          "path": "",
+          "routed": true
+        },
+        "text": "News releases"
+      }
+    ],
+    "path": "/lovell-federal-tricare-health-care/news-releases"
+  },
+  "entityMetatags": [
+    {
+      "__typename": "MetaLink",
+      "key": "image_src",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "title",
+      "value": "News releases | Lovell Federal TRICARE health care | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "description",
+      "value": "Lovell Federal TRICARE health care news releases and information for the TRICARE recipients, their families, and caregivers"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:site_name",
+      "value": "Veterans Affairs"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:title",
+      "value": "News releases | Lovell Federal TRICARE health care | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:description",
+      "value": "Lovell Federal TRICARE health care news releases and information for the TRICARE recipients, their families, and caregivers"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:image",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:image:alt",
+      "value": "U.S. Department of Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:card",
+      "value": "summary_large_image"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:site",
+      "value": "@DeptVetAffairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:description",
+      "value": "Lovell Federal TRICARE health care news releases and information for the TRICARE recipients, their families, and caregivers"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:title",
+      "value": "News releases | Lovell Federal TRICARE health care | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:image:alt",
+      "value": "U.S. Department of Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:image",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    }
+  ],
+  "fieldIntroText": "News releases for Lovell Federal TRICARE health care.",
+  "reverseFieldListingNode": {
+    "entities": [
+      {
+        "entityId": "49926",
+        "title": "TEST A press release for Lovell TRICARE",
+        "fieldReleaseDate": {
+          "value": "2022-10-05T19:50:12"
+        },
+        "entityUrl": {
+          "path": "/lovell-federal-tricare-health-care/news-releases/test-a-press-release-for-lovell-tricare"
+        },
+        "uid": {
+          "targetId": 1215,
+          "entity": {
+            "name": "Steve.Wirt@civicactions.com",
+            "timezone": null
+          }
+        },
+        "promote": false,
+        "created": 1664740982,
+        "fieldIntroText": "This is a press release for Lovell TRICARE"
+      }
+    ]
+  },
+  "fieldOffice": {
+    "targetId": 49011,
+    "entity": {
+      "entityLabel": "Lovell Federal TRICARE health care",
+      "title": "Lovell Federal TRICARE health care"
+    }
+  },
+  "fieldAdministration": {
+    "entity": {
+      "entityId": "1039"
+    }
+  }
+}

--- a/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/tricare/stories.json
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/tricare/stories.json
@@ -1,0 +1,158 @@
+{
+  "entityBundle": "story_listing",
+  "entityId": "49630",
+  "entityPublished": true,
+  "title": "Stories",
+  "vid": 736017,
+  "entityUrl": {
+    "breadcrumb": [
+      {
+        "url": {
+          "path": "/",
+          "routed": true
+        },
+        "text": "Home"
+      },
+      {
+        "url": {
+          "path": "/lovell-federal-health-care",
+          "routed": true
+        },
+        "text": "Lovell Federal health care"
+      },
+      {
+        "url": {
+          "path": "",
+          "routed": true
+        },
+        "text": "NEWS AND EVENTS"
+      },
+      {
+        "url": {
+          "path": "",
+          "routed": true
+        },
+        "text": "Stories"
+      }
+    ],
+    "path": "/lovell-federal-tricare-health-care/stories"
+  },
+  "entityMetatags": [
+    {
+      "__typename": "MetaLink",
+      "key": "image_src",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "title",
+      "value": "Stories | Lovell Federal TRICARE health care | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "description",
+      "value": "Lovell Federal TRICARE health care top stories."
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:site_name",
+      "value": "Veterans Affairs"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:title",
+      "value": "Stories | Lovell Federal TRICARE health care | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:description",
+      "value": "Lovell Federal TRICARE health care top stories."
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:image",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:image:alt",
+      "value": "U.S. Department of Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:card",
+      "value": "summary_large_image"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:site",
+      "value": "@DeptVetAffairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:description",
+      "value": "Lovell Federal TRICARE health care top stories."
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:title",
+      "value": "Stories | Lovell Federal TRICARE health care | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:image:alt",
+      "value": "U.S. Department of Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:image",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    }
+  ],
+  "fieldIntroText": "Lovell Federal TRICARE health care top stories.",
+  "reverseFieldListingNode": {
+    "entities": [
+      {
+        "entityId": "49930",
+        "title": "TEST story for TRICARE Lovell",
+        "fieldFeatured": true,
+        "entityUrl": {
+          "path": "/lovell-federal-tricare-health-care/stories/test-story-for-tricare-lovell"
+        },
+        "uid": {
+          "targetId": 1215,
+          "entity": {
+            "name": "Steve.Wirt@civicactions.com",
+            "timezone": null
+          }
+        },
+        "promote": false,
+        "created": 1664741414,
+        "fieldAuthor": {
+          "entity": {
+            "title": "Steven Winslow",
+            "fieldDescription": "Caregiver Support Social Worker (Manhattan Campus)"
+          }
+        },
+        "fieldImageCaption": null,
+        "fieldIntroText": "This is a smallish story for now.",
+        "fieldMedia": null,
+        "fieldFullStory": {
+          "processed": "<html><head></head><body><p>This is a meager story, but still important.</p></body></html>"
+        }
+      }
+    ]
+  },
+  "fieldOffice": {
+    "targetId": 49011,
+    "entity": {
+      "title": "Lovell Federal TRICARE health care",
+      "entityLabel": "Lovell Federal TRICARE health care"
+    }
+  },
+  "fieldAdministration": {
+    "entity": {
+      "entityId": "1039"
+    }
+  }
+}

--- a/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/va/events.json
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/va/events.json
@@ -1,0 +1,637 @@
+{
+  "entityBundle": "event_listing",
+  "entityId": "49455",
+  "entityPublished": true,
+  "title": "Events",
+  "vid": 736021,
+  "entityUrl": {
+    "breadcrumb": [
+      { "url": { "path": "/", "routed": true }, "text": "Home" },
+      {
+        "url": { "path": "/lovell-federal-health-care", "routed": true },
+        "text": "Lovell Federal health care"
+      },
+      { "url": { "path": "", "routed": true }, "text": "NEWS AND EVENTS" },
+      { "url": { "path": "", "routed": true }, "text": "Events" }
+    ],
+    "path": "/lovell-federal-va-health-care/events"
+  },
+  "entityMetatags": [
+    {
+      "__typename": "MetaLink",
+      "key": "image_src",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "title",
+      "value": "Events | Lovell Federal VA health care | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "description",
+      "value": "Check early and often to see upcoming events at Lovell Federal VA health care and regional events."
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:site_name",
+      "value": "Veterans Affairs"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:title",
+      "value": "Events | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:description",
+      "value": "Check early and often to see upcoming events at Lovell Federal VA health care and regional events."
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:image",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:image:alt",
+      "value": "U.S. Department of Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:card",
+      "value": "summary_large_image"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:site",
+      "value": "@DeptVetAffairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:description",
+      "value": "Check early and often to see upcoming events at Lovell Federal VA health care and regional events."
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:title",
+      "value": "Events | Lovell Federal VA health care | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:image:alt",
+      "value": "U.S. Department of Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:image",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    }
+  ],
+  "changed": 1671038416,
+  "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal VA health care and regional events.",
+  "pastEvents": {
+    "entities": [
+      {
+        "changed": 1671038406,
+        "entityBundle": "event",
+        "entityId": "49923",
+        "entityPublished": true,
+        "entityMetatags": [
+          {
+            "__typename": "MetaLink",
+            "key": "image_src",
+            "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "title",
+            "value": "Lovell Federal VA health care | Test Event X VA | Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:site_name",
+            "value": "Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:title",
+            "value": "Test Event X VA | Lovell Federal VA health care | Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:image:height",
+            "value": "314"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:card",
+            "value": "summary_large_image"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:site",
+            "value": "@DeptVetAffairs"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:title",
+            "value": "Test Event X VA | Lovell Federal VA health care | Veterans Affairs"
+          }
+        ],
+        "entityUrl": {
+          "path": "/lovell-federal-va-health-care/events/49923"
+        },
+        "title": "Test Event X VA",
+        "vid": 735964,
+        "fieldAdditionalInformationAbo": null,
+        "fieldAddress": {
+          "additionalName": null,
+          "addressLine1": "",
+          "addressLine2": "",
+          "administrativeArea": "",
+          "countryCode": "US",
+          "dependentLocality": null,
+          "familyName": null,
+          "givenName": null,
+          "langcode": null,
+          "locality": "",
+          "organization": null,
+          "postalCode": null,
+          "sortingCode": null
+        },
+        "fieldBody": {
+          "format": "rich_text",
+          "processed": "<html><head></head><body><p>This is another event that should appear in VA lovell.</p></body></html>",
+          "value": "<p>This is another event that should appear in VA lovell.</p>\r\n"
+        },
+        "fieldDatetimeRangeTimezone": [
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 1666269300,
+            "rrule": null,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/New_York",
+            "value": 1666265700
+          }
+        ],
+        "fieldDescription": null,
+        "fieldEventCost": "Free",
+        "fieldEventCta": null,
+        "fieldEventRegistrationrequired": false,
+        "fieldFacilityLocation": {
+          "entity": {
+            "entityBundle": "health_care_local_facility",
+            "entityId": "49055",
+            "entityType": "node",
+            "entityUrl": {
+              "path": "/lovell-federal-tricare-health-care/locations/captain-james-a-lovell-federal-health-care-center"
+            },
+            "title": "Captain James A. Lovell Federal Health Care Center"
+          }
+        },
+        "fieldFeatured": false,
+        "fieldLink": null,
+        "fieldListing": {
+          "entity": {
+            "entityBundle": "event_listing",
+            "entityId": "49455",
+            "entityType": "node",
+            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal VA health care and regional events.",
+            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal VA health care and regional events.",
+            "fieldOffice": {
+              "entity": {
+                "entityType": "node",
+                "entityBundle": "health_care_region_page",
+                "entityId": "49451"
+              }
+            }
+          }
+        },
+        "fieldLocationHumanreadable": null,
+        "fieldLocationType": "facility",
+        "fieldMedia": null,
+        "fieldMetaTags": null,
+        "fieldOrder": null,
+        "fieldUrlOfAnOnlineEvent": null,
+        "uid": {
+          "targetId": 1215,
+          "entity": {
+            "name": "Steve.Wirt@civicactions.com",
+            "timezone": null
+          }
+        },
+        "fieldAdministration": { "entity": { "entityId": "1040" } }
+      },
+      {
+        "changed": 1671038400,
+        "entityBundle": "event",
+        "entityId": "49924",
+        "entityPublished": true,
+        "entityMetatags": [
+          {
+            "__typename": "MetaLink",
+            "key": "image_src",
+            "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "title",
+            "value": "Lovell Federal VA health care | Test Event Y VA | Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:site_name",
+            "value": "Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:title",
+            "value": "Test Event Y VA | Lovell Federal VA health care | Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:image:height",
+            "value": "314"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:card",
+            "value": "summary_large_image"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:site",
+            "value": "@DeptVetAffairs"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:title",
+            "value": "Test Event Y VA | Lovell Federal VA health care | Veterans Affairs"
+          }
+        ],
+        "entityUrl": {
+          "path": "/lovell-federal-va-health-care/events/49924"
+        },
+        "title": "Test Event Y VA",
+        "vid": 735963,
+        "fieldAdditionalInformationAbo": null,
+        "fieldAddress": {
+          "additionalName": null,
+          "addressLine1": "",
+          "addressLine2": "",
+          "administrativeArea": "",
+          "countryCode": "US",
+          "dependentLocality": null,
+          "familyName": null,
+          "givenName": null,
+          "langcode": null,
+          "locality": "",
+          "organization": null,
+          "postalCode": null,
+          "sortingCode": null
+        },
+        "fieldBody": {
+          "format": "rich_text",
+          "processed": "<html><head></head><body><p>This is another event that should appear in VA lovell.</p></body></html>",
+          "value": "<p>This is another event that should appear in VA lovell.</p>\r\n"
+        },
+        "fieldDatetimeRangeTimezone": [
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 1666370100,
+            "rrule": null,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/New_York",
+            "value": 1666366500
+          }
+        ],
+        "fieldDescription": null,
+        "fieldEventCost": "Free",
+        "fieldEventCta": null,
+        "fieldEventRegistrationrequired": false,
+        "fieldFacilityLocation": {
+          "entity": {
+            "entityBundle": "health_care_local_facility",
+            "entityId": "49055",
+            "entityType": "node",
+            "entityUrl": {
+              "path": "/lovell-federal-tricare-health-care/locations/captain-james-a-lovell-federal-health-care-center"
+            },
+            "title": "Captain James A. Lovell Federal Health Care Center"
+          }
+        },
+        "fieldFeatured": false,
+        "fieldLink": null,
+        "fieldListing": {
+          "entity": {
+            "entityBundle": "event_listing",
+            "entityId": "49455",
+            "entityType": "node",
+            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal VA health care and regional events.",
+            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal VA health care and regional events.",
+            "fieldOffice": {
+              "entity": {
+                "entityType": "node",
+                "entityBundle": "health_care_region_page",
+                "entityId": "49451"
+              }
+            }
+          }
+        },
+        "fieldLocationHumanreadable": null,
+        "fieldLocationType": "facility",
+        "fieldMedia": null,
+        "fieldMetaTags": null,
+        "fieldOrder": null,
+        "fieldUrlOfAnOnlineEvent": null,
+        "uid": {
+          "targetId": 1215,
+          "entity": {
+            "name": "Steve.Wirt@civicactions.com",
+            "timezone": null
+          }
+        },
+        "fieldAdministration": { "entity": { "entityId": "1040" } }
+      }
+    ]
+  },
+  "reverseFieldListingNode": {
+    "entities": [
+      {
+        "changed": 1671038406,
+        "entityBundle": "event",
+        "entityId": "49923",
+        "entityPublished": true,
+        "entityMetatags": [
+          {
+            "__typename": "MetaLink",
+            "key": "image_src",
+            "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "title",
+            "value": "Lovell Federal VA health care | Test Event X VA | Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:site_name",
+            "value": "Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:title",
+            "value": "Test Event X VA | Lovell Federal VA health care | Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:image:height",
+            "value": "314"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:card",
+            "value": "summary_large_image"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:site",
+            "value": "@DeptVetAffairs"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:title",
+            "value": "Test Event X VA | Lovell Federal VA health care | Veterans Affairs"
+          }
+        ],
+        "entityUrl": {
+          "path": "/lovell-federal-va-health-care/events/49923"
+        },
+        "title": "Test Event X VA",
+        "vid": 735964,
+        "fieldAdditionalInformationAbo": null,
+        "fieldAddress": {
+          "additionalName": null,
+          "addressLine1": "",
+          "addressLine2": "",
+          "administrativeArea": "",
+          "countryCode": "US",
+          "dependentLocality": null,
+          "familyName": null,
+          "givenName": null,
+          "langcode": null,
+          "locality": "",
+          "organization": null,
+          "postalCode": null,
+          "sortingCode": null
+        },
+        "fieldBody": {
+          "format": "rich_text",
+          "processed": "<html><head></head><body><p>This is another event that should appear in VA lovell.</p></body></html>",
+          "value": "<p>This is another event that should appear in VA lovell.</p>\r\n"
+        },
+        "fieldDatetimeRangeTimezone": [
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 1666269300,
+            "rrule": null,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/New_York",
+            "value": 1666265700
+          }
+        ],
+        "fieldDescription": null,
+        "fieldEventCost": "Free",
+        "fieldEventCta": null,
+        "fieldEventRegistrationrequired": false,
+        "fieldFacilityLocation": {
+          "entity": {
+            "entityBundle": "health_care_local_facility",
+            "entityId": "49055",
+            "entityType": "node",
+            "entityUrl": {
+              "path": "/lovell-federal-tricare-health-care/locations/captain-james-a-lovell-federal-health-care-center"
+            },
+            "title": "Captain James A. Lovell Federal Health Care Center"
+          }
+        },
+        "fieldFeatured": false,
+        "fieldLink": null,
+        "fieldListing": {
+          "entity": {
+            "entityBundle": "event_listing",
+            "entityId": "49455",
+            "entityType": "node",
+            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal VA health care and regional events.",
+            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal VA health care and regional events.",
+            "fieldOffice": {
+              "entity": {
+                "entityType": "node",
+                "entityBundle": "health_care_region_page",
+                "entityId": "49451"
+              }
+            }
+          }
+        },
+        "fieldLocationHumanreadable": null,
+        "fieldLocationType": "facility",
+        "fieldMedia": null,
+        "fieldMetaTags": null,
+        "fieldOrder": null,
+        "fieldUrlOfAnOnlineEvent": null,
+        "uid": {
+          "targetId": 1215,
+          "entity": {
+            "name": "Steve.Wirt@civicactions.com",
+            "timezone": null
+          }
+        },
+        "fieldAdministration": { "entity": { "entityId": "1040" } }
+      },
+      {
+        "changed": 1671038400,
+        "entityBundle": "event",
+        "entityId": "49924",
+        "entityPublished": true,
+        "entityMetatags": [
+          {
+            "__typename": "MetaLink",
+            "key": "image_src",
+            "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "title",
+            "value": "Lovell Federal VA health care | Test Event Y VA | Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:site_name",
+            "value": "Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:title",
+            "value": "Test Event Y VA | Lovell Federal VA health care | Veterans Affairs"
+          },
+          {
+            "__typename": "MetaProperty",
+            "key": "og:image:height",
+            "value": "314"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:card",
+            "value": "summary_large_image"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:site",
+            "value": "@DeptVetAffairs"
+          },
+          {
+            "__typename": "MetaValue",
+            "key": "twitter:title",
+            "value": "Test Event Y VA | Lovell Federal VA health care | Veterans Affairs"
+          }
+        ],
+        "entityUrl": {
+          "path": "/lovell-federal-va-health-care/events/49924"
+        },
+        "title": "Test Event Y VA",
+        "vid": 735963,
+        "fieldAdditionalInformationAbo": null,
+        "fieldAddress": {
+          "additionalName": null,
+          "addressLine1": "",
+          "addressLine2": "",
+          "administrativeArea": "",
+          "countryCode": "US",
+          "dependentLocality": null,
+          "familyName": null,
+          "givenName": null,
+          "langcode": null,
+          "locality": "",
+          "organization": null,
+          "postalCode": null,
+          "sortingCode": null
+        },
+        "fieldBody": {
+          "format": "rich_text",
+          "processed": "<html><head></head><body><p>This is another event that should appear in VA lovell.</p></body></html>",
+          "value": "<p>This is another event that should appear in VA lovell.</p>\r\n"
+        },
+        "fieldDatetimeRangeTimezone": [
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 1666370100,
+            "rrule": null,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/New_York",
+            "value": 1666366500
+          }
+        ],
+        "fieldDescription": null,
+        "fieldEventCost": "Free",
+        "fieldEventCta": null,
+        "fieldEventRegistrationrequired": false,
+        "fieldFacilityLocation": {
+          "entity": {
+            "entityBundle": "health_care_local_facility",
+            "entityId": "49055",
+            "entityType": "node",
+            "entityUrl": {
+              "path": "/lovell-federal-tricare-health-care/locations/captain-james-a-lovell-federal-health-care-center"
+            },
+            "title": "Captain James A. Lovell Federal Health Care Center"
+          }
+        },
+        "fieldFeatured": false,
+        "fieldLink": null,
+        "fieldListing": {
+          "entity": {
+            "entityBundle": "event_listing",
+            "entityId": "49455",
+            "entityType": "node",
+            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal VA health care and regional events.",
+            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal VA health care and regional events.",
+            "fieldOffice": {
+              "entity": {
+                "entityType": "node",
+                "entityBundle": "health_care_region_page",
+                "entityId": "49451"
+              }
+            }
+          }
+        },
+        "fieldLocationHumanreadable": null,
+        "fieldLocationType": "facility",
+        "fieldMedia": null,
+        "fieldMetaTags": null,
+        "fieldOrder": null,
+        "fieldUrlOfAnOnlineEvent": null,
+        "uid": {
+          "targetId": 1215,
+          "entity": {
+            "name": "Steve.Wirt@civicactions.com",
+            "timezone": null
+          }
+        },
+        "fieldAdministration": { "entity": { "entityId": "1040" } }
+      }
+    ]
+  },
+  "fieldOffice": {
+    "entity": { "entityLabel": "Lovell Federal VA health care" }
+  },
+  "fieldAdministration": { "entity": { "entityId": "1040" } }
+}

--- a/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/va/news.json
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/va/news.json
@@ -1,0 +1,122 @@
+{
+  "entityBundle": "press_releases_listing",
+  "entityId": "49629",
+  "entityPublished": true,
+  "title": "News releases",
+  "vid": 736019,
+  "entityUrl": {
+    "breadcrumb": [
+      { "url": { "path": "/", "routed": true }, "text": "Home" },
+      {
+        "url": { "path": "/lovell-federal-health-care", "routed": true },
+        "text": "Lovell Federal health care"
+      },
+      { "url": { "path": "", "routed": true }, "text": "NEWS AND EVENTS" },
+      { "url": { "path": "", "routed": true }, "text": "News releases" }
+    ],
+    "path": "/lovell-federal-va-health-care/news-releases"
+  },
+  "entityMetatags": [
+    {
+      "__typename": "MetaLink",
+      "key": "image_src",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "title",
+      "value": "News releases | Lovell Federal VA health care | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "description",
+      "value": "Lovell Federal VA health care news releases and information for the Veterans, their families, and caregivers"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:site_name",
+      "value": "Veterans Affairs"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:title",
+      "value": "News releases | Lovell Federal VA health care | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:description",
+      "value": "Lovell Federal VA health care news releases and information for the Veterans, their families, and caregivers"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:image",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:image:alt",
+      "value": "U.S. Department of Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:card",
+      "value": "summary_large_image"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:site",
+      "value": "@DeptVetAffairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:description",
+      "value": "Lovell Federal VA health care news releases and information for the Veterans, their families, and caregivers"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:title",
+      "value": "News releases | Lovell Federal VA health care | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:image:alt",
+      "value": "U.S. Department of Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:image",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    }
+  ],
+  "fieldIntroText": "News releases for Lovell Federal VA health care.",
+  "reverseFieldListingNode": {
+    "entities": [
+      {
+        "entityId": "49928",
+        "title": "TEST C press release for Lovell VA",
+        "fieldReleaseDate": { "value": "2022-10-13T19:50:12" },
+        "entityUrl": {
+          "path": "/lovell-federal-va-health-care/news-releases/test-c-press-release-for-lovell-va"
+        },
+        "uid": {
+          "targetId": 1215,
+          "entity": {
+            "name": "Steve.Wirt@civicactions.com",
+            "timezone": null
+          }
+        },
+        "promote": false,
+        "created": 1664741101,
+        "fieldIntroText": "This is a press release for Lovell VA"
+      }
+    ]
+  },
+  "fieldOffice": {
+    "targetId": 49451,
+    "entity": {
+      "entityLabel": "Lovell Federal VA health care",
+      "title": "Lovell Federal VA health care"
+    }
+  },
+  "fieldAdministration": { "entity": { "entityId": "1040" } }
+}

--- a/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/va/stories.json
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/va/stories.json
@@ -1,0 +1,133 @@
+{
+  "entityBundle": "story_listing",
+  "entityId": "49631",
+  "entityPublished": true,
+  "title": "Stories",
+  "vid": 736018,
+  "entityUrl": {
+    "breadcrumb": [
+      { "url": { "path": "/", "routed": true }, "text": "Home" },
+      {
+        "url": { "path": "/lovell-federal-health-care", "routed": true },
+        "text": "Lovell Federal health care"
+      },
+      { "url": { "path": "", "routed": true }, "text": "NEWS AND EVENTS" },
+      { "url": { "path": "", "routed": true }, "text": "Stories" }
+    ],
+    "path": "/lovell-federal-va-health-care/stories"
+  },
+  "entityMetatags": [
+    {
+      "__typename": "MetaLink",
+      "key": "image_src",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "title",
+      "value": "Stories | Lovell Federal VA health care | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "description",
+      "value": "Lovell Federal VA health care top stories."
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:site_name",
+      "value": "Veterans Affairs"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:title",
+      "value": "Stories | Lovell Federal VA health care | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:description",
+      "value": "Lovell Federal VA health care top stories."
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:image",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:image:alt",
+      "value": "U.S. Department of Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:card",
+      "value": "summary_large_image"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:site",
+      "value": "@DeptVetAffairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:description",
+      "value": "Lovell Federal VA health care top stories."
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:title",
+      "value": "Stories | Lovell Federal VA health care | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:image:alt",
+      "value": "U.S. Department of Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:image",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    }
+  ],
+  "fieldIntroText": "Lovell Federal VA health care top stories.",
+  "reverseFieldListingNode": {
+    "entities": [
+      {
+        "entityId": "49931",
+        "title": "TEST story for VA Lovell",
+        "fieldFeatured": true,
+        "entityUrl": {
+          "path": "/lovell-federal-va-health-care/stories/test-story-for-va-lovell"
+        },
+        "uid": {
+          "targetId": 1215,
+          "entity": {
+            "name": "Steve.Wirt@civicactions.com",
+            "timezone": null
+          }
+        },
+        "promote": false,
+        "created": 1664741589,
+        "fieldAuthor": {
+          "entity": {
+            "title": "Jill Vinge",
+            "fieldDescription": "Caregiver Support Coordinator"
+          }
+        },
+        "fieldImageCaption": null,
+        "fieldIntroText": "This is a goodish story for now.",
+        "fieldMedia": null,
+        "fieldFullStory": {
+          "processed": "<html><head></head><body><p>This is a fun little story, but still important.</p></body></html>"
+        }
+      }
+    ]
+  },
+  "fieldOffice": {
+    "targetId": 49451,
+    "entity": {
+      "title": "Lovell Federal VA health care",
+      "entityLabel": "Lovell Federal VA health care"
+    }
+  },
+  "fieldAdministration": { "entity": { "entityId": "1040" } }
+}

--- a/src/site/stages/build/drupal/tests/lovell/fixtures/sidebar.json
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/sidebar.json
@@ -1,0 +1,629 @@
+{
+  "name": "Lovell Federal health care",
+  "description": "VISN 12 | va.gov/lovell-federal-health-care",
+  "links": [
+    {
+      "expanded": false,
+      "description": null,
+      "label": "Lovell Federal TRICARE health care",
+      "url": {
+        "path": "/lovell-federal-tricare-health-care"
+      },
+      "entity": {
+        "linkedEntity": {
+          "entityPublished": true,
+          "moderationState": "published"
+        },
+        "fieldMenuSection": "tricare"
+      },
+      "links": []
+    },
+    {
+      "expanded": false,
+      "description": null,
+      "label": "Lovell Federal VA health care",
+      "url": {
+        "path": "/lovell-federal-va-health-care"
+      },
+      "entity": {
+        "linkedEntity": {
+          "entityPublished": true,
+          "moderationState": "published"
+        },
+        "fieldMenuSection": "va"
+      },
+      "links": []
+    },
+    {
+      "expanded": false,
+      "description": null,
+      "label": "Lovell Federal health care",
+      "url": {
+        "path": "/lovell-federal-health-care"
+      },
+      "entity": {
+        "linkedEntity": {
+          "entityPublished": false,
+          "moderationState": "archived"
+        },
+        "fieldMenuSection": "both"
+      },
+      "links": [
+        {
+          "expanded": false,
+          "description": null,
+          "label": "Services and Locations",
+          "url": {
+            "path": ""
+          },
+          "entity": {
+            "linkedEntity": null,
+            "fieldMenuSection": "both"
+          },
+          "links": [
+            {
+              "expanded": false,
+              "description": null,
+              "label": "Health services",
+              "url": {
+                "path": "/lovell-federal-va-health-care/health-services"
+              },
+              "entity": {
+                "linkedEntity": {
+                  "entityPublished": true,
+                  "moderationState": "published"
+                },
+                "fieldMenuSection": "va"
+              },
+              "links": []
+            },
+            {
+              "expanded": false,
+              "description": null,
+              "label": "Health services",
+              "url": {
+                "path": "/lovell-federal-tricare-health-care/health-services"
+              },
+              "entity": {
+                "linkedEntity": {
+                  "entityPublished": true,
+                  "moderationState": "published"
+                },
+                "fieldMenuSection": "tricare"
+              },
+              "links": []
+            },
+            {
+              "expanded": false,
+              "description": null,
+              "label": "Locations",
+              "url": {
+                "path": "/lovell-federal-va-health-care/locations"
+              },
+              "entity": {
+                "linkedEntity": {
+                  "entityPublished": true,
+                  "moderationState": "published"
+                },
+                "fieldMenuSection": "va"
+              },
+              "links": [
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Captain James A. Lovell Federal Health Care Center",
+                  "url": {
+                    "path": "/lovell-federal-va-health-care/locations/captain-james-a-lovell-federal-health-care-center"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": true,
+                      "moderationState": "published"
+                    },
+                    "fieldMenuSection": "va"
+                  },
+                  "links": []
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Evanston VA Clinic",
+                  "url": {
+                    "path": "/lovell-federal-va-health-care/locations/evanston-va-clinic"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": true,
+                      "moderationState": "published"
+                    },
+                    "fieldMenuSection": "va"
+                  },
+                  "links": []
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Kenosha VA Clinic",
+                  "url": {
+                    "path": "/lovell-federal-va-health-care/locations/kenosha-va-clinic"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": true,
+                      "moderationState": "published"
+                    },
+                    "fieldMenuSection": "va"
+                  },
+                  "links": []
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "McHenry VA Clinic",
+                  "url": {
+                    "path": "/lovell-federal-va-health-care/locations/mchenry-va-clinic"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": true,
+                      "moderationState": "published"
+                    },
+                    "fieldMenuSection": "va"
+                  },
+                  "links": []
+                }
+              ]
+            },
+            {
+              "expanded": false,
+              "description": "TRICARE locations",
+              "label": "Locations",
+              "url": {
+                "path": "/lovell-federal-tricare-health-care/locations"
+              },
+              "entity": {
+                "linkedEntity": {
+                  "entityPublished": true,
+                  "moderationState": "published"
+                },
+                "fieldMenuSection": "tricare"
+              },
+              "links": [
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Captain James A. Lovell Federal TRICARE Health Care Center",
+                  "url": {
+                    "path": "/lovell-federal-tricare-health-care/locations/captain-james-a-lovell-federal-health-care-center"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": true,
+                      "moderationState": "published"
+                    },
+                    "fieldMenuSection": "tricare"
+                  },
+                  "links": []
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "USS Osborne Dental Clinic",
+                  "url": {
+                    "path": "/lovell-federal-tricare-health-care/locations/uss-osborne-dental-clinic"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": true,
+                      "moderationState": "published"
+                    },
+                    "fieldMenuSection": "tricare"
+                  },
+                  "links": []
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "USS Red Rover",
+                  "url": {
+                    "path": "/lovell-federal-tricare-health-care/locations/uss-red-rover"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": true,
+                      "moderationState": "published"
+                    },
+                    "fieldMenuSection": "tricare"
+                  },
+                  "links": []
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "USS Tranquillity",
+                  "url": {
+                    "path": "/lovell-federal-tricare-health-care/locations/uss-tranquillity"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": true,
+                      "moderationState": "published"
+                    },
+                    "fieldMenuSection": "tricare"
+                  },
+                  "links": []
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Zachary and Elizabeth Fisher Medical and Dental Clinic",
+                  "url": {
+                    "path": "/lovell-federal-tricare-health-care/locations/zachary-and-elizabeth-fisher-medical-and-dental-clinic"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": true,
+                      "moderationState": "published"
+                    },
+                    "fieldMenuSection": "tricare"
+                  },
+                  "links": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "expanded": false,
+          "description": null,
+          "label": "NEWS AND EVENTS",
+          "url": {
+            "path": ""
+          },
+          "entity": {
+            "linkedEntity": null,
+            "fieldMenuSection": "both"
+          },
+          "links": [
+            {
+              "expanded": false,
+              "description": null,
+              "label": "Events",
+              "url": {
+                "path": "/lovell-federal-va-health-care/events"
+              },
+              "entity": {
+                "linkedEntity": {
+                  "entityPublished": true,
+                  "moderationState": "published"
+                },
+                "fieldMenuSection": "va"
+              },
+              "links": []
+            },
+            {
+              "expanded": false,
+              "description": null,
+              "label": "Events",
+              "url": {
+                "path": "/lovell-federal-tricare-health-care/events"
+              },
+              "entity": {
+                "linkedEntity": {
+                  "entityPublished": true,
+                  "moderationState": "published"
+                },
+                "fieldMenuSection": "tricare"
+              },
+              "links": []
+            },
+            {
+              "expanded": false,
+              "description": null,
+              "label": "News releases",
+              "url": {
+                "path": "/lovell-federal-tricare-health-care/news-releases"
+              },
+              "entity": {
+                "linkedEntity": {
+                  "entityPublished": true,
+                  "moderationState": "published"
+                },
+                "fieldMenuSection": "tricare"
+              },
+              "links": []
+            },
+            {
+              "expanded": false,
+              "description": null,
+              "label": "News releases",
+              "url": {
+                "path": "/lovell-federal-va-health-care/news-releases"
+              },
+              "entity": {
+                "linkedEntity": {
+                  "entityPublished": true,
+                  "moderationState": "published"
+                },
+                "fieldMenuSection": "va"
+              },
+              "links": []
+            },
+            {
+              "expanded": false,
+              "description": null,
+              "label": "Stories",
+              "url": {
+                "path": "/lovell-federal-tricare-health-care/stories"
+              },
+              "entity": {
+                "linkedEntity": {
+                  "entityPublished": true,
+                  "moderationState": "published"
+                },
+                "fieldMenuSection": "tricare"
+              },
+              "links": []
+            },
+            {
+              "expanded": false,
+              "description": null,
+              "label": "Stories",
+              "url": {
+                "path": "/lovell-federal-va-health-care/stories"
+              },
+              "entity": {
+                "linkedEntity": {
+                  "entityPublished": true,
+                  "moderationState": "published"
+                },
+                "fieldMenuSection": "va"
+              },
+              "links": []
+            }
+          ]
+        },
+        {
+          "expanded": false,
+          "description": null,
+          "label": "ABOUT LOVELL FEDERAL",
+          "url": {
+            "path": ""
+          },
+          "entity": {
+            "linkedEntity": null,
+            "fieldMenuSection": "both"
+          },
+          "links": [
+            {
+              "expanded": false,
+              "description": null,
+              "label": "About us",
+              "url": {
+                "path": "/lovell-federal-va-health-care/about-us"
+              },
+              "entity": {
+                "linkedEntity": {
+                  "entityPublished": true,
+                  "moderationState": "published"
+                },
+                "fieldMenuSection": "both"
+              },
+              "links": [
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Mission and vision",
+                  "url": {
+                    "path": "/lovell-federal-va-health-care/about-us/mission-and-vision"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": true,
+                      "moderationState": "published"
+                    },
+                    "fieldMenuSection": "both"
+                  },
+                  "links": []
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "History",
+                  "url": {
+                    "path": "/lovell-federal-va-health-care/about-us/history"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": true,
+                      "moderationState": "published"
+                    },
+                    "fieldMenuSection": "both"
+                  },
+                  "links": []
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Performance",
+                  "url": {
+                    "path": "/lovell-federal-va-health-care/about-us/performance"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": true,
+                      "moderationState": "published"
+                    },
+                    "fieldMenuSection": "va"
+                  },
+                  "links": []
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Leadership",
+                  "url": {
+                    "path": "/lovell-federal-va-health-care/about-us/leadership"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": true,
+                      "moderationState": "published"
+                    },
+                    "fieldMenuSection": "both"
+                  },
+                  "links": []
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Leadership",
+                  "url": {
+                    "path": "/lovell-federal-tricare-health-care/about-us/leadership-0"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": true,
+                      "moderationState": "published"
+                    },
+                    "fieldMenuSection": "tricare"
+                  },
+                  "links": []
+                }
+              ]
+            },
+            {
+              "expanded": false,
+              "description": null,
+              "label": "Work with us",
+              "url": {
+                "path": "/lovell-federal-va-health-care/work-with-us"
+              },
+              "entity": {
+                "linkedEntity": {
+                  "entityPublished": true,
+                  "moderationState": "published"
+                },
+                "fieldMenuSection": "both"
+              },
+              "links": [
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Jobs and careers",
+                  "url": {
+                    "path": "/lovell-federal-va-health-care/work-with-us/jobs-and-careers"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": true,
+                      "moderationState": "published"
+                    },
+                    "fieldMenuSection": "both"
+                  },
+                  "links": []
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Internships and fellowships",
+                  "url": {
+                    "path": "/lovell-federal-va-health-care/work-with-us/internships-and-fellowships"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": true,
+                      "moderationState": "published"
+                    },
+                    "fieldMenuSection": "both"
+                  },
+                  "links": []
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Volunteer or donate",
+                  "url": {
+                    "path": "/lovell-federal-va-health-care/work-with-us/volunteer-or-donate"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": true,
+                      "moderationState": "published"
+                    },
+                    "fieldMenuSection": "both"
+                  },
+                  "links": []
+                }
+              ]
+            },
+            {
+              "expanded": false,
+              "description": null,
+              "label": "Contact us",
+              "url": {
+                "path": "/lovell-federal-va-health-care/contact-us"
+              },
+              "entity": {
+                "linkedEntity": {
+                  "entityPublished": true,
+                  "moderationState": "published"
+                },
+                "fieldMenuSection": "both"
+              },
+              "links": []
+            },
+            {
+              "expanded": false,
+              "description": null,
+              "label": "Policies",
+              "url": {
+                "path": "/lovell-federal-va-health-care/policies"
+              },
+              "entity": {
+                "linkedEntity": {
+                  "entityPublished": true,
+                  "moderationState": "published"
+                },
+                "fieldMenuSection": "va"
+              },
+              "links": []
+            },
+            {
+              "expanded": false,
+              "description": null,
+              "label": "Policies",
+              "url": {
+                "path": "/lovell-federal-tricare-health-care/policies"
+              },
+              "entity": {
+                "linkedEntity": {
+                  "entityPublished": true,
+                  "moderationState": "published"
+                },
+                "fieldMenuSection": "tricare"
+              },
+              "links": []
+            },
+            {
+              "expanded": false,
+              "description": null,
+              "label": "Programs",
+              "url": {
+                "path": "/lovell-federal-va-health-care/programs"
+              },
+              "entity": {
+                "linkedEntity": {
+                  "entityPublished": true,
+                  "moderationState": "published"
+                },
+                "fieldMenuSection": "both"
+              },
+              "links": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/site/stages/build/drupal/tests/lovell/listingPages.unit.spec.js
+++ b/src/site/stages/build/drupal/tests/lovell/listingPages.unit.spec.js
@@ -1,0 +1,154 @@
+import { expect } from 'chai';
+import {
+  processLovellPages,
+  isLovellVaPage,
+  isLovellTricarePage,
+} from '../../process-lovell-pages';
+// Mock Data
+import federalStories from './fixtures/listing-pages/federal/stories.json';
+import federalEvents from './fixtures/listing-pages/federal/events.json';
+import federalNews from './fixtures/listing-pages/federal/news.json';
+import tricareStories from './fixtures/listing-pages/tricare/stories.json';
+import tricareEvents from './fixtures/listing-pages/tricare/events.json';
+import tricareNews from './fixtures/listing-pages/tricare/news.json';
+import vaStories from './fixtures/listing-pages/va/stories.json';
+import vaEvents from './fixtures/listing-pages/va/events.json';
+import vaNews from './fixtures/listing-pages/va/news.json';
+import lovellFederalHealthCareFacilitySidebarQuery from './fixtures/sidebar.json';
+
+const getMergedListing = (drupalData, lovellVariant, listingVariant) => {
+  return drupalData.data.nodeQuery.entities
+    .filter(page => {
+      if (lovellVariant === 'tricare') {
+        return isLovellTricarePage(page);
+      }
+      if (lovellVariant === 'va') {
+        return isLovellVaPage(page);
+      }
+
+      return false;
+    })
+    .filter(page => page.entityBundle === `${listingVariant}_listing`)[0];
+};
+
+describe('processLovelPages (listing pages)', () => {
+  let counts;
+  let drupalData;
+
+  before(() => {
+    counts = {
+      federal: {
+        stories: federalStories.reverseFieldListingNode.entities.length,
+        events: {
+          past: federalEvents.pastEvents.entities.length,
+          all: federalEvents.reverseFieldListingNode.entities.length,
+        },
+        news: federalNews.reverseFieldListingNode.entities.length,
+      },
+      tricare: {
+        stories: tricareStories.reverseFieldListingNode.entities.length,
+        events: {
+          past: tricareEvents.pastEvents.entities.length,
+          all: tricareEvents.reverseFieldListingNode.entities.length,
+        },
+        news: tricareNews.reverseFieldListingNode.entities.length,
+      },
+      va: {
+        stories: vaStories.reverseFieldListingNode.entities.length,
+        events: {
+          past: vaEvents.pastEvents.entities.length,
+          all: vaEvents.reverseFieldListingNode.entities.length,
+        },
+        news: vaNews.reverseFieldListingNode.entities.length,
+      },
+    };
+
+    drupalData = {
+      data: {
+        lovellFederalHealthCareFacilitySidebarQuery,
+        nodeQuery: {
+          entities: [
+            federalStories,
+            federalNews,
+            federalEvents,
+            tricareStories,
+            tricareEvents,
+            tricareNews,
+            vaStories,
+            vaEvents,
+            vaNews,
+          ],
+        },
+      },
+    };
+
+    processLovellPages(drupalData);
+  });
+
+  describe('stories listing pages', () => {
+    it('correctly merges Federal and Tricare stories for Tricare listing page', () => {
+      const mergedStories = getMergedListing(drupalData, 'tricare', 'story');
+      const mergedStoryCount =
+        mergedStories.reverseFieldListingNode.entities.length;
+      expect(mergedStoryCount).to.equal(
+        counts.federal.stories + counts.tricare.stories,
+      );
+    });
+    it('correctly merges Federal and VA stories for VA listing page', () => {
+      const mergedStories = getMergedListing(drupalData, 'va', 'story');
+      const mergedStoryCount =
+        mergedStories.reverseFieldListingNode.entities.length;
+      expect(mergedStoryCount).to.equal(
+        counts.federal.stories + counts.va.stories,
+      );
+    });
+  });
+
+  describe('events listing pages', () => {
+    it('correctly merges Federal and Tricare events for Tricare listing page', () => {
+      const mergedEvents = getMergedListing(drupalData, 'tricare', 'event');
+      const mergedAllEventsCount =
+        mergedEvents.reverseFieldListingNode.entities.length;
+      const mergedPastEventsCount = mergedEvents.pastEvents.entities.length;
+      expect(mergedAllEventsCount).to.equal(
+        counts.federal.events.all + counts.tricare.events.all,
+      );
+      expect(mergedPastEventsCount).to.equal(
+        counts.federal.events.past + counts.tricare.events.past,
+      );
+    });
+    it('correctly merges Federal and VA events for VA listing page', () => {
+      const mergedEvents = getMergedListing(drupalData, 'va', 'event');
+      const mergedAllEventsCount =
+        mergedEvents.reverseFieldListingNode.entities.length;
+      const mergedPastEventsCount = mergedEvents.pastEvents.entities.length;
+      expect(mergedAllEventsCount).to.equal(
+        counts.federal.events.all + counts.va.events.all,
+      );
+      expect(mergedPastEventsCount).to.equal(
+        counts.federal.events.past + counts.va.events.past,
+      );
+    });
+  });
+
+  describe('press-release listing pages', () => {
+    it('correctly merges Federal and Tricare press releases for Tricare listing page', () => {
+      const mergedNews = getMergedListing(
+        drupalData,
+        'tricare',
+        'press_releases',
+      );
+      const mergedNewsCount =
+        mergedNews.reverseFieldListingNode.entities.length;
+      expect(mergedNewsCount).to.equal(
+        counts.federal.news + counts.tricare.news,
+      );
+    });
+    it('correctly merges Federal and VA press releases for VA listing page', () => {
+      const mergedNews = getMergedListing(drupalData, 'va', 'press_releases');
+      const mergedNewsCount =
+        mergedNews.reverseFieldListingNode.entities.length;
+      expect(mergedNewsCount).to.equal(counts.federal.news + counts.va.news);
+    });
+  });
+});

--- a/src/site/stages/build/drupal/tests/lovell/listingPages.unit.spec.js
+++ b/src/site/stages/build/drupal/tests/lovell/listingPages.unit.spec.js
@@ -1,3 +1,5 @@
+/* eslint-disable @department-of-veterans-affairs/axe-check-required */
+/* eslint-disable camelcase */
 import { expect } from 'chai';
 import {
   processLovellPages,
@@ -16,6 +18,17 @@ import vaEvents from './fixtures/listing-pages/va/events.json';
 import vaNews from './fixtures/listing-pages/va/news.json';
 import lovellFederalHealthCareFacilitySidebarQuery from './fixtures/sidebar.json';
 
+const entityBundleFromListingVariant = listingVariant => {
+  let prefix = listingVariant;
+  if (listingVariant === 'stories') {
+    prefix = 'story';
+  } else if (listingVariant === 'events') {
+    prefix = 'event';
+  }
+
+  return `${prefix}_listing`;
+};
+
 const getMergedListing = (drupalData, lovellVariant, listingVariant) => {
   return drupalData.data.nodeQuery.entities
     .filter(page => {
@@ -28,11 +41,19 @@ const getMergedListing = (drupalData, lovellVariant, listingVariant) => {
 
       return false;
     })
-    .filter(page => page.entityBundle === `${listingVariant}_listing`)[0];
+    .filter(
+      page =>
+        page.entityBundle === entityBundleFromListingVariant(listingVariant),
+    )[0];
+};
+
+const stringArraysContainSameElements = (a, b) => {
+  return a.sort().join(',') === b.sort().join(',');
 };
 
 describe('processLovelPages (listing pages)', () => {
   let counts;
+  let titles;
   let drupalData;
 
   before(() => {
@@ -43,7 +64,7 @@ describe('processLovelPages (listing pages)', () => {
           past: federalEvents.pastEvents.entities.length,
           all: federalEvents.reverseFieldListingNode.entities.length,
         },
-        news: federalNews.reverseFieldListingNode.entities.length,
+        press_releases: federalNews.reverseFieldListingNode.entities.length,
       },
       tricare: {
         stories: tricareStories.reverseFieldListingNode.entities.length,
@@ -51,7 +72,7 @@ describe('processLovelPages (listing pages)', () => {
           past: tricareEvents.pastEvents.entities.length,
           all: tricareEvents.reverseFieldListingNode.entities.length,
         },
-        news: tricareNews.reverseFieldListingNode.entities.length,
+        press_releases: tricareNews.reverseFieldListingNode.entities.length,
       },
       va: {
         stories: vaStories.reverseFieldListingNode.entities.length,
@@ -59,7 +80,52 @@ describe('processLovelPages (listing pages)', () => {
           past: vaEvents.pastEvents.entities.length,
           all: vaEvents.reverseFieldListingNode.entities.length,
         },
-        news: vaNews.reverseFieldListingNode.entities.length,
+        press_releases: vaNews.reverseFieldListingNode.entities.length,
+      },
+    };
+
+    titles = {
+      federal: {
+        stories: federalStories.reverseFieldListingNode.entities.map(
+          entity => entity.title,
+        ),
+        events: {
+          past: federalEvents.pastEvents.entities.map(entity => entity.title),
+          all: federalEvents.reverseFieldListingNode.entities.map(
+            entity => entity.title,
+          ),
+        },
+        press_releases: federalNews.reverseFieldListingNode.entities.map(
+          entity => entity.title,
+        ),
+      },
+      tricare: {
+        stories: tricareStories.reverseFieldListingNode.entities.map(
+          entity => entity.title,
+        ),
+        events: {
+          past: tricareEvents.pastEvents.entities.map(entity => entity.title),
+          all: tricareEvents.reverseFieldListingNode.entities.map(
+            entity => entity.title,
+          ),
+        },
+        press_releases: tricareNews.reverseFieldListingNode.entities.map(
+          entity => entity.title,
+        ),
+      },
+      va: {
+        stories: vaStories.reverseFieldListingNode.entities.map(
+          entity => entity.title,
+        ),
+        events: {
+          past: vaEvents.pastEvents.entities.map(entity => entity.title),
+          all: vaEvents.reverseFieldListingNode.entities.map(
+            entity => entity.title,
+          ),
+        },
+        press_releases: vaNews.reverseFieldListingNode.entities.map(
+          entity => entity.title,
+        ),
       },
     };
 
@@ -85,70 +151,93 @@ describe('processLovelPages (listing pages)', () => {
     processLovellPages(drupalData);
   });
 
-  describe('stories listing pages', () => {
-    it('correctly merges Federal and Tricare stories for Tricare listing page', () => {
-      const mergedStories = getMergedListing(drupalData, 'tricare', 'story');
-      const mergedStoryCount =
-        mergedStories.reverseFieldListingNode.entities.length;
-      expect(mergedStoryCount).to.equal(
-        counts.federal.stories + counts.tricare.stories,
-      );
-    });
-    it('correctly merges Federal and VA stories for VA listing page', () => {
-      const mergedStories = getMergedListing(drupalData, 'va', 'story');
-      const mergedStoryCount =
-        mergedStories.reverseFieldListingNode.entities.length;
-      expect(mergedStoryCount).to.equal(
-        counts.federal.stories + counts.va.stories,
-      );
-    });
-  });
+  const testMergedListingCounts = (
+    mergedListing,
+    lovellVariant,
+    listingVariant,
+  ) => {
+    const mergedListingCount =
+      mergedListing.reverseFieldListingNode.entities.length;
+    const expectedMergedListingCount =
+      listingVariant === 'events'
+        ? counts.federal.events.all + counts[lovellVariant].events.all
+        : counts.federal[listingVariant] +
+          counts[lovellVariant][listingVariant];
+    expect(mergedListingCount).to.equal(expectedMergedListingCount);
+  };
 
-  describe('events listing pages', () => {
-    it('correctly merges Federal and Tricare events for Tricare listing page', () => {
-      const mergedEvents = getMergedListing(drupalData, 'tricare', 'event');
-      const mergedAllEventsCount =
-        mergedEvents.reverseFieldListingNode.entities.length;
-      const mergedPastEventsCount = mergedEvents.pastEvents.entities.length;
-      expect(mergedAllEventsCount).to.equal(
-        counts.federal.events.all + counts.tricare.events.all,
-      );
-      expect(mergedPastEventsCount).to.equal(
-        counts.federal.events.past + counts.tricare.events.past,
-      );
-    });
-    it('correctly merges Federal and VA events for VA listing page', () => {
-      const mergedEvents = getMergedListing(drupalData, 'va', 'event');
-      const mergedAllEventsCount =
-        mergedEvents.reverseFieldListingNode.entities.length;
-      const mergedPastEventsCount = mergedEvents.pastEvents.entities.length;
-      expect(mergedAllEventsCount).to.equal(
-        counts.federal.events.all + counts.va.events.all,
-      );
-      expect(mergedPastEventsCount).to.equal(
-        counts.federal.events.past + counts.va.events.past,
-      );
-    });
-  });
+  const testMergedListingTitles = (
+    mergedListing,
+    lovellVariant,
+    listingVariant,
+  ) => {
+    const mergedListingTitles = mergedListing.reverseFieldListingNode.entities.map(
+      entity => entity.title,
+    );
+    const expectedMergedListingTitles =
+      listingVariant === 'events'
+        ? [
+            ...titles.federal[listingVariant].all,
+            ...titles[lovellVariant][listingVariant].all,
+          ]
+        : [
+            ...titles.federal[listingVariant],
+            ...titles[lovellVariant][listingVariant],
+          ];
+    expect(
+      stringArraysContainSameElements(
+        mergedListingTitles,
+        expectedMergedListingTitles,
+      ),
+    ).to.be.true;
+  };
 
-  describe('press-release listing pages', () => {
-    it('correctly merges Federal and Tricare press releases for Tricare listing page', () => {
-      const mergedNews = getMergedListing(
-        drupalData,
-        'tricare',
-        'press_releases',
-      );
-      const mergedNewsCount =
-        mergedNews.reverseFieldListingNode.entities.length;
-      expect(mergedNewsCount).to.equal(
-        counts.federal.news + counts.tricare.news,
-      );
-    });
-    it('correctly merges Federal and VA press releases for VA listing page', () => {
-      const mergedNews = getMergedListing(drupalData, 'va', 'press_releases');
-      const mergedNewsCount =
-        mergedNews.reverseFieldListingNode.entities.length;
-      expect(mergedNewsCount).to.equal(counts.federal.news + counts.va.news);
+  const testMergedPastEvents = (mergedEvents, lovellVariant) => {
+    const mergedPastEventsCount = mergedEvents.pastEvents.entities.length;
+    expect(mergedPastEventsCount).to.equal(
+      counts.federal.events.past + counts[lovellVariant].events.past,
+    );
+
+    const mergedPastEventTitles = mergedEvents.pastEvents.entities.map(
+      entity => entity.title,
+    );
+    const expectedPastEventTitles = [
+      ...titles.federal.events.past,
+      ...titles[lovellVariant].events.past,
+    ];
+    expect(
+      stringArraysContainSameElements(
+        mergedPastEventTitles,
+        expectedPastEventTitles,
+      ),
+    ).to.be.true;
+  };
+
+  // Create tests for each of six (6) listing pages
+  // - VA Stories
+  // - VA Events
+  // - VA Press Releases
+  // - Tricare Stories
+  // - Tricare Events
+  // - Tricare Press Releases
+  ['stories', 'events', 'press_releases'].forEach(listingVariant => {
+    describe(`${listingVariant} listing pages`, () => {
+      ['va', 'tricare'].forEach(lovellVariant => {
+        it(`correctly merges federal and ${lovellVariant} ${listingVariant} for ${lovellVariant} listing page`, () => {
+          const mergedListing = getMergedListing(
+            drupalData,
+            lovellVariant,
+            listingVariant,
+          );
+
+          testMergedListingCounts(mergedListing, lovellVariant, listingVariant);
+          testMergedListingTitles(mergedListing, lovellVariant, listingVariant);
+
+          if (listingVariant === 'events') {
+            testMergedPastEvents(mergedListing, lovellVariant);
+          }
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
## Description
closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11996

Listing pages (stories, events, news) for Lovell Health Care are created by combining the entities from the Lovell Federal listing pages with the entities from the Lovell Tricare and Lovell VA listing pages. Entities on Lovell Federal should ultimately be displayed on both Lovell Tricare and Lovell VA listing pages so that a listing page for Lovell Tricare, for example, is comprised of entities that are specific to Tricare _combined with_ entities that are defined at the Federal level.

This PR adds unit tests to confirm that the Lovell-specific processing correctly handles things as described above.

## Testing done & Screenshots
This PR is entirely focused on creating tests. The tests all pass with the created fixtures.


## QA steps
Locally
1. `yarn test:unit src/site/stages/build/drupal/tests/lovell/listingPages.unit.spec.js`
   - [ ] Validate that there are six (6) passing tests and no failing tests.

On review instance
1. Examine unit tests
   - [ ] Validate that the six (6) tests in question pass.
