### PR TITLE
[VA-12776] Lovell Federal System Page Cloning Exception

### DIFF
--- a/src/site/stages/build/drupal/lovell/helpers.js
+++ b/src/site/stages/build/drupal/lovell/helpers.js
@@ -35,6 +35,12 @@ function isListingPage(page) {
   return listingPageTypes.includes(page.entityBundle);
 }
 
+function isFederalRegionHomepage(page) {
+  return (
+    isLovellFederalPage(page) && page.entityBundle === 'health_care_region_page'
+  );
+}
+
 function getLovellTitle(variant) {
   return `${LOVELL_TITLE_STRING} health care - ${variant}`;
 }
@@ -71,6 +77,7 @@ module.exports = {
   isLovellTricarePage,
   isLovellVaPage,
   isListingPage,
+  isFederalRegionHomepage,
   getLovellTitle,
   getLovellTitleVariation,
   getLovellUrl,

--- a/src/site/stages/build/drupal/lovell/update-page.js
+++ b/src/site/stages/build/drupal/lovell/update-page.js
@@ -43,22 +43,6 @@ function getLovellSwitchPath(vars) {
   return getLovellVariantOfUrl(page.entityUrl.path, oppositeVariant);
 }
 
-function getLovellBreadcrumbs(vars) {
-  const { page, variantName, linkVar } = vars;
-  // Modify Breadcrumb
-  return page.entityUrl.breadcrumb.map(crumb => {
-    // eslint-disable-next-line no-param-reassign
-    crumb.text = crumb.text.replace(
-      /Lovell Federal health care/,
-      getLovellTitle(variantName),
-    );
-    // eslint-disable-next-line no-param-reassign
-    crumb.url.path = getLovellVariantOfUrl(crumb.url.path, linkVar);
-
-    return crumb;
-  });
-}
-
 function getLovellVariantTitle(title, vars) {
   const { variantName } = vars;
 
@@ -69,6 +53,20 @@ function getLovellVariantTitle(title, vars) {
     ),
     getLovellTitle(variantName),
   );
+}
+
+function getLovellBreadcrumbs(vars) {
+  const { page, linkVar } = vars;
+  // Modify Breadcrumb
+  return page.entityUrl.breadcrumb.map(crumb => {
+    // eslint-disable-next-line no-param-reassign
+    crumb.text = getLovellVariantTitle(crumb.text, vars);
+
+    // eslint-disable-next-line no-param-reassign
+    crumb.url.path = getLovellVariantOfUrl(crumb.url.path, linkVar);
+
+    return crumb;
+  });
 }
 
 module.exports = {

--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -14,6 +14,7 @@ const {
   isLovellTricarePage,
   isLovellVaPage,
   isListingPage,
+  isFederalRegionHomepage,
   getLovellTitle,
   getLovellTitleVariation,
   getLovellVariantOfUrl,
@@ -234,6 +235,11 @@ function processLovellPages(drupalData) {
   } = drupalData.data.nodeQuery.entities.reduce(
     (acc, page) => {
       if (isLovellFederalPage(page)) {
+        // Federal Region Homepage should not be cloned
+        if (isFederalRegionHomepage(page)) {
+          return acc;
+        }
+
         if (isListingPage(page)) {
           acc.lovellFederalListingPages.push(page);
         } else {


### PR DESCRIPTION
## Description

closes [#12776](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12776) and closes [#12690](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12690)

## Testing done & Screenshots

Visual, see below. Titles, content, and breadcrumb are updated/corrected.

<img width="1034" alt="Screen Shot 2023-02-27 at 7 50 04 PM" src="https://user-images.githubusercontent.com/10790736/221725147-986f755d-1ec4-476e-a0cc-f423c6653317.png">

## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

1. Check that the Tricare and VA pages have the right information
   - [ ] The titles are correct
   - [ ] The breadcrumbs are correct
   - [ ] The content reflects the correct title and the info in the CMS
   - [ ] The Tricare page doesn't have a "Manage Your Health Online" section

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
