### PR TITLE
Add mhv landing-page registry entry

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1310,5 +1310,15 @@
       "vagovprod": false,
       "layout": "page-react.html"
     }
+  },
+  {
+    "appName": "MyHealtheVet on VA.gov",
+    "entryName": "mhv-landing-page",
+    "rootUrl": "/my-health",
+    "productId": "4d8b0801-dd86-4728-9609-9d794c923e03",
+    "template": {
+      "vagovprod": false,
+      "layout": "page-react.html"
+    }
   }
 ]


### PR DESCRIPTION
## Description

* Scaffold new landing page for MHV on va.gov
* `"vagovprod": false`
* @vfs-mhv-integration will be code owners, per [related PR](https://github.com/department-of-veterans-affairs/vets-website/pull/23321)
 
## Related Issues

* https://github.com/department-of-veterans-affairs/va.gov-team/issues/53194
* https://github.com/department-of-veterans-affairs/va.gov-team/issues/52804

## Related PRs

* https://github.com/department-of-veterans-affairs/vets-website/pull/23321

## Testing done & Screenshots

None, app scaffolding only at this time.

## QA steps

None. Axe tests should pass on initial app scaffolding PR, but testing will be updated and increased in future implementation PRs.