### PR TITLE
12100 Change order of new spotlight block columns for better 508

### DIFF
--- a/src/site/includes/news-spotlight.drupal.liquid
+++ b/src/site/includes/news-spotlight.drupal.liquid
@@ -3,7 +3,7 @@
   <div class="vads-l-grid-container vads-u-padding-x--0 homepage-blog">
     <div class="vads-l-row vads-u-flex-direction--row-reverse">
 
-      <!-- start second column -->
+      <!-- start first column -->
       <div class="vads-l-col--12 medium-screen:vads-l-col--8">
         <div
           class="vads-u-padding--2p5 small-desktop-screen:vads-u-padding--6 small-desktop-screen:vads-u-padding-right--0 vads-u-color--white">
@@ -40,8 +40,8 @@
           </div>
         </div>
       </div>
-      <!-- end second column -->
-      <!-- start first column-->
+      <!-- end first column -->
+      <!-- start second column-->
       <div
         class="vads-l-col--12 vads-u-display--none small-desktop-screen:vads-u-display--block medium-screen:vads-l-col--4">
         <div class="homepage-blog__image">
@@ -51,7 +51,7 @@
           {% endif %}
         </div>
       </div>
-      <!-- end first column -->
+      <!-- end second column -->
     </div>
   </div>
 </div>

--- a/src/site/includes/news-spotlight.drupal.liquid
+++ b/src/site/includes/news-spotlight.drupal.liquid
@@ -1,9 +1,19 @@
 <!-- Blog Promo -->
 <div class="vads-u-background-color--primary-darker">
   <div class="vads-l-grid-container vads-u-padding-x--0 homepage-blog">
-    <div class="vads-l-row vads-u-flex-direction--row-reverse">
+    <div class="vads-l-row">
+      <!-- start first column-->
+      <div
+        class="vads-l-col--12 vads-u-display--none small-desktop-screen:vads-u-display--block medium-screen:vads-l-col--4">
+        <div class="homepage-blog__image">
+          {% if fieldImage.entity.image.derivative.url and fieldImage.entity.image.alt %}
+            <img class="lazy" src="{{ fieldImage.entity.image.derivative.url }}" alt="" />
+          {% endif %}
+        </div>
+      </div>
+      <!-- end first column -->
 
-      <!-- start first column -->
+      <!-- start second column -->
       <div class="vads-l-col--12 medium-screen:vads-l-col--8">
         <div
           class="vads-u-padding--2p5 small-desktop-screen:vads-u-padding--6 small-desktop-screen:vads-u-padding-right--0 vads-u-color--white">
@@ -38,17 +48,6 @@
               <i class="fas fa-chevron-right vads-u-margin-left--1" role="presentation"></i>
             </a>
           </div>
-        </div>
-      </div>
-      <!-- end first column -->
-      <!-- start second column-->
-      <div
-        class="vads-l-col--12 vads-u-display--none small-desktop-screen:vads-u-display--block medium-screen:vads-l-col--4">
-        <div class="homepage-blog__image">
-          {% if fieldImage.entity.image.derivative.url and fieldImage.entity.image.alt %}
-            <img class="lazy" src="{{ fieldImage.entity.image.derivative.url }}"
-              alt="{{ fieldImage.entity.image.alt }}" />
-          {% endif %}
         </div>
       </div>
       <!-- end second column -->

--- a/src/site/includes/news-spotlight.drupal.liquid
+++ b/src/site/includes/news-spotlight.drupal.liquid
@@ -1,18 +1,7 @@
 <!-- Blog Promo -->
 <div class="vads-u-background-color--primary-darker">
   <div class="vads-l-grid-container vads-u-padding-x--0 homepage-blog">
-    <div class="vads-l-row">
-      <!-- start first column-->
-      <div
-        class="vads-l-col--12 vads-u-display--none small-desktop-screen:vads-u-display--block medium-screen:vads-l-col--4">
-        <div class="homepage-blog__image">
-          {% if fieldImage.entity.image.derivative.url and fieldImage.entity.image.alt %}
-            <img class="lazy" src="{{ fieldImage.entity.image.derivative.url }}"
-              alt="{{ fieldImage.entity.image.alt }}" />
-          {% endif %}
-        </div>
-      </div>
-      <!-- end first column -->
+    <div class="vads-l-row vads-u-flex-direction--row-reverse">
 
       <!-- start second column -->
       <div class="vads-l-col--12 medium-screen:vads-l-col--8">
@@ -52,6 +41,17 @@
         </div>
       </div>
       <!-- end second column -->
+      <!-- start first column-->
+      <div
+        class="vads-l-col--12 vads-u-display--none small-desktop-screen:vads-u-display--block medium-screen:vads-l-col--4">
+        <div class="homepage-blog__image">
+          {% if fieldImage.entity.image.derivative.url and fieldImage.entity.image.alt %}
+            <img class="lazy" src="{{ fieldImage.entity.image.derivative.url }}"
+              alt="{{ fieldImage.entity.image.alt }}" />
+          {% endif %}
+        </div>
+      </div>
+      <!-- end first column -->
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Description
The ordering of the News Spotlight section of the new homepage needed to be reversed to allow the text content to come before the image in the markup, thus allowing a better screen reader experience. 

The solution was to reverse the flec-order of the containing row and then to place the image column second in the mark up. This allowed for screenreaders to catch to relavent h2 before attempting to read the image alt-text.

closes department-of-veterans-affairs/va.gov-cms/issues/12100
closes department-of-veterans-affairs/va.gov-team/issues/51185

## Testing done & Screenshots
Manual visual testing to assure order is visually the same, but semantically reversed
<img width="1193" alt="Screenshot 2023-01-03 at 11 57 23 AM" src="https://user-images.githubusercontent.com/732460/210414241-cfabfceb-f346-4bae-acfe-cbdbf81cdff6.png">


## QA steps
Assure that visually the image comes before the text content, but in the mark up, the text content comes first.


## Acceptance criteria
- [x] VA News promo image semantically follows the header
- [x] Screen reader users hear image attributes read after hearing section header read
- [ ] When complete / verified, close https://github.com/department-of-veterans-affairs/va.gov-team/issues/51185 as well

## Definition of done
- [n/a] Events are logged appropriately
- [n/a] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
