### PR TITLE
Entity ID for h5s added

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -179,8 +179,18 @@ module.exports = function registerFilters() {
       '113332',
       '7153',
       '37238',
+      '5697',
+      '101671',
     ];
-    return targetH3IDs.includes(id);
+    const targetH5IDs = ['112021'];
+
+    if (targetH3IDs.includes(id)) {
+      return 'h3';
+    }
+    if (targetH5IDs.includes(id)) {
+      return 'h5';
+    }
+    return 'h4';
   };
 
   liquid.filters.dateFromUnix = (dt, format, tz = 'America/New_York') => {

--- a/src/site/paragraphs/collapsible_panel.drupal.liquid
+++ b/src/site/paragraphs/collapsible_panel.drupal.liquid
@@ -35,7 +35,7 @@
     {% assign collapsibleHeaderH3 = entity.entityId | filterCollapsibleHeaderLevels %}
 
     {% if collapsibleHeaderH3 %}
-        {% assign panelHeaderLevel = 'h3' %}
+        {% assign panelHeaderLevel = collapsibleHeaderH3 %}
     {% else %}
         {% assign panelHeaderLevel = 'h4' %}
     {% endif %}


### PR DESCRIPTION
## Description
Fix accordion header levels on Burial Benefits detail pages. Allows for the use of h5 header levels when for collapsible panel components

closes 12183

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12183

## Testing done & Screenshots



## QA steps
<img width="1197" alt="Screen Shot 2023-01-23 at 10 38 14 AM" src="https://user-images.githubusercontent.com/61624970/214081740-0c4025b1-a20c-4e91-8c15-79964feb4832.png">
<img width="1197" alt="Screen Shot 2023-01-23 at 10 38 29 AM" src="https://user-images.githubusercontent.com/61624970/214081744-0384da67-5f6d-46e0-aeb2-8dafb963b28c.png">
<img width="1197" alt="Screen Shot 2023-01-23 at 10 38 42 AM" src="https://user-images.githubusercontent.com/61624970/214081746-746d04e5-a877-492f-931a-cb7c268eec92.png">


What needs to be checked to prove this works?  
1. Navigate to the following links and verify that header levels are correct:

- /burials-memorials/eligibility/
- /burials-memorials/eligibility/burial-in-private-cemetery/
- /burials-memorials/memorial-items/headstones-markers-medallions/

2. Only accordion components on these pages should see changes


## Acceptance criteria

- [x] Noted headers are updated
- [x] Other headers remain the same
- [x] Accessibility review

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
