### PR TITLE
VACMS-12382: Updates robots.txt with new Lovell disallow paths.

### DIFF
--- a/src/site/assets/robots.txt
+++ b/src/site/assets/robots.txt
@@ -17,8 +17,8 @@ Disallow: /covid19screen
 # to prevent sub-directories from being indexed
 # see https://developers.google.com/search/docs/advanced/robots/create-robots-txt#useful-robots.txt-rules
 
-Disallow: /lovell-federal-va-health-care/
-Disallow: /lovell-federal-tricare-health-care/
+Disallow: /lovell-federal-health-care-va/
+Disallow: /lovell-federal-health-care-tricare/
 
 # sitemap index
 Sitemap: https://www.va.gov/sitemap.xml


### PR DESCRIPTION
## Description
Robots.txt has some disallow paths for Lovell to accommodate dual state. Those paths have changed, and this PR updates to accommodate those changes.

closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12382

## Testing done & Screenshots
This is difficult to test. It's a very small change and I'm comfortable pushing this with a few eyes confirming we all agree. We should then confirm in production that the file is what we expect.


## QA steps
   - [ ] Once this deploys, confirm robots.txt exists in production and contains the changes described in the ticket's AC's.



## Acceptance criteria
See original ticket.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
