### PR TITLE
Remove usage of asg runners from content release.

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -127,6 +127,7 @@ jobs:
   notify-start:
     name: Notify Start
     runs-on: [self-hosted]
+    needs: validate-build-status
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   start-runner:
-    runs-on: [self-hosted, asg]
+    runs-on: [self-hosted]
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
@@ -126,8 +126,7 @@ jobs:
 
   notify-start:
     name: Notify Start
-    runs-on: [self-hosted, asg]
-    needs: validate-build-status
+    runs-on: [self-hosted]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -446,7 +445,7 @@ jobs:
 
   deploy:
     name: Deploy
-    runs-on: [self-hosted, asg]
+    runs-on: [self-hosted]
     needs:
       - validate-build-status
       - build
@@ -513,7 +512,7 @@ jobs:
 
   notify-success:
     name: Notify Success
-    runs-on: [self-hosted, asg]
+    runs-on: [self-hosted]
     needs:
       - validate-build-status
       - deploy
@@ -541,7 +540,7 @@ jobs:
 
   notify-failure:
     name: Notify Failure
-    runs-on: [self-hosted, asg]
+    runs-on: [self-hosted]
     if: |
       (failure() && needs.deploy.result != 'success')
     needs: deploy
@@ -592,7 +591,7 @@ jobs:
 
   record-metrics:
     name: Record metrics in Datadog
-    runs-on: [self-hosted, asg]
+    runs-on: [self-hosted]
     needs:
       - start-runner
       - build


### PR DESCRIPTION
Reverts work from #1450 and #1452 out for content release.