### PR TITLE
Updated GA events

### DIFF
--- a/src/site/includes/common-tasks.drupal.liquid
+++ b/src/site/includes/common-tasks.drupal.liquid
@@ -24,8 +24,16 @@
                   {% if link.url.path and link.label %}
                     <li>
                       <i role="presentation" class="fas fa-arrow-right vads-u-color--link-default vads-u-margin-right--1"></i>
-                      <a
+                      <!-- Uncomment custom event and delete generic once analytics team implements -->
+                      <!-- <a
                         onclick="recordEvent({ event: 'homepage-search-tools-click', action: 'Other search tools - {{link.label}}' })"
+                        href="{{ link.url.path }}">{{ link.label }}</a> -->
+                        <a
+                        onclick="recordEvent({
+                          event: 'nav-zone-one',
+                          'nav-path': '->{% if link.url.path != empty %}{{ link.url.path }}{% else %}{{ link.label }}{% endif %}',
+                          'click-text': '{{ link.label | strip }}',
+                        });"
                         href="{{ link.url.path }}">{{ link.label }}</a>
                     </li>
                   {% endif %}
@@ -41,15 +49,23 @@
       <div class="vads-l-col--12 medium-screen:vads-l-col--6">
         <div class="vads-u-padding-left--2p5 medium-screen:vads-u-padding-left--6 vads-u-padding-bottom--5">
           <h2 class="vads-u-color--gray-dark vads-u-font-family--serif">
-            Top Pages
+            Top pages
           </h2>
           <ul class="homepage-common-tasks__list vads-u-padding-left--0 " role="list">
             {% if popularLinks %}
               {% for link in popularLinks%}
                 {% if link.url.path and link.label %}
                   <li>
-                    <a
+                    <!-- Uncomment custom event and delete generic once analytics team implements -->
+                    <!-- <a
                       onclick="recordEvent({ event: 'homepage-popular-links-click', action: 'Top Pages - {{link.label}}' })"
+                      href="{{ link.url.path }}">{{ link.label }}</a> -->
+                      <a
+                      onclick="recordEvent({
+                        event: 'nav-zone-one',
+                        'nav-path': '->{% if link.url.path != empty %}{{ link.url.path }}{% else %}{{ link.label }}{% endif %}',
+                        'click-text': '{{ link.label | strip }}',
+                      });"
                       href="{{ link.url.path }}">{{ link.label }}</a>
                   </li>
                 {% endif %}

--- a/src/site/includes/email-update-signup.drupal.liquid
+++ b/src/site/includes/email-update-signup.drupal.liquid
@@ -25,8 +25,11 @@
                          autocomplete="email"
                          class="vads-u-width--full
                                 medium-screen:vads-u-width-auto" />
+                  <!--Uncomment custom event and delete generic event when analytics team implelements custom-->
+                  <!-- <button
+                    onclick="recordEvent({ event: 'homepage-email-sign-up', action: 'Homepage email sign up' })" -->
                   <button
-                    onclick="recordEvent({ event: 'homepage-email-sign-up', action: 'Homepage email sign up' })"
+                    onclick="recordEvent({ event: 'cta-button-click', 'button-type': 'primary', 'button-click-label': 'Sign up',  });"
                     type="submit"
                     class="vads-u-width--full
                           medium-screen:vads-u-width--auto

--- a/src/site/includes/hero.drupal.liquid
+++ b/src/site/includes/hero.drupal.liquid
@@ -58,7 +58,11 @@
             <button class="vads-u-padding-x--4 vads-u-margin-bottom--3" onclick="openLoginModal()">
               Create account
             </button>
-            <a href="/resources/creating-an-account-for-vagov">
+            <a 
+              href="/resources/creating-an-account-for-vagov"
+              onclick="recordEvent({ event: 'cta-button-click', 'button-type': 'secondary', 'button-click-label': 'Learn how an account helps you',  });"
+
+            >
               Learn how an account helps you
             </a>
           </div>

