### PR TITLE
VACMS-12351: Home page v2 hub list menu

### DIFF
--- a/src/site/includes/homepage-benefits.drupal.liquid
+++ b/src/site/includes/homepage-benefits.drupal.liquid
@@ -10,13 +10,13 @@
     </h2>
     {% if hubs %}
       {% for hub in hubs %}
-        {% if hub.entity.entityUrl.path and hub.entity.fieldHomePageHubLabel and hub.entity.fieldTeaserText and hub.entity.fieldTitleIcon %}
-        <div class="usa-width-one-third" data-e2e="hub" data-entity-id="{{ hub.entity.entityId }}">
-          <h3 class="heading-level-4"><a href="{{ hub.entity.entityUrl.path }}"
-              onclick="recordEvent({ event: 'nav-linkslist', action: 'Benefit hub - {{ hub.entity.fieldHomePageHubLabel }}' });"><i
-                class="icon-small icon-heading hub-icon-{{ hub.entity.fieldTitleIcon }} hub-background-{{ hub.entity.fieldTitleIcon }} white vads-u-margin-right--1"></i>{{
-              hub.entity.fieldHomePageHubLabel }}</a></h3>
-          <p class="vads-u-margin-top--0 ">{{ hub.entity.fieldTeaserText }}</p>
+        {% if hub.url.path and hub.label and hub.entity.fieldLinkSummary and hub.entity.fieldIcon %}
+        <div class="usa-width-one-third" data-e2e="hub" data-entity-id="{{ forloop.index }}">
+          <h3 class="heading-level-4"><a href="{{ hub.url.path }}"
+              onclick="recordEvent({ event: 'nav-linkslist', action: 'Benefit hub - {{ hub.label }}' });"><i
+                class="icon-small icon-heading hub-icon-{{ hub.entity.fieldIcon }} hub-background-{{ hub.entity.fieldIcon }} white vads-u-margin-right--1"></i>{{
+                  hub.label }}</a></h3>
+          <p class="vads-u-margin-top--0 ">{{ hub.entity.fieldLinkSummary }}</p>
         </div> 
         {% endif %}
         {% comment %} Close this row and open a new one when needed. {% endcomment %}

