### PR TITLE
VACMS-11174: expands filtering unpublished links in sidebar

### DIFF
--- a/src/site/filters/fixtures/sidebarData.json
+++ b/src/site/filters/fixtures/sidebarData.json
@@ -92,11 +92,124 @@
           "links": []
         },
         {
+          "expanded": false,
+          "description": null,
           "label": "ABOUT VA FAYETTEVILLE COASTAL",
           "url": {
             "path": ""
           },
-          "links": []
+          "entity": {
+            "linkedEntity": null
+          },
+          "links": [
+            {
+              "expanded": false,
+              "description": null,
+              "label": "About us",
+              "url": {
+                "path": "/fayetteville-coastal-health-care/about-us"
+              },
+              "entity": {
+                "linkedEntity": {
+                  "entityPublished": true,
+                  "moderationState": "published"
+                }
+              },
+              "links": [
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Mission and vision",
+                  "url": {
+                    "path": "/fayetteville-coastal-health-care/about-us/mission-and-vision"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": true,
+                      "moderationState": "published"
+                    }
+                  },
+                  "links": []
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "History",
+                  "url": {
+                    "path": "/fayetteville-coastal-health-care/about-us/history"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": false,
+                      "moderationState": "draft"
+                    }
+                  },
+                  "links": []
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Performance",
+                  "url": {
+                    "path": "/fayetteville-coastal-health-care/about-us/performance"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": false,
+                      "moderationState": "archived"
+                    }
+                  },
+                  "links": []
+                },
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Leadership",
+                  "url": {
+                    "path": "/fayetteville-coastal-health-care/about-us/leadership"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": true,
+                      "moderationState": "published"
+                    }
+                  },
+                  "links": []
+                }
+              ]
+            },
+            {
+              "expanded": false,
+              "description": null,
+              "label": "Work with us",
+              "url": {
+                "path": "/fayetteville-coastal-health-care/work-with-us"
+              },
+              "entity": {
+                "linkedEntity": {
+                  "entityPublished": true,
+                  "moderationState": "published"
+                }
+              },
+              "links": [
+                {
+                  "expanded": false,
+                  "description": null,
+                  "label": "Jobs and careers",
+                  "url": {
+                    "path": "/fayetteville-coastal-health-care/work-with-us/jobs-and-careers"
+                  },
+                  "entity": {
+                    "linkedEntity": {
+                      "entityPublished": true,
+                      "moderationState": "published"
+                    }
+                  },
+                  "links": []
+                }
+              ]
+            }
+          ]
         }
       ]
     }

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable @department-of-veterans-affairs/axe-check-required */
 // Node modules.
 import _ from 'lodash';
 import liquid from 'tinyliquid';
