### PR TITLE
Revert "Revert "[VA-12570] Update COVID status field with facility-sp…

### DIFF
--- a/src/site/includes/covid-status.drupal.liquid
+++ b/src/site/includes/covid-status.drupal.liquid
@@ -10,6 +10,10 @@ class="vads-u-margin-top--{{topMargin}} vads-u-margin-bottom--{{bottomMargin}} v
 			'covid-status-heading':  '{{ fieldSupplementalStatus.entity.fieldStatusId }}',
 		});"
 	>
-		{{ fieldSupplementalStatus.entity.description.processed }}
+		{% if fieldSupplementalStatusMoreI.processed %}
+			{{ fieldSupplementalStatusMoreI.processed }}
+		{% else %}
+			{{ fieldSupplementalStatus.entity.description.processed }}
+		{% endif %}
 	</va-alert-expandable>
 {% endif %}

--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareLocalFacility.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareLocalFacility.node.graphql.js
@@ -30,6 +30,11 @@ const FACILITIES_RESULTS = `
           }
         }
       }
+      fieldSupplementalStatusMoreI {
+        value
+        format
+        processed
+      }
       fieldOperatingStatusFacility
       fieldFacilityLocatorApiId
       fieldIntroText

--- a/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
@@ -27,6 +27,11 @@ const healthCareLocalFacilityPageFragment = `
         }
       }
     }
+    fieldSupplementalStatusMoreI {
+      value
+      format
+      processed
+    }
     fieldOperatingStatusFacility
     fieldLocationServices {
       entity {

--- a/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
@@ -72,6 +72,11 @@ const nodeHealthCareRegionPage = `
               }
             }
           }
+          fieldSupplementalStatusMoreI {
+            value
+            format
+            processed
+          }
         }
       }
     }

--- a/src/site/stages/build/drupal/graphql/locationsListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/locationsListingPage.graphql.js
@@ -37,6 +37,11 @@ const locationListingPage = `
                     }
                   }
                 }
+                fieldSupplementalStatusMoreI {
+                  value
+                  format
+                  processed
+                }
               }
             }
           }

--- a/src/site/stages/build/drupal/graphql/locationsOperatingStatus.graphql.js
+++ b/src/site/stages/build/drupal/graphql/locationsOperatingStatus.graphql.js
@@ -28,6 +28,11 @@ const locationsOperatingStatus = `
             }
           }
         }
+        fieldSupplementalStatusMoreI {
+          value
+          format
+          processed
+        }
         fieldOperatingStatusFacility
         fieldOperatingStatusMoreInfo
         fieldRegionPage {

--- a/src/site/stages/build/drupal/graphql/vamcOperatingStatusAndAlerts.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vamcOperatingStatusAndAlerts.graphql.js
@@ -29,6 +29,11 @@ const vamcOperatingStatusAndAlerts = `
                     }
                   }
                 }
+                fieldSupplementalStatusMoreI {
+                  value
+                  format
+                  processed
+                }
               }
             }
           }


### PR DESCRIPTION
…ecific supplemental info (#1479)" (#1492)"

This reverts commit 50a69432050bd8abe3c84c3033122ae5ac5f06b1.

## Description

Re-implements the changes from [this PR](https://github.com/department-of-veterans-affairs/content-build/pull/1488) that were reverted due to timing with corresponding CMS changes. Those CMS changes have gone to production now, and we are good to merge this (again).