--- a/src/site/includes/hero.drupal.liquid
+++ b/src/site/includes/hero.drupal.liquid
@@ -38,7 +38,10 @@
       <!-- start second column for  bplogin card -->
       <script>
         function openLoginModal() {
-          recordEvent({ event: "homepage-create-account", action: "Homepage Create Account CTA" });
+          // Uncomment custom event and delete generic event once analytics team has implemented
+          // recordEvent({ event: "homepage-create-account", action: "Homepage Create Account CTA" });
+          recordEvent({ event: 'cta-button-click', 'button-type': 'primary', 'button-click-label': 'Create Account',  });
+          
           const params = (new URL(document.location)).searchParams;
           params.set("next", "loginModal")
           document.location = "?" + params.toString();

--- a/src/site/includes/news-spotlight.drupal.liquid
+++ b/src/site/includes/news-spotlight.drupal.liquid
@@ -45,11 +45,20 @@
           </p>
 
           <div>
-            <a
+            <!-- <a
               onclick="recordEvent({ event: 'homepage-news-promo-more-news-click', action: 'Homepage news promo - More VA News' })"
               href="https://news.va.gov/" class="vads-u-color--white">More VA news
               <i class="fas fa-chevron-right vads-u-margin-left--1" role="presentation"></i>
-            </a>
+            </a> -->
+            <a
+            onclick="recordEvent({
+              event: 'nav-zone-one',
+              'nav-path': '->{% if fieldLink.url.path != empty %}{{ fieldLink.url.path }}{% else %}{{ fieldLinkLabel }}{% endif %}',
+              'click-text': '{{ fieldLinkLabel | strip }}',
+            });"
+            href="https://news.va.gov/" class="vads-u-color--white">More VA news
+            <i class="fas fa-chevron-right vads-u-margin-left--1" role="presentation"></i>
+          </a>
           </div>
         </div>
       </div>
@@ -58,3 +67,5 @@
   </div>
 </div>
 <!-- /Blog promo -->
+
+


### PR DESCRIPTION
## Description

relates to #12065

## Testing done & Screenshots
Local testing in console with AdSwerve


## QA steps

Click the changed links and verify the GA events work with either the AdSwerve extention or dev tools network tab


## Acceptance criteria

- [x] Custom events implemented previously _are not altered nor removed_. (They've been left in code, but commented out with instructions on what to remove once analytics team has implemented our custom events) 
- [x] Possibly not documented elsewhere: GA event for the link in Create Account block, "Learn how an account helps you"
- [ ] Events detailed in "AC" text of Mural above:
  - [x] "Create Account" button has a Primary Button Click event, e.g. the "Feedback" button on the existing HP: `ec: Interactions ea: Default Button CTA - [button text] - [optional: button color]`
  - [ ] Search input in-page gets same GA event as header search, e.g. `ec: Search ea: Search Results Returned ~ Type Ahead Enabled ~ All VA.gov ~ [search term input] el: view_search_results`. (This AC will be addressed in a seperate vets-website PR)
  - [x] Other search tools links get same GA as "zone one" links on existing HP (i.e., the 4 boxes): `ec: Interactions ea: Navigation - Zone One - ->[optional: path of destination] - [required: link text] - [optional/not defined]`
  - [x] "Top pages" links get same GA as "zone one" links on existing HP (i.e., the 4 boxes): `ec: Interactions ea: Navigation - Zone One - ->[optional: path of destination] - [required: link text] - [optional/not defined]`
  - [x] Random fix: changed "Top Pages" header text to "Top pages" (sentence case)
  - [x] News promo ("Pathfinder...") links all tracked as "zone one" 
    - [x] Block title
    - [x] "read full article"
    - [x] "More VA news"
  - [x] "Sign up" button for newsletter gets "primary button click" similar to Feedback button: `ec: Interactions ea: Default Button CTA - [button text] - [optional: button color]` 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
