### PR TITLE
11823 adds sr-only text for news spotlight cta

### DIFF
--- a/src/site/includes/news-spotlight.drupal.liquid
+++ b/src/site/includes/news-spotlight.drupal.liquid
@@ -38,6 +38,9 @@
                 onclick="recordEvent({ event: 'homepage-news-promo-click', action: 'Homepage news promo - {{  fieldPromoHeadline }} - CTA' })"
                 href="{{ fieldLink.url.path }}" class="vads-u-color--white">
                 {{fieldLinkLabel}}
+                <span class="sr-only">
+                  about {{fieldPromoHeadline}}
+                </span>
               </a>
             {% endif %}
           </p>


### PR DESCRIPTION
## Description
This PR adds additional screen reader-only text to specify the destination of the Call To Action link at the end of the Homepage News Spotlight section.

closes department-of-veterans-affairs/va.gov-cms/issues/11823

## Testing done & Screenshots

<img width="959" alt="Screenshot 2023-01-03 at 4 25 00 PM" src="https://user-images.githubusercontent.com/732460/210451411-ce75f3b9-b408-4407-b845-75c804feae78.png">

## QA steps

Validate that Screen reader-only text has been added that reads "Read the full article about [Article Title]"



## Acceptance criteria

- [x] A &lt;span&gt; is added with class="sr-only" that is only available to screen readers (visual users will not see this additional text)
- [x] This span should dynamically pull in the text of the H3 title above
- [x] There should all be a hardcoded "about" so the full link would be announced as "Read the full article ABOUT [title of the article]"

## Definition of done
- [n/a] Events are logged appropriately
- [n/a] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
