### PR TITLE
switch feedback button container's display to block on mobile

### DIFF
--- a/src/site/includes/above-footer-elements.drupal.liquid
+++ b/src/site/includes/above-footer-elements.drupal.liquid
@@ -1,5 +1,5 @@
 <div class="last-updated usa-content vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
-  <div class="vads-u-display--flex above-footer-elements-container">
+  <div class="small-screen:vads-u-display--flex above-footer-elements-container">
     <div class="vads-u-flex--auto">
       <span class="vads-u-text-align--justify">
         {% include "src/site/includes/last-updated.drupal.liquid" %}


### PR DESCRIPTION
## Description

On small screen sizes the feedback button can overlap the last updated text. This PR makes the container responsive so that at smaller screen sizes the container has display block and the text and button don't overlap.

closes [55368](https://app.zenhub.com/workspaces/platform-tech-team-2-633efe4ca5a428e5294d7ade/issues/gh/department-of-veterans-affairs/va.gov-team/55368)

## Testing done & Screenshots
Before:
<img width="465" alt="Screenshot 2023-04-13 at 2 50 03 PM" src="https://user-images.githubusercontent.com/8867779/231868377-2d9f03da-3ea8-4313-84b1-e6c90b9ffb27.png">

After:
<img width="462" alt="Screenshot 2023-04-13 at 2 51 30 PM" src="https://user-images.githubusercontent.com/8867779/231868411-79c4aebb-1119-43c3-9f3c-83798d5369ab.png">


## QA steps

Verify that at small screen sizes the last updated text and feedback button do not overlap


## Acceptance criteria

- [ ] at small screen sizes the last updated text and feedback button do not overlap

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
