### PR TITLE
[VA-12570] Update COVID status field with facility-specific supplemental info

### DIFF
--- a/src/site/includes/covid-status.drupal.liquid
+++ b/src/site/includes/covid-status.drupal.liquid
@@ -10,6 +10,10 @@ class="vads-u-margin-top--{{topMargin}} vads-u-margin-bottom--{{bottomMargin}} v
 			'covid-status-heading':  '{{ fieldSupplementalStatus.entity.fieldStatusId }}',
 		});"
 	>
-		{{ fieldSupplementalStatus.entity.description.processed }}
+		{% if fieldSupplementalStatusMoreI.processed %}
+			{{ fieldSupplementalStatusMoreI.processed }}
+		{% else %}
+			{{ fieldSupplementalStatus.entity.description.processed }}
+		{% endif %}
 	</va-alert-expandable>
 {% endif %}

--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareLocalFacility.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareLocalFacility.node.graphql.js
@@ -30,6 +30,11 @@ const FACILITIES_RESULTS = `
           }
         }
       }
+      fieldSupplementalStatusMoreI {
+        value
+        format
+        processed
+      }
       fieldOperatingStatusFacility
       fieldFacilityLocatorApiId
       fieldIntroText

--- a/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
@@ -27,6 +27,11 @@ const healthCareLocalFacilityPageFragment = `
         }
       }
     }
+    fieldSupplementalStatusMoreI {
+      value
+      format
+      processed
+    }
     fieldOperatingStatusFacility
     fieldLocationServices {
       entity {

--- a/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
@@ -72,6 +72,11 @@ const nodeHealthCareRegionPage = `
               }
             }
           }
+          fieldSupplementalStatusMoreI {
+            value
+            format
+            processed
+          }
         }
       }
     }

--- a/src/site/stages/build/drupal/graphql/locationsListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/locationsListingPage.graphql.js
@@ -37,6 +37,11 @@ const locationListingPage = `
                     }
                   }
                 }
+                fieldSupplementalStatusMoreI {
+                  value
+                  format
+                  processed
+                }
               }
             }
           }

--- a/src/site/stages/build/drupal/graphql/locationsOperatingStatus.graphql.js
+++ b/src/site/stages/build/drupal/graphql/locationsOperatingStatus.graphql.js
@@ -28,6 +28,11 @@ const locationsOperatingStatus = `
             }
           }
         }
+        fieldSupplementalStatusMoreI {
+          value
+          format
+          processed
+        }
         fieldOperatingStatusFacility
         fieldOperatingStatusMoreInfo
         fieldRegionPage {

--- a/src/site/stages/build/drupal/graphql/vamcOperatingStatusAndAlerts.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vamcOperatingStatusAndAlerts.graphql.js
@@ -29,6 +29,11 @@ const vamcOperatingStatusAndAlerts = `
                     }
                   }
                 }
+                fieldSupplementalStatusMoreI {
+                  value
+                  format
+                  processed
+                }
               }
             }
           }


### PR DESCRIPTION
## Description

Facilities can have COVID info specific to them that should be displayed instead. This pull request adds the extra GraphQL query to the ones with COVID precaution info and shows it in place of the regular COVID info if it's present.

Closes [#12570](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12570)
Blocked by [#12403](https://github.com/department-of-veterans-affairs/va.gov-cms/pull/12403) since it relies on new CMS data that the GraphQL queries need.

## Testing done & Screenshots

Checking some facilities locally and making sure that the facility COVID data still shows up as expected.

<img width="1676" alt="Screen Shot 2023-02-17 at 5 03 28 PM" src="https://user-images.githubusercontent.com/10790736/219802412-434dbf90-015a-445e-948f-947a87d6558d.png">

## QA steps

Build the repo locally with `yarn build --pull-drupal --drupal-address=https://pr12403-yjq5zexhavmhassuj4kctou3kauqjue2.ci.cms.va.gov/`

1. The new COVID status data is queried in needed facilities pages
   - [ ] Check that the data is present on the page locally in the console
2. Confirm that it uses the new COVID status data when available
   - [ ] Check that the new data is used when it's present on a page
   - [ ] Check that when the new data isn't present, the old COVID status data is used

## Acceptance criteria

- [ ] All QA steps are met and passed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
