### PR TITLE
VA-12717: Facility health services use phone number component

### DIFF
--- a/src/site/facilities/health_care_local_health_service.drupal.liquid
+++ b/src/site/facilities/health_care_local_health_service.drupal.liquid
@@ -40,23 +40,19 @@
       <h5>Phone</h5>
       {% if locationEntity.fieldPhoneNumbersParagraph %}
         {% for number in locationEntity.fieldPhoneNumbersParagraph %}
-          <a aria-label="{{ number.entity.fieldPhoneNumber | accessibleNumber }}"
-             href="tel:{{ number.entity.fieldPhoneNumber }}{% if number.entity.fieldPhoneExtension %}p{{ number.entity.fieldPhoneExtension }}{% endif %}">
-            {{ number.entity.fieldPhoneNumber }}
-            {% if number.entity.fieldPhoneExtension %}
-              x {{ number.entity.fieldPhoneExtension }}
-            {% endif %}
-          </a>
+          <va-telephone
+            contact="{{ number.entity.fieldPhoneNumber | removeDashes }}"
+            extension="{{ number.entity.fieldPhoneExtension | default: '' }}"
+          />
         {% endfor %}
       {% endif %}
     </div>
   {% else %}
     <div class="vads-u-display--flex vads-u-flex-direction--column vads-u-margin-bottom--1" data-template="facilities/health_care_local_health_service">
       <h5>Phone</h5>
-      <a aria-label="{{ fieldPhoneNumber | accessibleNumber }}"
-          href="tel:{{ fieldPhoneNumber }}">
-        {{ fieldPhoneNumber }}
-      </a>
+      <va-telephone
+        contact="{{ fieldPhoneNumber | removeDashes }}"
+      />
     </div>
   {% endif %}
 

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -543,6 +543,10 @@ module.exports = function registerFilters() {
     return null;
   };
 
+  liquid.filters.removeDashes = data => {
+    return data?.replace?.(/-/g, '') || null;
+  };
+
   liquid.filters.deriveLastBreadcrumbFromPath = (
     breadcrumbs,
     string,


### PR DESCRIPTION
## Description

Facility health services have phone numbers that are improperly formatted. This uses our existing `va-telephone` component which fixes these formatting issues and gets it set up for better maintainability.

closes [#12717](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12717)

## Testing done & Screenshots

Visual, see below

<img width="1393" alt="Screen Shot 2023-04-03 at 11 35 10 AM" src="https://user-images.githubusercontent.com/10790736/229558159-c9942bf1-ac80-4ce6-8251-5a097ff2d9a3.png">

## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

1. Do a new build with this pull request
2. Check that the [Jamaica Plain VA Medical Center](http://localhost:3002/boston-health-care/locations/jamaica-plain-va-medical-center/) "Blind and Low Vision Rehabilitation" section phone number is correct
   - [ ] The `aria-label` includes the extension
   - [ ] The anchor tag's `href` includes a "+1" at the start
   - [ ] The anchor tag's `href` has the extension after a comma

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
