### PR TITLE
SM to VA.gov MHV-35899 MHV secure messaging enable vagovprod

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1287,7 +1287,7 @@
     "rootUrl": "/my-health/secure-messages",
     "productId": "95453f74-9e08-4bd0-902a-938836bde1d0",
     "template": {
-      "vagovprod": false,
+      "vagovprod": true,
       "layout": "page-react.html"
     }
   },


### PR DESCRIPTION
## Description

Enabling My Health Secure Messaging in prod environment. Entire functionality is behind a feature flag `mhv_secure_messaging_to_va_gov_release`, this will not affect current flow. `/my-health/secure-messaging` will still be unaccessible to public. Users will be redirected to an existing static page at `/health-care/secure-messaging`. 

Releasing for testing in preparation to Phase 0 release

## Testing done & Screenshots
<img width="1174" alt="image" src="https://user-images.githubusercontent.com/87077843/217839215-68a7c993-193c-48d6-955c-3344f7728328.png">


## QA steps

Once this is enabled, QA account will be whitelisted under a feature flag above, and will conduct testing prior to Phase 0 release

