### PR TITLE
Fix typography on pre-need

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -324,7 +324,7 @@
         },
         {
           "path": "burials-and-memorials/pre-need/form-10007-apply-for-eligibility/",
-          "name": "Pre-need Eligibility Determination"
+          "name": "Pre&#8211;need Eligibility Determination"
         }
       ]
     }

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -324,7 +324,7 @@
         },
         {
           "path": "burials-and-memorials/pre-need/form-10007-apply-for-eligibility/",
-          "name": "Pre&#8211;need Eligibility Determination"
+          "name": "Pre&#8211;need eligibility determination"
         }
       ]
     }

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -320,7 +320,7 @@
       "breadcrumbs_override": [
         {
           "path": "burials-memorials/",
-          "name": "Burials and Memorials"
+          "name": "Burials and memorials"
         },
         {
           "path": "burials-and-memorials/pre-need/form-10007-apply-for-eligibility/",


### PR DESCRIPTION
Fixes text of bread crumbs for the Pre need application on Va.gov. The current text incorrectly uses: Pre need Eligibility Determination instead of Pre-need Eligibility Determination as well as Memorials and Burials being incorrectly in title case instead of sentence case. (Memorials and Burials should be Burials and memorials).


Application: Pre-need
	change text of bread crumbs
		“Pre need Eligibility Determination” to “Pre-need Eligibility Determination”
		“Memorials and Burials” to “Memorials and burials”