### PR TITLE
VA-12809: Update Press Release "View All" link

### DIFF
--- a/src/site/layouts/press_release.drupal.liquid
+++ b/src/site/layouts/press_release.drupal.liquid
@@ -82,7 +82,7 @@
                     <section class="vads-u-margin-bottom--3">
                         {{ fieldOffice.entity.fieldPressReleaseBlurb.processed }}
                     </section>
-                    {% assign index = entityUrl.breadcrumb.length | minus: 1 %}
+                    {% assign index = entityUrl.breadcrumb.length | minus: 2 %}
                     <a onClick="recordEvent({ event: 'nav-secondary-button-click' });"
                        href="{{ entityUrl.breadcrumb | getValueFromArrayObjPath: index, 'url.path' }}">See all news releases</a>
                 </article>


### PR DESCRIPTION
## Description

The Press Release "View All" link goes to the current press release, not the list of press releases. The URL is coming from the wrong location in the breadcrumbs (the last link, not the second-to-last), so adjusting that fixed the bug.

closes [#12809](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12809)

## Testing done & Screenshots

Visual, see below

<img width="831" alt="Screen Shot 2023-03-07 at 11 00 05 AM" src="https://user-images.githubusercontent.com/10790736/223477952-dc819e81-fc86-49fa-b61d-f107bf0ed199.png">

## QA steps

1. Load `content-build` locally
2. Check the "see all news releases" link on [this Tricare news release](http://localhost:3002/lovell-federal-health-care-tricare/news-releases/test-a-press-release-for-both-lovell/)
   - [ ] It should go to all Tricare news releases
2. Check the "see all news releases" link on [this VA news release ](http://localhost:3002/lovell-federal-health-care-va/news-releases/test-a-press-release-for-both-lovell/)
   - [ ] It should go to all VA news releases


## Acceptance criteria

- [ ] Ensure all QA steps pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
