### PR TITLE
VACMS-12241: Updates Lovell mock data and tests to align with name change

### DIFF
--- a/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/federal/events.json
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/federal/events.json
@@ -181,7 +181,7 @@
           }
         ],
         "entityUrl": {
-          "path": "/lovell-federal-va-health-care/events/36405"
+          "path": "/lovell-federal-health-care-va/events/36405"
         },
         "title": "Lovell Federal health care Placeholder - Event",
         "vid": 736023,
@@ -313,7 +313,7 @@
           }
         ],
         "entityUrl": {
-          "path": "/lovell-federal-va-health-care/events/49919"
+          "path": "/lovell-federal-health-care-va/events/49919"
         },
         "title": "Test Event 1 Both",
         "vid": 735968,
@@ -360,7 +360,7 @@
             "entityId": "1480",
             "entityType": "node",
             "entityUrl": {
-              "path": "/lovell-federal-va-health-care/locations/captain-james-a-lovell-federal-health-care-center"
+              "path": "/lovell-federal-health-care-va/locations/captain-james-a-lovell-federal-health-care-center"
             },
             "title": "Captain James A. Lovell Federal Health Care Center"
           }
@@ -450,7 +450,7 @@
           }
         ],
         "entityUrl": {
-          "path": "/lovell-federal-va-health-care/events/49920"
+          "path": "/lovell-federal-health-care-va/events/49920"
         },
         "title": "Test Event 2 Both",
         "vid": 735967,
@@ -604,7 +604,7 @@
           }
         ],
         "entityUrl": {
-          "path": "/lovell-federal-va-health-care/events/36405"
+          "path": "/lovell-federal-health-care-va/events/36405"
         },
         "title": "Lovell Federal health care Placeholder - Event",
         "vid": 736023,
@@ -736,7 +736,7 @@
           }
         ],
         "entityUrl": {
-          "path": "/lovell-federal-va-health-care/events/49919"
+          "path": "/lovell-federal-health-care-va/events/49919"
         },
         "title": "Test Event 1 Both",
         "vid": 735968,
@@ -783,7 +783,7 @@
             "entityId": "1480",
             "entityType": "node",
             "entityUrl": {
-              "path": "/lovell-federal-va-health-care/locations/captain-james-a-lovell-federal-health-care-center"
+              "path": "/lovell-federal-health-care-va/locations/captain-james-a-lovell-federal-health-care-center"
             },
             "title": "Captain James A. Lovell Federal Health Care Center"
           }
@@ -873,7 +873,7 @@
           }
         ],
         "entityUrl": {
-          "path": "/lovell-federal-va-health-care/events/49920"
+          "path": "/lovell-federal-health-care-va/events/49920"
         },
         "title": "Test Event 2 Both",
         "vid": 735967,

--- a/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/federal/news.json
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/federal/news.json
@@ -119,7 +119,7 @@
           "value": "2022-10-02T19:50:12"
         },
         "entityUrl": {
-          "path": "/lovell-federal-va-health-care/news-releases/test-a-press-release-for-both-lovell"
+          "path": "/lovell-federal-health-care-va/news-releases/test-a-press-release-for-both-lovell"
         },
         "uid": {
           "targetId": 1215,

--- a/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/federal/stories.json
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/federal/stories.json
@@ -117,7 +117,7 @@
         "title": "TEST story for BOTH Lovell",
         "fieldFeatured": false,
         "entityUrl": {
-          "path": "/lovell-federal-va-health-care/stories/test-story-for-both-lovell"
+          "path": "/lovell-federal-health-care-va/stories/test-story-for-both-lovell"
         },
         "uid": {
           "targetId": 1215,

--- a/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/tricare/events.json
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/tricare/events.json
@@ -35,7 +35,7 @@
         "text": "Events"
       }
     ],
