### PR TITLE
VA-12806: Update Lovell listing links for variants

### DIFF
--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -167,7 +167,7 @@ function updateLovellSwitchLinks(page, pages) {
  * @param {*} federalPages Listing pages to merge into tricareOrVaPages
  * @returns
  */
-function combineLovellListingPages(tricareOrVaPages, federalPages) {
+function combineLovellListingPages(tricareOrVaPages, federalPages, variant) {
   return tricareOrVaPages.map(listingPage => {
     const typePastMap = {
       event_listing: 'pastEvents',
@@ -185,6 +185,16 @@ function combineLovellListingPages(tricareOrVaPages, federalPages) {
       page => page.entityBundle === entityBundle,
     );
 
+    const updateEntityUrlForVariant = entity => {
+      return {
+        ...entity,
+        entityUrl: {
+          ...entity.entityUrl,
+          path: getLovellVariantOfUrl(entity.entityUrl.path, variant),
+        },
+      };
+    };
+
     const {
       [pastObjectLabel]: pastListItemsToCombine,
       reverseFieldListingNode: reverseFieldListingNodeToCombine,
@@ -194,9 +204,11 @@ function combineLovellListingPages(tricareOrVaPages, federalPages) {
     const allListItemEntities = reverseFieldListingNode?.entities || [];
 
     const pastListItemEntitiesToCombine =
-      pastListItemsToCombine?.entities || [];
+      pastListItemsToCombine?.entities.map(updateEntityUrlForVariant) || [];
     const allListItemEntitiesToCombine =
-      reverseFieldListingNodeToCombine?.entities || [];
+      reverseFieldListingNodeToCombine?.entities.map(
+        updateEntityUrlForVariant,
+      ) || [];
 
     const combinedPastListItemEntities = [
       ...pastListItemEntities,
@@ -277,10 +289,12 @@ function processLovellPages(drupalData) {
   const lovellTricareListingPagesWithFederal = combineLovellListingPages(
     lovellTricareListingPages,
     lovellFederalListingPages,
+    'tricare',
   );
   const lovellVaListingPagesWithFederal = combineLovellListingPages(
     lovellVaListingPages,
     lovellFederalListingPages,
+    'va',
   );
 
   // modify all tricare pages


### PR DESCRIPTION
## Description

Lovell listing pages have a combination of Tricare/VA and federal events. The Federal event links need the appropriate Tricare/VA variations in their URLs to keep users in a consistent section. But links that should be Tricare have VA in the URL. This pull request adds an extra adjustment to listing page data so the URLs are correct.

closes [#12806](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12806) 

## Testing done & Screenshots

Visual, see below.

<img width="1074" alt="Screen Shot 2023-03-03 at 3 57 26 PM" src="https://user-images.githubusercontent.com/10790736/222828461-980fbfcb-0317-4f18-9959-0f1506db90ff.png">

## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

1. Go to a VA listing page
   - [ ] Validate that all URLs use the `va` variant
2. Go to a Tricare listing page
   - [ ] Validate that all URLs use the `tricare` variant

## Acceptance criteria

- [ ] All QA steps are successful

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
