### PR TITLE
VA-12686: Hide "Manage Your Health" for Tricare pages

### DIFF
--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -52,89 +52,89 @@
 
           <!-- "Manage your health online" section -->
           {% comment %} Hide this section for Lovell TRICARE {% endcomment %}
-          {% if fieldAdministration.entity.entityId != '1039' %}
-          <section>
-            {% if fieldAdministration.entity.entityId == '1040' %}
-              <h3>Manage your VA health online</h3>
-            {% else %}
-              <h3>Manage your health online</h3>
-            {% endif %}
-            <div
-              class="vads-u-display--flex medium-screen:vads-u-flex-direction--row vads-u-flex-direction--column">
+          {% unless fieldAdministration.entity.entityId == '1039' or entityUrl.path contains '-tricare' %}
+            <section>
+              {% if fieldAdministration.entity.entityId == '1040' %}
+                <h3>Manage your VA health online</h3>
+              {% else %}
+                <h3>Manage your health online</h3>
+              {% endif %}
               <div
-                class="vads-u-margin-right--0 medium-screen:vads-u-margin-right--3">
-                <div class="vads-facility-hub-cta">
-                  <a onClick="recordEvent({ event: 'cta-hub-link-click' });"
-                    href="{{ fieldVamcEhrSystem | topTaskUrl: "refill-track-prescriptions/", buildtype }}"
-                    class="top-task-link vads-u-height--full vads-u-width--full">
-                    <i
-                      class=" fa fa-prescription-bottle vads-facility-hub-cta-circle">&nbsp;</i>
-                    <span class="vads-facility-hub-cta-label">Refill and track
-                      your prescriptions<i
-                        class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
-                  </a>
-                </div>
-                <div class="vads-facility-hub-cta">
-                  <a onClick="recordEvent({ event: 'cta-hub-link-click' });"
-                    href="{{ fieldVamcEhrSystem | topTaskUrl: "secure-messaging/", buildtype }}"
-                    class="top-task-link vads-u-height--full vads-u-width--full">
-                    <i
-                      class="far fa-comments vads-facility-hub-cta-circle">&nbsp;</i>
-                    <span class="vads-facility-hub-cta-label">Send a secure
-                      message to your health care team<i
-                        class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
-                  </a>
-                </div>
+                class="vads-u-display--flex medium-screen:vads-u-flex-direction--row vads-u-flex-direction--column">
                 <div
-                  class="vads-facility-hub-cta vads-u-border-color--primary-alt-light medium-screen:vads-u-border-bottom--1px">
-                  <a onClick="recordEvent({ event: 'cta-hub-link-click' });"
-                    href="{{ fieldVamcEhrSystem | topTaskUrl: "schedule-view-va-appointments/", buildtype }}"
-                    class="top-task-link vads-u-height--full vads-u-width--full">
-                    <i
-                      class="far fa-calendar-check vads-facility-hub-cta-circle">&nbsp;</i>
-                    <span class="vads-facility-hub-cta-label">Schedule and manage
-                      health appointments<i
-                        class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
-                  </a>
+                  class="vads-u-margin-right--0 medium-screen:vads-u-margin-right--3">
+                  <div class="vads-facility-hub-cta">
+                    <a onClick="recordEvent({ event: 'cta-hub-link-click' });"
+                      href="{{ fieldVamcEhrSystem | topTaskUrl: "refill-track-prescriptions/", buildtype }}"
+                      class="top-task-link vads-u-height--full vads-u-width--full">
+                      <i
+                        class=" fa fa-prescription-bottle vads-facility-hub-cta-circle">&nbsp;</i>
+                      <span class="vads-facility-hub-cta-label">Refill and track
+                        your prescriptions<i
+                          class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
+                    </a>
+                  </div>
+                  <div class="vads-facility-hub-cta">
+                    <a onClick="recordEvent({ event: 'cta-hub-link-click' });"
+                      href="{{ fieldVamcEhrSystem | topTaskUrl: "secure-messaging/", buildtype }}"
+                      class="top-task-link vads-u-height--full vads-u-width--full">
+                      <i
+                        class="far fa-comments vads-facility-hub-cta-circle">&nbsp;</i>
+                      <span class="vads-facility-hub-cta-label">Send a secure
+                        message to your health care team<i
+                          class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
+                    </a>
+                  </div>
+                  <div
+                    class="vads-facility-hub-cta vads-u-border-color--primary-alt-light medium-screen:vads-u-border-bottom--1px">
+                    <a onClick="recordEvent({ event: 'cta-hub-link-click' });"
+                      href="{{ fieldVamcEhrSystem | topTaskUrl: "schedule-view-va-appointments/", buildtype }}"
+                      class="top-task-link vads-u-height--full vads-u-width--full">
+                      <i
+                        class="far fa-calendar-check vads-facility-hub-cta-circle">&nbsp;</i>
+                      <span class="vads-facility-hub-cta-label">Schedule and manage
+                        health appointments<i
+                          class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
+                    </a>
+                  </div>
+                </div>
+                <div>
+                  <div class="vads-facility-hub-cta">
+                    <a onClick="recordEvent({ event: 'cta-hub-link-click' });"
+                      href="{{ fieldVamcEhrSystem | topTaskUrl: "get-medical-records/", buildtype }}"
+                      class="top-task-link vads-u-height--full vads-u-width--full">
+                      <i
+                        class="fa fa-file-medical vads-facility-hub-cta-circle">&nbsp;</i>
+                      <span class="vads-facility-hub-cta-label">Download your VA
+                        medical records (Blue Button)<i
+                          class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
+                    </a>
+                  </div>
+                  <div class="vads-facility-hub-cta">
+                    <a onClick="recordEvent({ event: 'cta-hub-link-click' });"
+                      href="{{ fieldVamcEhrSystem | topTaskUrl: "view-test-and-lab-results/", buildtype }}"
+                      class="top-task-link vads-u-height--full vads-u-width--full">
+                      <i
+                        class="fa fa-clipboard-list vads-facility-hub-cta-circle">&nbsp;</i>
+                      <span class="vads-facility-hub-cta-label">View your lab and
+                        test results<i
+                          class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
+                    </a>
+                  </div>
+                  <div
+                    class="vads-facility-hub-cta vads-facility-hub-cta-last-line vads-u-border-top--1px vads-u-border-color--primary-alt-light">
+                    <a onClick="recordEvent({ event: 'cta-hub-link-click' });"
+                      href="/health-care/order-hearing-aid-batteries-and-accessories/"
+                      class="vads-u-height--full vads-u-width--full">
+                      <i
+                        class="fa fa-deaf vads-facility-hub-cta-circle">&nbsp;</i>
+                      <span class="vads-facility-hub-cta-label">Order hearing aid batteries <br/> and accessories<i class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
+                    </a>
+                  </div>
                 </div>
               </div>
