### PR TITLE
12138 Removed PDF Expiration Alert

### DIFF
--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -69,20 +69,6 @@
           {% endif %}
         </dl>
 
-        {% if fieldVaFormIssueDate %}
-          {% assign showPDFCertAlert = '2022-03-01'| isLaterThan: fieldVaFormIssueDate.value %}
-          {% if showPDFCertAlert %}
-            <va-alert status="info">
-              <h2 slot="headline">
-                We’re updating this form
-              </h2>
-              <p>
-                If you download this form now, you won't be able to use it after January 7, 2023. You can download a new copy in January.
-              </p>
-            </va-alert>
-          {% endif %}
-        {% endif %}
-
         {% if fieldVaFormUsage %}
           <h2 class="vads-u-margin-top--4" data-testid="va_form--when-to-use-this-form-header">When to use this form</h3>
           {% if fieldVaFormLanguage %}


### PR DESCRIPTION
## Description
This PR removed entirely the Find Forms results pages.

closes department-of-veterans-affairs/va.gov-cms/issues/12138


## Testing done & Screenshots
Manual testing

## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

1. Visits /find-forms  and perform a search for any form.
2. Then click thru the form detail page.
   - [ ] Validate an Alert warning about PDF certificate expirations does not appear at the top.
3. Then validate Acceptance Criteria from issue department-of-veterans-affairs/va.gov-cms/issues/12138


## Acceptance criteria

- [ ] Search page – info alert updated (see PR here: department-of-veterans-affairs/vets-website/pull/23051)
- [ ] Form Detail page – remove alert completely

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
