### PR TITLE
[VA-12904] Increase Lovell test coverage

### DIFF
--- a/src/site/stages/build/drupal/tests/lovell/fixtures/updatePage.js
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/updatePage.js
@@ -1,0 +1,154 @@
+export const lovellPage = {
+  title: 'Gynecology clinic',
+  entityBundle: 'health_care_region_detail_page',
+  entityId: '52623',
+  entityPublished: true,
+  vid: 748505,
+  entityUrl: {
+    breadcrumb: [
+      {
+        url: {
+          path: '/',
+          routed: true,
+        },
+        text: 'Home',
+      },
+      {
+        url: {
+          path: '/lovell-federal-health-care',
+          routed: true,
+        },
+        text: 'Lovell Federal health care',
+      },
+      {
+        url: {
+          path: '',
+          routed: true,
+        },
+        text: 'ABOUT LOVELL FEDERAL',
+      },
+      {
+        url: {
+          path: '/lovell-federal-health-care-va/programs',
+          routed: true,
+        },
+        text: 'Programs',
+      },
+      {
+        url: {
+          path: '',
+          routed: true,
+        },
+        text: 'Gynecology clinic',
+      },
+    ],
+    path: '/lovell-federal-health-care/programs/gynecology-clinic-0',
+  },
+  entityMetatags: [
+    {
+      __typename: 'MetaLink',
+      key: 'image_src',
+      value: 'https://www.va.gov/img/design/logo/va-og-image.png',
+    },
+    {
+      __typename: 'MetaValue',
+      key: 'title',
+      value:
+        'Gynecology clinic | Lovell Federal health care | Veterans Affairs',
+    },
+    {
+      __typename: 'MetaValue',
+      key: 'description',
+      value:
+        "The Gynecology Clinic consists of three Gynecologists and one Women's Health Nurse Practitioner. A referral is required to be seen in the Gynecology Clinic, except for routine well woman care. The Gynecology Clinic serves veterans, active duty servicemembers, dependents, and retirees.",
+    },
+    {
+      __typename: 'MetaProperty',
+      key: 'og:site_name',
+      value: 'Veterans Affairs',
+    },
+    {
+      __typename: 'MetaProperty',
+      key: 'og:title',
+      value: 'Gynecology clinic | Veterans Affairs',
+    },
+    {
+      __typename: 'MetaProperty',
+      key: 'og:description',
+      value:
+        "The Gynecology Clinic consists of three Gynecologists and one Women's Health Nurse Practitioner. A referral is required to be seen in the Gynecology Clinic, except for routine well woman care. The Gynecology Clinic serves veterans, active duty servicemembers, dependents, and retirees.",
+    },
+    {
+      __typename: 'MetaProperty',
+      key: 'og:image',
+      value: 'https://www.va.gov/img/design/logo/va-og-image.png',
+    },
+    {
+      __typename: 'MetaProperty',
+      key: 'og:image:alt',
+      value: 'U.S. Department of Veterans Affairs',
+    },
+    {
+      __typename: 'MetaValue',
+      key: 'twitter:card',
+      value: 'summary_large_image',
+    },
+    {
+      __typename: 'MetaValue',
+      key: 'twitter:site',
+      value: '@DeptVetAffairs',
+    },
+    {
+      __typename: 'MetaValue',
+      key: 'twitter:description',
+      value: 'gynecology',
+    },
+    {
+      __typename: 'MetaValue',
+      key: 'twitter:title',
+      value:
+        'Gynecology clinic | Lovell Federal health care | Veterans Affairs',
+    },
+    {
+      __typename: 'MetaValue',
+      key: 'twitter:image:alt',
+      value: 'U.S. Department of Veterans Affairs',
+    },
+    {
+      __typename: 'MetaValue',
+      key: 'twitter:image',
+      value: 'https://www.va.gov/img/design/logo/va-og-image.png',
+    },
+  ],
+  changed: 1676922457,
+  fieldIntroText:
+    "The Gynecology Clinic consists of three Gynecologists and one Women's Health Nurse Practitioner. A referral is required to be seen in the Gynecology Clinic, except for routine well woman care. The Gynecology Clinic serves veterans, active duty servicemembers, dependents, and retirees.",
+  fieldTableOfContentsBoolean: false,
+  fieldFeaturedContent: [],
+  fieldContentBlock: [
+    {
+      entity: {
+        entityType: 'paragraph',
+        entityBundle: 'wysiwyg',
+        entityId: '120329',
+        fieldWysiwyg: {
+          processed:
+            '<html><head></head><body><p>The Gynecology Clinic provides evaluation and management of the following conditions:</p>\n\n<ul><li>Vaginal bleeding problems</li>\n\t<li>Uterine fibroids</li>\n\t<li>Uterine polyps</li>\n\t<li>Pelvic pain</li>\n\t<li>Painful menses</li>\n\t<li>Endometriosis</li>\n\t<li>Cervical polyps</li>\n\t<li>Abnormal Pap tests / Cervical dysplasia</li>\n\t<li>Postmenopausal bleeding</li>\n\t<li>Ovarian/adnexal cysts/masses</li>\n\t<li>Family planning/contraception</li>\n\t<li>Infertility workup and initial treatment</li>\n\t<li>Vulvar issues (lesions/masses/irritation)</li>\n\t<li>Menopause symptoms / hormone replacement</li>\n\t<li>Early pregnancy issues (ectopics, miscarriages, unlocated pregnancies)</li>\n</ul><p>We are a surgical subspecialty and perform the following procedures:</p>\n\n<ul><li>Diagnostic laparoscopy</li>\n\t<li>Laparoscopic treatment of endometriosis</li>\n\t<li>Laparoscopic cystectomy, oophorectomy, salpingectomy</li>\n\t<li>Sterilization</li>\n\t<li>Laparoscopic myomectomy</li>\n\t<li>Essure removal</li>\n\t<li>Laparoscopic hysterectomy</li>\n\t<li>Laparoscopic adhesiolysis</li>\n\t<li>Hysteroscopy / D&amp;C</li>\n\t<li>Operative hysteroscopy for polyps, fibroids, Asherman&#x2019;s, septum, foreign bodies, ablation</li>\n\t<li>D&amp;C for nonviable pregnancies</li>\n\t<li>Bartholins gland excision</li>\n\t<li>Vulvar lesions</li>\n\t<li>Labiaplasty</li>\n\t<li>LEEP / cold knife cone for cervical dysplasia (in-office or in the OR)</li>\n</ul></body></html>',
+        },
+      },
+    },
+  ],
+  fieldRelatedLinks: null,
+  fieldAlert: null,
+  fieldOffice: {
+    entity: {
+      entityLabel: 'Lovell Federal health care',
+      title: 'Lovell Federal health care',
+    },
+  },
+  fieldAdministration: {
+    entity: {
+      entityId: '1039',
+    },
+  },
+};

