### PR TITLE
VACMS-12532: Drupalizes the create-account hero block on the new home page

### DIFF
--- a/src/site/includes/hero.drupal.liquid
+++ b/src/site/includes/hero.drupal.liquid
@@ -41,8 +41,8 @@
           // Uncomment custom event and delete generic event once analytics team has implemented
           // recordEvent({ event: "homepage-create-account", action: "Homepage Create Account CTA" });
           recordMultipleEvents([
-            { event: 'cta-button-click', 'button-type': 'primary', 'button-click-label': 'Create Account'  },
-            { event: "homepage-create-account", action: "Homepage Create Account CTA" }
+            { event: 'cta-button-click', 'button-type': 'primary', 'button-click-label': '{{ createAccountBlock.entityLabel }}'  },
+            { event: "homepage-create-account", action: "{{ createAccountBlock.fieldPrimaryCtaButtonText }}" }
           ]);
           const params = (new URL(document.location)).searchParams;
           params.set("next", "loginModal")
@@ -55,18 +55,19 @@
             class="va-flex vads-u-flex-direction--column vads-u-align-items--flex-start vads-u-background-color--white vads-u-margin-top--6 vads-u-margin-bottom--6 vads-u-padding-x--3 vads-u-padding-y--2 vads-u-width--full homepage-hero__create-account ">
             <h2
               class="vads-u-font-size--md vads-u-line-height--5 vads-u-color--gray vads-u-margin-top--0 vads-u-padding-right--2 vads-u-font-family--sans vads-u-font-weight--normal">
-              Create an account to manage your VA benefits and care in one place — any time, from anywhere.
+              {{ createAccountBlock.fieldCtaSummaryText }}
             </h2>
             <button class="vads-u-padding-x--4 vads-u-margin-bottom--3" onclick="openLoginModal()">
-              Create account
+              {{ createAccountBlock.fieldPrimaryCtaButtonText }}
             </button>
-            <a 
-              href="/resources/creating-an-account-for-vagov"
-              onclick="recordEvent({ event: 'cta-button-click', 'button-type': 'secondary', 'button-click-label': 'Learn how an account helps you',  });"
-
-            >
-              Learn how an account helps you
-            </a>
+            {% for link in createAccountBlock.fieldRelatedInfoLinks %}
+              <a
+                href="{{ link.url.path }}"
+                onclick="recordEvent({ event: 'cta-button-click', 'button-type': 'secondary', 'button-click-label': '{{ link.title }}',  });"
+                >
+                {{ link.title }}
+              </a>
+            {% endfor %}
           </div>
         </div>
       </div>

--- a/src/site/stages/build/drupal/graphql/homePage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/homePage.graphql.js
@@ -5,6 +5,7 @@
 const menu = 'homepage-top-tasks-blocks';
 const hubListQueue = 'home_page_hub_list';
 const hubListMenu = 'home-page-hub-list';
+const hubListCreateAccountQueue = 'v2_home_page_create_account';
 const promoBlocksQueue = 'home_page_promos';
 const homePageHeroQueue = 'home_page_hero';
 const homePageNewsSpotlightQueue = 'home_page_news_spotlight';
@@ -183,6 +184,27 @@ const query = `
   }
   homePageOtherSearchToolsMenuQuery:  menuByName(name: "${otherSearchToolsMenu}") {
     ${linksQueryPartial}
+  }
+  homePageCreateAccountQuery: entitySubqueueById(id: "${hubListCreateAccountQueue}") {
+    ... on EntitySubqueueV2HomePageCreateAccount {
+      itemsOfEntitySubqueueV2HomePageCreateAccount {
+        entity {
+          entityId
+          ... on BlockContentCtaWithLink {
+            entityId
+            entityLabel
+            fieldCtaSummaryText
+            fieldPrimaryCtaButtonText
+            fieldRelatedInfoLinks {
+              title
+              url {
+                path
+              }
+            }
+          }
+        }
+      }
+    }
   }
 `;
 

--- a/src/site/stages/build/drupal/home.js
+++ b/src/site/stages/build/drupal/home.js
@@ -73,6 +73,7 @@ function addHomeContent(contentData, files, metalsmith, buildOptions) {
         homePagePopularOnVaGovMenuQuery,
         homePageOtherSearchToolsMenuQuery,
         homePageHubListMenuQuery,
+        homePageCreateAccountQuery,
       },
     } = contentData;
 
@@ -80,6 +81,9 @@ function addHomeContent(contentData, files, metalsmith, buildOptions) {
 
     const hero =
       homePageHeroQuery?.itemsOfEntitySubqueueHomePageHero?.[0]?.entity || {};
+    hero.createAccountBlock =
+      homePageCreateAccountQuery
+        ?.itemsOfEntitySubqueueV2HomePageCreateAccount?.[0]?.entity || {};
     const searchLinks = homePageOtherSearchToolsMenuQuery?.links || [];
     const popularLinks = homePagePopularOnVaGovMenuQuery?.links || [];
     const newsSpotlight =


### PR DESCRIPTION
## Description
Uses Drupal content for the create account block in the new home page hero.

relates to https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12532

## Testing done & Screenshots
Tested using existing Production Drupal 'CTA with Links' block created in the previous sprint.

![Screenshot 2023-03-03 at 1 28 11 PM](https://user-images.githubusercontent.com/221539/222833634-3c80d2db-2883-456c-91cb-5f77ae05a3c7.png)


## QA steps
1. Visit /new-home-page
   - [ ] Validate that the 'create account' block in the hero appears as in the screenshot above.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable (not applicable)
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