-    "path": "/lovell-federal-tricare-health-care/events"
+    "path": "/lovell-federal-health-care-tricare/events"
   },
   "entityMetatags": [
     {
@@ -46,12 +46,12 @@
     {
       "__typename": "MetaValue",
       "key": "title",
-      "value": "Events | Lovell Federal TRICARE health care | Veterans Affairs"
+      "value": "Events | Lovell Federal health care - TRICARE | Veterans Affairs"
     },
     {
       "__typename": "MetaValue",
       "key": "description",
-      "value": "Check early and often to see upcoming events at Lovell Federal TRICARE health care and regional events."
+      "value": "Check early and often to see upcoming events at Lovell Federal health care - TRICARE and regional events."
     },
     {
       "__typename": "MetaProperty",
@@ -66,7 +66,7 @@
     {
       "__typename": "MetaProperty",
       "key": "og:description",
-      "value": "Check early and often to see upcoming events at Lovell Federal TRICARE health care and regional events."
+      "value": "Check early and often to see upcoming events at Lovell Federal health care - TRICARE and regional events."
     },
     {
       "__typename": "MetaProperty",
@@ -91,12 +91,12 @@
     {
       "__typename": "MetaValue",
       "key": "twitter:description",
-      "value": "Check early and often to see upcoming events at Lovell Federal TRICARE health care and regional events."
+      "value": "Check early and often to see upcoming events at Lovell Federal health care - TRICARE and regional events."
     },
     {
       "__typename": "MetaValue",
       "key": "twitter:title",
-      "value": "Events | Lovell Federal TRICARE health care | Veterans Affairs"
+      "value": "Events | Lovell Federal health care - TRICARE | Veterans Affairs"
     },
     {
       "__typename": "MetaValue",
@@ -110,7 +110,7 @@
     }
   ],
   "changed": 1671038416,
-  "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal TRICARE health care and regional events.",
+  "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care - TRICARE and regional events.",
   "pastEvents": {
     "entities": [
       {
@@ -127,7 +127,7 @@
           {
             "__typename": "MetaValue",
             "key": "title",
-            "value": "Lovell Federal TRICARE health care | Test Event A TRICARE | Veterans Affairs"
+            "value": "Lovell Federal health care - TRICARE | Test Event A TRICARE | Veterans Affairs"
           },
           {
             "__typename": "MetaProperty",
@@ -137,7 +137,7 @@
           {
             "__typename": "MetaProperty",
             "key": "og:title",
-            "value": "Test Event A TRICARE | Lovell Federal TRICARE health care | Veterans Affairs"
+            "value": "Test Event A TRICARE | Lovell Federal health care - TRICARE | Veterans Affairs"
           },
           {
             "__typename": "MetaProperty",
@@ -157,11 +157,11 @@
           {
             "__typename": "MetaValue",
             "key": "twitter:title",
-            "value": "Test Event A TRICARE | Lovell Federal TRICARE health care | Veterans Affairs"
+            "value": "Test Event A TRICARE | Lovell Federal health care - TRICARE | Veterans Affairs"
           }
         ],
         "entityUrl": {
-          "path": "/lovell-federal-tricare-health-care/events/49921"
+          "path": "/lovell-federal-health-care-tricare/events/49921"
         },
         "title": "Test Event A TRICARE",
         "vid": 735966,
@@ -210,8 +210,8 @@
             "entityBundle": "event_listing",
             "entityId": "49454",
             "entityType": "node",
-            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal TRICARE health care and regional events.",
-            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal TRICARE health care and regional events.",
+            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal health care - TRICARE and regional events.",
+            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care - TRICARE and regional events.",
             "fieldOffice": {
               "entity": {
                 "entityType": "node",
@@ -257,7 +257,7 @@
           {
             "__typename": "MetaValue",
             "key": "title",
-            "value": "Lovell Federal TRICARE health care | Test Event B TRICARE | Veterans Affairs"
+            "value": "Lovell Federal health care - TRICARE | Test Event B TRICARE | Veterans Affairs"
           },
           {
             "__typename": "MetaProperty",
@@ -267,7 +267,7 @@
           {
             "__typename": "MetaProperty",
             "key": "og:title",
-            "value": "Test Event B TRICARE | Lovell Federal TRICARE health care | Veterans Affairs"
+            "value": "Test Event B TRICARE | Lovell Federal health care - TRICARE | Veterans Affairs"
           },
           {
             "__typename": "MetaProperty",
@@ -287,11 +287,11 @@
           {
             "__typename": "MetaValue",
             "key": "twitter:title",
-            "value": "Test Event B TRICARE | Lovell Federal TRICARE health care | Veterans Affairs"
+            "value": "Test Event B TRICARE | Lovell Federal health care - TRICARE | Veterans Affairs"
           }
         ],
         "entityUrl": {
-          "path": "/lovell-federal-tricare-health-care/events/49922"
+          "path": "/lovell-federal-health-care-tricare/events/49922"
         },
         "title": "Test Event B TRICARE",
         "vid": 735965,
@@ -338,7 +338,7 @@
             "entityId": "49055",
             "entityType": "node",
             "entityUrl": {
-              "path": "/lovell-federal-tricare-health-care/locations/captain-james-a-lovell-federal-health-care-center"
+              "path": "/lovell-federal-health-care-tricare/locations/captain-james-a-lovell-federal-health-care-center"
             },
             "title": "Captain James A. Lovell Federal Health Care Center"
           }
@@ -350,8 +350,8 @@
             "entityBundle": "event_listing",
             "entityId": "49454",
             "entityType": "node",
-            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal TRICARE health care and regional events.",
-            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal TRICARE health care and regional events.",
+            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal health care - TRICARE and regional events.",
+            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care - TRICARE and regional events.",
             "fieldOffice": {
               "entity": {
                 "entityType": "node",
@@ -398,7 +398,7 @@
           {
             "__typename": "MetaValue",
             "key": "title",
-            "value": "Lovell Federal TRICARE health care | Test Event A TRICARE | Veterans Affairs"
+            "value": "Lovell Federal health care - TRICARE | Test Event A TRICARE | Veterans Affairs"
           },
           {
             "__typename": "MetaProperty",
@@ -408,7 +408,7 @@
           {
             "__typename": "MetaProperty",
             "key": "og:title",
-            "value": "Test Event A TRICARE | Lovell Federal TRICARE health care | Veterans Affairs"
+            "value": "Test Event A TRICARE | Lovell Federal health care - TRICARE | Veterans Affairs"
           },
           {
             "__typename": "MetaProperty",
@@ -428,11 +428,11 @@
           {
             "__typename": "MetaValue",
             "key": "twitter:title",
-            "value": "Test Event A TRICARE | Lovell Federal TRICARE health care | Veterans Affairs"
+            "value": "Test Event A TRICARE | Lovell Federal health care - TRICARE | Veterans Affairs"
           }
         ],
         "entityUrl": {
-          "path": "/lovell-federal-tricare-health-care/events/49921"
+          "path": "/lovell-federal-health-care-tricare/events/49921"
         },
         "title": "Test Event A TRICARE",
         "vid": 735966,
@@ -481,8 +481,8 @@
             "entityBundle": "event_listing",
             "entityId": "49454",
             "entityType": "node",
-            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal TRICARE health care and regional events.",
-            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal TRICARE health care and regional events.",
+            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal health care - TRICARE and regional events.",
+            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care - TRICARE and regional events.",
             "fieldOffice": {
               "entity": {
                 "entityType": "node",
@@ -528,7 +528,7 @@
           {
             "__typename": "MetaValue",
             "key": "title",
-            "value": "Lovell Federal TRICARE health care | Test Event B TRICARE | Veterans Affairs"
+            "value": "Lovell Federal health care - TRICARE | Test Event B TRICARE | Veterans Affairs"
           },
           {
             "__typename": "MetaProperty",
@@ -538,7 +538,7 @@
           {
             "__typename": "MetaProperty",
             "key": "og:title",
-            "value": "Test Event B TRICARE | Lovell Federal TRICARE health care | Veterans Affairs"
+            "value": "Test Event B TRICARE | Lovell Federal health care - TRICARE | Veterans Affairs"
           },
           {
             "__typename": "MetaProperty",
@@ -558,11 +558,11 @@
           {
             "__typename": "MetaValue",
             "key": "twitter:title",
-            "value": "Test Event B TRICARE | Lovell Federal TRICARE health care | Veterans Affairs"
+            "value": "Test Event B TRICARE | Lovell Federal health care - TRICARE | Veterans Affairs"
           }
         ],
         "entityUrl": {
-          "path": "/lovell-federal-tricare-health-care/events/49922"
+          "path": "/lovell-federal-health-care-tricare/events/49922"
         },
         "title": "Test Event B TRICARE",
         "vid": 735965,
@@ -609,7 +609,7 @@
             "entityId": "49055",
             "entityType": "node",
             "entityUrl": {
-              "path": "/lovell-federal-tricare-health-care/locations/captain-james-a-lovell-federal-health-care-center"
+              "path": "/lovell-federal-health-care-tricare/locations/captain-james-a-lovell-federal-health-care-center"
             },
             "title": "Captain James A. Lovell Federal Health Care Center"
           }
@@ -621,8 +621,8 @@
             "entityBundle": "event_listing",
             "entityId": "49454",
             "entityType": "node",
-            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal TRICARE health care and regional events.",
-            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal TRICARE health care and regional events.",
+            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal health care - TRICARE and regional events.",
+            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care - TRICARE and regional events.",
             "fieldOffice": {
               "entity": {
                 "entityType": "node",
@@ -655,7 +655,7 @@
   },
   "fieldOffice": {
     "entity": {
-      "entityLabel": "Lovell Federal TRICARE health care"
+      "entityLabel": "Lovell Federal health care - TRICARE"
     }
   },
   "fieldAdministration": {

--- a/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/tricare/news.json
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/tricare/news.json
@@ -35,7 +35,7 @@
         "text": "News releases"
       }
     ],
-    "path": "/lovell-federal-tricare-health-care/news-releases"
+    "path": "/lovell-federal-health-care-tricare/news-releases"
   },
   "entityMetatags": [
     {
@@ -46,12 +46,12 @@
     {
       "__typename": "MetaValue",
       "key": "title",
-      "value": "News releases | Lovell Federal TRICARE health care | Veterans Affairs"
+      "value": "News releases | Lovell Federal health care - TRICARE | Veterans Affairs"
     },
     {
       "__typename": "MetaValue",
       "key": "description",
-      "value": "Lovell Federal TRICARE health care news releases and information for the TRICARE recipients, their families, and caregivers"
+      "value": "Lovell Federal health care - TRICARE news releases and information for the TRICARE recipients, their families, and caregivers"
     },
     {
       "__typename": "MetaProperty",
@@ -61,12 +61,12 @@
     {
       "__typename": "MetaProperty",
       "key": "og:title",
-      "value": "News releases | Lovell Federal TRICARE health care | Veterans Affairs"
+      "value": "News releases | Lovell Federal health care - TRICARE | Veterans Affairs"
     },
     {
       "__typename": "MetaProperty",
       "key": "og:description",
-      "value": "Lovell Federal TRICARE health care news releases and information for the TRICARE recipients, their families, and caregivers"
+      "value": "Lovell Federal health care - TRICARE news releases and information for the TRICARE recipients, their families, and caregivers"
     },
     {
       "__typename": "MetaProperty",
@@ -91,12 +91,12 @@
     {
       "__typename": "MetaValue",
       "key": "twitter:description",
-      "value": "Lovell Federal TRICARE health care news releases and information for the TRICARE recipients, their families, and caregivers"
+      "value": "Lovell Federal health care - TRICARE news releases and information for the TRICARE recipients, their families, and caregivers"
     },
     {
       "__typename": "MetaValue",
       "key": "twitter:title",
-      "value": "News releases | Lovell Federal TRICARE health care | Veterans Affairs"
+      "value": "News releases | Lovell Federal health care - TRICARE | Veterans Affairs"
     },
     {
       "__typename": "MetaValue",
@@ -109,7 +109,7 @@
       "value": "https://www.va.gov/img/design/logo/va-og-image.png"
     }
   ],
-  "fieldIntroText": "News releases for Lovell Federal TRICARE health care.",
+  "fieldIntroText": "News releases for Lovell Federal health care - TRICARE.",
   "reverseFieldListingNode": {
     "entities": [
       {
@@ -119,7 +119,7 @@
           "value": "2022-10-05T19:50:12"
         },
         "entityUrl": {
-          "path": "/lovell-federal-tricare-health-care/news-releases/test-a-press-release-for-lovell-tricare"
+          "path": "/lovell-federal-health-care-tricare/news-releases/test-a-press-release-for-lovell-tricare"
         },
         "uid": {
           "targetId": 1215,
@@ -137,8 +137,8 @@
   "fieldOffice": {
     "targetId": 49011,
     "entity": {
-      "entityLabel": "Lovell Federal TRICARE health care",
-      "title": "Lovell Federal TRICARE health care"
+      "entityLabel": "Lovell Federal health care - TRICARE",
+      "title": "Lovell Federal health care - TRICARE"
     }
   },
   "fieldAdministration": {

--- a/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/tricare/stories.json
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/tricare/stories.json
@@ -35,7 +35,7 @@
         "text": "Stories"
       }
     ],
-    "path": "/lovell-federal-tricare-health-care/stories"
+    "path": "/lovell-federal-health-care-tricare/stories"
   },
   "entityMetatags": [
     {
@@ -46,12 +46,12 @@
     {
       "__typename": "MetaValue",
       "key": "title",
-      "value": "Stories | Lovell Federal TRICARE health care | Veterans Affairs"
+      "value": "Stories | Lovell Federal health care - TRICARE | Veterans Affairs"
     },
     {
       "__typename": "MetaValue",
       "key": "description",
-      "value": "Lovell Federal TRICARE health care top stories."
+      "value": "Lovell Federal health care - TRICARE top stories."
     },
     {
       "__typename": "MetaProperty",
@@ -61,12 +61,12 @@
     {
       "__typename": "MetaProperty",
       "key": "og:title",
-      "value": "Stories | Lovell Federal TRICARE health care | Veterans Affairs"
+      "value": "Stories | Lovell Federal health care - TRICARE | Veterans Affairs"
     },
     {
       "__typename": "MetaProperty",
       "key": "og:description",
-      "value": "Lovell Federal TRICARE health care top stories."
+      "value": "Lovell Federal health care - TRICARE top stories."
     },
     {
       "__typename": "MetaProperty",
@@ -91,12 +91,12 @@
     {
       "__typename": "MetaValue",
       "key": "twitter:description",
-      "value": "Lovell Federal TRICARE health care top stories."
+      "value": "Lovell Federal health care - TRICARE top stories."
     },
     {
       "__typename": "MetaValue",
       "key": "twitter:title",
-      "value": "Stories | Lovell Federal TRICARE health care | Veterans Affairs"
+      "value": "Stories | Lovell Federal health care - TRICARE | Veterans Affairs"
     },
     {
       "__typename": "MetaValue",
@@ -109,7 +109,7 @@
       "value": "https://www.va.gov/img/design/logo/va-og-image.png"
     }
   ],
-  "fieldIntroText": "Lovell Federal TRICARE health care top stories.",
+  "fieldIntroText": "Lovell Federal health care - TRICARE top stories.",
   "reverseFieldListingNode": {
     "entities": [
       {
@@ -117,7 +117,7 @@
         "title": "TEST story for TRICARE Lovell",
         "fieldFeatured": true,
         "entityUrl": {
-          "path": "/lovell-federal-tricare-health-care/stories/test-story-for-tricare-lovell"
+          "path": "/lovell-federal-health-care-tricare/stories/test-story-for-tricare-lovell"
         },
         "uid": {
           "targetId": 1215,
@@ -146,8 +146,8 @@
   "fieldOffice": {
     "targetId": 49011,
     "entity": {
-      "title": "Lovell Federal TRICARE health care",
-      "entityLabel": "Lovell Federal TRICARE health care"
+      "title": "Lovell Federal health care - TRICARE",
+      "entityLabel": "Lovell Federal health care - TRICARE"
     }
   },
   "fieldAdministration": {

--- a/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/va/events.json
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/va/events.json
@@ -14,7 +14,7 @@
       { "url": { "path": "", "routed": true }, "text": "NEWS AND EVENTS" },
       { "url": { "path": "", "routed": true }, "text": "Events" }
     ],
-    "path": "/lovell-federal-va-health-care/events"
+    "path": "/lovell-federal-health-care-va/events"
   },
   "entityMetatags": [
     {
@@ -25,12 +25,12 @@
     {
       "__typename": "MetaValue",
       "key": "title",
-      "value": "Events | Lovell Federal VA health care | Veterans Affairs"
+      "value": "Events | Lovell Federal health care - VA | Veterans Affairs"
     },
     {
       "__typename": "MetaValue",
       "key": "description",
-      "value": "Check early and often to see upcoming events at Lovell Federal VA health care and regional events."
+      "value": "Check early and often to see upcoming events at Lovell Federal health care - VA and regional events."
     },
     {
       "__typename": "MetaProperty",
@@ -45,7 +45,7 @@
     {
       "__typename": "MetaProperty",
       "key": "og:description",
-      "value": "Check early and often to see upcoming events at Lovell Federal VA health care and regional events."
+      "value": "Check early and often to see upcoming events at Lovell Federal health care - VA and regional events."
     },
     {
       "__typename": "MetaProperty",
@@ -70,12 +70,12 @@
     {
       "__typename": "MetaValue",
       "key": "twitter:description",
-      "value": "Check early and often to see upcoming events at Lovell Federal VA health care and regional events."
+      "value": "Check early and often to see upcoming events at Lovell Federal health care - VA and regional events."
     },
     {
       "__typename": "MetaValue",
       "key": "twitter:title",
-      "value": "Events | Lovell Federal VA health care | Veterans Affairs"
+      "value": "Events | Lovell Federal health care - VA | Veterans Affairs"
     },
     {
       "__typename": "MetaValue",
@@ -89,7 +89,7 @@
     }
   ],
   "changed": 1671038416,
-  "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal VA health care and regional events.",
+  "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care - VA and regional events.",
   "pastEvents": {
     "entities": [
       {
@@ -106,7 +106,7 @@
           {
             "__typename": "MetaValue",
             "key": "title",
-            "value": "Lovell Federal VA health care | Test Event X VA | Veterans Affairs"
+            "value": "Lovell Federal health care - VA | Test Event X VA | Veterans Affairs"
           },
           {
             "__typename": "MetaProperty",
@@ -116,7 +116,7 @@
           {
             "__typename": "MetaProperty",
             "key": "og:title",
-            "value": "Test Event X VA | Lovell Federal VA health care | Veterans Affairs"
+            "value": "Test Event X VA | Lovell Federal health care - VA | Veterans Affairs"
           },
           {
             "__typename": "MetaProperty",
@@ -136,11 +136,11 @@
           {
             "__typename": "MetaValue",
             "key": "twitter:title",
-            "value": "Test Event X VA | Lovell Federal VA health care | Veterans Affairs"
+            "value": "Test Event X VA | Lovell Federal health care - VA | Veterans Affairs"
           }
         ],
         "entityUrl": {
-          "path": "/lovell-federal-va-health-care/events/49923"
+          "path": "/lovell-federal-health-care-va/events/49923"
         },
         "title": "Test Event X VA",
         "vid": 735964,
@@ -199,8 +199,8 @@
             "entityBundle": "event_listing",
             "entityId": "49455",
             "entityType": "node",
-            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal VA health care and regional events.",
-            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal VA health care and regional events.",
+            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal health care - VA and regional events.",
+            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care - VA and regional events.",
             "fieldOffice": {
               "entity": {
                 "entityType": "node",
@@ -239,7 +239,7 @@
           {
             "__typename": "MetaValue",
             "key": "title",
-            "value": "Lovell Federal VA health care | Test Event Y VA | Veterans Affairs"
+            "value": "Lovell Federal health care - VA | Test Event Y VA | Veterans Affairs"
           },
           {
             "__typename": "MetaProperty",
@@ -249,7 +249,7 @@
           {
             "__typename": "MetaProperty",
             "key": "og:title",
-            "value": "Test Event Y VA | Lovell Federal VA health care | Veterans Affairs"
+            "value": "Test Event Y VA | Lovell Federal health care - VA | Veterans Affairs"
           },
           {
             "__typename": "MetaProperty",
@@ -269,11 +269,11 @@
           {
             "__typename": "MetaValue",
             "key": "twitter:title",
-            "value": "Test Event Y VA | Lovell Federal VA health care | Veterans Affairs"
+            "value": "Test Event Y VA | Lovell Federal health care - VA | Veterans Affairs"
           }
         ],
         "entityUrl": {
-          "path": "/lovell-federal-va-health-care/events/49924"
+          "path": "/lovell-federal-health-care-va/events/49924"
         },
         "title": "Test Event Y VA",
         "vid": 735963,
@@ -332,8 +332,8 @@
             "entityBundle": "event_listing",
             "entityId": "49455",
             "entityType": "node",
-            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal VA health care and regional events.",
-            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal VA health care and regional events.",
+            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal health care - VA and regional events.",
+            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care - VA and regional events.",
             "fieldOffice": {
               "entity": {
                 "entityType": "node",
@@ -376,7 +376,7 @@
           {
             "__typename": "MetaValue",
             "key": "title",
-            "value": "Lovell Federal VA health care | Test Event X VA | Veterans Affairs"
+            "value": "Lovell Federal health care - VA | Test Event X VA | Veterans Affairs"
           },
           {
             "__typename": "MetaProperty",
@@ -386,7 +386,7 @@
           {
             "__typename": "MetaProperty",
             "key": "og:title",
-            "value": "Test Event X VA | Lovell Federal VA health care | Veterans Affairs"
+            "value": "Test Event X VA | Lovell Federal health care - VA | Veterans Affairs"
           },
           {
             "__typename": "MetaProperty",
@@ -406,11 +406,11 @@
           {
             "__typename": "MetaValue",
             "key": "twitter:title",
-            "value": "Test Event X VA | Lovell Federal VA health care | Veterans Affairs"
+            "value": "Test Event X VA | Lovell Federal health care - VA | Veterans Affairs"
           }
         ],
         "entityUrl": {
-          "path": "/lovell-federal-va-health-care/events/49923"
+          "path": "/lovell-federal-health-care-va/events/49923"
         },
         "title": "Test Event X VA",
         "vid": 735964,
@@ -469,8 +469,8 @@
             "entityBundle": "event_listing",
             "entityId": "49455",
             "entityType": "node",
-            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal VA health care and regional events.",
-            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal VA health care and regional events.",
+            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal health care - VA and regional events.",
+            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care - VA and regional events.",
             "fieldOffice": {
               "entity": {
                 "entityType": "node",
@@ -509,7 +509,7 @@
           {
             "__typename": "MetaValue",
             "key": "title",
-            "value": "Lovell Federal VA health care | Test Event Y VA | Veterans Affairs"
+            "value": "Lovell Federal health care - VA | Test Event Y VA | Veterans Affairs"
           },
           {
             "__typename": "MetaProperty",
@@ -519,7 +519,7 @@
           {
             "__typename": "MetaProperty",
             "key": "og:title",
-            "value": "Test Event Y VA | Lovell Federal VA health care | Veterans Affairs"
+            "value": "Test Event Y VA | Lovell Federal health care - VA | Veterans Affairs"
           },
           {
             "__typename": "MetaProperty",
@@ -539,11 +539,11 @@
           {
             "__typename": "MetaValue",
             "key": "twitter:title",
-            "value": "Test Event Y VA | Lovell Federal VA health care | Veterans Affairs"
+            "value": "Test Event Y VA | Lovell Federal health care - VA | Veterans Affairs"
           }
         ],
         "entityUrl": {
-          "path": "/lovell-federal-va-health-care/events/49924"
+          "path": "/lovell-federal-health-care-va/events/49924"
         },
         "title": "Test Event Y VA",
         "vid": 735963,
@@ -602,8 +602,8 @@
             "entityBundle": "event_listing",
             "entityId": "49455",
             "entityType": "node",
-            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal VA health care and regional events.",
-            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal VA health care and regional events.",
+            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal health care - VA and regional events.",
+            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care - VA and regional events.",
             "fieldOffice": {
               "entity": {
                 "entityType": "node",
@@ -631,7 +631,7 @@
     ]
   },
   "fieldOffice": {
-    "entity": { "entityLabel": "Lovell Federal VA health care" }
+    "entity": { "entityLabel": "Lovell Federal health care - VA" }
   },
   "fieldAdministration": { "entity": { "entityId": "1040" } }
 }

--- a/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/va/events.json
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/va/events.json
@@ -187,7 +187,7 @@
             "entityId": "49055",
             "entityType": "node",
             "entityUrl": {
-              "path": "/lovell-federal-tricare-health-care/locations/captain-james-a-lovell-federal-health-care-center"
+              "path": "/lovell-federal-health-care-tricare/locations/captain-james-a-lovell-federal-health-care-center"
             },
             "title": "Captain James A. Lovell Federal Health Care Center"
           }
@@ -320,7 +320,7 @@
             "entityId": "49055",
             "entityType": "node",
             "entityUrl": {
-              "path": "/lovell-federal-tricare-health-care/locations/captain-james-a-lovell-federal-health-care-center"
+              "path": "/lovell-federal-health-care-tricare/locations/captain-james-a-lovell-federal-health-care-center"
             },
             "title": "Captain James A. Lovell Federal Health Care Center"
           }
@@ -457,7 +457,7 @@
             "entityId": "49055",
             "entityType": "node",
             "entityUrl": {
-              "path": "/lovell-federal-tricare-health-care/locations/captain-james-a-lovell-federal-health-care-center"
+              "path": "/lovell-federal-health-care-tricare/locations/captain-james-a-lovell-federal-health-care-center"
             },
             "title": "Captain James A. Lovell Federal Health Care Center"
           }
@@ -590,7 +590,7 @@
             "entityId": "49055",
             "entityType": "node",
             "entityUrl": {
-              "path": "/lovell-federal-tricare-health-care/locations/captain-james-a-lovell-federal-health-care-center"
+              "path": "/lovell-federal-health-care-tricare/locations/captain-james-a-lovell-federal-health-care-center"
             },
             "title": "Captain James A. Lovell Federal Health Care Center"
           }

--- a/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/va/news.json
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/va/news.json
@@ -14,7 +14,7 @@
       { "url": { "path": "", "routed": true }, "text": "NEWS AND EVENTS" },
       { "url": { "path": "", "routed": true }, "text": "News releases" }
     ],
-    "path": "/lovell-federal-va-health-care/news-releases"
+    "path": "/lovell-federal-health-care-va/news-releases"
   },
   "entityMetatags": [
     {
@@ -25,12 +25,12 @@
     {
       "__typename": "MetaValue",
       "key": "title",
-      "value": "News releases | Lovell Federal VA health care | Veterans Affairs"
+      "value": "News releases | Lovell Federal health care - VA | Veterans Affairs"
     },
     {
       "__typename": "MetaValue",
       "key": "description",
-      "value": "Lovell Federal VA health care news releases and information for the Veterans, their families, and caregivers"
+      "value": "Lovell Federal health care - VA news releases and information for the Veterans, their families, and caregivers"
     },
     {
       "__typename": "MetaProperty",
@@ -40,12 +40,12 @@
     {
       "__typename": "MetaProperty",
       "key": "og:title",
-      "value": "News releases | Lovell Federal VA health care | Veterans Affairs"
+      "value": "News releases | Lovell Federal health care - VA | Veterans Affairs"
     },
     {
       "__typename": "MetaProperty",
       "key": "og:description",
-      "value": "Lovell Federal VA health care news releases and information for the Veterans, their families, and caregivers"
+      "value": "Lovell Federal health care - VA news releases and information for the Veterans, their families, and caregivers"
     },
     {
       "__typename": "MetaProperty",
@@ -70,12 +70,12 @@
     {
       "__typename": "MetaValue",
       "key": "twitter:description",
-      "value": "Lovell Federal VA health care news releases and information for the Veterans, their families, and caregivers"
+      "value": "Lovell Federal health care - VA news releases and information for the Veterans, their families, and caregivers"
     },
     {
       "__typename": "MetaValue",
       "key": "twitter:title",
-      "value": "News releases | Lovell Federal VA health care | Veterans Affairs"
+      "value": "News releases | Lovell Federal health care - VA | Veterans Affairs"
     },
     {
       "__typename": "MetaValue",
@@ -88,7 +88,7 @@
       "value": "https://www.va.gov/img/design/logo/va-og-image.png"
     }
   ],
-  "fieldIntroText": "News releases for Lovell Federal VA health care.",
+  "fieldIntroText": "News releases for Lovell Federal health care - VA.",
   "reverseFieldListingNode": {
     "entities": [
       {
@@ -96,7 +96,7 @@
         "title": "TEST C press release for Lovell VA",
         "fieldReleaseDate": { "value": "2022-10-13T19:50:12" },
         "entityUrl": {
-          "path": "/lovell-federal-va-health-care/news-releases/test-c-press-release-for-lovell-va"
+          "path": "/lovell-federal-health-care-va/news-releases/test-c-press-release-for-lovell-va"
         },
         "uid": {
           "targetId": 1215,
@@ -114,8 +114,8 @@
   "fieldOffice": {
     "targetId": 49451,
     "entity": {
-      "entityLabel": "Lovell Federal VA health care",
-      "title": "Lovell Federal VA health care"
+      "entityLabel": "Lovell Federal health care - VA",
+      "title": "Lovell Federal health care - VA"
     }
   },
   "fieldAdministration": { "entity": { "entityId": "1040" } }

--- a/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/va/stories.json
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/va/stories.json
@@ -14,7 +14,7 @@
       { "url": { "path": "", "routed": true }, "text": "NEWS AND EVENTS" },
       { "url": { "path": "", "routed": true }, "text": "Stories" }
     ],
-    "path": "/lovell-federal-va-health-care/stories"
+    "path": "/lovell-federal-health-care-va/stories"
   },
   "entityMetatags": [
     {
@@ -25,12 +25,12 @@
     {
       "__typename": "MetaValue",
       "key": "title",
-      "value": "Stories | Lovell Federal VA health care | Veterans Affairs"
+      "value": "Stories | Lovell Federal health care - VA | Veterans Affairs"
     },
     {
       "__typename": "MetaValue",
       "key": "description",
-      "value": "Lovell Federal VA health care top stories."
+      "value": "Lovell Federal health care - VA top stories."
     },
     {
       "__typename": "MetaProperty",
@@ -40,12 +40,12 @@
     {
       "__typename": "MetaProperty",
       "key": "og:title",
-      "value": "Stories | Lovell Federal VA health care | Veterans Affairs"
+      "value": "Stories | Lovell Federal health care - VA | Veterans Affairs"
     },
     {
       "__typename": "MetaProperty",
       "key": "og:description",
-      "value": "Lovell Federal VA health care top stories."
+      "value": "Lovell Federal health care - VA top stories."
     },
     {
       "__typename": "MetaProperty",
@@ -70,12 +70,12 @@
     {
       "__typename": "MetaValue",
       "key": "twitter:description",
-      "value": "Lovell Federal VA health care top stories."
+      "value": "Lovell Federal health care - VA top stories."
     },
     {
       "__typename": "MetaValue",
       "key": "twitter:title",
-      "value": "Stories | Lovell Federal VA health care | Veterans Affairs"
+      "value": "Stories | Lovell Federal health care - VA | Veterans Affairs"
     },
     {
       "__typename": "MetaValue",
@@ -88,7 +88,7 @@
       "value": "https://www.va.gov/img/design/logo/va-og-image.png"
     }
   ],
-  "fieldIntroText": "Lovell Federal VA health care top stories.",
+  "fieldIntroText": "Lovell Federal health care - VA top stories.",
   "reverseFieldListingNode": {
     "entities": [
       {
@@ -96,7 +96,7 @@
         "title": "TEST story for VA Lovell",
         "fieldFeatured": true,
         "entityUrl": {
-          "path": "/lovell-federal-va-health-care/stories/test-story-for-va-lovell"
+          "path": "/lovell-federal-health-care-va/stories/test-story-for-va-lovell"
         },
         "uid": {
           "targetId": 1215,
@@ -125,8 +125,8 @@
   "fieldOffice": {
     "targetId": 49451,
     "entity": {
-      "title": "Lovell Federal VA health care",
-      "entityLabel": "Lovell Federal VA health care"
+      "title": "Lovell Federal health care - VA",
+      "entityLabel": "Lovell Federal health care - VA"
     }
   },
   "fieldAdministration": { "entity": { "entityId": "1040" } }

--- a/src/site/stages/build/drupal/tests/lovell/fixtures/sidebar.json
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/sidebar.json
@@ -5,14 +5,14 @@
     {
       "expanded": false,
       "description": null,
-      "label": "Lovell Federal TRICARE health care",
+      "label": "Lovell Federal health care - TRICARE",
       "url": {
-        "path": "/lovell-federal-tricare-health-care"
+        "path": "/lovell-federal-health-care-tricare"
       },
       "entity": {
         "linkedEntity": {
-          "entityPublished": true,
-          "moderationState": "published"
+          "entityPublished": false,
+          "moderationState": "draft"
         },
         "fieldMenuSection": "tricare"
       },
@@ -21,14 +21,14 @@
     {
       "expanded": false,
       "description": null,
-      "label": "Lovell Federal VA health care",
+      "label": "Lovell Federal health care - VA",
       "url": {
-        "path": "/lovell-federal-va-health-care"
+        "path": "/lovell-federal-health-care-va"
       },
       "entity": {
         "linkedEntity": {
-          "entityPublished": true,
-          "moderationState": "published"
+          "entityPublished": false,
+          "moderationState": "draft"
         },
         "fieldMenuSection": "va"
       },
@@ -52,7 +52,7 @@
         {
           "expanded": false,
           "description": null,
-          "label": "Services and Locations",
+          "label": "SERVICES AND LOCATIONS",
           "url": {
             "path": ""
           },
@@ -66,12 +66,12 @@
               "description": null,
               "label": "Health services",
               "url": {
-                "path": "/lovell-federal-va-health-care/health-services"
+                "path": "/lovell-federal-health-care-va/health-services"
               },
               "entity": {
                 "linkedEntity": {
-                  "entityPublished": true,
-                  "moderationState": "published"
+                  "entityPublished": false,
+                  "moderationState": "draft"
                 },
                 "fieldMenuSection": "va"
               },
@@ -82,12 +82,12 @@
               "description": null,
               "label": "Health services",
               "url": {
-                "path": "/lovell-federal-tricare-health-care/health-services"
+                "path": "/lovell-federal-health-care-tricare/health-services"
               },
               "entity": {
                 "linkedEntity": {
-                  "entityPublished": true,
-                  "moderationState": "published"
+                  "entityPublished": false,
+                  "moderationState": "draft"
                 },
                 "fieldMenuSection": "tricare"
               },
@@ -98,12 +98,12 @@
               "description": null,
               "label": "Locations",
               "url": {
-                "path": "/lovell-federal-va-health-care/locations"
+                "path": "/lovell-federal-health-care-va/locations"
               },
               "entity": {
                 "linkedEntity": {
-                  "entityPublished": true,
-                  "moderationState": "published"
+                  "entityPublished": false,
+                  "moderationState": "draft"
                 },
                 "fieldMenuSection": "va"
               },
@@ -113,12 +113,12 @@
                   "description": null,
                   "label": "Captain James A. Lovell Federal Health Care Center",
                   "url": {
-                    "path": "/lovell-federal-va-health-care/locations/captain-james-a-lovell-federal-health-care-center"
+                    "path": "/lovell-federal-health-care-va/locations/captain-james-a-lovell-federal-health-care-center"
                   },
                   "entity": {
                     "linkedEntity": {
-                      "entityPublished": true,
-                      "moderationState": "published"
+                      "entityPublished": false,
+                      "moderationState": "draft"
                     },
                     "fieldMenuSection": "va"
                   },
@@ -129,12 +129,12 @@
                   "description": null,
                   "label": "Evanston VA Clinic",
                   "url": {
-                    "path": "/lovell-federal-va-health-care/locations/evanston-va-clinic"
+                    "path": "/lovell-federal-health-care-va/locations/evanston-va-clinic"
                   },
                   "entity": {
                     "linkedEntity": {
-                      "entityPublished": true,
-                      "moderationState": "published"
+                      "entityPublished": false,
+                      "moderationState": "draft"
                     },
                     "fieldMenuSection": "va"
                   },
@@ -145,12 +145,12 @@
                   "description": null,
                   "label": "Kenosha VA Clinic",
                   "url": {
-                    "path": "/lovell-federal-va-health-care/locations/kenosha-va-clinic"
+                    "path": "/lovell-federal-health-care-va/locations/kenosha-va-clinic"
                   },
                   "entity": {
                     "linkedEntity": {
-                      "entityPublished": true,
-                      "moderationState": "published"
+                      "entityPublished": false,
+                      "moderationState": "draft"
                     },
                     "fieldMenuSection": "va"
                   },
@@ -161,12 +161,12 @@
                   "description": null,
                   "label": "McHenry VA Clinic",
                   "url": {
-                    "path": "/lovell-federal-va-health-care/locations/mchenry-va-clinic"
+                    "path": "/lovell-federal-health-care-va/locations/mchenry-va-clinic"
                   },
                   "entity": {
                     "linkedEntity": {
-                      "entityPublished": true,
-                      "moderationState": "published"
+                      "entityPublished": false,
+                      "moderationState": "draft"
                     },
                     "fieldMenuSection": "va"
                   },
@@ -179,12 +179,12 @@
               "description": "TRICARE locations",
               "label": "Locations",
               "url": {
-                "path": "/lovell-federal-tricare-health-care/locations"
+                "path": "/lovell-federal-health-care-tricare/locations"
               },
               "entity": {
                 "linkedEntity": {
-                  "entityPublished": true,
-                  "moderationState": "published"
+                  "entityPublished": false,
+                  "moderationState": "draft"
                 },
                 "fieldMenuSection": "tricare"
               },
@@ -192,14 +192,14 @@
                 {
                   "expanded": false,
                   "description": null,
-                  "label": "Captain James A. Lovell Federal TRICARE Health Care Center",
+                  "label": "Captain James A. Lovell Federal Health Care Center",
                   "url": {
-                    "path": "/lovell-federal-tricare-health-care/locations/captain-james-a-lovell-federal-health-care-center"
+                    "path": "/lovell-federal-health-care-tricare/locations/captain-james-a-lovell-federal-health-care-center"
                   },
                   "entity": {
                     "linkedEntity": {
-                      "entityPublished": true,
-                      "moderationState": "published"
+                      "entityPublished": false,
+                      "moderationState": "draft"
                     },
                     "fieldMenuSection": "tricare"
                   },
@@ -210,12 +210,12 @@
                   "description": null,
                   "label": "USS Osborne Dental Clinic",
                   "url": {
-                    "path": "/lovell-federal-tricare-health-care/locations/uss-osborne-dental-clinic"
+                    "path": "/lovell-federal-health-care-tricare/locations/uss-osborne-dental-clinic"
                   },
                   "entity": {
                     "linkedEntity": {
-                      "entityPublished": true,
-                      "moderationState": "published"
+                      "entityPublished": false,
+                      "moderationState": "draft"
                     },
                     "fieldMenuSection": "tricare"
                   },
@@ -226,12 +226,12 @@
                   "description": null,
                   "label": "USS Red Rover",
                   "url": {
-                    "path": "/lovell-federal-tricare-health-care/locations/uss-red-rover"
+                    "path": "/lovell-federal-health-care-tricare/locations/uss-red-rover"
                   },
                   "entity": {
                     "linkedEntity": {
-                      "entityPublished": true,
-                      "moderationState": "published"
+                      "entityPublished": false,
+                      "moderationState": "draft"
                     },
                     "fieldMenuSection": "tricare"
                   },
@@ -242,12 +242,12 @@
                   "description": null,
                   "label": "USS Tranquillity",
                   "url": {
-                    "path": "/lovell-federal-tricare-health-care/locations/uss-tranquillity"
+                    "path": "/lovell-federal-health-care-tricare/locations/uss-tranquillity"
                   },
                   "entity": {
                     "linkedEntity": {
-                      "entityPublished": true,
-                      "moderationState": "published"
+                      "entityPublished": false,
+                      "moderationState": "draft"
                     },
                     "fieldMenuSection": "tricare"
                   },
@@ -258,12 +258,12 @@
                   "description": null,
                   "label": "Zachary and Elizabeth Fisher Medical and Dental Clinic",
                   "url": {
-                    "path": "/lovell-federal-tricare-health-care/locations/zachary-and-elizabeth-fisher-medical-and-dental-clinic"
+                    "path": "/lovell-federal-health-care-tricare/locations/zachary-and-elizabeth-fisher-medical-and-dental-clinic"
                   },
                   "entity": {
                     "linkedEntity": {
-                      "entityPublished": true,
-                      "moderationState": "published"
+                      "entityPublished": false,
+                      "moderationState": "draft"
                     },
                     "fieldMenuSection": "tricare"
                   },
@@ -290,12 +290,12 @@
               "description": null,
               "label": "Events",
               "url": {
-                "path": "/lovell-federal-va-health-care/events"
+                "path": "/lovell-federal-health-care-va/events"
               },
               "entity": {
                 "linkedEntity": {
-                  "entityPublished": true,
-                  "moderationState": "published"
+                  "entityPublished": false,
+                  "moderationState": "draft"
                 },
                 "fieldMenuSection": "va"
               },
@@ -306,12 +306,12 @@
               "description": null,
               "label": "Events",
               "url": {
-                "path": "/lovell-federal-tricare-health-care/events"
+                "path": "/lovell-federal-health-care-tricare/events"
               },
               "entity": {
                 "linkedEntity": {
-                  "entityPublished": true,
-                  "moderationState": "published"
+                  "entityPublished": false,
+                  "moderationState": "draft"
                 },
                 "fieldMenuSection": "tricare"
               },
@@ -322,12 +322,12 @@
               "description": null,
               "label": "News releases",
               "url": {
-                "path": "/lovell-federal-tricare-health-care/news-releases"
+                "path": "/lovell-federal-health-care-tricare/news-releases"
               },
               "entity": {
                 "linkedEntity": {
-                  "entityPublished": true,
-                  "moderationState": "published"
+                  "entityPublished": false,
+                  "moderationState": "draft"
                 },
                 "fieldMenuSection": "tricare"
               },
@@ -338,12 +338,12 @@
               "description": null,
               "label": "News releases",
               "url": {
-                "path": "/lovell-federal-va-health-care/news-releases"
+                "path": "/lovell-federal-health-care-va/news-releases"
               },
               "entity": {
                 "linkedEntity": {
-                  "entityPublished": true,
-                  "moderationState": "published"
+                  "entityPublished": false,
+                  "moderationState": "draft"
                 },
                 "fieldMenuSection": "va"
               },
@@ -354,12 +354,12 @@
               "description": null,
               "label": "Stories",
               "url": {
-                "path": "/lovell-federal-tricare-health-care/stories"
+                "path": "/lovell-federal-health-care-tricare/stories"
               },
               "entity": {
                 "linkedEntity": {
-                  "entityPublished": true,
-                  "moderationState": "published"
+                  "entityPublished": false,
+                  "moderationState": "draft"
                 },
                 "fieldMenuSection": "tricare"
               },
@@ -370,12 +370,12 @@
               "description": null,
               "label": "Stories",
               "url": {
-                "path": "/lovell-federal-va-health-care/stories"
+                "path": "/lovell-federal-health-care-va/stories"
               },
               "entity": {
                 "linkedEntity": {
-                  "entityPublished": true,
-                  "moderationState": "published"
+                  "entityPublished": false,
+                  "moderationState": "draft"
                 },
                 "fieldMenuSection": "va"
               },
@@ -400,12 +400,12 @@
               "description": null,
               "label": "About us",
               "url": {
-                "path": "/lovell-federal-va-health-care/about-us"
+                "path": "/lovell-federal-health-care-va/about-us"
               },
               "entity": {
                 "linkedEntity": {
-                  "entityPublished": true,
-                  "moderationState": "published"
+                  "entityPublished": false,
+                  "moderationState": "draft"
                 },
                 "fieldMenuSection": "both"
               },
@@ -415,12 +415,12 @@
                   "description": null,
                   "label": "Mission and vision",
                   "url": {
-                    "path": "/lovell-federal-va-health-care/about-us/mission-and-vision"
+                    "path": "/lovell-federal-health-care-va/about-us/mission-and-vision"
                   },
                   "entity": {
                     "linkedEntity": {
-                      "entityPublished": true,
-                      "moderationState": "published"
+                      "entityPublished": false,
+                      "moderationState": "draft"
                     },
                     "fieldMenuSection": "both"
                   },
@@ -431,12 +431,12 @@
                   "description": null,
                   "label": "History",
                   "url": {
-                    "path": "/lovell-federal-va-health-care/about-us/history"
+                    "path": "/lovell-federal-health-care-va/about-us/history"
                   },
                   "entity": {
                     "linkedEntity": {
-                      "entityPublished": true,
-                      "moderationState": "published"
+                      "entityPublished": false,
+                      "moderationState": "draft"
                     },
                     "fieldMenuSection": "both"
                   },
@@ -447,12 +447,12 @@
                   "description": null,
                   "label": "Performance",
                   "url": {
-                    "path": "/lovell-federal-va-health-care/about-us/performance"
+                    "path": "/lovell-federal-health-care-va/about-us/performance"
                   },
                   "entity": {
                     "linkedEntity": {
-                      "entityPublished": true,
-                      "moderationState": "published"
+                      "entityPublished": false,
+                      "moderationState": "draft"
                     },
                     "fieldMenuSection": "va"
                   },
@@ -463,14 +463,14 @@
                   "description": null,
                   "label": "Leadership",
                   "url": {
-                    "path": "/lovell-federal-va-health-care/about-us/leadership"
+                    "path": "/lovell-federal-health-care-va/about-us/leadership-0"
                   },
                   "entity": {
                     "linkedEntity": {
-                      "entityPublished": true,
-                      "moderationState": "published"
+                      "entityPublished": false,
+                      "moderationState": "draft"
                     },
-                    "fieldMenuSection": "both"
+                    "fieldMenuSection": "va"
                   },
                   "links": []
                 },
@@ -479,12 +479,12 @@
                   "description": null,
                   "label": "Leadership",
                   "url": {
-                    "path": "/lovell-federal-tricare-health-care/about-us/leadership-0"
+                    "path": "/lovell-federal-health-care-tricare/about-us/leadership"
                   },
                   "entity": {
                     "linkedEntity": {
-                      "entityPublished": true,
-                      "moderationState": "published"
+                      "entityPublished": false,
+                      "moderationState": "draft"
                     },
                     "fieldMenuSection": "tricare"
                   },
@@ -497,12 +497,12 @@
               "description": null,
               "label": "Work with us",
               "url": {
-                "path": "/lovell-federal-va-health-care/work-with-us"
+                "path": "/lovell-federal-health-care-va/work-with-us"
               },
               "entity": {
                 "linkedEntity": {
-                  "entityPublished": true,
-                  "moderationState": "published"
+                  "entityPublished": false,
+                  "moderationState": "draft"
                 },
                 "fieldMenuSection": "both"
               },
@@ -512,12 +512,12 @@
                   "description": null,
                   "label": "Jobs and careers",
                   "url": {
-                    "path": "/lovell-federal-va-health-care/work-with-us/jobs-and-careers"
+                    "path": "/lovell-federal-health-care-va/work-with-us/jobs-and-careers"
                   },
                   "entity": {
                     "linkedEntity": {
-                      "entityPublished": true,
-                      "moderationState": "published"
+                      "entityPublished": false,
+                      "moderationState": "draft"
                     },
                     "fieldMenuSection": "both"
                   },
@@ -528,12 +528,12 @@
                   "description": null,
                   "label": "Internships and fellowships",
                   "url": {
-                    "path": "/lovell-federal-va-health-care/work-with-us/internships-and-fellowships"
+                    "path": "/lovell-federal-health-care-va/work-with-us/internships-and-fellowships"
                   },
                   "entity": {
                     "linkedEntity": {
-                      "entityPublished": true,
-                      "moderationState": "published"
+                      "entityPublished": false,
+                      "moderationState": "draft"
                     },
                     "fieldMenuSection": "both"
                   },
@@ -544,12 +544,12 @@
                   "description": null,
                   "label": "Volunteer or donate",
                   "url": {
-                    "path": "/lovell-federal-va-health-care/work-with-us/volunteer-or-donate"
+                    "path": "/lovell-federal-health-care-va/work-with-us/volunteer-or-donate"
                   },
                   "entity": {
                     "linkedEntity": {
-                      "entityPublished": true,
-                      "moderationState": "published"
+                      "entityPublished": false,
+                      "moderationState": "draft"
                     },
                     "fieldMenuSection": "both"
                   },
@@ -562,12 +562,12 @@
               "description": null,
               "label": "Contact us",
               "url": {
-                "path": "/lovell-federal-va-health-care/contact-us"
+                "path": "/lovell-federal-health-care-va/contact-us"
               },
               "entity": {
                 "linkedEntity": {
-                  "entityPublished": true,
-                  "moderationState": "published"
+                  "entityPublished": false,
+                  "moderationState": "draft"
                 },
                 "fieldMenuSection": "both"
               },
@@ -578,12 +578,12 @@
               "description": null,
               "label": "Policies",
               "url": {
-                "path": "/lovell-federal-va-health-care/policies"
+                "path": "/lovell-federal-health-care-va/policies"
               },
               "entity": {
                 "linkedEntity": {
-                  "entityPublished": true,
-                  "moderationState": "published"
+                  "entityPublished": false,
+                  "moderationState": "draft"
                 },
                 "fieldMenuSection": "va"
               },
@@ -594,12 +594,12 @@
               "description": null,
               "label": "Policies",
               "url": {
-                "path": "/lovell-federal-tricare-health-care/policies"
+                "path": "/lovell-federal-health-care-tricare/policies"
               },
               "entity": {
                 "linkedEntity": {
-                  "entityPublished": true,
-                  "moderationState": "published"
+                  "entityPublished": false,
+                  "moderationState": "draft"
                 },
                 "fieldMenuSection": "tricare"
               },
@@ -610,16 +610,322 @@
               "description": null,
               "label": "Programs",
               "url": {
-                "path": "/lovell-federal-va-health-care/programs"
+                "path": "/lovell-federal-health-care-va/programs"
               },
               "entity": {
                 "linkedEntity": {
-                  "entityPublished": true,
-                  "moderationState": "published"
+                  "entityPublished": false,
+                  "moderationState": "draft"
                 },
                 "fieldMenuSection": "both"
               },
-              "links": []
+              "links": [
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Audiology and speech",
+                  "url": {
+                    "path": "/lovell-federal-health-care-va/programs/audiology-and-speech"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": false,
+                      "moderationState": "draft"
+                    },
+                    "fieldMenuSection": "va"
+                  },
+                  "links": [
+                    {
+                      "expanded": false,
+                      "description": null,
+                      "label": "Audiology and speech",
+                      "url": {
+                        "path": "/lovell-federal-health-care-tricare/programs/audiology-and-speech/audiology-and-speech"
+                      },
+                      "entity": {
+                        "linkedEntity": {
+                          "entityPublished": false,
+                          "moderationState": "draft"
+                        },
+                        "fieldMenuSection": "tricare"
+                      },
+                      "links": []
+                    }
+                  ]
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Gynecology clinic",
+                  "url": {
+                    "path": "/lovell-federal-health-care-tricare/programs/gynecology-clinic-0"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": false,
+                      "moderationState": "draft"
+                    },
+                    "fieldMenuSection": "tricare"
+                  },
+                  "links": []
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Gynecology clinic",
+                  "url": {
+                    "path": "/lovell-federal-health-care-va/programs/gynecology-clinic"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": false,
+                      "moderationState": "draft"
+                    },
+                    "fieldMenuSection": "va"
+                  },
+                  "links": []
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Internal Medicine",
+                  "url": {
+                    "path": "/lovell-federal-health-care-va/programs/internal-medicine"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": false,
+                      "moderationState": "draft"
+                    },
+                    "fieldMenuSection": "va"
+                  },
+                  "links": []
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Internal Medicine",
+                  "url": {
+                    "path": "/lovell-federal-health-care-tricare/programs/internal-medicine-0"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": false,
+                      "moderationState": "draft"
+                    },
+                    "fieldMenuSection": "tricare"
+                  },
+                  "links": []
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Intimate partner violence support",
+                  "url": {
+                    "path": "/lovell-federal-health-care-va/programs/intimate-partner-violence-support"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": false,
+                      "moderationState": "draft"
+                    },
+                    "fieldMenuSection": "va"
+                  },
+                  "links": []
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Intimate partner violence support",
+                  "url": {
+                    "path": "/lovell-federal-health-care-tricare/programs/intimate-partner-violence-support"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": false,
+                      "moderationState": "draft"
+                    },
+                    "fieldMenuSection": "tricare"
+                  },
+                  "links": []
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "MOVE! weight management",
+                  "url": {
+                    "path": "/lovell-federal-health-care-va/programs/move-weight-management"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": false,
+                      "moderationState": "draft"
+                    },
+                    "fieldMenuSection": "va"
+                  },
+                  "links": []
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Mental health",
+                  "url": {
+                    "path": "/lovell-federal-health-care-va/programs/mental-health-services"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": false,
+                      "moderationState": "draft"
+                    },
+                    "fieldMenuSection": "va"
+                  },
+                  "links": []
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Ophthalmology",
+                  "url": {
+                    "path": "/lovell-federal-health-care-tricare/programs/ophthalmology"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": false,
+                      "moderationState": "draft"
+                    },
+                    "fieldMenuSection": "tricare"
+                  },
+                  "links": []
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Ophthalmology",
+                  "url": {
+                    "path": "/lovell-federal-health-care-va/programs/ophthalmology"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": false,
+                      "moderationState": "draft"
+                    },
+                    "fieldMenuSection": "va"
+                  },
+                  "links": []
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Palliative and hospice care",
+                  "url": {
+                    "path": "/lovell-federal-health-care-va/programs/palliative-and-hospice-care"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": false,
+                      "moderationState": "draft"
+                    },
+                    "fieldMenuSection": "va"
+                  },
+                  "links": []
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Patient advocates",
+                  "url": {
+                    "path": "/lovell-federal-health-care-tricare/programs/patient-advocates"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": false,
+                      "moderationState": "draft"
+                    },
+                    "fieldMenuSection": "tricare"
+                  },
+                  "links": []
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Pharmacy",
+                  "url": {
+                    "path": "/lovell-federal-health-care-tricare/programs/pharmacy"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": false,
+                      "moderationState": "draft"
+                    },
+                    "fieldMenuSection": "tricare"
+                  },
+                  "links": []
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Physical medicine and rehabilitation",
+                  "url": {
+                    "path": "/lovell-federal-health-care-tricare/programs/physical-medicine-and-rehabilitation"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": false,
+                      "moderationState": "draft"
+                    },
+                    "fieldMenuSection": "tricare"
+                  },
+                  "links": []
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Physical medicine and rehabilitation",
+                  "url": {
+                    "path": "/lovell-federal-health-care-va/programs/physical-medicine-and-rehabilitation"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": false,
+                      "moderationState": "draft"
+                    },
+                    "fieldMenuSection": "va"
+                  },
+                  "links": []
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Veterans justice outreach",
+                  "url": {
+                    "path": "/lovell-federal-health-care-tricare/programs/veterans-justice-outreach"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": false,
+                      "moderationState": "draft"
+                    },
+                    "fieldMenuSection": "tricare"
+                  },
+                  "links": []
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Veterans justice outreach",
+                  "url": {
+                    "path": "/lovell-federal-health-care-va/programs/veterans-justice-outreach"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": false,
+                      "moderationState": "draft"
+                    },
+                    "fieldMenuSection": "va"
+                  },
+                  "links": []
+                }
+              ]
             }
           ]
         }

--- a/src/site/stages/build/drupal/tests/lovell/listingPages.unit.spec.js
+++ b/src/site/stages/build/drupal/tests/lovell/listingPages.unit.spec.js
@@ -48,7 +48,7 @@ const getMergedListing = (drupalData, lovellVariant, listingVariant) => {
     )[0];
 };
 
-describe('processLovelPages (listing pages)', () => {
+describe('processLovellPages (listing pages)', () => {
   let counts;
   let titles;
   let drupalData;

--- a/src/site/stages/build/drupal/tests/lovell/utils.js
+++ b/src/site/stages/build/drupal/tests/lovell/utils.js
@@ -17,6 +17,6 @@ export const findSidebarMenuLinkBySectionAndOptionalLabel = (
     ? parent.find(
         link =>
           link.entity.fieldMenuSection === menuSection &&
-          (label ? link.label === label : true),
+          (label ? link.label.toLowerCase() === label.toLowerCase() : true),
       )
     : undefined;


### PR DESCRIPTION
## Description
Lovell naming conventions have changed. This PR updates mock data and tests to align with the changed naming conventions.

### Changed naming conventions
#### URLs
##### FROM
/lovell-federal-va-health-care
/lovell-federal-tricare-health-care
##### TO
/lovell-federal-health-care-va
/lovell-federal-health-care-tricare

#### Names
##### FROM
Lovell Federal VA health care
Lovell Federal TRICARE health care
##### TO
Lovell Federal health care - VA
Lovell Federal health care - TRICARE

closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12241

## Testing done & Screenshots
Ran updated unit tests locally. All passed.


## QA steps

What needs to be checked to prove this works?
- [ ] Pull branch
- [ ] `yarn test:unit src/site/stages/build/drupal/tests/lovell/listingPages.unit.spec.js`
- [ ] `yarn test:unit src/site/stages/build/drupal/tests/lovell/sidebarLocations.unit.spec.js`

## Acceptance criteria
See original issue

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