--- a/src/site/stages/build/drupal/tests/lovell/helpers.unit.spec.js
+++ b/src/site/stages/build/drupal/tests/lovell/helpers.unit.spec.js
@@ -1,0 +1,94 @@
+/* eslint-disable @department-of-veterans-affairs/axe-check-required */
+import { expect } from 'chai';
+
+import {
+  LOVELL_VA_TITLE_VARIATION,
+  LOVELL_TRICARE_TITLE_VARIATION,
+  LOVELL_VA_LINK_VARIATION,
+  LOVELL_TRICARE_LINK_VARIATION,
+  getLovellTitle,
+  getLovellTitleVariation,
+  getLovellUrl,
+  getLovellVariantOfUrl,
+} from '../../lovell/helpers';
+
+describe('getLovellTitle', () => {
+  it('returns the proper title for the variant', () => {
+    expect(getLovellTitle(LOVELL_VA_TITLE_VARIATION)).to.eq(
+      'Lovell Federal health care - VA',
+    );
+    expect(getLovellTitle(LOVELL_TRICARE_TITLE_VARIATION)).to.eq(
+      'Lovell Federal health care - TRICARE',
+    );
+  });
+});
+
+describe('getLovellTitleVariation', () => {
+  it('returns the expected variations', () => {
+    expect(getLovellTitleVariation('va')).to.eq(LOVELL_VA_TITLE_VARIATION);
+    expect(getLovellTitleVariation(' - va')).to.eq(LOVELL_VA_TITLE_VARIATION);
+    expect(getLovellTitleVariation('tricare')).to.eq(
+      LOVELL_TRICARE_TITLE_VARIATION,
+    );
+    expect(getLovellTitleVariation(' - tricare')).to.eq(
+      LOVELL_TRICARE_TITLE_VARIATION,
+    );
+  });
+});
+
+describe('getLovellUrl', () => {
+  it('return the proper url for the variant', () => {
+    expect(getLovellUrl(LOVELL_VA_LINK_VARIATION)).to.eq(
+      '/lovell-federal-health-care-va',
+    );
+    expect(getLovellUrl(LOVELL_TRICARE_LINK_VARIATION)).to.eq(
+      '/lovell-federal-health-care-tricare',
+    );
+  });
+});
+
+describe('getLovellVariantOfUrl', () => {
+  const testLovellUrlVariation = (given, linkVar, expected) => {
+    expect(getLovellVariantOfUrl(given, linkVar)).to.eq(expected);
+  };
+
+  it('returns expected VA URL variants', () => {
+    testLovellUrlVariation(
+      '/lovell-federal-health-care/some-page',
+      LOVELL_VA_LINK_VARIATION,
+      '/lovell-federal-health-care-va/some-page',
+    );
+
+    testLovellUrlVariation(
+      '/lovell-federal-health-care-tricare/some-page',
+      LOVELL_VA_LINK_VARIATION,
+      '/lovell-federal-health-care-va/some-page',
+    );
+
+    testLovellUrlVariation(
+      '/lovell-federal-health-care-va/some-page',
+      LOVELL_VA_LINK_VARIATION,
+      '/lovell-federal-health-care-va/some-page',
+    );
+  });
+
+  it('gets expected Tricare URL variants', () => {
+    testLovellUrlVariation(
+      '/lovell-federal-health-care/some-page',
+      LOVELL_TRICARE_LINK_VARIATION,
+      '/lovell-federal-health-care-tricare/some-page',
+    );
+
+    testLovellUrlVariation(
+      '/lovell-federal-health-care-va/some-page',
+      LOVELL_TRICARE_LINK_VARIATION,
+      '/lovell-federal-health-care-tricare/some-page',
+    );
+
+    testLovellUrlVariation(
+      '/lovell-federal-health-care-tricare/some-page',
+      LOVELL_TRICARE_LINK_VARIATION,
+      '/lovell-federal-health-care-tricare/some-page',
+    );
+  });
+});

