### PR TITLE
VACMS-11997: Adds unit tests for lovell sidebar locations

### DIFF
--- a/src/site/stages/build/drupal/tests/lovell/fixtures/generateSidebar.js
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/generateSidebar.js
@@ -1,0 +1,55 @@
+import cloneDeep from 'lodash/cloneDeep';
+import sidebarTemplate from './sidebar.json';
+import { findSidebarMenuLinkBySectionAndOptionalLabel } from '../utils';
+
+/**
+ * Generates an individual location menu link
+ */
+const generateSidebarLocation = (lovellVariant, label, urlString) => ({
+  label: `${lovellVariant.toUpperCase()} Location ${label}`,
+  url: {
+    path: `/lovell-federal-${lovellVariant}-health-care/locations/${urlString}`,
+  },
+  entity: {
+    fieldMenuSection: lovellVariant,
+  },
+  links: [],
+});
+
+/**
+ * Generates a sidebar menu tree for testing
+ */
+export default (vaLocationCount, tricareLocationCount) => {
+  const sidebar = cloneDeep(sidebarTemplate);
+
+  const lovellFederal = findSidebarMenuLinkBySectionAndOptionalLabel(
+    sidebar.links,
+    'both',
+  );
+
+  const servicesAndLocations = findSidebarMenuLinkBySectionAndOptionalLabel(
+    lovellFederal.links,
+    'both',
+    'Services and Locations',
+  );
+
+  const vaLocations = findSidebarMenuLinkBySectionAndOptionalLabel(
+    servicesAndLocations.links,
+    'va',
+    'Locations',
+  );
+  vaLocations.links = [...Array(vaLocationCount)].map((item, i) =>
+    generateSidebarLocation('va', i + 1, `va-location-${i + 1}`),
+  );
+
+  const tricareLocations = findSidebarMenuLinkBySectionAndOptionalLabel(
+    servicesAndLocations.links,
+    'tricare',
+    'Locations',
+  );
+  tricareLocations.links = [...Array(tricareLocationCount)].map((item, i) =>
+    generateSidebarLocation('tricare', i + 1, `tricare-location-${i + 1}`),
+  );
+
+  return sidebar;
+};

--- a/src/site/stages/build/drupal/tests/lovell/fixtures/generateSidebar.js
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/generateSidebar.js
@@ -15,6 +15,10 @@ const generateSidebarLocation = (lovellVariant, label, urlString) => ({
   },
   links: [],
 });
