### PR TITLE
[VA-12013] Refacter `getModifiedLovellPage` function

### DIFF
--- a/src/site/stages/build/drupal/lovell/helpers.js
+++ b/src/site/stages/build/drupal/lovell/helpers.js
@@ -45,24 +45,15 @@ function getLovellTitleVariation(variant) {
     : LOVELL_TRICARE_TITLE_VARIATION;
 }
 
-function getLovellUrl(urlVar) {
-  return `/lovell-federal-${urlVar}-health-care`;
+function getLovellUrl(linkVar) {
+  return `/lovell-federal-${linkVar}-health-care`;
 }
 
-function getLovellFormOfExistingUrl(url, urlVar) {
-  return url.replace(LOVELL_BASE_URL, getLovellUrl(urlVar));
-}
-
-function resetToFederalUrlIfNeeded(path, variant) {
-  const oppositeVariant =
-    variant === 'va' ? LOVELL_TRICARE_LINK_VARIATION : LOVELL_VA_LINK_VARIATION;
-  const reverseUrl = getLovellUrl(oppositeVariant);
-
-  if (path.includes(reverseUrl)) {
-    return path.replace(reverseUrl, LOVELL_BASE_URL);
-  }
-
-  return path;
+function getLovellVariantOfUrl(path, linkVar) {
+  return path.replace(
+    /\/lovell-federal(?:(?:-va|-tricare)?)-health-care/i,
+    getLovellUrl(linkVar),
+  );
 }
 
 module.exports = {
@@ -82,6 +73,6 @@ module.exports = {
   isListingPage,
   getLovellTitle,
   getLovellTitleVariation,
-  getLovellFormOfExistingUrl,
-  resetToFederalUrlIfNeeded,
+  getLovellUrl,
+  getLovellVariantOfUrl,
 };

--- a/src/site/stages/build/drupal/lovell/helpers.js
+++ b/src/site/stages/build/drupal/lovell/helpers.js
@@ -7,6 +7,7 @@ const LOVELL_VA_TITLE_VARIATION = 'VA';
 const LOVELL_TRICARE_TITLE_VARIATION = 'TRICARE';
 const LOVELL_VA_LINK_VARIATION = 'va';
 const LOVELL_TRICARE_LINK_VARIATION = 'tricare';
+const LOVELL_BASE_URL = '/lovell-federal-health-care';
 
 function isLovellFederalPage(page) {
   return (
@@ -34,13 +35,21 @@ function isListingPage(page) {
   return listingPageTypes.includes(page.entityBundle);
 }
 
+function getLovellUrl(urlVar) {
+  return `/lovell-federal-${urlVar}-health-care`;
+}
+
+function getLovellFormOfUrl(url, urlVar) {
+  return url.replace(LOVELL_BASE_URL, getLovellUrl(urlVar));
+}
+
 function resetToFederalUrlIfNeeded(path, variant) {
   const oppositeVariant =
     variant === 'va' ? LOVELL_TRICARE_LINK_VARIATION : LOVELL_VA_LINK_VARIATION;
-  const reverseUrl = `/lovell-federal-${oppositeVariant}-health-care`;
+  const reverseUrl = getLovellUrl(oppositeVariant);
 
   if (path.includes(reverseUrl)) {
-    return path.replace(reverseUrl, `/lovell-federal-health-care`);
+    return path.replace(reverseUrl, LOVELL_BASE_URL);
   }
 
   return path;
@@ -56,9 +65,11 @@ module.exports = {
   LOVELL_TRICARE_TITLE_VARIATION,
   LOVELL_VA_LINK_VARIATION,
   LOVELL_TRICARE_LINK_VARIATION,
+  LOVELL_BASE_URL,
   isLovellFederalPage,
   isLovellTricarePage,
   isLovellVaPage,
   isListingPage,
+  getLovellFormOfUrl,
   resetToFederalUrlIfNeeded,
 };

--- a/src/site/stages/build/drupal/lovell/helpers.js
+++ b/src/site/stages/build/drupal/lovell/helpers.js
@@ -43,7 +43,7 @@ function getLovellUrl(urlVar) {
   return `/lovell-federal-${urlVar}-health-care`;
 }
 
-function getLovellFormOfUrl(url, urlVar) {
+function getLovellFormOfExistingUrl(url, urlVar) {
   return url.replace(LOVELL_BASE_URL, getLovellUrl(urlVar));
 }
 
@@ -75,6 +75,6 @@ module.exports = {
   isLovellVaPage,
   isListingPage,
   getLovellTitle,
-  getLovellFormOfUrl,
+  getLovellFormOfExistingUrl,
   resetToFederalUrlIfNeeded,
 };

--- a/src/site/stages/build/drupal/lovell/helpers.js
+++ b/src/site/stages/build/drupal/lovell/helpers.js
@@ -39,6 +39,12 @@ function getLovellTitle(variant) {
   return `${LOVELL_TITLE_STRING} ${variant}`;
 }
 
+function getLovellTitleVariation(variant) {
+  return variant === 'va'
+    ? LOVELL_VA_TITLE_VARIATION
+    : LOVELL_TRICARE_TITLE_VARIATION;
+}
+
 function getLovellUrl(urlVar) {
   return `/lovell-federal-${urlVar}-health-care`;
 }
@@ -75,6 +81,7 @@ module.exports = {
   isLovellVaPage,
   isListingPage,
   getLovellTitle,
+  getLovellTitleVariation,
   getLovellFormOfExistingUrl,
   resetToFederalUrlIfNeeded,
 };

--- a/src/site/stages/build/drupal/lovell/helpers.js
+++ b/src/site/stages/build/drupal/lovell/helpers.js
@@ -51,7 +51,7 @@ function getLovellUrl(linkVar) {
 
 function getLovellVariantOfUrl(path, linkVar) {
   return path.replace(
-    /\/lovell-federal(?:(?:-va|-tricare)?)-health-care/i,
+    /\/lovell-federal-health-care(?:(?:-va|-tricare)?)/i,
     getLovellUrl(linkVar),
   );
 }

--- a/src/site/stages/build/drupal/lovell/helpers.js
+++ b/src/site/stages/build/drupal/lovell/helpers.js
@@ -36,17 +36,17 @@ function isListingPage(page) {
 }
 
 function getLovellTitle(variant) {
-  return `${LOVELL_TITLE_STRING} ${variant}`;
+  return `${LOVELL_TITLE_STRING} health care - ${variant}`;
 }
 
 function getLovellTitleVariation(variant) {
-  return variant === 'va'
+  return variant === 'va' || variant.includes('va')
     ? LOVELL_VA_TITLE_VARIATION
     : LOVELL_TRICARE_TITLE_VARIATION;
 }
 
 function getLovellUrl(linkVar) {
-  return `/lovell-federal-${linkVar}-health-care`;
+  return `/lovell-federal-health-care-${linkVar}`;
 }
 
 function getLovellVariantOfUrl(path, linkVar) {

--- a/src/site/stages/build/drupal/lovell/helpers.js
+++ b/src/site/stages/build/drupal/lovell/helpers.js
@@ -1,0 +1,64 @@
+const LOVELL_TITLE_STRING = 'Lovell Federal';
+const LOVELL_FEDERAL_ENTITY_ID = '347';
+const LOVELL_TRICARE_ENTITY_ID = '1039';
+const LOVELL_VA_ENTITY_ID = '1040';
+const LOVELL_MENU_KEY = 'lovellFederalHealthCareFacilitySidebarQuery';
+const LOVELL_VA_TITLE_VARIATION = 'VA';
+const LOVELL_TRICARE_TITLE_VARIATION = 'TRICARE';
+const LOVELL_VA_LINK_VARIATION = 'va';
+const LOVELL_TRICARE_LINK_VARIATION = 'tricare';
+
+function isLovellFederalPage(page) {
+  return (
+    page?.fieldAdministration?.entity?.entityId === LOVELL_FEDERAL_ENTITY_ID
+  );
+}
+
+function isLovellTricarePage(page) {
+  return (
+    page?.fieldAdministration?.entity?.entityId === LOVELL_TRICARE_ENTITY_ID
+  );
+}
+
+function isLovellVaPage(page) {
+  return page?.fieldAdministration?.entity?.entityId === LOVELL_VA_ENTITY_ID;
+}
+
+function isListingPage(page) {
+  const listingPageTypes = [
+    'event_listing',
+    'press_releases_listing',
+    'story_listing',
+  ];
+
+  return listingPageTypes.includes(page.entityBundle);
+}
+
+function resetToFederalUrlIfNeeded(path, variant) {
+  const oppositeVariant =
+    variant === 'va' ? LOVELL_TRICARE_LINK_VARIATION : LOVELL_VA_LINK_VARIATION;
+  const reverseUrl = `/lovell-federal-${oppositeVariant}-health-care`;
+
+  if (path.includes(reverseUrl)) {
+    return path.replace(reverseUrl, `/lovell-federal-health-care`);
+  }
+
+  return path;
+}
+
+module.exports = {
+  LOVELL_TITLE_STRING,
+  LOVELL_FEDERAL_ENTITY_ID,
+  LOVELL_TRICARE_ENTITY_ID,
+  LOVELL_VA_ENTITY_ID,
+  LOVELL_MENU_KEY,
+  LOVELL_VA_TITLE_VARIATION,
+  LOVELL_TRICARE_TITLE_VARIATION,
+  LOVELL_VA_LINK_VARIATION,
+  LOVELL_TRICARE_LINK_VARIATION,
+  isLovellFederalPage,
+  isLovellTricarePage,
+  isLovellVaPage,
+  isListingPage,
+  resetToFederalUrlIfNeeded,
+};

--- a/src/site/stages/build/drupal/lovell/helpers.js
+++ b/src/site/stages/build/drupal/lovell/helpers.js
@@ -35,6 +35,10 @@ function isListingPage(page) {
   return listingPageTypes.includes(page.entityBundle);
 }
 
+function getLovellTitle(variant) {
+  return `${LOVELL_TITLE_STRING} ${variant}`;
+}
+
 function getLovellUrl(urlVar) {
   return `/lovell-federal-${urlVar}-health-care`;
 }
@@ -70,6 +74,7 @@ module.exports = {
   isLovellTricarePage,
   isLovellVaPage,
   isListingPage,
+  getLovellTitle,
   getLovellFormOfUrl,
   resetToFederalUrlIfNeeded,
 };

--- a/src/site/stages/build/drupal/lovell/update-page.js
+++ b/src/site/stages/build/drupal/lovell/update-page.js
@@ -8,7 +8,7 @@ const {
   isLovellFederalPage,
   getLovellTitle,
   getLovellUrl,
-  getLovellFormOfUrl,
+  getLovellFormOfExistingUrl,
   resetToFederalUrlIfNeeded,
 } = require('./helpers');
 
@@ -39,13 +39,16 @@ function getLovellVariantPath(vars) {
     pagePath = resetToFederalUrlIfNeeded(page.entityUrl.path, variant);
   }
 
-  return getLovellFormOfUrl(pagePath, linkVar);
+  return getLovellFormOfExistingUrl(pagePath, linkVar);
 }
 
 function getLovellCanonicalLink(vars) {
   const { page } = vars;
 
-  return getLovellFormOfUrl(page.entityUrl.path, LOVELL_VA_LINK_VARIATION);
+  return getLovellFormOfExistingUrl(
+    page.entityUrl.path,
+    LOVELL_VA_LINK_VARIATION,
+  );
 }
 
 function getLovellSwitchPath(vars) {
@@ -63,7 +66,7 @@ function getLovellSwitchPath(vars) {
   }
 
   // If not a variant page, gets switch link option for federal pages
-  return getLovellFormOfUrl(page.entityUrl.path, oppositeVariant);
+  return getLovellFormOfExistingUrl(page.entityUrl.path, oppositeVariant);
 }
 
 function getLovellBreadcrumbs(vars) {
@@ -100,7 +103,7 @@ function getLovellVariantTitle(title, vars) {
 
 module.exports = {
   getLovellPageVariables,
-  getLovellFormOfUrl,
+  getLovellFormOfExistingUrl,
   getLovellVariantPath,
   getLovellCanonicalLink,
   getLovellSwitchPath,

--- a/src/site/stages/build/drupal/lovell/update-page.js
+++ b/src/site/stages/build/drupal/lovell/update-page.js
@@ -20,7 +20,6 @@ function getLovellPageVariables(page, variant) {
       variant === 'va'
         ? LOVELL_VA_LINK_VARIATION
         : LOVELL_TRICARE_LINK_VARIATION,
-    regexNeedle: new RegExp(`${LOVELL_TITLE_STRING} ${variantName}`, 'gi'),
   };
 }
 

--- a/src/site/stages/build/drupal/lovell/update-page.js
+++ b/src/site/stages/build/drupal/lovell/update-page.js
@@ -6,6 +6,8 @@ const {
   LOVELL_VA_LINK_VARIATION,
   LOVELL_TRICARE_LINK_VARIATION,
   isLovellFederalPage,
+  getLovellUrl,
+  getLovellFormOfUrl,
   resetToFederalUrlIfNeeded,
 } = require('./helpers');
 
@@ -36,19 +38,13 @@ function getLovellVariantPath(vars) {
     pagePath = resetToFederalUrlIfNeeded(page.entityUrl.path, variant);
   }
 
-  return pagePath.replace(
-    '/lovell-federal-health-care',
-    `/lovell-federal-${linkVar}-health-care`,
-  );
+  return getLovellFormOfUrl(pagePath, linkVar);
 }
 
 function getLovellCanonicalLink(vars) {
   const { page } = vars;
 
-  return page.entityUrl.path.replace(
-    '/lovell-federal-health-care',
-    `/lovell-federal-va-health-care`,
-  );
+  return getLovellFormOfUrl(page.entityUrl.path, LOVELL_VA_LINK_VARIATION);
 }
 
 function getLovellSwitchPath(vars) {
@@ -58,22 +54,15 @@ function getLovellSwitchPath(vars) {
   const oppositeVariant =
     variant === 'va' ? LOVELL_TRICARE_LINK_VARIATION : LOVELL_VA_LINK_VARIATION;
   const isVariantUrl =
-    page.entityUrl.path.includes(
-      `/lovell-federal-${LOVELL_TRICARE_LINK_VARIATION}-health-care`,
-    ) ||
-    page.entityUrl.path.includes(
-      `/lovell-federal-${LOVELL_VA_LINK_VARIATION}-health-care`,
-    );
+    page.entityUrl.path.includes(getLovellUrl(LOVELL_TRICARE_LINK_VARIATION)) ||
+    page.entityUrl.path.includes(getLovellUrl(LOVELL_VA_LINK_VARIATION));
 
   if (isVariantUrl) {
     return page.entityUrl.path.replace(currentVariant, oppositeVariant);
   }
 
   // If not a variant page, gets switch link option for federal pages
-  return page.entityUrl.path.replace(
-    '/lovell-federal-health-care',
-    `/lovell-federal-${oppositeVariant}-health-care`,
-  );
+  return getLovellFormOfUrl(page.entityUrl.path, oppositeVariant);
 }
 
 function getLovellBreadcrumbs(vars) {
@@ -88,7 +77,7 @@ function getLovellBreadcrumbs(vars) {
     // eslint-disable-next-line no-param-reassign
     crumb.url.path = crumb.url.path.replace(
       /\/lovell-federal-(va-)?health-care/,
-      `/lovell-federal-${linkVar}-health-care`,
+      getLovellUrl(linkVar),
     );
     return crumb;
   });
@@ -113,6 +102,7 @@ function getLovellVariantTitle(title, vars) {
 
 module.exports = {
   getLovellPageVariables,
+  getLovellFormOfUrl,
   getLovellVariantPath,
   getLovellCanonicalLink,
   getLovellSwitchPath,

--- a/src/site/stages/build/drupal/lovell/update-page.js
+++ b/src/site/stages/build/drupal/lovell/update-page.js
@@ -39,19 +39,9 @@ function getLovellCanonicalLink(vars) {
 
 function getLovellSwitchPath(vars) {
   const { page, variant } = vars;
-  const currentVariant =
-    variant === 'va' ? LOVELL_VA_LINK_VARIATION : LOVELL_TRICARE_LINK_VARIATION;
   const oppositeVariant =
     variant === 'va' ? LOVELL_TRICARE_LINK_VARIATION : LOVELL_VA_LINK_VARIATION;
-  const isVariantUrl =
-    page.entityUrl.path.includes(getLovellUrl(LOVELL_TRICARE_LINK_VARIATION)) ||
-    page.entityUrl.path.includes(getLovellUrl(LOVELL_VA_LINK_VARIATION));
 
-  if (isVariantUrl) {
-    return page.entityUrl.path.replace(currentVariant, oppositeVariant);
-  }
-
-  // If not a variant page, gets switch link option for federal pages
   return getLovellVariantOfUrl(page.entityUrl.path, oppositeVariant);
 }
 

--- a/src/site/stages/build/drupal/lovell/update-page.js
+++ b/src/site/stages/build/drupal/lovell/update-page.js
@@ -10,21 +10,20 @@ const {
 } = require('./helpers');
 
 function getLovellPageVariables(page, variant) {
-  const variantName = variant === 'tricare' ? 'TRICARE' : 'VA';
+  const variantName =
+    variant === 'va'
+      ? LOVELL_VA_TITLE_VARIATION
+      : LOVELL_TRICARE_TITLE_VARIATION;
   const pageClone = cloneDeep(page);
 
   return {
-    pageClone,
+    page: pageClone,
     variant,
     variantName,
     linkVar:
       variant === 'va'
         ? LOVELL_VA_LINK_VARIATION
         : LOVELL_TRICARE_LINK_VARIATION,
-    fieldOfficeMod:
-      variant === 'va'
-        ? LOVELL_VA_TITLE_VARIATION
-        : LOVELL_TRICARE_TITLE_VARIATION,
     regexNeedle: new RegExp(`${LOVELL_TITLE_STRING} ${variantName}`, 'gi'),
   };
 }
@@ -78,13 +77,13 @@ function getLovellSwitchPath(vars) {
 }
 
 function getLovellBreadcrumbs(vars) {
-  const { page, fieldOfficeMod, linkVar } = vars;
+  const { page, variantName, linkVar } = vars;
   // Modify Breadcrumb
   return page.entityUrl.breadcrumb.map(crumb => {
     // eslint-disable-next-line no-param-reassign
     crumb.text = crumb.text.replace(
       /Lovell Federal (VA )?health care/,
-      `${LOVELL_TITLE_STRING} ${fieldOfficeMod} health care`,
+      `${LOVELL_TITLE_STRING} ${variantName} health care`,
     );
     // eslint-disable-next-line no-param-reassign
     crumb.url.path = crumb.url.path.replace(
@@ -96,22 +95,19 @@ function getLovellBreadcrumbs(vars) {
 }
 
 function getLovellVariantTitle(title, vars) {
-  const { variantName, regexNeedle, fieldOfficeMod } = vars;
+  const { variantName, regexNeedle } = vars;
 
   if (
     title
       .toLowerCase()
       .includes(`${LOVELL_TITLE_STRING} ${variantName}`.toLowerCase())
   ) {
-    return title.replace(
-      regexNeedle,
-      `${LOVELL_TITLE_STRING} ${fieldOfficeMod}`,
-    );
+    return title.replace(regexNeedle, `${LOVELL_TITLE_STRING} ${variantName}`);
   }
 
   return title.replace(
     `${LOVELL_TITLE_STRING}`,
-    `${LOVELL_TITLE_STRING} ${fieldOfficeMod}`,
+    `${LOVELL_TITLE_STRING} ${variantName}`,
   );
 }
 

--- a/src/site/stages/build/drupal/lovell/update-page.js
+++ b/src/site/stages/build/drupal/lovell/update-page.js
@@ -1,22 +1,18 @@
 const cloneDeep = require('lodash/cloneDeep');
 const {
   LOVELL_TITLE_STRING,
-  LOVELL_VA_TITLE_VARIATION,
-  LOVELL_TRICARE_TITLE_VARIATION,
   LOVELL_VA_LINK_VARIATION,
   LOVELL_TRICARE_LINK_VARIATION,
   isLovellFederalPage,
   getLovellTitle,
+  getLovellTitleVariation,
   getLovellUrl,
   getLovellFormOfExistingUrl,
   resetToFederalUrlIfNeeded,
 } = require('./helpers');
 
 function getLovellPageVariables(page, variant) {
-  const variantName =
-    variant === 'va'
-      ? LOVELL_VA_TITLE_VARIATION
-      : LOVELL_TRICARE_TITLE_VARIATION;
+  const variantName = getLovellTitleVariation(variant);
   const pageClone = cloneDeep(page);
 
   return {

--- a/src/site/stages/build/drupal/lovell/update-page.js
+++ b/src/site/stages/build/drupal/lovell/update-page.js
@@ -6,6 +6,7 @@ const {
   LOVELL_VA_LINK_VARIATION,
   LOVELL_TRICARE_LINK_VARIATION,
   isLovellFederalPage,
+  getLovellTitle,
   getLovellUrl,
   getLovellFormOfUrl,
   resetToFederalUrlIfNeeded,
@@ -72,7 +73,7 @@ function getLovellBreadcrumbs(vars) {
     // eslint-disable-next-line no-param-reassign
     crumb.text = crumb.text.replace(
       /Lovell Federal (VA )?health care/,
-      `${LOVELL_TITLE_STRING} ${variantName} health care`,
+      getLovellTitle(variantName),
     );
     // eslint-disable-next-line no-param-reassign
     crumb.url.path = crumb.url.path.replace(
@@ -91,13 +92,10 @@ function getLovellVariantTitle(title, vars) {
       .toLowerCase()
       .includes(`${LOVELL_TITLE_STRING} ${variantName}`.toLowerCase())
   ) {
-    return title.replace(regexNeedle, `${LOVELL_TITLE_STRING} ${variantName}`);
+    return title.replace(regexNeedle, getLovellTitle(variantName));
   }
 
-  return title.replace(
-    `${LOVELL_TITLE_STRING}`,
-    `${LOVELL_TITLE_STRING} ${variantName}`,
-  );
+  return title.replace(`${LOVELL_TITLE_STRING}`, getLovellTitle(variantName));
 }
 
 module.exports = {

--- a/src/site/stages/build/drupal/lovell/update-page.js
+++ b/src/site/stages/build/drupal/lovell/update-page.js
@@ -5,7 +5,6 @@ const {
   LOVELL_TRICARE_LINK_VARIATION,
   getLovellTitle,
   getLovellTitleVariation,
-  getLovellUrl,
   getLovellVariantOfUrl,
 } = require('./helpers');
 
@@ -55,10 +54,8 @@ function getLovellBreadcrumbs(vars) {
       getLovellTitle(variantName),
     );
     // eslint-disable-next-line no-param-reassign
-    crumb.url.path = crumb.url.path.replace(
-      /\/lovell-federal-(va-)?health-care/,
-      getLovellUrl(linkVar),
-    );
+    crumb.url.path = getLovellVariantOfUrl(crumb.url.path, linkVar);
+
     return crumb;
   });
 }

--- a/src/site/stages/build/drupal/lovell/update-page.js
+++ b/src/site/stages/build/drupal/lovell/update-page.js
@@ -1,0 +1,162 @@
+const {
+  LOVELL_TITLE_STRING,
+  LOVELL_VA_LINK_VARIATION,
+  LOVELL_TRICARE_LINK_VARIATION,
+  isLovellFederalPage,
+  resetToFederalUrlIfNeeded,
+} = require('./helpers');
+
+function updateLovellPagePath(vars) {
+  const { page, linkVar, variant } = vars;
+
+  if (isLovellFederalPage(page)) {
+    page.entityUrl.path = resetToFederalUrlIfNeeded(
+      page.entityUrl.path,
+      variant,
+    );
+  }
+
+  const modifiedPath = page.entityUrl.path.replace(
+    '/lovell-federal-health-care',
+    `/lovell-federal-${linkVar}-health-care`,
+  );
+
+  page.entityUrl.path = modifiedPath;
+}
+
+function updateLovellPageCanonicalLink(vars) {
+  const { page, variant } = vars;
+
+  if (variant === 'tricare' && isLovellFederalPage(page)) {
+    page.entityUrl.path.replace(
+      '/lovell-federal-health-care',
+      `/lovell-federal-va-health-care`,
+    );
+  }
+}
+
+function updateLovellPageSwitchPath(vars) {
+  const { page, variant } = vars;
+
+  if (
+    page.entityUrl.path.includes(
+      `/lovell-federal-${LOVELL_TRICARE_LINK_VARIATION}-health-care`,
+    ) ||
+    page.entityUrl.path.includes(
+      `/lovell-federal-${LOVELL_VA_LINK_VARIATION}-health-care`,
+    )
+  ) {
+    page.entityUrl.switchPath = page.entityUrl.path.replace(
+      variant === 'va'
+        ? LOVELL_VA_LINK_VARIATION
+        : LOVELL_TRICARE_LINK_VARIATION,
+      variant === 'va'
+        ? LOVELL_TRICARE_LINK_VARIATION
+        : LOVELL_VA_LINK_VARIATION,
+    );
+  } else {
+    page.entityUrl.switchPath = page.entityUrl.path.replace(
+      '/lovell-federal-health-care',
+      `/lovell-federal-${
+        variant === 'va'
+          ? LOVELL_TRICARE_LINK_VARIATION
+          : LOVELL_VA_LINK_VARIATION
+      }-health-care`,
+    );
+  }
+}
+
+function updateLovellPageBreadcrumbs(vars) {
+  const { page, fieldOfficeMod, linkVar } = vars;
+  // Modify Breadcrumb
+  if (page.entityUrl.breadcrumb) {
+    page.entityUrl.breadcrumb = page.entityUrl.breadcrumb.map(crumb => {
+      // eslint-disable-next-line no-param-reassign
+      crumb.text = crumb.text.replace(
+        /Lovell Federal (VA )?health care/,
+        `${LOVELL_TITLE_STRING} ${fieldOfficeMod} health care`,
+      );
+      // eslint-disable-next-line no-param-reassign
+      crumb.url.path = crumb.url.path.replace(
+        /\/lovell-federal-(va-)?health-care/,
+        `/lovell-federal-${linkVar}-health-care`,
+      );
+      return crumb;
+    });
+  }
+}
+
+function updateLovellPageFieldRegionPage(vars) {
+  const { page, variantName, regexNeedle, fieldOfficeMod } = vars;
+
+  if (page.fieldRegionPage) {
+    if (
+      page.fieldRegionPage.entity.title
+        .toLowerCase()
+        .includes(`${LOVELL_TITLE_STRING} ${variantName}`.toLowerCase())
+    ) {
+      page.fieldRegionPage.entity.title = page.fieldRegionPage.entity.title.replace(
+        regexNeedle,
+        `${LOVELL_TITLE_STRING} ${fieldOfficeMod}`,
+      );
+    } else {
+      page.fieldRegionPage.entity.title = page.fieldRegionPage.entity.title.replace(
+        `${LOVELL_TITLE_STRING}`,
+        `${LOVELL_TITLE_STRING} ${fieldOfficeMod}`,
+      );
+    }
+  }
+}
+
+function updateLovellPageFieldOfficeTitle(vars) {
+  const { page, variantName, regexNeedle, fieldOfficeMod } = vars;
+
+  if (page.fieldOffice) {
+    // services, facilites
+    if (
+      page.fieldOffice.entity.entityLabel
+        .toLowerCase()
+        .includes(`${LOVELL_TITLE_STRING} ${variantName}`.toLowerCase())
+    ) {
+      page.fieldOffice.entity.entityLabel = page.fieldOffice.entity.entityLabel.replace(
+        regexNeedle,
+        `${LOVELL_TITLE_STRING} ${fieldOfficeMod}`,
+      );
+    } else {
+      page.fieldOffice.entity.entityLabel = page.fieldOffice.entity.entityLabel.replace(
+        `${LOVELL_TITLE_STRING}`,
+        `${LOVELL_TITLE_STRING} ${fieldOfficeMod}`,
+      );
+    }
+  }
+}
+
+function updateLovellPageTitle(vars) {
+  const { page, variantName, regexNeedle, fieldOfficeMod } = vars;
+
+  if (
+    page.title
+      .toLowerCase()
+      .includes(`${LOVELL_TITLE_STRING} ${variantName}`.toLowerCase())
+  ) {
+    page.title = page.title.replace(
+      regexNeedle,
+      `${LOVELL_TITLE_STRING} ${fieldOfficeMod}`,
+    );
+  } else {
+    page.title = page.title.replace(
+      `${LOVELL_TITLE_STRING}`,
+      `${LOVELL_TITLE_STRING} ${fieldOfficeMod}`,
+    );
+  }
+}
+
+module.exports = {
+  updateLovellPagePath,
+  updateLovellPageCanonicalLink,
+  updateLovellPageSwitchPath,
+  updateLovellPageBreadcrumbs,
+  updateLovellPageFieldRegionPage,
+  updateLovellPageFieldOfficeTitle,
+  updateLovellPageTitle,
+};

--- a/src/site/stages/build/drupal/lovell/update-page.js
+++ b/src/site/stages/build/drupal/lovell/update-page.js
@@ -61,17 +61,20 @@ function getLovellBreadcrumbs(vars) {
 }
 
 function getLovellVariantTitle(title, vars) {
-  const { variantName, regexNeedle } = vars;
+  const { variantName } = vars;
 
   if (
     title
       .toLowerCase()
       .includes(`${LOVELL_TITLE_STRING} ${variantName}`.toLowerCase())
   ) {
-    return title.replace(regexNeedle, getLovellTitle(variantName));
+    return getLovellTitle(variantName);
   }
 
-  return title.replace(`${LOVELL_TITLE_STRING}`, getLovellTitle(variantName));
+  return title.replace(
+    `${LOVELL_TITLE_STRING}`,
+    `${LOVELL_TITLE_STRING} ${getLovellTitleVariation(variantName)}`,
+  );
 }
 
 module.exports = {

--- a/src/site/stages/build/drupal/lovell/update-page.js
+++ b/src/site/stages/build/drupal/lovell/update-page.js
@@ -1,3 +1,4 @@
+const cloneDeep = require('lodash/cloneDeep');
 const {
   LOVELL_TITLE_STRING,
   LOVELL_VA_TITLE_VARIATION,
@@ -10,9 +11,10 @@ const {
 
 function getLovellPageVariables(page, variant) {
   const variantName = variant === 'tricare' ? 'TRICARE' : 'VA';
+  const pageClone = cloneDeep(page);
 
   return {
-    page,
+    pageClone,
     variant,
     variantName,
     linkVar:
@@ -27,7 +29,7 @@ function getLovellPageVariables(page, variant) {
   };
 }
 
-function getLovellPagePath(vars) {
+function getLovellVariantPath(vars) {
   const { page, linkVar, variant } = vars;
   let pagePath = page.entityUrl.path;
 
@@ -41,21 +43,21 @@ function getLovellPagePath(vars) {
   );
 }
 
-function getLovellPageCanonicalLink(vars) {
-  const { page, variant } = vars;
+function getLovellCanonicalLink(vars) {
+  const { page } = vars;
 
-  if (variant === 'tricare' && isLovellFederalPage(page)) {
-    return page.entityUrl.path.replace(
-      '/lovell-federal-health-care',
-      `/lovell-federal-va-health-care`,
-    );
-  }
-
-  return false;
+  return page.entityUrl.path.replace(
+    '/lovell-federal-health-care',
+    `/lovell-federal-va-health-care`,
+  );
 }
 
-function getLovellPageSwitchPath(vars) {
+function getLovellSwitchPath(vars) {
   const { page, variant } = vars;
+  const currentVariant =
+    variant === 'va' ? LOVELL_VA_LINK_VARIATION : LOVELL_TRICARE_LINK_VARIATION;
+  const oppositeVariant =
+    variant === 'va' ? LOVELL_TRICARE_LINK_VARIATION : LOVELL_VA_LINK_VARIATION;
   const isVariantUrl =
     page.entityUrl.path.includes(
       `/lovell-federal-${LOVELL_TRICARE_LINK_VARIATION}-health-care`,
@@ -65,29 +67,17 @@ function getLovellPageSwitchPath(vars) {
     );
 
   if (isVariantUrl) {
-    return page.entityUrl.path.replace(
-      variant === 'va'
-        ? LOVELL_VA_LINK_VARIATION
-        : LOVELL_TRICARE_LINK_VARIATION,
-      variant === 'va'
-        ? LOVELL_TRICARE_LINK_VARIATION
-        : LOVELL_VA_LINK_VARIATION,
-    );
+    return page.entityUrl.path.replace(currentVariant, oppositeVariant);
   }
 
   // If not a variant page, gets switch link option for federal pages
-  // If  no page has this URL it will be set to "false" later
   return page.entityUrl.path.replace(
     '/lovell-federal-health-care',
-    `/lovell-federal-${
-      variant === 'va'
-        ? LOVELL_TRICARE_LINK_VARIATION
-        : LOVELL_VA_LINK_VARIATION
-    }-health-care`,
+    `/lovell-federal-${oppositeVariant}-health-care`,
   );
 }
 
-function getLovellPageBreadcrumbs(vars) {
+function getLovellBreadcrumbs(vars) {
   const { page, fieldOfficeMod, linkVar } = vars;
   // Modify Breadcrumb
   return page.entityUrl.breadcrumb.map(crumb => {
@@ -105,7 +95,7 @@ function getLovellPageBreadcrumbs(vars) {
   });
 }
 
-function getLovellTitleVariant(title, vars) {
+function getLovellVariantTitle(title, vars) {
   const { variantName, regexNeedle, fieldOfficeMod } = vars;
 
   if (
@@ -127,9 +117,9 @@ function getLovellTitleVariant(title, vars) {
 
 module.exports = {
   getLovellPageVariables,
-  getLovellPagePath,
-  getLovellPageCanonicalLink,
-  getLovellPageSwitchPath,
-  getLovellPageBreadcrumbs,
-  getLovellTitleVariant,
+  getLovellVariantPath,
+  getLovellCanonicalLink,
+  getLovellSwitchPath,
+  getLovellBreadcrumbs,
+  getLovellVariantTitle,
 };

--- a/src/site/stages/build/drupal/lovell/update-page.js
+++ b/src/site/stages/build/drupal/lovell/update-page.js
@@ -1,52 +1,71 @@
 const {
   LOVELL_TITLE_STRING,
+  LOVELL_VA_TITLE_VARIATION,
+  LOVELL_TRICARE_TITLE_VARIATION,
   LOVELL_VA_LINK_VARIATION,
   LOVELL_TRICARE_LINK_VARIATION,
   isLovellFederalPage,
   resetToFederalUrlIfNeeded,
 } = require('./helpers');
 
-function updateLovellPagePath(vars) {
+function getLovellPageVariables(page, variant) {
+  const variantName = variant === 'tricare' ? 'TRICARE' : 'VA';
+
+  return {
+    page,
+    variant,
+    variantName,
+    linkVar:
+      variant === 'va'
+        ? LOVELL_VA_LINK_VARIATION
+        : LOVELL_TRICARE_LINK_VARIATION,
+    fieldOfficeMod:
+      variant === 'va'
+        ? LOVELL_VA_TITLE_VARIATION
+        : LOVELL_TRICARE_TITLE_VARIATION,
+    regexNeedle: new RegExp(`${LOVELL_TITLE_STRING} ${variantName}`, 'gi'),
+  };
+}
+
+function getLovellPagePath(vars) {
   const { page, linkVar, variant } = vars;
+  let pagePath = page.entityUrl.path;
 
   if (isLovellFederalPage(page)) {
-    page.entityUrl.path = resetToFederalUrlIfNeeded(
-      page.entityUrl.path,
-      variant,
-    );
+    pagePath = resetToFederalUrlIfNeeded(page.entityUrl.path, variant);
   }
 
-  const modifiedPath = page.entityUrl.path.replace(
+  return pagePath.replace(
     '/lovell-federal-health-care',
     `/lovell-federal-${linkVar}-health-care`,
   );
-
-  page.entityUrl.path = modifiedPath;
 }
 
-function updateLovellPageCanonicalLink(vars) {
+function getLovellPageCanonicalLink(vars) {
   const { page, variant } = vars;
 
   if (variant === 'tricare' && isLovellFederalPage(page)) {
-    page.entityUrl.path.replace(
+    return page.entityUrl.path.replace(
       '/lovell-federal-health-care',
       `/lovell-federal-va-health-care`,
     );
   }
+
+  return false;
 }
 
-function updateLovellPageSwitchPath(vars) {
+function getLovellPageSwitchPath(vars) {
   const { page, variant } = vars;
-
-  if (
+  const isVariantUrl =
     page.entityUrl.path.includes(
       `/lovell-federal-${LOVELL_TRICARE_LINK_VARIATION}-health-care`,
     ) ||
     page.entityUrl.path.includes(
       `/lovell-federal-${LOVELL_VA_LINK_VARIATION}-health-care`,
-    )
-  ) {
-    page.entityUrl.switchPath = page.entityUrl.path.replace(
+    );
+
+  if (isVariantUrl) {
+    return page.entityUrl.path.replace(
       variant === 'va'
         ? LOVELL_VA_LINK_VARIATION
         : LOVELL_TRICARE_LINK_VARIATION,
@@ -54,109 +73,63 @@ function updateLovellPageSwitchPath(vars) {
         ? LOVELL_TRICARE_LINK_VARIATION
         : LOVELL_VA_LINK_VARIATION,
     );
-  } else {
-    page.entityUrl.switchPath = page.entityUrl.path.replace(
-      '/lovell-federal-health-care',
-      `/lovell-federal-${
-        variant === 'va'
-          ? LOVELL_TRICARE_LINK_VARIATION
-          : LOVELL_VA_LINK_VARIATION
-      }-health-care`,
-    );
   }
+
+  // If not a variant page, gets switch link option for federal pages
+  // If  no page has this URL it will be set to "false" later
+  return page.entityUrl.path.replace(
+    '/lovell-federal-health-care',
+    `/lovell-federal-${
+      variant === 'va'
+        ? LOVELL_TRICARE_LINK_VARIATION
+        : LOVELL_VA_LINK_VARIATION
+    }-health-care`,
+  );
 }
 
-function updateLovellPageBreadcrumbs(vars) {
+function getLovellPageBreadcrumbs(vars) {
   const { page, fieldOfficeMod, linkVar } = vars;
   // Modify Breadcrumb
-  if (page.entityUrl.breadcrumb) {
-    page.entityUrl.breadcrumb = page.entityUrl.breadcrumb.map(crumb => {
-      // eslint-disable-next-line no-param-reassign
-      crumb.text = crumb.text.replace(
-        /Lovell Federal (VA )?health care/,
-        `${LOVELL_TITLE_STRING} ${fieldOfficeMod} health care`,
-      );
-      // eslint-disable-next-line no-param-reassign
-      crumb.url.path = crumb.url.path.replace(
-        /\/lovell-federal-(va-)?health-care/,
-        `/lovell-federal-${linkVar}-health-care`,
-      );
-      return crumb;
-    });
-  }
+  return page.entityUrl.breadcrumb.map(crumb => {
+    // eslint-disable-next-line no-param-reassign
+    crumb.text = crumb.text.replace(
+      /Lovell Federal (VA )?health care/,
+      `${LOVELL_TITLE_STRING} ${fieldOfficeMod} health care`,
+    );
+    // eslint-disable-next-line no-param-reassign
+    crumb.url.path = crumb.url.path.replace(
+      /\/lovell-federal-(va-)?health-care/,
+      `/lovell-federal-${linkVar}-health-care`,
+    );
+    return crumb;
+  });
 }
 
-function updateLovellPageFieldRegionPage(vars) {
-  const { page, variantName, regexNeedle, fieldOfficeMod } = vars;
-
-  if (page.fieldRegionPage) {
-    if (
-      page.fieldRegionPage.entity.title
-        .toLowerCase()
-        .includes(`${LOVELL_TITLE_STRING} ${variantName}`.toLowerCase())
-    ) {
-      page.fieldRegionPage.entity.title = page.fieldRegionPage.entity.title.replace(
-        regexNeedle,
-        `${LOVELL_TITLE_STRING} ${fieldOfficeMod}`,
-      );
-    } else {
-      page.fieldRegionPage.entity.title = page.fieldRegionPage.entity.title.replace(
-        `${LOVELL_TITLE_STRING}`,
-        `${LOVELL_TITLE_STRING} ${fieldOfficeMod}`,
-      );
-    }
-  }
-}
-
-function updateLovellPageFieldOfficeTitle(vars) {
-  const { page, variantName, regexNeedle, fieldOfficeMod } = vars;
-
-  if (page.fieldOffice) {
-    // services, facilites
-    if (
-      page.fieldOffice.entity.entityLabel
-        .toLowerCase()
-        .includes(`${LOVELL_TITLE_STRING} ${variantName}`.toLowerCase())
-    ) {
-      page.fieldOffice.entity.entityLabel = page.fieldOffice.entity.entityLabel.replace(
-        regexNeedle,
-        `${LOVELL_TITLE_STRING} ${fieldOfficeMod}`,
-      );
-    } else {
-      page.fieldOffice.entity.entityLabel = page.fieldOffice.entity.entityLabel.replace(
-        `${LOVELL_TITLE_STRING}`,
-        `${LOVELL_TITLE_STRING} ${fieldOfficeMod}`,
-      );
-    }
-  }
-}
-
-function updateLovellPageTitle(vars) {
-  const { page, variantName, regexNeedle, fieldOfficeMod } = vars;
+function getLovellTitleVariant(title, vars) {
+  const { variantName, regexNeedle, fieldOfficeMod } = vars;
 
   if (
-    page.title
+    title
       .toLowerCase()
       .includes(`${LOVELL_TITLE_STRING} ${variantName}`.toLowerCase())
   ) {
-    page.title = page.title.replace(
+    return title.replace(
       regexNeedle,
       `${LOVELL_TITLE_STRING} ${fieldOfficeMod}`,
     );
-  } else {
-    page.title = page.title.replace(
-      `${LOVELL_TITLE_STRING}`,
-      `${LOVELL_TITLE_STRING} ${fieldOfficeMod}`,
-    );
   }
+
+  return title.replace(
+    `${LOVELL_TITLE_STRING}`,
+    `${LOVELL_TITLE_STRING} ${fieldOfficeMod}`,
+  );
 }
 
 module.exports = {
-  updateLovellPagePath,
-  updateLovellPageCanonicalLink,
-  updateLovellPageSwitchPath,
-  updateLovellPageBreadcrumbs,
-  updateLovellPageFieldRegionPage,
-  updateLovellPageFieldOfficeTitle,
-  updateLovellPageTitle,
+  getLovellPageVariables,
+  getLovellPagePath,
+  getLovellPageCanonicalLink,
+  getLovellPageSwitchPath,
+  getLovellPageBreadcrumbs,
+  getLovellTitleVariant,
 };

--- a/src/site/stages/build/drupal/lovell/update-page.js
+++ b/src/site/stages/build/drupal/lovell/update-page.js
@@ -49,7 +49,7 @@ function getLovellBreadcrumbs(vars) {
   return page.entityUrl.breadcrumb.map(crumb => {
     // eslint-disable-next-line no-param-reassign
     crumb.text = crumb.text.replace(
-      /Lovell Federal (VA )?health care/,
+      /Lovell Federal health care/,
       getLovellTitle(variantName),
     );
     // eslint-disable-next-line no-param-reassign
@@ -62,17 +62,12 @@ function getLovellBreadcrumbs(vars) {
 function getLovellVariantTitle(title, vars) {
   const { variantName } = vars;
 
-  if (
-    title
-      .toLowerCase()
-      .includes(`${LOVELL_TITLE_STRING} ${variantName}`.toLowerCase())
-  ) {
-    return getLovellTitle(variantName);
-  }
-
   return title.replace(
-    `${LOVELL_TITLE_STRING}`,
-    `${LOVELL_TITLE_STRING} ${getLovellTitleVariation(variantName)}`,
+    new RegExp(
+      `${LOVELL_TITLE_STRING} health care(?:(?: - VA| - TRICARE)?)`,
+      'i',
+    ),
+    getLovellTitle(variantName),
   );
 }
 

--- a/src/site/stages/build/drupal/lovell/update-page.js
+++ b/src/site/stages/build/drupal/lovell/update-page.js
@@ -3,12 +3,10 @@ const {
   LOVELL_TITLE_STRING,
   LOVELL_VA_LINK_VARIATION,
   LOVELL_TRICARE_LINK_VARIATION,
-  isLovellFederalPage,
   getLovellTitle,
   getLovellTitleVariation,
   getLovellUrl,
-  getLovellFormOfExistingUrl,
-  resetToFederalUrlIfNeeded,
+  getLovellVariantOfUrl,
 } = require('./helpers');
 
 function getLovellPageVariables(page, variant) {
@@ -28,23 +26,15 @@ function getLovellPageVariables(page, variant) {
 }
 
 function getLovellVariantPath(vars) {
-  const { page, linkVar, variant } = vars;
-  let pagePath = page.entityUrl.path;
+  const { page, linkVar } = vars;
 
-  if (isLovellFederalPage(page)) {
-    pagePath = resetToFederalUrlIfNeeded(page.entityUrl.path, variant);
-  }
-
-  return getLovellFormOfExistingUrl(pagePath, linkVar);
+  return getLovellVariantOfUrl(page.entityUrl.path, linkVar);
 }
 
 function getLovellCanonicalLink(vars) {
   const { page } = vars;
 
-  return getLovellFormOfExistingUrl(
-    page.entityUrl.path,
-    LOVELL_VA_LINK_VARIATION,
-  );
+  return getLovellVariantOfUrl(page.entityUrl.path, LOVELL_VA_LINK_VARIATION);
 }
 
 function getLovellSwitchPath(vars) {
@@ -62,7 +52,7 @@ function getLovellSwitchPath(vars) {
   }
 
   // If not a variant page, gets switch link option for federal pages
-  return getLovellFormOfExistingUrl(page.entityUrl.path, oppositeVariant);
+  return getLovellVariantOfUrl(page.entityUrl.path, oppositeVariant);
 }
 
 function getLovellBreadcrumbs(vars) {
@@ -99,7 +89,6 @@ function getLovellVariantTitle(title, vars) {
 
 module.exports = {
   getLovellPageVariables,
-  getLovellFormOfExistingUrl,
   getLovellVariantPath,
   getLovellCanonicalLink,
   getLovellSwitchPath,

--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -20,36 +20,39 @@ const {
 
 const {
   getLovellPageVariables,
-  getLovellPagePath,
-  getLovellPageCanonicalLink,
-  getLovellPageSwitchPath,
-  getLovellPageBreadcrumbs,
-  getLovellTitleVariant,
+  getLovellVariantPath,
+  getLovellCanonicalLink,
+  getLovellSwitchPath,
+  getLovellBreadcrumbs,
+  getLovellVariantTitle,
 } = require('./lovell/update-page');
 
 function getModifiedLovellPage(page, variant) {
-  const updateVars = getLovellPageVariables(page, variant);
+  const pageVars = getLovellPageVariables(page, variant);
 
-  page.entityUrl.path = getLovellPagePath(updateVars);
-  page.canonicalLink = getLovellPageCanonicalLink(updateVars);
-  page.entityUrl.switchPath = getLovellPageSwitchPath(updateVars);
-  page.title = getLovellTitleVariant(page.title, updateVars);
+  page.title = getLovellVariantTitle(page.title, pageVars);
+  page.entityUrl.path = getLovellVariantPath(pageVars);
+  page.entityUrl.switchPath = getLovellSwitchPath(pageVars);
+
+  if (variant === 'tricare' && isLovellFederalPage(page)) {
+    page.canonicalLink = getLovellCanonicalLink(pageVars);
+  }
 
   if (page.entityUrl.breadcrumb) {
-    page.entityUrl.breadcrumb = getLovellPageBreadcrumbs(updateVars);
+    page.entityUrl.breadcrumb = getLovellBreadcrumbs(pageVars);
   }
 
   if (page.fieldRegionPage) {
-    page.fieldRegionPage.entity.title = getLovellTitleVariant(
+    page.fieldRegionPage.entity.title = getLovellVariantTitle(
       page.fieldRegionPage.entity.title,
-      updateVars,
+      pageVars,
     );
   }
 
   if (page.fieldOffice) {
-    page.fieldOffice.entity.entityLabel = getLovellTitleVariant(
+    page.fieldOffice.entity.entityLabel = getLovellVariantTitle(
       page.fieldOffice.entity.entityLabel,
-      updateVars,
+      pageVars,
     );
   }
 

--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -1,56 +1,22 @@
 /* eslint-disable camelcase */
 /* eslint-disable no-param-reassign, no-console */
-const cloneDeep = require('lodash/cloneDeep');
 
+const cloneDeep = require('lodash/cloneDeep');
 const { camelize } = require('../../../utilities/stringHelpers');
 
-const LOVELL_TITLE_STRING = 'Lovell Federal';
-const LOVELL_FEDERAL_ENTITY_ID = '347';
-const LOVELL_TRICARE_ENTITY_ID = '1039';
-const LOVELL_VA_ENTITY_ID = '1040';
-const LOVELL_MENU_KEY = 'lovellFederalHealthCareFacilitySidebarQuery';
-const LOVELL_VA_TITLE_VARIATION = 'VA';
-const LOVELL_TRICARE_TITLE_VARIATION = 'TRICARE';
-const LOVELL_VA_LINK_VARIATION = 'va';
-const LOVELL_TRICARE_LINK_VARIATION = 'tricare';
-
-function isLovellFederalPage(page) {
-  return (
-    page?.fieldAdministration?.entity?.entityId === LOVELL_FEDERAL_ENTITY_ID
-  );
-}
-
-function isLovellTricarePage(page) {
-  return (
-    page?.fieldAdministration?.entity?.entityId === LOVELL_TRICARE_ENTITY_ID
-  );
-}
-
-function isLovellVaPage(page) {
-  return page?.fieldAdministration?.entity?.entityId === LOVELL_VA_ENTITY_ID;
-}
-
-function isListingPage(page) {
-  const listingPageTypes = [
-    'event_listing',
-    'press_releases_listing',
-    'story_listing',
-  ];
-
-  return listingPageTypes.includes(page.entityBundle);
-}
-
-function resetToFederalUrlIfNeeded(path, variant) {
-  const oppositeVariant =
-    variant === 'va' ? LOVELL_TRICARE_LINK_VARIATION : LOVELL_VA_LINK_VARIATION;
-  const reverseUrl = `/lovell-federal-${oppositeVariant}-health-care`;
-
-  if (path.includes(reverseUrl)) {
-    return path.replace(reverseUrl, `/lovell-federal-health-care`);
-  }
-
-  return path;
-}
+const {
+  LOVELL_TITLE_STRING,
+  LOVELL_MENU_KEY,
+  LOVELL_VA_TITLE_VARIATION,
+  LOVELL_TRICARE_TITLE_VARIATION,
+  LOVELL_VA_LINK_VARIATION,
+  LOVELL_TRICARE_LINK_VARIATION,
+  isLovellFederalPage,
+  isLovellTricarePage,
+  isLovellVaPage,
+  isListingPage,
+  resetToFederalUrlIfNeeded,
+} = require('./lovell/helpers');
 
 function getModifiedLovellPage(page, variant) {
   const fieldOfficeMod =

--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -19,40 +19,39 @@ const {
 } = require('./lovell/helpers');
 
 const {
-  updateLovellPagePath,
-  updateLovellPageCanonicalLink,
-  updateLovellPageSwitchPath,
-  updateLovellPageBreadcrumbs,
-  updateLovellPageFieldRegionPage,
-  updateLovellPageFieldOfficeTitle,
-  updateLovellPageTitle,
+  getLovellPageVariables,
+  getLovellPagePath,
+  getLovellPageCanonicalLink,
+  getLovellPageSwitchPath,
+  getLovellPageBreadcrumbs,
+  getLovellTitleVariant,
 } = require('./lovell/update-page');
 
 function getModifiedLovellPage(page, variant) {
-  const variantName = variant === 'tricare' ? 'TRICARE' : 'VA';
+  const updateVars = getLovellPageVariables(page, variant);
 
-  const updateVars = {
-    page,
-    variant,
-    variantName,
-    linkVar:
-      variant === 'va'
-        ? LOVELL_VA_LINK_VARIATION
-        : LOVELL_TRICARE_LINK_VARIATION,
-    fieldOfficeMod:
-      variant === 'va'
-        ? LOVELL_VA_TITLE_VARIATION
-        : LOVELL_TRICARE_TITLE_VARIATION,
-    regexNeedle: new RegExp(`${LOVELL_TITLE_STRING} ${variantName}`, 'gi'),
-  };
+  page.entityUrl.path = getLovellPagePath(updateVars);
+  page.canonicalLink = getLovellPageCanonicalLink(updateVars);
+  page.entityUrl.switchPath = getLovellPageSwitchPath(updateVars);
+  page.title = getLovellTitleVariant(page.title, updateVars);
 
-  updateLovellPagePath(updateVars);
-  updateLovellPageCanonicalLink(updateVars);
-  updateLovellPageSwitchPath(updateVars);
-  updateLovellPageBreadcrumbs(updateVars);
-  updateLovellPageFieldOfficeTitle(updateVars);
-  updateLovellPageFieldRegionPage(updateVars);
-  updateLovellPageTitle(updateVars);
+  if (page.entityUrl.breadcrumb) {
+    page.entityUrl.breadcrumb = getLovellPageBreadcrumbs(updateVars);
+  }
+
+  if (page.fieldRegionPage) {
+    page.fieldRegionPage.entity.title = getLovellTitleVariant(
+      page.fieldRegionPage.entity.title,
+      updateVars,
+    );
+  }
+
+  if (page.fieldOffice) {
+    page.fieldOffice.entity.entityLabel = getLovellTitleVariant(
+      page.fieldOffice.entity.entityLabel,
+      updateVars,
+    );
+  }
 
   return page;
 }

--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -44,9 +44,8 @@ function getModifiedLovellPage(page, variant) {
   }
 
   if (page.fieldRegionPage) {
-    page.fieldRegionPage.entity.title = getLovellVariantTitle(
-      page.fieldRegionPage.entity.title,
-      pageVars,
+    page.fieldRegionPage.entity.title = getLovellTitle(
+      getLovellTitleVariation(pageVars.variant),
     );
   }
 
@@ -71,9 +70,9 @@ function lovellMenusModifyLinks(link) {
       LOVELL_TITLE_STRING,
       getLovellTitle(titleVar),
     );
-  }
 
-  link.url.path = getLovellVariantOfUrl(link.url.path, linkVar);
+    link.url.path = getLovellVariantOfUrl(link.url.path, linkVar);
+  }
 
   // Use recursion to modify nested links
   if (link && link.links.length > 0) {

--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -14,6 +14,7 @@ const {
   LOVELL_BASE_URL,
   isLovellFederalPage,
   isLovellTricarePage,
+  getLovellTitle,
   isLovellVaPage,
   isListingPage,
   getLovellFormOfExistingUrl,
@@ -74,7 +75,7 @@ function lovellMenusModifyLinks(link) {
   if (link.entity.fieldMenuSection === 'both') {
     link.label = link.label.replace(
       LOVELL_TITLE_STRING,
-      `${LOVELL_TITLE_STRING} ${titleVar}`,
+      getLovellTitle(titleVar),
     );
 
     link.url.path = getLovellFormOfExistingUrl(
@@ -115,7 +116,7 @@ function getLovellCloneMenu(drupalData, lovellMenuKey, variant) {
   // Rename the name so our new cloned pages can find the cloned menu
   lovellCloneMenu.name = lovellCloneMenu.name.replace(
     LOVELL_TITLE_STRING,
-    `${LOVELL_TITLE_STRING} ${titleVar}`,
+    getLovellTitle(titleVar),
   );
 
   // Move federal health care links to the top of the menu

--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -16,8 +16,7 @@ const {
   isListingPage,
   getLovellTitle,
   getLovellTitleVariation,
-  getLovellFormOfExistingUrl,
-  resetToFederalUrlIfNeeded,
+  getLovellVariantOfUrl,
 } = require('./lovell/helpers');
 
 const {
@@ -34,6 +33,8 @@ function getModifiedLovellPage(page, variant) {
 
   page.title = getLovellVariantTitle(page.title, pageVars);
   page.entityUrl.path = getLovellVariantPath(pageVars);
+
+  // Could be switched with the same hard set with the opposite variant?
   page.entityUrl.switchPath = getLovellSwitchPath(pageVars);
 
   if (variant === 'tricare' && isLovellFederalPage(page)) {
@@ -74,10 +75,7 @@ function lovellMenusModifyLinks(link) {
       getLovellTitle(titleVar),
     );
 
-    link.url.path = getLovellFormOfExistingUrl(
-      resetToFederalUrlIfNeeded(link.url.path, variant),
-      linkVar,
-    );
+    link.url.path = getLovellVariantOfUrl(link.url.path, linkVar);
   }
 
   // Use recursion to modify nested links

--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -16,7 +16,7 @@ const {
   isLovellTricarePage,
   isLovellVaPage,
   isListingPage,
-  getLovellFormOfUrl,
+  getLovellFormOfExistingUrl,
   resetToFederalUrlIfNeeded,
 } = require('./lovell/helpers');
 
@@ -77,7 +77,7 @@ function lovellMenusModifyLinks(link) {
       `${LOVELL_TITLE_STRING} ${titleVar}`,
     );
 
-    link.url.path = getLovellFormOfUrl(
+    link.url.path = getLovellFormOfExistingUrl(
       resetToFederalUrlIfNeeded(link.url.path, variant),
       linkVar,
     );

--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -7,16 +7,15 @@ const { camelize } = require('../../../utilities/stringHelpers');
 const {
   LOVELL_TITLE_STRING,
   LOVELL_MENU_KEY,
-  LOVELL_VA_TITLE_VARIATION,
-  LOVELL_TRICARE_TITLE_VARIATION,
   LOVELL_VA_LINK_VARIATION,
   LOVELL_TRICARE_LINK_VARIATION,
   LOVELL_BASE_URL,
   isLovellFederalPage,
   isLovellTricarePage,
-  getLovellTitle,
   isLovellVaPage,
   isListingPage,
+  getLovellTitle,
+  getLovellTitleVariation,
   getLovellFormOfExistingUrl,
   resetToFederalUrlIfNeeded,
 } = require('./lovell/helpers');
@@ -64,10 +63,7 @@ function getModifiedLovellPage(page, variant) {
 
 function lovellMenusModifyLinks(link) {
   const { variant } = this;
-  const titleVar =
-    variant === 'va'
-      ? LOVELL_VA_TITLE_VARIATION
-      : LOVELL_TRICARE_TITLE_VARIATION;
+  const titleVar = getLovellTitleVariation(variant);
   const linkVar =
     variant === 'va' ? LOVELL_VA_LINK_VARIATION : LOVELL_TRICARE_LINK_VARIATION;
 
@@ -105,10 +101,7 @@ function lovellMenusModifyLinks(link) {
 }
 
 function getLovellCloneMenu(drupalData, lovellMenuKey, variant) {
-  const titleVar =
-    variant === 'va'
-      ? LOVELL_VA_TITLE_VARIATION
-      : LOVELL_TRICARE_TITLE_VARIATION;
+  const titleVar = getLovellTitleVariation(variant);
 
   // Clone the original menu
   const lovellCloneMenu = cloneDeep(drupalData.data[lovellMenuKey]);

--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -51,9 +51,8 @@ function getModifiedLovellPage(page, variant) {
   }
 
   if (page.fieldOffice) {
-    page.fieldOffice.entity.entityLabel = getLovellVariantTitle(
-      page.fieldOffice.entity.entityLabel,
-      pageVars,
+    page.fieldOffice.entity.entityLabel = getLovellTitle(
+      getLovellTitleVariation(pageVars.variant),
     );
   }
 
@@ -72,9 +71,9 @@ function lovellMenusModifyLinks(link) {
       LOVELL_TITLE_STRING,
       getLovellTitle(titleVar),
     );
-
-    link.url.path = getLovellVariantOfUrl(link.url.path, linkVar);
   }
+
+  link.url.path = getLovellVariantOfUrl(link.url.path, linkVar);
 
   // Use recursion to modify nested links
   if (link && link.links.length > 0) {
@@ -98,15 +97,11 @@ function lovellMenusModifyLinks(link) {
 
 function getLovellCloneMenu(drupalData, lovellMenuKey, variant) {
   const titleVar = getLovellTitleVariation(variant);
-
   // Clone the original menu
   const lovellCloneMenu = cloneDeep(drupalData.data[lovellMenuKey]);
 
   // Rename the name so our new cloned pages can find the cloned menu
-  lovellCloneMenu.name = lovellCloneMenu.name.replace(
-    LOVELL_TITLE_STRING,
-    getLovellTitle(titleVar),
-  );
+  lovellCloneMenu.name = getLovellTitle(titleVar);
 
   // Move federal health care links to the top of the menu
   // Otherwise the menu renders as blank

--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -33,8 +33,6 @@ function getModifiedLovellPage(page, variant) {
 
   page.title = getLovellVariantTitle(page.title, pageVars);
   page.entityUrl.path = getLovellVariantPath(pageVars);
-
-  // Could be switched with the same hard set with the opposite variant?
   page.entityUrl.switchPath = getLovellSwitchPath(pageVars);
 
   if (variant === 'tricare' && isLovellFederalPage(page)) {

--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -11,10 +11,12 @@ const {
   LOVELL_TRICARE_TITLE_VARIATION,
   LOVELL_VA_LINK_VARIATION,
   LOVELL_TRICARE_LINK_VARIATION,
+  LOVELL_BASE_URL,
   isLovellFederalPage,
   isLovellTricarePage,
   isLovellVaPage,
   isListingPage,
+  getLovellFormOfUrl,
   resetToFederalUrlIfNeeded,
 } = require('./lovell/helpers');
 
@@ -75,11 +77,9 @@ function lovellMenusModifyLinks(link) {
       `${LOVELL_TITLE_STRING} ${titleVar}`,
     );
 
-    link.url.path = resetToFederalUrlIfNeeded(link.url.path, variant);
-
-    link.url.path = link.url.path.replace(
-      '/lovell-federal-health-care',
-      `/lovell-federal-${linkVar}-health-care`,
+    link.url.path = getLovellFormOfUrl(
+      resetToFederalUrlIfNeeded(link.url.path, variant),
+      linkVar,
     );
   }
 
@@ -129,7 +129,7 @@ function getLovellCloneMenu(drupalData, lovellMenuKey, variant) {
   // Change the root level item
   // It's coming in from the cms as a va item when it should be both
   lovellCloneMenu.links[0].label = 'Lovell Federal Health Care';
-  lovellCloneMenu.links[0].url.path = '/lovell-federal-health-care';
+  lovellCloneMenu.links[0].url.path = LOVELL_BASE_URL;
   lovellCloneMenu.links[0].entity.fieldMenuSection = 'both';
 
   // Use recursion to Filter and Modify labels and paths of those links

--- a/src/site/stages/build/drupal/tests/lovell/listingPages.unit.spec.js
+++ b/src/site/stages/build/drupal/tests/lovell/listingPages.unit.spec.js
@@ -1,11 +1,7 @@
 /* eslint-disable @department-of-veterans-affairs/axe-check-required */
 /* eslint-disable camelcase */
 import { expect } from 'chai';
-import {
-  processLovellPages,
-  isLovellVaPage,
-  isLovellTricarePage,
-} from '../../process-lovell-pages';
+import { processLovellPages } from '../../process-lovell-pages';
 import { stringArraysContainSameElements } from './utils';
 // Mock Data
 import federalStories from './fixtures/listing-pages/federal/stories.json';
@@ -18,6 +14,8 @@ import vaStories from './fixtures/listing-pages/va/stories.json';
 import vaEvents from './fixtures/listing-pages/va/events.json';
 import vaNews from './fixtures/listing-pages/va/news.json';
 import lovellFederalHealthCareFacilitySidebarQuery from './fixtures/sidebar.json';
+
+const { isLovellVaPage, isLovellTricarePage } = require('../../lovell/helpers');
 
 const entityBundleFromListingVariant = listingVariant => {
   let prefix = listingVariant;

--- a/src/site/stages/build/drupal/tests/lovell/sidebarLocations.unit.spec.js
+++ b/src/site/stages/build/drupal/tests/lovell/sidebarLocations.unit.spec.js
@@ -9,8 +9,8 @@ import generateSidebar from './fixtures/generateSidebar';
 
 const getSidebarQuery = (drupalData, lovellVariant) =>
   lovellVariant === 'va'
-    ? drupalData.data?.vaLovellFederalVaHealthCareFacilitySidebarQuery
-    : drupalData.data?.vaLovellFederalTricareHealthCareFacilitySidebarQuery;
+    ? drupalData.data?.vaLovellFederalHealthCareVaFacilitySidebarQuery
+    : drupalData.data?.vaLovellFederalHealthCareTricareFacilitySidebarQuery;
 
 const getLocationList = (sidebarProperty, lovellVariant) => {
   const topLevel = findSidebarMenuLinkBySectionAndOptionalLabel(


### PR DESCRIPTION
## Description

The Lovell `getModifiedLovellPage` function is big and confusing. This PR does a few things to simplify it and make things easier to manage.

* The code for changing each property (title, URL, switch link, etc) was extracted to individual functions so each one has a single, clear purpose.
* Each of these functions has been moved to a separate `lovell/update-page.js` file.
* These functions have been made into pure functions, so they only return values without changing them. This makes it more explicit in `process-lovell-pages.js` what properties are being changed and under what conditions. This also makes them easier to edit and understand.
* The page variables needed by all these functions are created by a single function, and are passed to all the above functions as a single object to be destructured. This keeps the code in `process-lovell-pages.js` from getting too noisy, and each pure function can be explicit in what it needs without code crowding in the functions either.
* The Lovell processing variables and helper functions (page IDs, variation strings, page type checks) have also been extracted to a new file, `lovell/helpers.js`. This is because they're used in multiple files, and having them in a separate, single source of truth makes them easier to use and understand.

closes [#12013](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12013)

## Testing done & Screenshots

Check local Lovell build pages, automated tests.

## QA steps

**What needs to be checked to prove this works?**
Lovell pages still work as normal and the automated tests still pass.

**What needs to be checked to prove it didn't break any related things?**
Lovell pages and checks.

## Acceptance criteria

- [ ] Lovell pages all still function as expected
- [ ] All current tests pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