--- a/src/site/stages/build/drupal/tests/lovell/updatePage.unit.spec.js
+++ b/src/site/stages/build/drupal/tests/lovell/updatePage.unit.spec.js
@@ -1,0 +1,279 @@
+/* eslint-disable @department-of-veterans-affairs/axe-check-required */
+import { expect } from 'chai';
+import { lovellPage } from './fixtures/updatePage';
+
+import {
+  getLovellPageVariables,
+  getLovellVariantPath,
+  getLovellCanonicalLink,
+  getLovellSwitchPath,
+  getLovellBreadcrumbs,
+  getLovellVariantTitle,
+} from '../../lovell/update-page';
+
+const getVariantPageVariables = (overrides, variant) => {
+  const newPage = {
+    ...lovellPage,
+    ...overrides,
+  };
+
+  return getLovellPageVariables(newPage, variant);
+};
+
+const testLovellUrlForFunction = (lovellFunction, variant, given, expected) => {
+  expect(
+    lovellFunction(
+      getVariantPageVariables(
+        {
+          entityUrl: {
+            path: given,
+          },
+        },
+        variant,
+      ),
+    ),
+  ).to.eq(expected);
+};
+
+describe('getLovellVariantPath', () => {
+  it('returns a lovell variant of the URL from federal URLs', () => {
+    testLovellUrlForFunction(
+      getLovellVariantPath,
+      'va',
+      '/lovell-federal-health-care/programs/some-program',
+      '/lovell-federal-health-care-va/programs/some-program',
+    );
+
+    testLovellUrlForFunction(
+      getLovellVariantPath,
+      'tricare',
+      '/lovell-federal-health-care/programs/some-program',
+      '/lovell-federal-health-care-tricare/programs/some-program',
+    );
+  });
+
+  it('returns a lovell variant of the URL from variant URLs', () => {
+    testLovellUrlForFunction(
+      getLovellVariantPath,
+      'va',
+      '/lovell-federal-health-care-tricare/programs/some-program',
+      '/lovell-federal-health-care-va/programs/some-program',
+    );
+
+    testLovellUrlForFunction(
+      getLovellVariantPath,
+      'tricare',
+      '/lovell-federal-health-care-va/programs/some-program',
+      '/lovell-federal-health-care-tricare/programs/some-program',
+    );
+  });
+});
+
+describe('getLovellCanonicalLink', () => {
+  it('returns the VA variants of any URL', () => {
+    testLovellUrlForFunction(
+      getLovellCanonicalLink,
+      'tricare',
+      '/lovell-federal-health-care/programs/some-program',
+      '/lovell-federal-health-care-va/programs/some-program',
+    );
+
+    testLovellUrlForFunction(
+      getLovellCanonicalLink,
+      'tricare',
+      '/lovell-federal-health-care-tricare/programs/some-program',
+      '/lovell-federal-health-care-va/programs/some-program',
+    );
+
+    testLovellUrlForFunction(
+      getLovellCanonicalLink,
+      'tricare',
+      '/lovell-federal-health-care-va/programs/some-program',
+      '/lovell-federal-health-care-va/programs/some-program',
+    );
+  });
+});
+
+describe('getLovellSwitchPath', () => {
+  it('returns the opposite variant of the URL from federal URLs', () => {
+    testLovellUrlForFunction(
+      getLovellSwitchPath,
+      'tricare',
+      '/lovell-federal-health-care/programs/some-program',
+      '/lovell-federal-health-care-va/programs/some-program',
+    );
+
+    testLovellUrlForFunction(
+      getLovellSwitchPath,
+      'va',
+      '/lovell-federal-health-care/programs/some-program',
+      '/lovell-federal-health-care-tricare/programs/some-program',
+    );
+  });
+
+  it('returns the opposite variant of the URL with a variant already', () => {
+    testLovellUrlForFunction(
+      getLovellSwitchPath,
+      'va',
+      '/lovell-federal-health-care-va/programs/some-program',
+      '/lovell-federal-health-care-tricare/programs/some-program',
+    );
+
+    testLovellUrlForFunction(
+      getLovellSwitchPath,
+      'tricare',
+      '/lovell-federal-health-care-tricare/programs/some-program',
+      '/lovell-federal-health-care-va/programs/some-program',
+    );
+  });
+});
+
+describe('getLovellVariantTitle', () => {
+  it('returns the variant of a federal page title', () => {
+    expect(
+      getLovellVariantTitle(
+        'Lovell Federal health care: Some Department',
+        getVariantPageVariables({}, 'va'),
+      ),
+    ).to.eq('Lovell Federal health care - VA: Some Department');
+
+    expect(
+      getLovellVariantTitle(
+        'Lovell Federal health care: Some Department',
+        getVariantPageVariables({}, 'tricare'),
+      ),
+    ).to.eq('Lovell Federal health care - TRICARE: Some Department');
+  });
+
+  it('returns changed titles that have an existing variant in them', () => {
+    expect(
+      getLovellVariantTitle(
+        'Lovell Federal health care - VA: Some Department',
+        getVariantPageVariables({}, 'tricare'),
+      ),
+    ).to.eq('Lovell Federal health care - TRICARE: Some Department');
+
+    expect(
+      getLovellVariantTitle(
+        'Lovell Federal health care - TRICARE: Some Department',
+        getVariantPageVariables({}, 'va'),
+      ),
+    ).to.eq('Lovell Federal health care - VA: Some Department');
+  });
+
+  it('keeps titles the same if they do not have a Lovell title', () => {
+    expect(
+      getLovellVariantTitle(
+        'Some Department',
+        getVariantPageVariables({}, 'va'),
+      ),
+    ).to.eq('Some Department');
+
+    expect(
+      getLovellVariantTitle(
+        'Some Department',
+        getVariantPageVariables({}, 'tricare'),
+      ),
+    ).to.eq('Some Department');
+  });
+});
+
+describe('getLovellBreadcrumbs', () => {
+  const pageEntityUrlVars = {
+    entityUrl: {
+      breadcrumb: [
+        {
+          url: {
+            path: '/',
+          },
+          text: 'Home',
+        },
+        {
+          url: {
+            path: '/lovell-federal-health-care',
+          },
+          text: 'Lovell Federal health care',
+        },
+        {
+          url: {
+            path: '/lovell-federal-health-care/programs',
+          },
+          text: 'Programs',
+        },
+        {
+          url: {
+            path: '',
+          },
+          text: 'Some Program',
+        },
+      ],
+      path: '/lovell-federal-health-care/programs/some-program',
+    },
+  };
+
+  it('returns proper breadcrumbs for VA', () => {
+    const lovellVaBreadcrumbs = getLovellBreadcrumbs(
+      getVariantPageVariables(pageEntityUrlVars, 'va'),
+    );
+
+    expect(lovellVaBreadcrumbs).to.deep.equal([
+      {
+        url: {
+          path: '/',
+        },
+        text: 'Home',
+      },
+      {
+        url: {
+          path: '/lovell-federal-health-care-va',
+        },
+        text: 'Lovell Federal health care - VA',
+      },
+      {
+        url: {
+          path: '/lovell-federal-health-care-va/programs',
+        },
+        text: 'Programs',
+      },
+      {
+        url: {
+          path: '',
+        },
+        text: 'Some Program',
+      },
+    ]);
+  });
+
+  it('returns proper breadcrumbs for Tricare', () => {
+    const lovellTricareBreadcrumbs = getLovellBreadcrumbs(
+      getVariantPageVariables(pageEntityUrlVars, 'tricare'),
+    );
+
+    expect(lovellTricareBreadcrumbs).to.deep.equal([
+      {
+        url: {
+          path: '/',
+        },
+        text: 'Home',
+      },
+      {
+        url: {
+          path: '/lovell-federal-health-care-tricare',
+        },
+        text: 'Lovell Federal health care - TRICARE',
+      },
+      {
+        url: {
+          path: '/lovell-federal-health-care-tricare/programs',
+        },
+        text: 'Programs',
+      },
+      {
+        url: {
+          path: '',
+        },
+        text: 'Some Program',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Description

This adds unit tests to the Lovell pure functions to ensure proper functionality. Tests have been added to all the `updatePage.js`, but only most of `helpers.js` since a few of them are so simple they don't need tests.

closes [#12904](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12904)

## Testing done & Screenshots

Testing suite

## QA steps

Run `yarn test:unit src/site/stages/build/drupal/tests/lovell/updatePage.unit.spec.js src/site/stages/build/drupal/tests/lovell/helpers.unit.spec.js` to run unit tests on both the added files to ensure they pass.

## Acceptance criteria

- [ ] All the tests on the two new test pages pass.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
