### PR TITLE
VACMS-12770: Updates new home page title.

### DIFF
--- a/src/site/stages/build/drupal/home.js
+++ b/src/site/stages/build/drupal/home.js
@@ -120,6 +120,7 @@ function addHomeContent(contentData, files, metalsmith, buildOptions) {
         path: homePreviewPath,
       },
       hubs: divideHubRows(homePreviewHubs),
+      title: 'New VA.gov home page',
     };
 
     files[`.${homePreviewPath}.html`] = createFileObj(


### PR DESCRIPTION
## Description
Updates title for new home page.

relates to https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12770  

## Testing done & Screenshots
Manual testing

## QA steps
1. Visit /new-home-page
   - [ ] Validate that the page title is: `New VA.gov home page | Veterans Affairs`
2. Then visit /
   - [ ] Validate that current page title remains as: `VA.gov Home | Veterans Affairs`

## Definition of done
- [x] No event logging necessary
- [x] Documentation update not applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
