### PR TITLE
VA-13252: E2E test for presence of Lovell Menus

### DIFF
--- a/src/site/facilities/tests/lovell/lovell-pages.cypress.spec.js
+++ b/src/site/facilities/tests/lovell/lovell-pages.cypress.spec.js
@@ -1,0 +1,45 @@
+const testForLovellSidebar = (section, url = '/') => {
+  const pageUrl = `/lovell-federal-health-care-${section}${url}`;
+
+  it('has a sidebar with visible sections with headers', () => {
+    cy.visit(pageUrl);
+    cy.injectAxeThenAxeCheck();
+
+    const numberOfMenuSections = 3;
+
+    cy.get('.va-sidenav')
+      .find('.va-sidenav-level-1')
+      .should('be.visible')
+      .should('have.length', numberOfMenuSections)
+      .find('h2')
+      .should('be.visible')
+      .should('have.length', numberOfMenuSections);
+  });
+
+  it('has a sidebar with clickable links', () => {
+    cy.visit(pageUrl);
+    cy.injectAxeThenAxeCheck();
+
+    // Top level sidebar links
+    cy.get('.va-sidenav')
+      .find('.va-sidenav-level-2 a.va-sidenav-item-label')
+      .should('be.visible')
+      .should('have.length.greaterThan', 0);
+
+    // 2nd level sidebar links for "About Us"
+    if (url === '/about-us/') {
+      cy.get('.va-sidenav')
+        .find('.va-sidenav-level-3 a.va-sidenav-item-label')
+        .should('be.visible')
+        .should('have.length.greaterThan', 0);
+    }
+  });
+};
+
+describe('Lovell Tricare - Main Page', () => testForLovellSidebar('tricare'));
+describe('Lovell Tricare - About Page', () =>
+  testForLovellSidebar('tricare', '/about-us/'));
+
+describe('Lovell VA - Main Page', () => testForLovellSidebar('va'));
+describe('Lovell VA - About Page', () =>
+  testForLovellSidebar('va', '/about-us/'));


### PR DESCRIPTION
## Description

Lovell menus vanished without notice until the change was in production. This adds End To End tests to ensure the menus are still present in Lovell. They specifically check the "About Us" pages for VA and Tricare for the following elements:

* There are three menu "sections" and each has a header for a label
* There are top level menu links present
* There are at sublevel menu links present (for "About Us")

This amount of testing ensures that the menu is present along with some of the key elements to make sure everything is there, not just the wrapper.

closes [#13252](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13252)
relates to [#13244](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13244)

## Testing done & Screenshots

Successfully ran the new tests locally

<img width="727" alt="Screen Shot 2023-04-19 at 1 04 35 PM" src="https://user-images.githubusercontent.com/10790736/233148469-4ce8b0ab-c15d-418c-b005-37d67d8b3e2c.png">

## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

1. Ensure that all the tests pass
   - [ ] Run the tests locally with `yarn cy:run`
   - [ ] See that all automated tests for this PR pass
2. Check that the tests also fail when expected
   - [ ] Make sure tests fail when the menu isn't present (I confirmed this myself in an old local build)
   - [ ] Change the tests to purposefully make them fail, and run them again to see if they actually fail

## Acceptance criteria

- [ ] Tests pass when the Lovell menus are present, and fail when the Lovell menus are not present

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
