### PR TITLE
VACMS-12068: Updates header levels on service-location template.

### DIFF
--- a/src/site/components/phone-number.drupal.liquid
+++ b/src/site/components/phone-number.drupal.liquid
@@ -4,11 +4,7 @@
 {% if phoneLabel == empty %}
   {% assign phoneLabel = 'Phone' %}
 {% endif %}
-{% if haveLocationName != empty %}
-  <h4>{{ phoneLabel }}</h4>
-{% else %}
-  <h3 class="force-small-header">{{ phoneLabel }}</h3>
-{% endif %}
+<h{{ phoneHeaderLevel }}>{{ phoneLabel }}</h{{ phoneHeaderLevel }}>
 <a class="vads-u-margin-bottom--1" aria-label="{{ number.fieldPhoneNumber | accessibleNumber }}{% if number.fieldPhoneExtension %} extension: {{ number.fieldPhoneExtension | accessibleNumber }}{% endif %}"
    href="tel:{{ number.fieldPhoneNumber }}{% if number.fieldPhoneExtension %}p{{ number.fieldPhoneExtension }}{% endif %}">
   {{ number.fieldPhoneNumber }}{% if number.fieldPhoneExtension %}x {{ number.fieldPhoneExtension }}{% endif %}

--- a/src/site/components/phone.drupal.liquid
+++ b/src/site/components/phone.drupal.liquid
@@ -3,25 +3,41 @@
     {% assign phoneNumberObj = numbers | phoneNumberArrayToObject %}
     {% if phoneNumberObj.tel %}
       {% for number in phoneNumberObj.tel %}
-        {% include "src/site/components/phone-number.drupal.liquid" with number = number phoneLabel = 'Phone' %}
+        {% include "src/site/components/phone-number.drupal.liquid" with
+          number = number
+          phoneLabel = 'Phone'
+          phoneHeaderLevel = phoneHeaderLevel
+        %}
       {% endfor %}
     {% endif %}
 
     {% if phoneNumberObj.fax %}
       {% for number in phoneNumberObj.fax %}
-        {% include "src/site/components/phone-number.drupal.liquid" with number = number phoneLabel = 'Fax' %}
+        {% include "src/site/components/phone-number.drupal.liquid" with
+          number = number
+          phoneLabel = 'Fax'
+          phoneHeaderLevel = phoneHeaderLevel
+        %}
       {% endfor %}
     {% endif %}
 
     {% if phoneNumberObj.sms %}
       {% for number in phoneNumberObj.sms %}
-        {% include "src/site/components/phone-number.drupal.liquid" with number = number phoneLabel = 'SMS' %}
+        {% include "src/site/components/phone-number.drupal.liquid" with
+          number = number
+          phoneLabel = 'SMS'
+          phoneHeaderLevel = phoneHeaderLevel
+        %}
       {% endfor %}
     {% endif %}
 
     {% if phoneNumberObj.tty %}
       {% for number in phoneNumberObj.tty %}
-        {% include "src/site/components/phone-number.drupal.liquid" with number = number phoneLabel = 'TTY'%}
+        {% include "src/site/components/phone-number.drupal.liquid" with
+          number = number
+          phoneLabel = 'TTY'
+          phoneHeaderLevel = phoneHeaderLevel
+        %}
       {% endfor %}
     {% endif %}
   </div>

--- a/src/site/facilities/health_care_local_health_service.drupal.liquid
+++ b/src/site/facilities/health_care_local_health_service.drupal.liquid
@@ -3,11 +3,12 @@
 {% for location in locations %}
   {% include "src/site/paragraphs/service_location.drupal.liquid" with
     single = location.entity
+    serviceLocationSubHeaderLevel = 5
   %}
 {% endfor %}
 
 {% if locationEntity.fieldReferralRequired or locationEntity.fieldWalkInsAccepted or locationEntity.fieldOnlineSchedulingAvailabl %}
