### PR TITLE
11392 adds role=list to search tools and top pages lists

### DIFF
--- a/src/site/includes/common-tasks.drupal.liquid
+++ b/src/site/includes/common-tasks.drupal.liquid
@@ -18,7 +18,7 @@
             Other search tools
           </h3>
           <div class="homepage-common-tasks__search-tools">
-            <ul class="vads-u-padding-left--0">
+            <ul class="vads-u-padding-left--0" role="list">
               {% if searchLinks %}
                 {% for link in searchLinks %}
                   {% if link.url.path and link.label %}
@@ -43,7 +43,7 @@
           <h2 class="vads-u-color--gray-dark vads-u-font-family--serif">
             Top Pages
           </h2>
-          <ul class="homepage-common-tasks__list vads-u-padding-left--0 ">
+          <ul class="homepage-common-tasks__list vads-u-padding-left--0 " role="list">
             {% if popularLinks %}
               {% for link in popularLinks%}
                 {% if link.url.path and link.label %}


### PR DESCRIPTION
## Description
This PR adds attributes of "role='list'" to the new Homepage's Other Search Tools and Top Pages list of links for improved accessibility

closes department-of-veterans-affairs/va.gov-cms/issues/11392
 
## Testing done & Screenshots

<img width="937" alt="Screenshot 2023-01-03 at 3 14 08 PM" src="https://user-images.githubusercontent.com/732460/210442871-f435052c-5a39-4337-8bf0-18dc9d06e5f0.png">


## QA steps

Check the UL elements for both the Other Search Tools and Top Pages lists and validate that they both have the role="list" attribute. 

## Acceptance criteria
- [x] Top Pages menu ul includes `role="list"`
- [x] Other Search Tools menu ul includes `role="list"`
- [x] Accessibility review required

## Definition of done
- [n/a] Events are logged appropriately
- [n/a] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
