### PR TITLE
Added support for multiple GA events on homepage

### DIFF
--- a/src/site/assets/js/record-event.js
+++ b/src/site/assets/js/record-event.js
@@ -9,3 +9,6 @@ window.dataLayer = [] || window.dataLayer;
 window.recordEvent = function(data) {
   return window.dataLayer.push(data);
 };
+window.recordMultipleEvents = function (events){
+  events.forEach(event => recordEvent(event))
+}

--- a/src/site/includes/common-tasks.drupal.liquid
+++ b/src/site/includes/common-tasks.drupal.liquid
@@ -24,16 +24,17 @@
                   {% if link.url.path and link.label %}
                     <li>
                       <i role="presentation" class="fas fa-arrow-right vads-u-color--link-default vads-u-margin-right--1"></i>
-                      <!-- Uncomment custom event and delete generic once analytics team implements -->
-                      <!-- <a
-                        onclick="recordEvent({ event: 'homepage-search-tools-click', action: 'Other search tools - {{link.label}}' })"
-                        href="{{ link.url.path }}">{{ link.label }}</a> -->
                         <a
-                        onclick="recordEvent({
-                          event: 'nav-zone-one',
-                          'nav-path': '->{% if link.url.path != empty %}{{ link.url.path }}{% else %}{{ link.label }}{% endif %}',
-                          'click-text': '{{ link.label | strip }}',
-                        });"
+                        onclick="recordMultipleEvents([
+                          {
+                            event: 'nav-zone-one',
+                            'nav-path': '->{% if link.url.path != empty %}{{ link.url.path }}{% else %}{{ link.label }}{% endif %}',
+                            'click-text': '{{ link.label | strip }}',
+                          },
+                          { 
+                            event: 'homepage-search-tools-click', action: 'Other search tools - {{link.label}}' 
+                          }
+                        ]);"
                         href="{{ link.url.path }}">{{ link.label }}</a>
                     </li>
                   {% endif %}
@@ -56,16 +57,16 @@
               {% for link in popularLinks%}
                 {% if link.url.path and link.label %}
                   <li>
-                    <!-- Uncomment custom event and delete generic once analytics team implements -->
-                    <!-- <a
-                      onclick="recordEvent({ event: 'homepage-popular-links-click', action: 'Top Pages - {{link.label}}' })"
-                      href="{{ link.url.path }}">{{ link.label }}</a> -->
                       <a
-                      onclick="recordEvent({
+                      onclick="recordMultipleEvents([
+                        {
                         event: 'nav-zone-one',
                         'nav-path': '->{% if link.url.path != empty %}{{ link.url.path }}{% else %}{{ link.label }}{% endif %}',
                         'click-text': '{{ link.label | strip }}',
-                      });"
+                        },
+                        { 
+                          event: 'homepage-popular-links-click', action: 'Top Pages - {{link.label}}' }
+                      ]);"
                       href="{{ link.url.path }}">{{ link.label }}</a>
                   </li>
                 {% endif %}

--- a/src/site/includes/email-update-signup.drupal.liquid
+++ b/src/site/includes/email-update-signup.drupal.liquid
@@ -25,11 +25,13 @@
                          autocomplete="email"
                          class="vads-u-width--full
                                 medium-screen:vads-u-width-auto" />
-                  <!--Uncomment custom event and delete generic event when analytics team implelements custom-->
-                  <!-- <button
-                    onclick="recordEvent({ event: 'homepage-email-sign-up', action: 'Homepage email sign up' })" -->
                   <button
-                    onclick="recordEvent({ event: 'cta-button-click', 'button-type': 'primary', 'button-click-label': 'Sign up',  });"
+                    onclick="recordMultipleEvents([
+                      { 
+                        event: 'cta-button-click', 'button-type': 'primary', 'button-click-label': 'Sign up',  
+                      },
+                      { event: 'homepage-email-sign-up', action: 'Homepage email sign up' }
+                      ]);"
                     type="submit"
                     class="vads-u-width--full
                           medium-screen:vads-u-width--auto