+const generateVaSidebarLocation = label =>
+  generateSidebarLocation('va', label, `va-location-${label}`);
+const generateTricareSidebarLocation = label =>
+  generateSidebarLocation('tricare', label, `tricare-location-${label}`);
 
 /**
  * Generates a sidebar menu tree for testing
@@ -38,8 +42,8 @@ export default (vaLocationCount, tricareLocationCount) => {
     'va',
     'Locations',
   );
-  vaLocations.links = [...Array(vaLocationCount)].map((item, i) =>
-    generateSidebarLocation('va', i + 1, `va-location-${i + 1}`),
+  vaLocations.links = [...Array(vaLocationCount)].map((_item, i) =>
+    generateVaSidebarLocation(i + 1),
   );
 
   const tricareLocations = findSidebarMenuLinkBySectionAndOptionalLabel(
@@ -47,8 +51,8 @@ export default (vaLocationCount, tricareLocationCount) => {
     'tricare',
     'Locations',
   );
-  tricareLocations.links = [...Array(tricareLocationCount)].map((item, i) =>
-    generateSidebarLocation('tricare', i + 1, `tricare-location-${i + 1}`),
+  tricareLocations.links = [...Array(tricareLocationCount)].map((_item, i) =>
+    generateTricareSidebarLocation(i + 1),
   );
 
   return sidebar;

--- a/src/site/stages/build/drupal/tests/lovell/listingPages.unit.spec.js
+++ b/src/site/stages/build/drupal/tests/lovell/listingPages.unit.spec.js
@@ -6,6 +6,7 @@ import {
   isLovellVaPage,
   isLovellTricarePage,
 } from '../../process-lovell-pages';
+import { stringArraysContainSameElements } from './utils';
 // Mock Data
 import federalStories from './fixtures/listing-pages/federal/stories.json';
 import federalEvents from './fixtures/listing-pages/federal/events.json';
@@ -45,10 +46,6 @@ const getMergedListing = (drupalData, lovellVariant, listingVariant) => {
       page =>
         page.entityBundle === entityBundleFromListingVariant(listingVariant),
     )[0];
-};
-
-const stringArraysContainSameElements = (a, b) => {
-  return a.sort().join(',') === b.sort().join(',');
 };
 
 describe('processLovelPages (listing pages)', () => {

--- a/src/site/stages/build/drupal/tests/lovell/sidebarLocations.unit.spec.js
+++ b/src/site/stages/build/drupal/tests/lovell/sidebarLocations.unit.spec.js
@@ -7,7 +7,7 @@ import {
 } from './utils';
 import generateSidebar from './fixtures/generateSidebar';
 
-const getSidebarProperty = (drupalData, lovellVariant) =>
+const getSidebarQuery = (drupalData, lovellVariant) =>
   lovellVariant === 'va'
     ? drupalData.data?.vaLovellFederalVaHealthCareFacilitySidebarQuery
     : drupalData.data?.vaLovellFederalTricareHealthCareFacilitySidebarQuery;
@@ -32,7 +32,7 @@ const getLocationList = (sidebarProperty, lovellVariant) => {
 };
 
 const expectLocationListToBe = (drupalData, lovellVariant, expectedList) => {
-  const sidebarProperty = getSidebarProperty(drupalData, lovellVariant);
+  const sidebarProperty = getSidebarQuery(drupalData, lovellVariant);
   const locationList = getLocationList(sidebarProperty, lovellVariant);
   expect(sidebarProperty).to.exist;
   expect(locationList).to.exist;

--- a/src/site/stages/build/drupal/tests/lovell/sidebarLocations.unit.spec.js
+++ b/src/site/stages/build/drupal/tests/lovell/sidebarLocations.unit.spec.js
@@ -1,0 +1,92 @@
+/* eslint-disable @department-of-veterans-affairs/axe-check-required */
+import { expect } from 'chai';
+import { processLovellPages } from '../../process-lovell-pages';
+import {
+  stringArraysContainSameElements,
+  findSidebarMenuLinkBySectionAndOptionalLabel,
+} from './utils';
+import generateSidebar from './fixtures/generateSidebar';
+
+const getSidebarProperty = (drupalData, lovellVariant) =>
+  lovellVariant === 'va'
+    ? drupalData.data?.vaLovellFederalVaHealthCareFacilitySidebarQuery
+    : drupalData.data?.vaLovellFederalTricareHealthCareFacilitySidebarQuery;
+
+const getLocationList = (sidebarProperty, lovellVariant) => {
+  const topLevel = findSidebarMenuLinkBySectionAndOptionalLabel(
+    sidebarProperty?.links,
+    'both',
+  );
+
+  const servicesAndLocations = findSidebarMenuLinkBySectionAndOptionalLabel(
+    topLevel?.links,
+    'both',
+    'Services and Locations',
+  );
+
+  return findSidebarMenuLinkBySectionAndOptionalLabel(
+    servicesAndLocations?.links,
+    lovellVariant,
+    'Locations',
+  );
+};
+
+const expectLocationListToBe = (drupalData, lovellVariant, expectedList) => {
+  const sidebarProperty = getSidebarProperty(drupalData, lovellVariant);
+  const locationList = getLocationList(sidebarProperty, lovellVariant);
+  expect(sidebarProperty).to.exist;
+  expect(locationList).to.exist;
+  expect(
+    stringArraysContainSameElements(
+      locationList?.links?.map(link => link.label),
+      expectedList,
+    ),
+  ).to.be.true;
+};
+
+describe('processLovelPages (sidebar locations)', () => {
+  it('correctly generates and filters menu items when source lists are populated', () => {
+    const vaLocationCount = 2;
+    const tricareLocationCount = 3;
+    const sidebar = generateSidebar(vaLocationCount, tricareLocationCount);
+    const drupalData = {
+      data: {
+        lovellFederalHealthCareFacilitySidebarQuery: sidebar,
+        nodeQuery: {
+          entities: [],
+        },
+      },
+    };
+
+    processLovellPages(drupalData);
+
+    expectLocationListToBe(drupalData, 'va', [
+      'VA Location 1',
+      'VA Location 2',
+    ]);
+    expectLocationListToBe(drupalData, 'tricare', [
+      'TRICARE Location 1',
+      'TRICARE Location 2',
+      'TRICARE Location 3',
+    ]);
+  });
+
+  it('generates sidebar menus when source lists are empty', () => {
+    const vaLocationCount = 0;
+    const tricareLocationCount = 0;
+    const sidebar = generateSidebar(vaLocationCount, tricareLocationCount);
+    const drupalData = {
+      data: {
+        lovellFederalHealthCareFacilitySidebarQuery: sidebar,
+        nodeQuery: {
+          entities: [],
+        },
+      },
+    };
+
+    processLovellPages(drupalData);
+
+    expectLocationListToBe(drupalData, 'va', []);
+    expectLocationListToBe(drupalData, 'tricare', []);
+  });
+});

--- a/src/site/stages/build/drupal/tests/lovell/utils.js
+++ b/src/site/stages/build/drupal/tests/lovell/utils.js
@@ -1,0 +1,22 @@
+/**
+ * Returns true if two arrays contain the same strings (in any order)
+ */
+export const stringArraysContainSameElements = (a, b) => {
+  return a.sort().join(',') === b.sort().join(',');
+};
+
+/**
+ * Searches a sidebar menu link to find a child with given attributes, and returns the child object
+ */
+export const findSidebarMenuLinkBySectionAndOptionalLabel = (
+  parent,
+  menuSection,
+  label,
+) =>
+  parent
+    ? parent.find(
+        link =>
+          link.entity.fieldMenuSection === menuSection &&
+          (label ? link.label === label : true),
+      )
+    : undefined;


### PR DESCRIPTION
## Description
Adds unit tests to confirm existence and proper sorting of facility-location links in the sidebar menus on Lovell pages.

The structure here is as follows:
- Added some fixture code to generate sidebar data for various cases (i.e. edge cases).
- Generate sidebar data to plug into an otherwise empty `drupalData` object to test only this sidebar data.
- Call `processLovellPages` for each test case and confirm the generated sidebar is as expected (essentially, the initial data moved into new sidebar properties under `drupalData.data`.

closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11997
relates to https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11650

## Testing done & Screenshots
This PR introduces some new tests. They pass locally and need to pass in the review instance once this is built.


## QA steps

1. Pull branch and run this spec locally:
   - [ ] `yarn test:unit src/site/stages/build/drupal/tests/lovell/sidebarLocations.unit.spec.js`
1. Some small changes were made to move existing code to a shared location, so run this spec locally and confirm it passes as well: 
   - [ ] `yarn test:unit src/site/stages/build/drupal/tests/lovell/listingPages.unit.spec.js`
1. Confirm tests pass on CI
   - [ ] All tests should pass, but specifically confirm the unit tests added here do not fail in CI.