### PR TITLE
VACMS-13042: Removes fieldIntroText from graphql query

### DIFF
--- a/src/site/stages/build/drupal/graphql/locationsListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/locationsListingPage.graphql.js
@@ -10,7 +10,6 @@ const locationListingPage = `
     ${entityElementsFromPages}
     title
     entityId
-    fieldIntroText
     fieldMetaTags
     fieldOffice {
       targetId


### PR DESCRIPTION
## Description
This PR removes `fieldIntroText` from the GraphQL query for `locationsListingPage`. That field is not being rendered on the front end anymore, so querying it is no longer necessary. More importantly, we are doing work in https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11248 that will remove this field from the content type in question, and the build will fail if the query is not updated accordingly.

closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13042
relates to https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11248

## Testing done & Screenshots
Built locally successfully. That should be sufficient to test this small removal.

## QA steps
- [ ] A successful build on this PR review instance should confirm the change does not break anything.

## Acceptance criteria
See original ticket