### PR TITLE
Allow a11y Heading Order Cypress container to use host SSL certs

### DIFF
--- a/.github/workflows/a11y-heading-order.yml
+++ b/.github/workflows/a11y-heading-order.yml
@@ -125,7 +125,10 @@ jobs:
     runs-on: [self-hosted, asg]
     container:
       image: public.ecr.aws/cypress-io/cypress/browsers:node16.13.2-chrome100-ff98
-      options: --user 1001:1001 --volume /usr/local/share:/share
+      options: --user 1001:1001
+      volumes:
+        - /usr/local/share:/share
+        - /etc/ssl/certs:/etc/ssl/certs
     strategy:
       fail-fast: false
       max-parallel: 32


### PR DESCRIPTION
## Description

closes __   
relates to __  

## Testing done & Screenshots



## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue


## Acceptance criteria

- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
