### PR TITLE
Run a `escape` filter on alert-box-headline.

### DIFF
--- a/src/site/components/fullwidth_banner_alerts.drupal.liquid
+++ b/src/site/components/fullwidth_banner_alerts.drupal.liquid
@@ -44,7 +44,7 @@
               {
               "event": "nav-alert-box-link-click",
               "alert-box-status": "{{ alertType }}",
-              "alert-box-headline": {{ entity.title | escape }},
+              "alert-box-headline": "{{ entity.title | escape }}",
               "alert-box-headline-level": "3",
               "alert-box-background-only": "false",
               "alert-box-closeable": "false"

--- a/src/site/components/fullwidth_banner_alerts.drupal.liquid
+++ b/src/site/components/fullwidth_banner_alerts.drupal.liquid
@@ -44,7 +44,7 @@
               {
               "event": "nav-alert-box-link-click",
               "alert-box-status": "{{ alertType }}",
-              "alert-box-headline": {{ entity.title | jsonify }},
+              "alert-box-headline": {{ entity.title | json_encode }},
               "alert-box-headline-level": "3",
               "alert-box-background-only": "false",
               "alert-box-closeable": "false"

--- a/src/site/components/fullwidth_banner_alerts.drupal.liquid
+++ b/src/site/components/fullwidth_banner_alerts.drupal.liquid
@@ -44,7 +44,7 @@
               {
               "event": "nav-alert-box-link-click",
               "alert-box-status": "{{ alertType }}",
-              "alert-box-headline": {{ entity.title | json_encode }},
+              "alert-box-headline": {{ entity.title | escape }},
               "alert-box-headline-level": "3",
               "alert-box-background-only": "false",
               "alert-box-closeable": "false"

--- a/src/site/components/fullwidth_banner_alerts.drupal.liquid
+++ b/src/site/components/fullwidth_banner_alerts.drupal.liquid
@@ -44,7 +44,7 @@
               {
               "event": "nav-alert-box-link-click",
               "alert-box-status": "{{ alertType }}",
-              "alert-box-headline": "{{ entity.title }}",
+              "alert-box-headline": {{ entity.title | jsonify | uri_escape }},
               "alert-box-headline-level": "3",
               "alert-box-background-only": "false",
               "alert-box-closeable": "false"

--- a/src/site/components/fullwidth_banner_alerts.drupal.liquid
+++ b/src/site/components/fullwidth_banner_alerts.drupal.liquid
@@ -44,7 +44,7 @@
               {
               "event": "nav-alert-box-link-click",
               "alert-box-status": "{{ alertType }}",
-              "alert-box-headline": {{ entity.title | jsonify | uri_escape }},
+              "alert-box-headline": {{ entity.title | jsonify }},
               "alert-box-headline-level": "3",
               "alert-box-background-only": "false",
               "alert-box-closeable": "false"


### PR DESCRIPTION
## Description

See [here](https://dsva.slack.com/archives/CT4GZBM8F/p1675437134276429).

This appears to be a working fix.

## Testing done & Screenshots

Ran a content-build with it in place and verified that the `alert-box-headline` value was processed the same.

## QA steps

- [ ] `tugboat shell 63dbd964a22f3f424b1db134` to Tugboat into 
- [ ] `grep -rHin 'alert-box-headline' ./web/build/vagovdev/sierra-nevada-health-care/`
- [ ] Inspect the above results to show that the string values are valid.
