### PR TITLE
VACMS-12943: Fixes broken "Leadership" links on Lovell staff profile pages

### DIFF
--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -18,6 +18,7 @@ const {
   getLovellTitle,
   getLovellTitleVariation,
   getLovellVariantOfUrl,
+  getLovellUrl,
 } = require('./lovell/helpers');
 
 const {
@@ -50,10 +51,15 @@ function getModifiedLovellPage(page, variant) {
     );
   }
 
-  if (page.fieldOffice) {
-    page.fieldOffice.entity.entityLabel = getLovellTitle(
-      getLovellTitleVariation(pageVars.variant),
-    );
+  if (page?.fieldOffice?.entity) {
+    page.fieldOffice.entity = {
+      ...page.fieldOffice.entity,
+      entityLabel: getLovellTitle(getLovellTitleVariation(pageVars.variant)),
+      entityUrl: {
+        ...page.fieldOffice.entity?.entityUrl,
+        path: getLovellUrl(pageVars.linkVar),
+      },
+    };
   }
 
   if (page?.fieldListing?.entity?.entityUrl) {


### PR DESCRIPTION
## Description
Staff-profile pages have a link to a "Leadership" page for the VAMC System. That link is broken on Lovell pages. It points to the Federal level rather than the TRICARE/VA page. That Federal level doesn't exist.

closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12943   

## Testing done & Screenshots
Locally.

## QA steps
1. Pull this branch
2. Build (pull Lovell data from Prod or Lovell Tugboat)
4. Visit: http://localhost:3002/lovell-federal-health-care-va/staff-profiles/robert-buckley/ and ensure that "Leadership" link in left sidebar goes to http://localhost:3002/lovell-federal-health-care-va/about-us/leadership/
5. Visit: http://localhost:3002/lovell-federal-health-care-tricare/staff-profiles/robert-buckley/ and ensure that "Leadership" link in left sidebar goes to http://localhost:3002/lovell-federal-health-care-tricare/about-us/leadership/

## Acceptance criteria
See original ticket.

## Definition of done
- [ ] ~Events are logged appropriately~
- [ ] ~Documentation has been updated, if applicable~
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
