### PR TITLE
Fix incorrect breadcrumb casing for health care application

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -193,7 +193,7 @@
       "breadcrumbs_override": [
         {
           "path": "health-care/",
-          "name": "Health Care"
+          "name": "Health care"
         },
         {
           "path": "health-care/apply/application",


### PR DESCRIPTION
## Description
The breadcrumb on the [Health Care application](https://www.va.gov/health-care/apply/application/introduction) has incorrect casing for the "Health care" segment. It currently reads "Health Care", but should have a lower case "c" on "care". This PR updates the breadcrumb overrides for the application to correct this casing.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#31767

## Acceptance criteria
- [ ] Breadcrumb text contains appropriate casing