-              <div>
-                <div class="vads-facility-hub-cta">
-                  <a onClick="recordEvent({ event: 'cta-hub-link-click' });"
-                    href="{{ fieldVamcEhrSystem | topTaskUrl: "get-medical-records/", buildtype }}"
-                    class="top-task-link vads-u-height--full vads-u-width--full">
-                    <i
-                      class="fa fa-file-medical vads-facility-hub-cta-circle">&nbsp;</i>
-                    <span class="vads-facility-hub-cta-label">Download your VA
-                      medical records (Blue Button)<i
-                        class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
-                  </a>
-                </div>
-                <div class="vads-facility-hub-cta">
-                  <a onClick="recordEvent({ event: 'cta-hub-link-click' });"
-                    href="{{ fieldVamcEhrSystem | topTaskUrl: "view-test-and-lab-results/", buildtype }}"
-                    class="top-task-link vads-u-height--full vads-u-width--full">
-                    <i
-                      class="fa fa-clipboard-list vads-facility-hub-cta-circle">&nbsp;</i>
-                    <span class="vads-facility-hub-cta-label">View your lab and
-                      test results<i
-                        class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
-                  </a>
-                </div>
-                <div
-                  class="vads-facility-hub-cta vads-facility-hub-cta-last-line vads-u-border-top--1px vads-u-border-color--primary-alt-light">
-                  <a onClick="recordEvent({ event: 'cta-hub-link-click' });"
-                    href="/health-care/order-hearing-aid-batteries-and-accessories/"
-                    class="vads-u-height--full vads-u-width--full">
-                    <i
-                      class="fa fa-deaf vads-facility-hub-cta-circle">&nbsp;</i>
-                    <span class="vads-facility-hub-cta-label">Order hearing aid batteries <br/> and accessories<i class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
-                  </a>
-                </div>
-              </div>
-            </div>
-          </section>
-          {% endif %}
+            </section>
+          {% endunless %}
 
 
           <!-- List of links section -->


### PR DESCRIPTION
## Description

On Lovell, the "Manage your Health Online" section was removed from Tricare pages, but it still appears on Tricare pages that were formerly federal pages. This updates the check so it also excludes any pages with `tricare` in the URL, which is always the case for them due to the process that makes federal pages into VA and Tricare pages.

closes [#12686](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12686)

## Testing done & Screenshots

Locally, see below for VA and Tricare page comparisons.

<img width="1009" alt="Screen Shot 2023-02-27 at 12 54 17 PM" src="https://user-images.githubusercontent.com/10790736/221644829-503e4d3b-b74a-4a32-ab97-6d362377537e.png">

<img width="1109" alt="Screen Shot 2023-02-27 at 12 54 08 PM" src="https://user-images.githubusercontent.com/10790736/221644825-b38864b1-ebcd-478d-81fd-033381b393df.png">


## QA steps

1. Check the main Tricare page
   - [ ] "Manage Your Health Online" does not appear
1. Check the main VA page
   - [ ] "Manage Your Health Online" does appear


## Acceptance criteria
- [ ] "Manage Your Health Care" no longer appears on any Tricare pages.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
