### PR TITLE
Update 26-4555 vagovprod flag

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1307,7 +1307,7 @@
     "rootUrl": "/housing-assistance/disability-housing-grants/apply-for-grant-form-26-4555",
     "productId": "49929be5-0c92-42f2-b122-3cb426f691d4",
     "template": {
-      "vagovprod": false,
+      "vagovprod": true,
       "layout": "page-react.html",
       "includeBreadcrumbs": true,
       "breadcrumbs_override": [


### PR DESCRIPTION
## Description
This PR toggles the `vagovprod` flag for the 26-4555 form to true so that we can roll out the form to production.


## Related issues
- department-of-veterans-affairs/va.gov-team-forms#25