@@ -1868,18 +1869,35 @@ describe('processCentralizedContent', () => {
 });
 
 describe('filterSidebarData', () => {
-  it('returns null if sidebar data is null', () => {
-    expect(liquid.filters.filterSidebarData(null)).to.be.null;
+  describe('empty-ish data passed in', () => {
+    it('returns passed in sidebarData if it does not have a `links` prop', () => {
+      const emptySidebarData = {};
+      expect(liquid.filters.filterSidebarData(emptySidebarData)).to.deep.equal(
+        emptySidebarData,
+      );
+    });
+
+    it('returns passed in sidebarData if `links` prop has length zero ', () => {
+      const emptySidebarData = {
+        links: [],
+      };
+      expect(liquid.filters.filterSidebarData(emptySidebarData)).to.deep.equal(
+        emptySidebarData,
+      );
+    });
+
+    it('returns passed in sidebarData if `links` prop is not an array', () => {
+      const emptySidebarData = {
+        links: '',
+      };
+      expect(liquid.filters.filterSidebarData(emptySidebarData)).to.deep.equal(
+        emptySidebarData,
+      );
+    });
   });
 
-  it('returns null if arguments are not passed', () => {
-    expect(liquid.filters.filterSidebarData()).to.be.null;
-  });
-
-  it('returns sidebarData with published facilities only', () => {
-    const clonedSidebarData = _.cloneDeep(sidebarData);
-
-    const expected = [
+  describe('when NOT preview, includes only links to published entities', () => {
+    const expectedFacilities = [
       {
         label: 'Brunswick County VA Clinic',
         entity: {
@@ -1900,49 +1918,62 @@ describe('filterSidebarData', () => {
       },
     ];
 
-    const filteredData = liquid.filters.filterSidebarData(
-      clonedSidebarData,
-      false,
-    );
-    expect(filteredData.links[0].links[0].links[1].links).to.deep.equal(
-      expected,
-    );
-  });
-
-  it('returns sidebarData with published facilities if second argument is not passed - isPreview defaults to false', () => {
-    const clonedSidebarData = _.cloneDeep(sidebarData);
-
-    const expected = [
+    const expectedAboutUs = [
       {
-        label: 'Brunswick County VA Clinic',
+        expanded: false,
+        description: null,
+        label: 'Mission and vision',
+        url: {
+          path: '/fayetteville-coastal-health-care/about-us/mission-and-vision',
+        },
         entity: {
           linkedEntity: {
             entityPublished: true,
             moderationState: 'published',
           },
         },
+        links: [],
       },
       {
-        label: 'Jacksonville 2 VA Clinic',
+        expanded: false,
+        description: null,
+        label: 'Leadership',
+        url: {
+          path: '/fayetteville-coastal-health-care/about-us/leadership',
+        },
         entity: {
           linkedEntity: {
             entityPublished: true,
             moderationState: 'published',
           },
         },
+        links: [],
       },
     ];
 
-    const filteredData = liquid.filters.filterSidebarData(clonedSidebarData);
-    expect(filteredData.links[0].links[0].links[1].links).to.deep.equal(
-      expected,
-    );
+    it('returns only links to published entities when isPreview is explicitly false', () => {
+      const filteredData = liquid.filters.filterSidebarData(sidebarData, false);
+      expect(filteredData.links[0].links[0].links[1].links).to.deep.equal(
+        expectedFacilities,
+      );
+      expect(filteredData.links[0].links[2].links[0].links).to.deep.equal(
+        expectedAboutUs,
+      );
+    });
+
+    it('returns only links to published entities when isPreview is not passed (defaults to false)', () => {
+      const filteredData = liquid.filters.filterSidebarData(sidebarData);
+      expect(filteredData.links[0].links[0].links[1].links).to.deep.equal(
+        expectedFacilities,
+      );
+      expect(filteredData.links[0].links[2].links[0].links).to.deep.equal(
+        expectedAboutUs,
+      );
+    });
   });
 
-  it('returns sidebarData with published and draft facilities IF in preview mode', () => {
-    const clonedSidebarData = _.cloneDeep(sidebarData);
-
-    const expected = [
+  describe('when preview, includes links to both published and draft entities', () => {
+    const expectedFacilities = [
       {
         label: 'Fayetteville VA Medical Center',
         entity: {
@@ -1972,24 +2003,63 @@ describe('filterSidebarData', () => {
       },
     ];
 
-    const filteredData = liquid.filters.filterSidebarData(
-      clonedSidebarData,
-      true,
-    );
-    expect(filteredData.links[0].links[0].links[1].links).to.deep.equal(
-      expected,
-    );
-  });
+    const expectedAboutUs = [
+      {
+        expanded: false,
+        description: null,
+        label: 'Mission and vision',
+        url: {
+          path: '/fayetteville-coastal-health-care/about-us/mission-and-vision',
+        },
+        entity: {
+          linkedEntity: {
+            entityPublished: true,
+            moderationState: 'published',
+          },
+        },
+        links: [],
+      },
+      {
+        expanded: false,
+        description: null,
+        label: 'History',
+        url: {
+          path: '/fayetteville-coastal-health-care/about-us/history',
+        },
+        entity: {
+          linkedEntity: {
+            entityPublished: false,
+            moderationState: 'draft',
+          },
+        },
+        links: [],
+      },
+      {
+        expanded: false,
+        description: null,
+        label: 'Leadership',
+        url: {
+          path: '/fayetteville-coastal-health-care/about-us/leadership',
+        },
+        entity: {
+          linkedEntity: {
+            entityPublished: true,
+            moderationState: 'published',
+          },
+        },
+        links: [],
+      },
+    ];
 
-  it('returns empty array if array of facilities is empty', () => {
-    const clonedSidebarData = _.cloneDeep(sidebarData);
-    clonedSidebarData.links[0].links[0].links[1].links = [];
-
-    const filteredData = liquid.filters.filterSidebarData(
-      clonedSidebarData,
-      true,
-    );
-    expect(filteredData.links[0].links[0].links[1].links).to.deep.equal([]);
+    it('returns links to both published and draft entities IF in preview mode', () => {
+      const filteredData = liquid.filters.filterSidebarData(sidebarData, true);
+      expect(filteredData.links[0].links[0].links[1].links).to.deep.equal(
+        expectedFacilities,
+      );
+      expect(filteredData.links[0].links[2].links[0].links).to.deep.equal(
+        expectedAboutUs,
+      );
+    });
   });
 });
 


### PR DESCRIPTION
## Description

closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11174

## Testing done & Screenshots
Tested locally. Updated unit tests run locally.

## QA steps

### PREVIEW MODE
- Links to published content should appear ✔️ 
- Links to draft content should appear ✔️ 
- Links to archived content should NOT appear ❌ 

1. Pull down branch `VACMS-11174-sidebar-filter`
2. Remove cached sidebar data: `rm .cache/localhost/preview-server/nonNodeContent.json`
3. `yarn preview --drupal-address=https://cms-ogvo5d8kyveonzymjllajdl4credcmvw.demo.cms.va.gov`
4. Wait for sidebar data (non-node content) to be rebuilt.
5. In browser, navigate to http://localhost:3002/preview?nodeId=7912 and locate the "Locations" menu.
   - [ ] Verify that "SF PUBLISHED 1" appears.
   - [ ] Verify that "SF DRAFT 1" appears.
   - [ ] Verify that "SF ARCHIVED 1" does NOT appear.
   
![image](https://user-images.githubusercontent.com/6863534/230622014-f52c5d5e-53eb-4e75-bd70-bb479794bb02.png)

6. In browser, navigate to http://localhost:3002/preview?nodeId=7920 and locate the "Jobs and careers" menu.
   - [ ] Verify that "SF PUBLISHED 2" appears.
   - [ ] Verify that "SF DRAFT 2" appears.
   - [ ] Verify that "SF ARCHIVED 2" does NOT appear.

![image](https://user-images.githubusercontent.com/6863534/230622409-71e0adf4-49ee-4384-a64a-c573f38b4d7b.png)

### STANDARD BUILD
- Links to published content should appear ✔️ 
- Links to draft content should NOT appear ❌  
- Links to archived content should NOT appear ❌ 

1. Pull down branch `VACMS-11174-sidebar-filter`
2. `yarn build --pull-drupal --drupal-address=https://cms-ogvo5d8kyveonzymjllajdl4credcmvw.demo.cms.va.gov --use-cached-assets`
3. `yarn serve`
4. In browser, navigate to http://localhost:3002/san-francisco-health-care/locations and locate the "Locations" menu.
   - [ ] Verify that "SF PUBLISHED 1" appears.
   - [ ] Verify that "SF DRAFT 1" appears.
   - [ ] Verify that "SF ARCHIVED 1" does not appear.

![image](https://user-images.githubusercontent.com/6863534/230640543-35bf3ff8-63f0-4584-bed7-b1f5cd8c8e30.png)

   
6. In browser, navigate to http://localhost:3002/san-francisco-health-care/work-with-us/jobs-and-careers and locate the "Jobs and careers" menu.
   - [ ] Verify that "SF PUBLISHED 2" appears.
   - [ ] Verify that "SF DRAFT 2" appears.
   - [ ] Verify that "SF ARCHIVED 2" does not appear.

![image](https://user-images.githubusercontent.com/6863534/230640625-3946b461-c31a-4e5b-89f5-43de44771072.png)


## Acceptance criteria
See original issue.
