### PR TITLE
VACMS-13276: Fix footer social media link

### DIFF
--- a/src/platform/static-data/footer-links.json
+++ b/src/platform/static-data/footer-links.json
@@ -196,7 +196,7 @@
   },
   {
     "column": 3,
-    "href": "https://www.va.gov/opa/socialmedia.asp",
+    "href": "https://digital.va.gov/web-governance/social-media/social-media-sites/",
     "order": 9,
     "target": null,
     "title": "All VA social media"


### PR DESCRIPTION
## Description

relates to https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13276

## Testing done & Screenshots
TBD


## QA steps

Go to content-build on staging or a tugboat instance and click on the Social Media footer link. It should go to https://digital.va.gov/web-governance/social-media/social-media-sites/


## Acceptance criteria

- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