-  <h4 data-template="facilities/health_care_local_health_service">Appointments</h4>
+  <h5 data-template="facilities/health_care_local_health_service">Appointments</h5>
 
   {% assign introText = 'Contact us to schedule, reschedule, or
     cancel your appointment. If a referral is required, you’ll need to contact your

--- a/src/site/facilities/service_address.drupal.liquid
+++ b/src/site/facilities/service_address.drupal.liquid
@@ -1,8 +1,8 @@
 <div class="vads-u-display--flex vads-u-flex-direction--column">
   {% if serviceLocationAddress.fieldClinicName %}
-    <h4>
+    <h{{ serviceLocationAddressHeaderLevel }}>
       {{ serviceLocationAddress.fieldClinicName }}
-    </h4>
+    </h{{ serviceLocationAddressHeaderLevel }}>
   {% endif %}
 
   {% comment %}

--- a/src/site/facilities/vha_facility_nonclinical_service.drupal.liquid
+++ b/src/site/facilities/vha_facility_nonclinical_service.drupal.liquid
@@ -2,5 +2,6 @@
   {% include "src/site/paragraphs/service_location.drupal.liquid" with
     single = location.entity
     fieldOfficeHours = facility.fieldOfficeHours
+    serviceLocationSubHeaderLevel = serviceLocationSubHeaderLevel
   %}
 {% endfor %}

--- a/src/site/facilities/vha_facility_nonclinical_services.drupal.liquid
+++ b/src/site/facilities/vha_facility_nonclinical_services.drupal.liquid
@@ -33,6 +33,7 @@
 
     {% include "src/site/facilities/vha_facility_nonclinical_service.drupal.liquid" with
       facility = facility
+      serviceLocationSubHeaderLevel = 4
     %}
   {% endfor %}
 {% endif %}

--- a/src/site/paragraphs/service_location.drupal.liquid
+++ b/src/site/paragraphs/service_location.drupal.liquid
@@ -1,11 +1,7 @@
-{% assign serviceLocationAddress = single.fieldServiceLocationAddress.entity %}
-{% if serviceLocationAddress.fieldClinicName %}
-  {% assign haveLocationName = true %}
-{% else %}
-  {% assign haveLocationName = false %}
-{% endif %}
-
-{% include "src/site/facilities/service_address.drupal.liquid" %}
+{% include "src/site/facilities/service_address.drupal.liquid" with
+  serviceLocationAddress = single.fieldServiceLocationAddress.entity
+  serviceLocationAddressHeaderLevel = serviceLocationSubHeaderLevel
+%}
 
 {% comment %}
   single.fieldHours values:
@@ -15,11 +11,7 @@
 {% endcomment %}
 
 {% if single.fieldHours != "1" %}
-  {% if haveLocationName %}
-    <h4 data-template="paragraphs/service_location">Hours</h4>
-  {% else %}
-    <h3 class="force-small-header" data-template="paragraphs/service_location">Hours</h3>
-  {% endif %}
+  <h{{ serviceLocationSubHeaderLevel }} data-template="paragraphs/service_location">Hours</h{{ serviceLocationSubHeaderLevel }}>
 {% endif %}
 
 {% case single.fieldHours %}
@@ -38,17 +30,16 @@
   <span data-template="paragraphs/service_location"><i>{{ single.fieldAdditionalHoursInfo }}</i></span>
 {% endif %}
 
-{% include "src/site/components/phone.drupal.liquid" with numbers = single.fieldPhone haveLocationName = haveLocationName %}
+{% include "src/site/components/phone.drupal.liquid" with
+  numbers = single.fieldPhone
+  phoneHeaderLevel = serviceLocationSubHeaderLevel
+%}
 
 {% if single.fieldEmailContacts %}
   {% for email in single.fieldEmailContacts %}
     <p class="vads-u-margin-y--1" data-template="paragraphs/service_location">
     {% if email.entity.fieldEmailLabel %}
-      {% if haveLocationName %}
-        <h5>{{ email.entity.fieldEmailLabel }} </h5>
-      {% else %}
-        <h4 class="force-small-header">{{ email.entity.fieldEmailLabel }} </h4>
-      {% endif %}
+      <h{{ serviceLocationSubHeaderLevel }}>{{ email.entity.fieldEmailLabel }} </h{{ serviceLocationSubHeaderLevel }}>
     {% endif %}
     <a aria-label="{{ email.entity.fieldEmailAddress }}"
         data-template="paragraphs/service_location"


### PR DESCRIPTION
## Description
Subheadings on VAMC facility service locations are inconsistent. "Contact Information" is an h4, and everything underneath that can logically be considered as a subheading beneath that h4, so they should all be h5.

Importantly, the template used here is also used elsewhere. The other place it is currently being used is to render non-clinical services (i.e. Billing and Insurance). On the non-clinical services pages, this information is presented slightly differently, so the header levels are not the same. 

For this PR to be valid, we need to ensure that the health-service accordions render correctly **and** that there is no regression in the presentation of non-clinical services.

### IMPORTANT
This PR introduces a slight (desired) change to some conditional display of headers. Previously, there was a condition under which some of these subheaders would display differently than others because it was implemented in a way that treated some of these subheaders as having another level of nesting (hours, phone). This was removed, as the desired behavior in both places is to have all subheaders as children of either "Contact Information" (health services) or of the VAMC Facility name (non-clinical services). This change makes the code significantly cleaner.

closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12068


## Testing done & Screenshots
Local testing.

### Assures h5 subheadings on VAMC Facility health service accordions:
http://039c47a435072b98659a25b04edf11f7.review.vetsgov-internal/boston-health-care/locations/jamaica-plain-va-medical-center/
![image](https://user-images.githubusercontent.com/6863534/218623416-46c79120-4b8a-4e3f-b5f5-78b8df7eb064.png)

### Assures h4 subheadings on VAMC top-task non-clinical service pages:
http://039c47a435072b98659a25b04edf11f7.review.vetsgov-internal/boston-health-care/billing-and-insurance/
![image](https://user-images.githubusercontent.com/6863534/218621725-ad3e85a3-7710-46f0-ac00-3b79a82785b1.png)

## QA steps
What needs to be checked to prove this works?  
- [ ] Verify [here ](http://039c47a435072b98659a25b04edf11f7.review.vetsgov-internal/boston-health-care/locations/jamaica-plain-va-medical-center/)that VAMC Facility health-service accordions have h5 subheadings under "Contact Information".

What needs to be checked to prove it didn't break any related things?  
- [ ] Verify [here](http://039c47a435072b98659a25b04edf11f7.review.vetsgov-internal/boston-health-care/billing-and-insurance/) that VAMC System top-task pages (i.e. Billing and Insurance) pages have h4 subheadings under the h3 header showing the VAMC facility name where the service is offered.