### PR TITLE
Update cleanup script for content build

### DIFF
--- a/.github/workflows/preview-environment-cleanup.yml
+++ b/.github/workflows/preview-environment-cleanup.yml
@@ -60,5 +60,16 @@ jobs:
           author_email: devops@va.gov
           branch: main
           cwd: manifests/apps/preview-environment/dev/
-          add: 'environment-values'
+          add: 'pe-envs'
           message: 'Remove values file(s) in accordance with Preview Environment cleanup policies'
+
+      - name: Add and Commit change(s)
+        if: ${{ env.ENVS_TO_DELETE == 'true'}}
+        uses: EndBug/add-and-commit@v7
+        with:
+          author_name: va-vsp-bot
+          author_email: devops@va.gov
+          branch: main
+          cwd: manifests/apps/preview-environment/dev/
+          add: 'argocd-apps'
+          message: 'Remove envronment listing(s) in accordance with Preview Environment cleanup policies'

--- a/script/github-actions/pe-cleanup.js
+++ b/script/github-actions/pe-cleanup.js
@@ -1,25 +1,57 @@
 const fs = require('fs');
 const core = require('@actions/core');
+const yaml = require('js-yaml');
 
 /* eslint-disable no-console */
 
 const deleteFiles = valuesFiles => {
   core.exportVariable('FILES_TO_DELETE', true);
+  const envFileContents = yaml.load(
+    fs.readFileSync(
+      './manifests/apps/preview-environment/dev/argocd-apps/values.yaml',
+    ),
+  );
   valuesFiles.forEach(file => {
-    try {
-      fs.unlinkSync(
-        `./manifests/apps/preview-environment/dev/environment-values/${file}`,
-      );
-      console.log(`${file} removed`);
-    } catch (error) {
-      console.log(error);
+    const envFileMatch = envFileContents.environments.filter(
+      environment => environment.name === file.split('.')[0],
+    );
+    if (file !== 'template-values.yaml' && file !== 'Chart.yaml') {
+      try {
+        if (envFileMatch.length > 0) {
+          core.exportVariable('ENVS_TO_DELETE', true);
+          envFileMatch.forEach(match => {
+            envFileContents.environments.splice(
+              envFileContents.indexOf(match),
+              1,
+            );
+            console.log(`${match} deleted from environment list`);
+          });
+        } else {
+          core.exportVariable('ENVS_TO_DELETE', false);
+        }
+        fs.unlinkSync(
+          `./manifests/apps/preview-environment/dev/pe-envs/${file}`,
+        );
+        console.log(`${file} values file removed`);
+        const newEnvYaml = yaml.dump(envFileContents, {
+          skipInvalid: true,
+          lineWidth: -1,
+          indent: 0,
+        });
+        fs.writeFileSync(
+          './manifests/apps/preview-environment/dev/argocd-apps/values.yaml',
+          newEnvYaml,
+        );
+      } catch (error) {
+        console.log(error);
+      }
     }
   });
 };
 
 if (process.env.TRIGGERING_EVENT === 'delete') {
   const valuesFiles = fs
-    .readdirSync('./manifests/apps/preview-environment/dev/environment-values/')
+    .readdirSync('./manifests/apps/preview-environment/dev/pe-envs/')
     .filter(file =>
       file.includes(
         `${process.env.CURRENT_REPOSITORY}-${process.env.DELETED_BRANCH}`,
@@ -30,5 +62,6 @@ if (process.env.TRIGGERING_EVENT === 'delete') {
     deleteFiles(valuesFiles);
   } else {
     core.exportVariable('FILES_TO_DELETE', false);
+    core.exportVariable('ENVS_TO_DELETE', false);
   }
 }


### PR DESCRIPTION
## Summary

- Adds support for environment list cleanup.
- Updates directories to be current with structure in the infra manifests repository

## Related issue(s)
- https://app.zenhub.com/workspaces/platform-tech-team-4-633b069d2920b776613c93d8/issues/gh/department-of-veterans-affairs/va.gov-team/54825


## Testing done

Tested with push trigger and sample values - behaved as expected

## What areas of the site does it impact?
Preview Environments MVP

## Acceptance criteria

- [ ]  Values files cleaned up accordingly in their current directory.
- [ ]  Environment List has environments removed properly when appropriate.


