### PR TITLE
Restore older version of cert used for a11y container.

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -167,7 +167,7 @@ jobs:
         ci_node_index: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]
 
     env:
-      NODE_EXTRA_CA_CERTS: /etc/ssl/certs/ca-certificates.crt
+      NODE_EXTRA_CA_CERTS: /share/ca-certificates/VA-Internal-S2-RCA1-v1.cer.crt
       CHROMEDRIVER_FILEPATH: /share/chrome_driver/chromedriver
 
     steps:


### PR DESCRIPTION
## Description

This reverts a part of #1140 which changed how certs are handled in content-build workflows. We're restoring the working behavior for the a11y workflow.