### PR TITLE
Updated news promo GA event name

### DIFF
--- a/src/site/includes/news-spotlight.drupal.liquid
+++ b/src/site/includes/news-spotlight.drupal.liquid
@@ -45,7 +45,7 @@
                     event: 'nav-zone-one',
                       'click-text': '{{ fieldLinkLabel | strip }}',
                   },
-                  { event: 'nav-zone-one', action: 'Homepage news promo - {{  fieldPromoHeadline }} - CTA' }
+                  { event: 'homepage-news-promo-click', action: 'Homepage news promo - {{  fieldPromoHeadline }} - CTA' }
                 ]);"
                 href="{{ fieldLink.url.path }}" class="vads-u-color--white">
                 {{fieldLinkLabel}}


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12412

## Testing done & Screenshots
Local testing with adswerve
<img width="1512" alt="Screen Shot 2023-02-09 at 1 22 33 PM" src="https://user-images.githubusercontent.com/61624970/217904360-d0d5fb79-2053-4968-b8c1-e651b6db4867.png">


## QA steps

Verify that GA event fires on new homepage



## Acceptance criteria
- [ ] 'Read the full article' link send an event in line with what platform analytics is expecting

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
