### PR TITLE
Adjusted header levels bene hub-rail (12169)

### DIFF
--- a/src/site/blocks/promo.drupal.liquid
+++ b/src/site/blocks/promo.drupal.liquid
@@ -36,11 +36,12 @@
   {% if entity.fieldPromoLink != empty %}
     {% assign link = entity.fieldPromoLink.entity.fieldLink | featureSingleValueFieldLink %}
     <section class="hub-promo-text">
-        <h4 class="heading">
+        <h2 class="vads-u-font-size--h4 vads-u-text-decoration--underline vads-u-margin-top--0">
           <a onClick="recordEvent({ event: 'nav-hub-promo' });"
             href="{{ link.url.path }}">{{ link.title }}</a>
-        </h4>
+        </h2>
         <p>{{ entity.fieldPromoLink.entity.fieldLinkSummary }}</p>
     </section>
   {% endif %}
 </div>
+

--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -62,9 +62,9 @@
         {% endif %}
 
         <va-accordion bordered multi>
-          <va-accordion-item level="3" open="true" header="Ask questions">
+          <va-accordion-item level="2" open="true" header="Ask questions">
             <section>
-              <h4>Message us</h4>
+              <h3 class="vads-u-font-size--h4">Message us</h3>
               <ul class="va-nav-linkslist-list social">
                 <li data-widget-type="ask-va"></li>
               </ul>
@@ -72,7 +72,7 @@
 
             {% if fieldSupportServices != empty %}
               <section>
-                <h4>Call us</h4>
+                <h3 class="vads-u-font-size--h4">Call us</h3>
                 <ul class="va-nav-linkslist-list social">
                   {% for supportService in fieldSupportServices %}
                     {% assign service = supportService.entity %}
@@ -108,9 +108,9 @@
           </va-accordion-item>
 
           {% if fieldLinks != empty and fieldLinks.length > 0 %}
-            <va-accordion-item level="3" open="true" header="Not a Veteran?">
+            <va-accordion-item level="2" open="true" header="Not a Veteran?">
               <section>
-                <h4>Get information for:</h4>
+                <h3 class="vads-u-font-size--h4">Get information for:</h3>
                 <ul class="va-nav-linkslist-list links">
                   {% for link in fieldLinks %}
                     <li>
@@ -126,17 +126,17 @@
 
         <!-- Connect with us -->
         {% if fieldRelatedOffice != empty and fieldRelatedOffice.entity.fieldExternalLink.title != "Records benefits hub" %}
-            <va-accordion-item level="3" header="Connect with us" open="true">
+            <va-accordion-item level="2" header="Connect with us" open="true">
               {% if fieldRelatedOffice.entity.fieldExternalLink.url.path != empty %}
-                <h4 class="va-nav-linkslist-list">
+                <h3 class="va-nav-linkslist-list vads-u-font-size--h4">
                   <a class="vads-u-text-decoration--underline" href="{{ fieldRelatedOffice.entity.fieldExternalLink.url.path }}" onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });">
                     {{ fieldRelatedOffice.entity.fieldExternalLink.title }}
                   </a>
-                </h4>
+                </h3>
               {% endif %}
 
               <section>
-                <h4>Get updates</h4>
+                <h3 class="vads-u-font-size--h4">Get updates</h3>
                   <ul class="va-nav-linkslist-list social">
                     <li>
                       <a class="vads-u-text-decoration--underline" href="{{ fieldRelatedOffice.entity.fieldEmailUpdatesLink.url.path }}" onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });">
@@ -148,7 +148,7 @@
               </section>
 
               <section>
-                <h4>Follow us</h4>
+                <h3 class="vads-u-font-size--h4">Follow us</h3>
                 <ul class="va-nav-linkslist-list social">
                   {% assign socialLinks =  fieldRelatedOffice.entity.fieldSocialMediaLinks.platformValues | jsonToObj %}
                   {% assign socialPlatforms = socialLinks | keys %}


### PR DESCRIPTION
## Description
Updates header levels on the benefit hub rail without changing visual presentation

closes #12169

## Testing done & Screenshots
<img width="1414" alt="Screen Shot 2023-01-30 at 11 14 43 AM" src="https://user-images.githubusercontent.com/61624970/215532587-8133471e-281a-4e8e-bac0-2a4f24751a4a.png">
<img width="1414" alt="Screen Shot 2023-01-30 at 11 15 01 AM" src="https://user-images.githubusercontent.com/61624970/215532589-51650df0-19df-4944-85a6-6ff478018659.png">
<img width="1414" alt="Screen Shot 2023-01-30 at 11 15 11 AM" src="https://user-images.githubusercontent.com/61624970/215532592-da3f091d-6f48-41c1-8166-bb3d484551b9.png">



## QA steps

- Navigate to a benefit hub landing page (eg /health-care) 
- Verify that header levels are appropriate for hub rail.
- Verify that there are no visual changes

## Acceptance criteria

- [ ] Header levels updated to not skip any levels
- [ ] No visual changes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
