### PR TITLE
Add registry variable for minimal footer

### DIFF
--- a/src/site/includes/footer.html
+++ b/src/site/includes/footer.html
@@ -2,8 +2,7 @@
   <footer class="footer">
     <div
       id="footerNav"
-      data-show-language-assistance="{% if noFooterLanguageAssistance %}false{% else %}true{% endif %}"
-      data-show-links="{% if noFooterLinks %}false{% else %}true{% endif %}"
+      data-minimal-footer="{% if minimalFooter %}true{% else %}false{% endif %}"
     ></div>
   </footer>
 </section>

--- a/src/site/includes/footer.html
+++ b/src/site/includes/footer.html
@@ -1,6 +1,10 @@
 <section role="contentinfo">
   <footer class="footer">
-    <div id="footerNav"></div> <!-- let's try this React thing -->
+    <div
+      id="footerNav"
+      data-show-language-assistance="{% if noFooterLanguageAssistance %}false{% else %}true{% endif %}"
+      data-show-links="{% if noFooterLinks %}false{% else %}true{% endif %}"
+    ></div>
   </footer>
 </section>
 


### PR DESCRIPTION
## Description

This PR adds the capability to respect a `minimalFooter` parameter in the [application registry](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json). When present, the `footerNav` element will have the attributes `data-minimal-footer=true`, which otherwise defaults to false.

Paired with [this PR to the footer application](https://github.com/department-of-veterans-affairs/vets-website/pull/23135), they will cause the footer to look like this:

| mobile | desktop |
| ------- | -------- |
| ![Screenshot 2023-01-23 at 16 49 26](https://user-images.githubusercontent.com/101649/214177821-3b6335e4-704d-437d-a7db-752cb8a16392.png) | ![Screenshot 2023-01-23 at 16 49 31](https://user-images.githubusercontent.com/101649/214177859-045c8a0f-6826-4bf7-b752-3332e9036bec.png) |

Changes with the footer application changes may currently be seen at this review environment: http://f2a317ad566bc3445c43e4e82f957c5e.review.vetsgov-internal/health-care/appointment-check-in/error?error=no-token

Changed markup may be seen on the review environment associated with this PR.

relates to department-of-veterans-affairs/va.gov-team#49890

## Testing done & Screenshots

Tested locally and on review environment. See above for screenshots.

## QA steps

### What needs to be checked to prove this works?

Check footer markup to ensure that the variable is shown with the correct values depending on registry config.

### What needs to be checked to prove it didn't break any related things?

- [ ] Ensure that full footer display/styling is unchanged with this PR.

### What variations of circumstances (users, actions, values) need to be checked?

This change should not be dependent on users & actions. Registry value checks are handled in the above items.

## Acceptance criteria

- [ ] `footerNav` attribute `data-minimal-footer` is present and defaults to false
- [ ] `footerNav` attribute `data-minimal-footer ` is present and shown as true when the corresponding registry variables are present

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
