### PR TITLE
Set Supplemental Claims for production build

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1232,7 +1232,7 @@
     "rootUrl": "/decision-reviews/supplemental-claim/file-supplemental-claim-form-20-0995",
     "productId": "05712241-0f46-4e84-8d3e-70a6cf412a5e",
     "template": {
-      "vagovprod": false,
+      "vagovprod": true,
       "layout": "page-react.html",
       "includeBreadcrumbs": true,
       "breadcrumbs_override": [


### PR DESCRIPTION
## Description

Set Supplemental Claims to build in production

Part of [#48138](https://github.com/department-of-veterans-affairs/va.gov-team/issues/48138)

## Testing done & Screenshots

Feature flag disabled in production



## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

<img width="747" alt="Screenshot 2023-03-30 at 11 53 24 AM" src="https://user-images.githubusercontent.com/136959/228909241-956155d7-64ff-40d3-a42a-011432dd6a55.png">

## Acceptance criteria

- [ ] Supplemental Claims builds in production
- [ ] WIP alert shown at [root URL](https://www.va.gov/decision-reviews/supplemental-claim/file-supplemental-claim-form-20-0995/)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
