### PR TITLE
VACMS-13398: Doesn't render wait-time widget div on TRICARE services.

### DIFF
--- a/src/site/facilities/facility_health_service.drupal.liquid
+++ b/src/site/facilities/facility_health_service.drupal.liquid
@@ -32,11 +32,13 @@
           <div>{{ localServiceDescription }}</div>
         {% endif %}
 
-        <div
-          data-widget-type="facility-appointment-wait-times-widget"
-          data-facility="{{ fieldFacilityLocatorApiId | widgetFacilityDetail | escape }}"
-          data-service="{{ serviceTaxonomy | healthServiceApiId | escape }}"
-        ></div>
+        {% if fieldFacilityLocatorApiId contains "vha_" %}
+          <div
+            data-widget-type="facility-appointment-wait-times-widget"
+            data-facility="{{ fieldFacilityLocatorApiId | widgetFacilityDetail | escape }}"
+            data-service="{{ serviceTaxonomy | healthServiceApiId | escape }}"
+          ></div>
+        {% endif %}
 
         {% if healthService.fieldBody.processed %}
           <div>{{ healthService.fieldBody.processed | replace: 'h3', 'h4' }}</div>


### PR DESCRIPTION
## Description
Previously, [we did work](https://github.com/department-of-veterans-affairs/content-build/pull/1416) to hide the patient-satisfaction widget div on TRICARE services. This PR implements the same ([quick](https://github.com/department-of-veterans-affairs/content-build/pull/1416#pullrequestreview-1233148208)) solution for the wait-time widget on TRICARE services.

closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13398
relates to https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12069

## Testing done & Screenshots
See screenshots in QA steps

## QA steps
1. /lovell-federal-health-care-va/locations/captain-james-a-lovell-federal-health-care-center/
2. Expand "Ophthalmology"
   - Notice that wait times appear
![image](https://user-images.githubusercontent.com/6863534/233663283-e1ee801c-66e0-44be-861b-bdda068cc1c6.png)
3. /lovell-federal-health-care-tricare/locations/captain-james-a-lovell-federal-health-care-center/
4. Expand "Ophthalmology"
   - [ ] Validate that wait times do not appear
   - [ ] Validate that an infinite spinner does not appear
![image](https://user-images.githubusercontent.com/6863534/233665540-45e864c3-1dc4-45c6-93d9-8ef0150d7e11.png)
5. Expand some other services
   - [ ] Validate that an infinite spinner does not appear
## Acceptance criteria
See original issue

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
