### PR TITLE
Revert out most usage of asg instances for job running; grant cms-infra and FE COP co-ownership of qa-standards files.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,9 +18,9 @@
 script @department-of-veterans-affairs/cms-infrastructure @department-of-veterans-affairs/va-platform-cop-frontend
 
 # VSP QA Standards
-src/platform/testing/e2e/ @department-of-veterans-affairs/qa-standards
-config/cypress.json @department-of-veterans-affairs/qa-standards
-.github/workflows/a11y.yml @department-of-veterans-affairs/qa-standards
+src/platform/testing/e2e/ @department-of-veterans-affairs/qa-standards @department-of-veterans-affairs/cms-infrastructure
+config/cypress.json @department-of-veterans-affairs/qa-standards @department-of-veterans-affairs/cms-infrastructure
+.github/workflows/a11y.yml @department-of-veterans-affairs/qa-standards @department-of-veterans-affairs/cms-infrastructure
 
 # Shared templates
 src/site/includes @department-of-veterans-affairs/vsa-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend @department-of-veterans-affairs/1010-health-apps-frontend

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 # Review the CODEOWNERS guide before editing:
 # https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/codeowners.md
 
-# VSP
+# General ownership: CMS Team & FE COP
 *       @department-of-veterans-affairs/cms-infrastructure @department-of-veterans-affairs/va-platform-cop-frontend
 
 # Content release
@@ -16,11 +16,6 @@
 .github/workflows/wait-for-cms-ready @department-of-veterans-affairs/cms-infrastructure @department-of-veterans-affairs/va-platform-cop-frontend
 .github/workflows/record-release-interval @department-of-veterans-affairs/cms-infrastructure @department-of-veterans-affairs/va-platform-cop-frontend
 script @department-of-veterans-affairs/cms-infrastructure @department-of-veterans-affairs/va-platform-cop-frontend
-
-# VSP QA Standards
-src/platform/testing/e2e/ @department-of-veterans-affairs/qa-standards @department-of-veterans-affairs/cms-infrastructure
-config/cypress.json @department-of-veterans-affairs/qa-standards @department-of-veterans-affairs/cms-infrastructure
-.github/workflows/a11y.yml @department-of-veterans-affairs/qa-standards @department-of-veterans-affairs/cms-infrastructure
 
 # Shared templates
 src/site/includes @department-of-veterans-affairs/vsa-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend @department-of-veterans-affairs/1010-health-apps-frontend

--- a/.github/workflows/a11y-heading-order.yml
+++ b/.github/workflows/a11y-heading-order.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   build:
     name: Build
-    runs-on: [self-hosted, asg]
+    runs-on: [self-hosted]
     timeout-minutes: 180
     defaults:
       run:

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   build:
     name: Build
-    runs-on: [self-hosted, asg]
+    runs-on: [self-hosted]
     timeout-minutes: 180
     defaults:
       run:

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   start-runner:
-    runs-on: [self-hosted, asg]
+    runs-on: [self-hosted]
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
@@ -126,7 +126,7 @@ jobs:
 
   notify-start:
     name: Notify Start
-    runs-on: [self-hosted, asg]
+    runs-on: [self-hosted]
     needs: validate-build-status
     steps:
       - name: Checkout
@@ -446,7 +446,7 @@ jobs:
 
   deploy:
     name: Deploy
-    runs-on: [self-hosted, asg]
+    runs-on: [self-hosted]
     needs:
       - validate-build-status
       - build
@@ -513,7 +513,7 @@ jobs:
 
   notify-success:
     name: Notify Success
-    runs-on: [self-hosted, asg]
+    runs-on: [self-hosted]
     needs:
       - validate-build-status
       - deploy
@@ -541,7 +541,7 @@ jobs:
 
   notify-failure:
     name: Notify Failure
-    runs-on: [self-hosted, asg]
+    runs-on: [self-hosted]
     if: |
       (failure() && needs.deploy.result != 'success')
     needs: deploy
@@ -592,7 +592,7 @@ jobs:
 
   record-metrics:
     name: Record metrics in Datadog
-    runs-on: [self-hosted, asg]
+    runs-on: [self-hosted]
     needs:
       - start-runner
       - build

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   build:
     name: Build
-    runs-on: [self-hosted, asg]
+    runs-on: [self-hosted]
     timeout-minutes: 60
 
     defaults:
@@ -244,7 +244,7 @@ jobs:
           channel-id: ${{ env.BROKEN_LINKS_SLACK }}
 
   start-runner:
-    runs-on: [self-hosted, asg]
+    runs-on: [self-hosted]
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
@@ -663,7 +663,7 @@ jobs:
 
   deploy:
     name: Deploy
-    runs-on: [self-hosted, asg]
+    runs-on: [self-hosted]
     if: ${{ always() && github.ref == 'refs/heads/main' && needs.get-latest-run-number.result == 'success' && needs.get-latest-run-number.outputs.latest_run_number == github.run_number }}
     needs: [build, cypress-tests, get-latest-run-number]
 

--- a/.github/workflows/deploy-content-preview-server.yml
+++ b/.github/workflows/deploy-content-preview-server.yml
@@ -11,7 +11,7 @@ jobs:
   deploy-preview-server:
     name: Deploy Preview Servers (PROD, STAGING, DEV)
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: [self-hosted, asg]
+    runs-on: [self-hosted]
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/manual-deploy-dev-staging.yml
+++ b/.github/workflows/manual-deploy-dev-staging.yml
@@ -44,7 +44,7 @@ jobs:
 
   deploy:
     name: Deploy
-    runs-on: [self-hosted, asg]
+    runs-on: [self-hosted]
     needs: set-environment
     strategy:
       matrix: ${{ fromJson(needs.set-environment.outputs.environment) }}


### PR DESCRIPTION
Response to issues with #1450 and #1452. Moves back to no longer specifying the `asg` label for most self-hosted jobs that are not on-demand. 

Cypress testing in a11y.yml will continue to use the `asg` since it uses the most runners by far, by volume.

This PR also adds cms-infrastructure and FE COP as co-owners of the files currently previously owned by qa-standards. 