### PR TITLE
Do not fail out if Drupal downloads fail on localhost.

### DIFF
--- a/src/site/stages/build/plugins/download-drupal-assets.js
+++ b/src/site/stages/build/plugins/download-drupal-assets.js
@@ -6,6 +6,7 @@ const chalk = require('chalk');
 
 const { logDrupal: log } = require('../drupal/utilities-drupal');
 const getDrupalClient = require('../drupal/api');
+const ENVIRONMENTS = require('../../../constants/environments');
 
 async function downloadFile(
   files,
@@ -32,7 +33,8 @@ async function downloadFile(
 
   let response;
   let retries = 3;
-  while (retries--) {
+  // eslint-disable-next-line no-plusplus
+  while (retries++) {
     try {
       if (global.verbose) {
         const startDate = new Date().toISOString();
@@ -52,13 +54,20 @@ async function downloadFile(
         // Pause to give the proxy connection a break.
         // eslint-disable-next-line no-await-in-loop,no-loop-func
         await new Promise(resolve => setTimeout(resolve, 2000 - retries * 500));
+      } else if (options.buildtype === ENVIRONMENTS.LOCALHOST) {
+        // If this is local, do not fail on missing assets, but inform the user.
+        // Note that review instances run as local.
+        // eslint-disable-next-line no-console
+        console.error(
+          `Unable to download ${asset.src}. Error: ${e}. If you are developing locally, check that your proxy is active.`,
+        );
       } else {
         throw e;
       }
     }
   }
 
-  if (response.ok) {
+  if (response && response.ok) {
     files[asset.dest] = {
       path: asset.dest,
       isDrupalAsset: true,
@@ -70,6 +79,7 @@ async function downloadFile(
     // Store file contents directly on disk
     outputPaths.forEach(outputPath => fs.outputFileSync(outputPath, contents));
 
+    // eslint-disable-next-line no-plusplus
     downloadResults.downloadCount++;
 
     if (global.verbose) {
@@ -84,9 +94,10 @@ async function downloadFile(
   } else {
     // For now, not going to fail the build for a missing asset
     // Should get caught by the broken link checker, though
+    // eslint-disable-next-line no-plusplus
     downloadResults.errorCount++;
     if (global.verbose) {
-      log(`Image download failed: ${response.statusText}: ${asset.src}`);
+      log(`File download failed: ${response.statusText}: ${asset.src}`);
     } else {
       process.stdout.write(chalk.red('.'));
       if (!assetsToDownload.length) process.stdout.write('\n');
@@ -142,6 +153,7 @@ function downloadDrupalAssets(options) {
       const downloadersCount = 5;
 
       await new Promise(everythingDownloaded => {
+        // eslint-disable-next-line no-plusplus
         for (let i = 0; i < downloadersCount; i++) {
           downloadFile(
             files,

--- a/src/site/stages/build/plugins/download-drupal-assets.js
+++ b/src/site/stages/build/plugins/download-drupal-assets.js
@@ -34,7 +34,7 @@ async function downloadFile(
   let response;
   let retries = 3;
   // eslint-disable-next-line no-plusplus
-  while (retries++) {
+  while (retries--) {
     try {
       if (global.verbose) {
         const startDate = new Date().toISOString();


### PR DESCRIPTION
## Description

relates to https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12543

We sometimes see failures on vets-website review instances due to attempts to download images without a proper network connection. These changes downgrade failure due to inability to download images to a console warning for localhost environments only, which includes review instances.

## Testing done & Screenshots
Built locally, including turning off the proxy during the Download Drupal Assets step
* With proxy on, Download Drupal Assets proceeds as normal
* With proxy off, Download Drupal Assets gives warnings, but does not terminate the process.

## QA steps
1. Pull down the branch locally. Make sure your proxy is turned on.
2. Run `yarn build --pull-drupal`.
3. Let content build run until step 51, Download Drupal Assets. This should manifest as dots written to screen: `........` etc.
4. While step 51 is still running, disable the proxy. 

You should initially see warnings that the file was unreachable, at which point further attempts will be made. Eventually you will see the warning message as added in the PR.


## Acceptance criteria

- [ ] Content release and CI continue to operate as before
