### PR TITLE
Specify ASG label for all self-hosted that is not on-demand.

### DIFF
--- a/.github/workflows/a11y-heading-order.yml
+++ b/.github/workflows/a11y-heading-order.yml
@@ -122,7 +122,7 @@ jobs:
     name: Accessibility Tests
     needs: build
     timeout-minutes: 120
-    runs-on: self-hosted
+    runs-on: [self-hosted, asg]
     container:
       image: public.ecr.aws/cypress-io/cypress/browsers:node16.13.2-chrome100-ff98
       options: -u 1001:1001 -v /usr/local/share:/share --user root

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   build:
     name: Build
-    runs-on: self-hosted
+    runs-on: [self-hosted, asg]
     timeout-minutes: 180
     defaults:
       run:
@@ -156,7 +156,7 @@ jobs:
     name: Accessibility Tests
     needs: build
     timeout-minutes: 120
-    runs-on: self-hosted
+    runs-on: [self-hosted, asg]
     container:
       image: public.ecr.aws/cypress-io/cypress/browsers:node16.13.2-chrome100-ff98
       options: -u 1001:1001 -v /usr/local/share:/share --user root

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -24,10 +24,7 @@ env:
 
 jobs:
   start-runner:
-    runs-on:
-      - self-hosted
-      - linux
-      - x64
+    runs-on: [self-hosted, asg]
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
@@ -129,10 +126,7 @@ jobs:
 
   notify-start:
     name: Notify Start
-    runs-on:
-      - self-hosted
-      - linux
-      - x64
+    runs-on: [self-hosted, asg]
     needs: validate-build-status
     steps:
       - name: Checkout
@@ -452,10 +446,7 @@ jobs:
 
   deploy:
     name: Deploy
-    runs-on:
-      - self-hosted
-      - linux
-      - x64
+    runs-on: [self-hosted, asg]
     needs:
       - validate-build-status
       - build
@@ -522,10 +513,7 @@ jobs:
 
   notify-success:
     name: Notify Success
-    runs-on:
-      - self-hosted
-      - linux
-      - x64
+    runs-on: [self-hosted, asg]
     needs:
       - validate-build-status
       - deploy
@@ -553,10 +541,7 @@ jobs:
 
   notify-failure:
     name: Notify Failure
-    runs-on:
-      - self-hosted
-      - linux
-      - x64
+    runs-on: [self-hosted, asg]
     if: |
       (failure() && needs.deploy.result != 'success')
     needs: deploy
@@ -607,10 +592,7 @@ jobs:
 
   record-metrics:
     name: Record metrics in Datadog
-    runs-on:
-      - self-hosted
-      - linux
-      - x64
+    runs-on: [self-hosted, asg]
     needs:
       - start-runner
       - build

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   build:
     name: Build
-    runs-on: self-hosted
+    runs-on: [self-hosted, asg]
     timeout-minutes: 60
 
     defaults:
@@ -244,10 +244,7 @@ jobs:
           channel-id: ${{ env.BROKEN_LINKS_SLACK }}
 
   start-runner:
-    runs-on:
-      - self-hosted
-      - linux
-      - x64
+    runs-on: [self-hosted, asg]
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
@@ -666,7 +663,7 @@ jobs:
 
   deploy:
     name: Deploy
-    runs-on: self-hosted
+    runs-on: [self-hosted, asg]
     if: ${{ always() && github.ref == 'refs/heads/main' && needs.get-latest-run-number.result == 'success' && needs.get-latest-run-number.outputs.latest_run_number == github.run_number }}
     needs: [build, cypress-tests, get-latest-run-number]
 

--- a/.github/workflows/deploy-content-preview-server.yml
+++ b/.github/workflows/deploy-content-preview-server.yml
@@ -11,10 +11,7 @@ jobs:
   deploy-preview-server:
     name: Deploy Preview Servers (PROD, STAGING, DEV)
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on:
-      - self-hosted
-      - linux
-      - x64
+    runs-on: [self-hosted, asg]
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/manual-deploy-dev-staging.yml
+++ b/.github/workflows/manual-deploy-dev-staging.yml
@@ -44,7 +44,7 @@ jobs:
 
   deploy:
     name: Deploy
-    runs-on: self-hosted
+    runs-on: [self-hosted, asg]
     needs: set-environment
     strategy:
       matrix: ${{ fromJson(needs.set-environment.outputs.environment) }}


### PR DESCRIPTION
## Description
Relates to https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11402

We are looking to isolate the runners which run the Continuous Integration:Cypress Tests job from all other jobs.

#1450 moved the Cypress Tests job to use its own on-demand runner. Previously it had specified the `asg` label, picking a runner from the ASG pool.

This PR moves any job running self-hosted to use the `asg` label. This should prevent all these jobs from ever using the same runner as the Cypress Types job.

## Acceptance Criteria
- [ ] All workflows/jobs in this PR run without error. Many may need to be tested after merge, unfortunately.