### PR TITLE
Rebuilt header plugin for accordion headers

### DIFF
--- a/src/site/stages/build/plugins/modify-dom/force-correct-accordion-headers.js
+++ b/src/site/stages/build/plugins/modify-dom/force-correct-accordion-headers.js
@@ -29,9 +29,9 @@ module.exports = {
 
     const findPreviousHeaderLevel = node => {
       // Returns the header level when the last header is in a wysiwyg div
-      const previousHeaderLevelParent = dom(node).prev(
-        'div[data-template="paragraphs/wysiwyg"]',
-      );
+      const previousHeaderLevelParent = dom(node)
+        .prevAll('div[data-template="paragraphs/wysiwyg"]:has(:header)')
+        .first();
 
       const lastHeader = previousHeaderLevelParent.find(':header').last()[0];
       if (lastHeader) {

--- a/src/site/stages/build/plugins/modify-dom/force-correct-accordion-headers.js
+++ b/src/site/stages/build/plugins/modify-dom/force-correct-accordion-headers.js
@@ -62,13 +62,17 @@ module.exports = {
       let incrementedHeaderLevel =
         parseInt(previousHeaderLevel?.substring(1), 10) + 1;
       const accordionHeaders = dom(node).find(':header');
+      // Ensures that only the main header is affected and not headers in the accordion content
+      const topLevelAccordionHeaders = accordionHeaders.filter(function() {
+        return dom(this).parent()[0].tagName === 'va-accordion-item';
+      });
 
       // Prevents attempted to make a header larger than an H6
       if (incrementedHeaderLevel > 6) incrementedHeaderLevel = 6;
 
       // only reassign header level if incrementedHeaderLevel is actually a number
       if (incrementedHeaderLevel && typeof incrementedHeaderLevel === 'number')
-        accordionHeaders.each((_, header) => {
+        topLevelAccordionHeaders.each((_, header) => {
           dom(header).prop('tagName', `h${incrementedHeaderLevel}`);
           didModifyHeaders = true;
         });

--- a/src/site/stages/build/plugins/modify-dom/force-correct-accordion-headers.js
+++ b/src/site/stages/build/plugins/modify-dom/force-correct-accordion-headers.js
@@ -64,7 +64,7 @@ module.exports = {
       const accordionHeaders = dom(node).find(':header');
 
       // Prevents attempted to make a header larger than an H6
-      if (incrementedHeaderLevel === 6) incrementedHeaderLevel = 5;
+      if (incrementedHeaderLevel > 6) incrementedHeaderLevel = 6;
 
       // only reassign header level if incrementedHeaderLevel is actually a number
       if (incrementedHeaderLevel && typeof incrementedHeaderLevel === 'number')

--- a/src/site/stages/build/plugins/modify-dom/force-correct-accordion-headers.js
+++ b/src/site/stages/build/plugins/modify-dom/force-correct-accordion-headers.js
@@ -1,0 +1,81 @@
+/* eslint-disable no-param-reassign */
+/* eslint-disable no-console */
+
+/**
+ * The intention of this file is to check the DOM for accordions generated with incorrect
+ * Heading Hierachies and correct this issue by modifying the DOM.
+ * */
+
+module.exports = {
+  initialize() {
+    console.time('Force Correct Accordion Level');
+  },
+  conclude() {
+    console.timeEnd('Force Correct Accordion Level');
+  },
+  modifyFile(fileName, file) {
+    let didModifyHeaders = false;
+
+    if (!fileName.endsWith('html')) {
+      return;
+    }
+
+    const { dom } = file;
+
+    // Bail early if page doesnt have an Accordion
+    if (dom("[data-template='paragraphs/collapsible_panel']").length < 1) {
+      return;
+    }
+
+    const findPreviousHeaderLevel = node => {
+      // Returns the header level when the last header is in a wysiwyg div
+      const previousHeaderLevelParent = dom(node).prev(
+        'div[data-template="paragraphs/wysiwyg"]',
+      );
+
+      const lastHeader = previousHeaderLevelParent.find(':header').last()[0];
+      if (lastHeader) {
+        return lastHeader?.tagName;
+      }
+
+      // Returns the last header level for when there is no header nested in a wysiwyg
+      const fallbackPreviousHeader = dom(node)
+        .prevAll('h1, h2, h3, h4, h5, h6')
+        .first()[0];
+
+      if (fallbackPreviousHeader) {
+        return fallbackPreviousHeader?.tagName;
+      }
+
+      // Fallback for when no proper headers are provided
+      return 'h2';
+    };
+
+    const collapsiblePanelNodes = dom(
+      `[data-template="paragraphs/collapsible_panel"]`,
+    );
+
+    // Starts at each collapsible panel, steps back to the most recent wysiwyg header, and reassigns based on that
+    collapsiblePanelNodes.each((index, node) => {
+      const previousHeaderLevel = findPreviousHeaderLevel(node);
+      // in the case that there is a known previous header level in a wysiwyg div
+      let incrementedHeaderLevel =
+        parseInt(previousHeaderLevel?.substring(1), 10) + 1;
+      const accordionHeaders = dom(node).find(':header');
+
+      // Prevents attempted to make a header larger than an H6
+      if (incrementedHeaderLevel === 6) incrementedHeaderLevel = 5;
+
+      // only reassign header level if incrementedHeaderLevel is actually a number
+      if (incrementedHeaderLevel && typeof incrementedHeaderLevel === 'number')
+        accordionHeaders.each((_, header) => {
+          dom(header).prop('tagName', `h${incrementedHeaderLevel}`);
+          didModifyHeaders = true;
+        });
+    });
+
+    if (didModifyHeaders) {
+      file.modified = true;
+    }
+  },
+};

--- a/src/site/stages/build/plugins/modify-dom/index.js
+++ b/src/site/stages/build/plugins/modify-dom/index.js
@@ -9,6 +9,7 @@ const addSubheadingsIds = require('./add-id-to-subheadings');
 const checkBrokenLinks = require('./check-broken-links');
 const injectAxeCore = require('./inject-axe-core');
 const addLangToMain = require('./add-lang-to-main');
+const forceCorrectAccordionHeaders = require('./force-correct-accordion-headers');
 
 const getDomModifiers = BUILD_OPTIONS => {
   if (BUILD_OPTIONS.liquidUnitTestingFramework) {
@@ -18,6 +19,7 @@ const getDomModifiers = BUILD_OPTIONS => {
       addSubheadingsIds,
       injectAxeCore,
       addLangToMain,
+      forceCorrectAccordionHeaders,
     ];
   }
 
@@ -29,6 +31,7 @@ const getDomModifiers = BUILD_OPTIONS => {
     checkBrokenLinks,
     injectAxeCore,
     addLangToMain,
+    forceCorrectAccordionHeaders,
   ];
 };
 


### PR DESCRIPTION
## Description

closes 12342

## Testing done & Screenshots
Local testing on various headers.  


## QA steps

- Pull down branch
- Rebuild content-build
- verify various links from the accordion heading QA dock: https://docs.google.com/spreadsheets/d/1j1FgW1D78gFpVjPYTjsd0DpiDfCATYUf9xG_09-BeOQ/edit#gid=132464158


2. Then validate Acceptance Criteria from issue


## Acceptance criteria

- [ ] Heading levels are more accurate in most cases, and have a fallback for edge cases where predicting the level isnt possible

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