--- a/src/site/includes/hero.drupal.liquid
+++ b/src/site/includes/hero.drupal.liquid
@@ -40,8 +40,10 @@
         function openLoginModal() {
           // Uncomment custom event and delete generic event once analytics team has implemented
           // recordEvent({ event: "homepage-create-account", action: "Homepage Create Account CTA" });
-          recordEvent({ event: 'cta-button-click', 'button-type': 'primary', 'button-click-label': 'Create Account',  });
-          
+          recordMultipleEvents([
+            { event: 'cta-button-click', 'button-type': 'primary', 'button-click-label': 'Create Account'  },
+            { event: "homepage-create-account", action: "Homepage Create Account CTA" }
+          ]);
           const params = (new URL(document.location)).searchParams;
           params.set("next", "loginModal")
           document.location = "?" + params.toString();

--- a/src/site/includes/news-spotlight.drupal.liquid
+++ b/src/site/includes/news-spotlight.drupal.liquid
@@ -21,14 +21,14 @@
             NEWS</h2>
           {% if fieldPromoHeadline and fieldLink.url.path %}
             <h3 class="vads-u-font-family--serif vads-u-margin-top--0 vads-u-font-size--xl">
-              {% comment %} <a
-                onclick="recordEvent({ event: 'homepage-news-promo-title-click', action: 'Homepage News Promo - {{ fieldPromoHeadline }} - Title' })"
-                href="{{ fieldLink.url.path }}" class="vads-u-color--white">{{ fieldPromoHeadline }}</a> {% endcomment %}
               <a
-              onclick="recordEvent({
-                event: 'nav-zone-one',
-                  'click-text': '{{ fieldPromoHeadline }}',
-                });"
+              onclick="recordMultipleEvents([
+                {
+                  event: 'nav-zone-one',
+                    'click-text': '{{ fieldPromoHeadline }}',
+                },
+                { event: 'homepage-news-promo-title-click', action: 'Homepage News Promo - {{ fieldPromoHeadline }} - Title' }
+              ]);"
               href="{{ fieldLink.url.path }}" class="vads-u-color--white">{{ fieldPromoHeadline }}</a>
             </h3>
           {% endif %}
@@ -39,20 +39,14 @@
               {{ fieldPromoText }}
             {% endif %}
             {% if fieldLinkLabel and fieldLink.url.path %}
-              {% comment %} <a
-            onclick="recordEvent({ event: 'nav-zone-one', action: 'Homepage news promo - {{  fieldPromoHeadline }} - CTA' })"
-
-                href="{{ fieldLink.url.path }}" class="vads-u-color--white">
-                {{fieldLinkLabel}}
-                <span class="sr-only">
-                  about {{fieldPromoHeadline}}
-                </span>
-              </a> {% endcomment %}
               <a
-                onclick="recordEvent({
-                  event: 'nav-zone-one',
-                    'click-text': '{{ fieldLinkLabel | strip }}',
-                  });"
+                onclick="recordMultipleEvents([
+                  {
+                    event: 'nav-zone-one',
+                      'click-text': '{{ fieldLinkLabel | strip }}',
+                  },
+                  { event: 'nav-zone-one', action: 'Homepage news promo - {{  fieldPromoHeadline }} - CTA' }
+                ]);"
                 href="{{ fieldLink.url.path }}" class="vads-u-color--white">
                 {{fieldLinkLabel}}
                 <span class="sr-only">
@@ -64,17 +58,15 @@
           </p>
 
           <div>
-            <!-- <a
-              onclick="recordEvent({ event: 'homepage-news-promo-more-news-click', action: 'Homepage news promo - More VA News' })"
-              href="https://news.va.gov/" class="vads-u-color--white">More VA news
-              <i class="fas fa-chevron-right vads-u-margin-left--1" role="presentation"></i>
-            </a> -->
             <a
-            onclick="recordEvent({
-              event: 'nav-zone-one',
-              'nav-path': '->{% if fieldLink.url.path != empty %}{{ fieldLink.url.path }}{% else %}{{ fieldLinkLabel }}{% endif %}',
-              'click-text': 'More VA news',
-            });"
+            onclick="recordMultipleEvents([
+              {
+                event: 'nav-zone-one',
+                'nav-path': '->{% if fieldLink.url.path != empty %}{{ fieldLink.url.path }}{% else %}{{ fieldLinkLabel }}{% endif %}',
+                'click-text': 'More VA news',
+              },
+              { event: 'homepage-news-promo-more-news-click', action: 'Homepage news promo - More VA News' }
+            ]);"
             href="https://news.va.gov/" class="vads-u-color--white">More VA news
             <i class="fas fa-chevron-right vads-u-margin-left--1" role="presentation"></i>
           </a>


### PR DESCRIPTION
## Description
Addresses events for ticket https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12412

Adds support for multiple GA events, and adds them to the elements on the new-home-page


## Testing done & Screenshots
<img width="1130" alt="Screen Shot 2023-02-02 at 11 19 46 AM" src="https://user-images.githubusercontent.com/61624970/216390543-5a7823ba-2953-49de-bf4a-1830773eedcd.png">

Tested locally with adswerve extention

## QA steps

1. Navigate to new home page
2. Verify that gta events are sent correctly either in adswerve or network tab

## Acceptance criteria

- [ ] Elements on the homepage now send both their 'generic' GA event as well as the more specific GTA events

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
