### PR TITLE
Correct syntax on liquid case statement in press release.

### DIFF
--- a/src/site/layouts/press_release.drupal.liquid
+++ b/src/site/layouts/press_release.drupal.liquid
@@ -66,9 +66,9 @@
                                         {% case a.entityBundle %}
                                         {% when 'document' %}
                                             <a href="{{ a.fieldDocument.entity.url }}" download>{{ a.name }}</a>
-                                        {% when a.entityBundle === 'image' %}
+                                        {% when 'image' %}
                                             <a href="{{ a.image.url }}" download>{{ a.name }}</a>
-                                        {% when a.entityBundle === 'video' %}
+                                        {% when 'video' %}
                                             <a href="{{ a.fieldMediaVideoEmbedField }}">{{ a.name }}</a>
                                         {%  endcase %}
                                     </li>


### PR DESCRIPTION
## Description

closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13205

## Testing done & Screenshots
Built locally with the changes; the page mentioned in the ticket has a corrected link. 

Local url: http://localhost:3002/northern-california-health-care/news-releases/va-northern-california-provides-free-support-to-survivors-of-military-sexual-trauma/
Outcome (note link in bottom left corner): 
<img width="819" alt="image" src="https://user-images.githubusercontent.com/203623/232582316-70bea5b8-28c0-42af-bd42-d545cfc44612.png">


## QA steps

What needs to be checked to prove this works?  

1. Run a content release with this branch.
2. For the content release in question, view the page `/northern-california-health-care/news-releases/va-northern-california-provides-free-support-to-survivors-of-military-sexual-trauma/`
3. Scroll down and check the link "[If You Have Experienced MST, VA Can Help](https://youtu.be/N9XvzKACbfM)"; it should contain a working link to a YouTube video.


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
