### PR TITLE
VA-12807: Update Lovell Story "View All" links

### DIFF
--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -56,6 +56,13 @@ function getModifiedLovellPage(page, variant) {
     );
   }
 
+  if (page?.fieldListing?.entity?.entityUrl) {
+    page.fieldListing.entity.entityUrl.path = getLovellVariantOfUrl(
+      page.fieldListing.entity.entityUrl.path,
+      variant,
+    );
+  }
+
   return page;
 }
 


### PR DESCRIPTION
## Description

In Lovell Stories, the "View All" link on federal stories link isn't adjusted for the variant URL. It still works on the VA page but not the Tricare page. This updates the links in question so they have the proper variants included and aren't broken anymore.

closes [#12807](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12807)

## Testing done & Screenshots

Visually, see the updated URLs circled below:

<img width="851" alt="Screen Shot 2023-03-07 at 9 12 34 AM" src="https://user-images.githubusercontent.com/10790736/223447742-7d267834-f206-46c9-9599-3192177c1094.png">
<img width="789" alt="Screen Shot 2023-03-07 at 9 12 46 AM" src="https://user-images.githubusercontent.com/10790736/223447744-26fde057-d229-4de5-bd7f-06b3a797c525.png">

## QA steps

1. Rebuild the repo locally
2. Check the [federal Tricare story page](http://localhost:3002/lovell-federal-health-care-tricare/stories/test-story-for-both-lovell/)
   - [ ] Confirm that the "See all stories" link has the updated URL and properly links out.
3. Check the [federal TVA story page](http://localhost:3002/lovell-federal-health-care-va/stories/test-story-for-both-lovell/)
   - [ ] Confirm that the "See all stories" link has the updated URL and properly links out.


## Acceptance criteria

- [ ] All QA steps are completed.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
