### PR TITLE
Do not fail the job if the GovDelivery callback fails.

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -506,6 +506,8 @@ jobs:
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           url: ${{ env.DRUPAL_ADDRESS }}/api/govdelivery_bulletins/queue?EndTime=${{ needs.build.outputs.vagovprod_buildtime }}&src=gha&runId=${{ github.run_id }}&runNumber=${{ github.run_number }}
           method: GET
+        # This should not prevent the job from continuing.
+        continue-on-error: true
 
       - name: Export deploy end time
         id: export-deploy-end-time


### PR DESCRIPTION
## Description
The GovDelivery callback is not critical to the Content Release process to the point that it should cause the job to fail.