--- a/src/site/stages/build/drupal/graphql/homePage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/homePage.graphql.js
@@ -60,8 +60,7 @@ const query = `
     description
     links {
       ... on MenuLink {
-        expanded
-        description
+        enabled
         label
         url {
           path

--- a/src/site/stages/build/drupal/graphql/homePage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/homePage.graphql.js
@@ -4,6 +4,7 @@
 
 const menu = 'homepage-top-tasks-blocks';
 const hubListQueue = 'home_page_hub_list';
+const hubListMenu = 'home-page-hub-list';
 const promoBlocksQueue = 'home_page_promos';
 const homePageHeroQueue = 'home_page_hero';
 const homePageNewsSpotlightQueue = 'home_page_news_spotlight';
@@ -48,6 +49,33 @@ const query = `
             entityUrl {
               path
               routed
+            }
+          }
+        }
+      }
+    }
+  }
+  homePageHubListMenuQuery:menuByName(name: "${hubListMenu}") {
+    name
+    description
+    links {
+      ... on MenuLink {
+        expanded
+        description
+        label
+        url {
+          path
+        }
+        entity {
+          parent
+          ... on MenuLinkContentHomePageHubList {
+            fieldIcon
+            fieldLinkSummary
+            linkedEntity(language_fallback: true, bypass_access_check: true) {
+              ... on Node {
+                entityPublished
+                moderationState
+              }
             }
           }
         }

--- a/src/site/stages/build/drupal/home.js
+++ b/src/site/stages/build/drupal/home.js
@@ -72,6 +72,7 @@ function addHomeContent(contentData, files, metalsmith, buildOptions) {
         homePageNewsSpotlightQuery,
         homePagePopularOnVaGovMenuQuery,
         homePageOtherSearchToolsMenuQuery,
+        homePageHubListMenuQuery,
       },
     } = contentData;
 
@@ -98,6 +99,7 @@ function addHomeContent(contentData, files, metalsmith, buildOptions) {
       entityUrl: {
         path: homePreviewPath,
       },
+      hubs: divideHubRows(homePageHubListMenuQuery.links),
     };
 
     files[`.${homePreviewPath}.html`] = createFileObj(

--- a/src/site/stages/build/drupal/home.js
+++ b/src/site/stages/build/drupal/home.js
@@ -86,6 +86,22 @@ function addHomeContent(contentData, files, metalsmith, buildOptions) {
       homePageNewsSpotlightQuery
         ?.itemsOfEntitySubqueueHomePageNewsSpotlight?.[0]?.entity || {};
 
+    // Filter hub menu links. We do this here instead of in the template because the
+    // grouping of hubs also happens here, and we need to filter before we group in
+    // order to preserve the intended grouping. See divideHubRows().
+    const homePreviewHubs = homePageHubListMenuQuery.links.filter(link => {
+      // Any disabled links should not be displayed.
+      if (!link.enabled) {
+        return false;
+      }
+      // If the link has a linkedEntity, and the linkedEntity is not published, it
+      // should not be displayed.
+      return (
+        !link.entity.linkedEntity ||
+        (link.entity.linkedEntity && link.entity.linkedEntity.entityPublished)
+      );
+    });
+
     const homePreviewEntityObj = {
       ...homeEntityObj,
       canonicalLink: '/', // Match current homepage to avoid 'duplicate content' SEO demerit
@@ -99,7 +115,7 @@ function addHomeContent(contentData, files, metalsmith, buildOptions) {
       entityUrl: {
         path: homePreviewPath,
       },
-      hubs: divideHubRows(homePageHubListMenuQuery.links),
+      hubs: divideHubRows(homePreviewHubs),
     };
 
     files[`.${homePreviewPath}.html`] = createFileObj(


### PR DESCRIPTION
## Description
This PR moves to using a Drupal menu for controlling the _new_ home page hub list links. This builds on the Drupal work that adds a new menu for managing the links. The original home page is using Benefit Hub Landing Page nodes, but we are moving to using a menu for the new home page to allow for non-BHLP links to be included while maintaining canonical management in the CMS.

This PR depends on the Drupal menu work: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11968

relates to https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12351  

## Testing done & Screenshots
<img width="1105" alt="Screen Shot 2023-02-06 at 1 08 46 PM" src="https://user-images.githubusercontent.com/221539/217088398-28ee6a9f-1b00-4eca-9101-e62d44c868f0.png">

## QA and Acceptance Criteria

### Testing will be performed on the Tugboat instance created by the related BE PR.
CMS: https://cms-7kaomxlwh9vfmuyg1u9xup0etcqzmggi.demo.cms.va.gov/
WEB: https://web-7kaomxlwh9vfmuyg1u9xup0etcqzmggi.demo.cms.va.gov/

1. Visit the new nome page at https://web-7kaomxlwh9vfmuyg1u9xup0etcqzmggi.demo.cms.va.gov/new-home-page/new-home-page
   - [ ] Validate that the home page hub links appear as [designed in Sketch](https://www.sketch.com/s/3aa40506-4be2-46cc-876b-93f1a9f3a857/p/EAD305BC-3082-4F81-ADEC-C2486F7B6BEF/canvas).
2. Visit the Drupal CMS menu at https://cms-7kaomxlwh9vfmuyg1u9xup0etcqzmggi.demo.cms.va.gov/admin/structure/menu/manage/home-page-hub-list/admin/structure/menu/manage/home-page-hub-list 
3. Then change a link to be disabled and save the form
4. Re-arrange the items and save the form
5. Edit the "Health care" node at /node/67/edit and set the Editorial workflow to "Archived" and save the form
6. Do a [content release](https://cms-7kaomxlwh9vfmuyg1u9xup0etcqzmggi.demo.cms.va.gov/admin/content/deploy) using the branch `VACMS-12351-home-page-v2-hub-list-menu` (screenshot below)
7. Wait for the content release status to be 'Ready'. This will take a while. It may take up to one minute for the status of new content releases to be reflected here, so refresh the page after a minute to see if the release is underway.
8. Visit the new home page at https://cms-pfcgaquu99xi4wzksftxmvukusulz3bh.ci.cms.va.gov/new-home-page
   - [ ] Validate the disabled link no longer appears on the new home page
   - [ ] Validate the order of the menu items is reflected
   - [ ] Validate any links to unpublished nodes no longer appear on the new home page

### Content release screenshot
<img width="781" alt="Screen Shot 2023-02-07 at 9 01 46 AM" src="https://user-images.githubusercontent.com/221539/217321037-54c03e85-c7cf-4e51-bc45-3386667025f1.png">

## Definition of done
- [x] Events are logged appropriately
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
