### PR TITLE
Add breadcrumbs for form 21-4142

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1343,7 +1343,18 @@
     "productId": "56438c7b-e586-490d-a7f6-7e3c92136564",
     "template": {
       "vagovprod": false,
-      "layout": "page-react.html"
+      "layout": "page-react.html",
+      "includeBreadcrumbs": true,
+      "breadcrumbs_override": [
+        {
+          "name": "Health care",
+          "path": "health-care"
+        },
+        {
+          "name": "Authorize the release of medical information to the VA",
+          "path": "health-care/medical-release-form"
+        }
+      ]
     }
   },
   {


### PR DESCRIPTION
## Description

Add breadcrumbs for form 21-4142

closes https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/199
relates to form 21-4142 (not yet prod)

## Testing done & Screenshots

BEFORE:

<img width="732" alt="Screenshot 2023-04-17 at 10 20 54 AM" src="https://user-images.githubusercontent.com/57802560/232516187-b8c14c9e-4e9a-436f-8f52-590969107586.png">

AFTER:
<img width="675" alt="Screenshot 2023-04-17 at 11 17 27 AM" src="https://user-images.githubusercontent.com/57802560/232532231-18a0d1ea-036d-47a1-ad8b-7b9001c3d6f8.png">


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

1. Navigate to `/health-care/medical-release-form` in the deployed branch
   - [ ] A breadcrumb for 'Home' appears, and correctly navigates to the va home page `/`
   - [ ] A breadcrumb for 'Health care' appears, and correctly navigates to `/health-care`
   - [ ] A breadcrumb for 'Authorize the release of medical information to the VA' appears, and is the selected location


## Acceptance criteria

- [ ] Breadcrumbs appear and function as described above

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
