### PR TITLE
VACMS-12064 update "in the spotlight" facility header

### DIFF
--- a/src/site/paragraphs/facilities/list_of_link_teasers_facility.drupal.liquid
+++ b/src/site/paragraphs/facilities/list_of_link_teasers_facility.drupal.liquid
@@ -7,7 +7,7 @@
 {% endcomment %}
 {% if paragraph != empty %}
   <section data-template="paragraphs/list_of_link_teasers_facility" data-entity-id="{{ paragraph.entityId }}" class="feature vads-u-padding-x--2 small-screen:vads-u-padding-x--4 vads-u-padding-top--3 vads-u-padding-bottom--2">
-    <h2 class="vads-u-margin-bottom--2">
+    <h2 class="vads-u-margin-bottom--2 vads-u-font-size--h3">
         {% if regionNickname != empty %}
             In the spotlight at {{ regionNickname }}
         {% else %}

--- a/src/site/paragraphs/facilities/list_of_link_teasers_facility.drupal.liquid
+++ b/src/site/paragraphs/facilities/list_of_link_teasers_facility.drupal.liquid
@@ -7,13 +7,13 @@
 {% endcomment %}
 {% if paragraph != empty %}
   <section data-template="paragraphs/list_of_link_teasers_facility" data-entity-id="{{ paragraph.entityId }}" class="feature vads-u-padding-x--2 small-screen:vads-u-padding-x--4 vads-u-padding-top--3 vads-u-padding-bottom--2">
-    <h3 class="vads-u-margin-bottom--2">
+    <h2 class="vads-u-margin-bottom--2">
         {% if regionNickname != empty %}
             In the spotlight at {{ regionNickname }}
         {% else %}
             {{ paragraph.fieldTitle }}
         {% endif %}
-    </h3>
+    </h2>
 
     <div class="va-c-list-link-teasers">
       <div class="usa-grid usa-grid-full vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row">


### PR DESCRIPTION
## Description

closes [#12064](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12064)

Updates the "In the spotlight" header to be an h2, with existing h3 styles.

## Testing done & Screenshots
Verified that the header size for this section was an h2 instead of h3, but styled as it was still an h3.

![Screen Shot 2023-01-05 at 8 38 10 AM](https://user-images.githubusercontent.com/11279744/210833291-08bca0e7-cb1a-41d3-b64b-484da5e1abb8.png)


## QA steps

What needs to be checked to prove this works?  
- Check system pages for Lovell TRICARE, Lovell VA, and non-Lovell system and see the "In the spotlight" is the correct size while also being a semantically correct h2.

http://localhost:3002/lovell-federal-tricare-health-care/
http://localhost:3002/lovell-federal-va-health-care/
http://localhost:3002/new-mexico-health-care/

## Acceptance criteria

- [ ] "In the spotlight" header is an h2 with the h3 styles.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
