### PR TITLE
Update actions that are outdated.

### DIFF
--- a/.github/workflows/authenticated-cms-request/action.yml
+++ b/.github/workflows/authenticated-cms-request/action.yml
@@ -34,19 +34,19 @@ runs:
         aws-region: ${{ inputs.aws_region }}
 
     - name: Get Drupal prod password
-      uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+      uses: department-of-veterans-affairs/action-inject-ssm-secrets@latest
       with:
         ssm_parameter: /cms/prod/drupal_api_users/content_build_api/password
         env_variable_name: DRUPAL_PASSWORD
 
     - name: Get Drupal prod username
-      uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+      uses: department-of-veterans-affairs/action-inject-ssm-secrets@latest
       with:
         ssm_parameter: /cms/prod/drupal_api_users/content_build_api/username
         env_variable_name: DRUPAL_USERNAME
 
     - name: HTTP request
-      uses: fjogeleit/http-request-action@master
+      uses: fjogeleit/http-request-action@v1
       with:
         url: ${{ inputs.url}}
         method: ${{ inputs.method }}

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -176,13 +176,13 @@ jobs:
           aws-region: us-gov-west-1
 
       - name: set Drupal prod password
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        uses: department-of-veterans-affairs/action-inject-ssm-secrets@latest
         with:
           ssm_parameter: /cms/prod/drupal_api_users/content_build_api/password
           env_variable_name: DRUPAL_PASSWORD
 
       - name: set Drupal prod username
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        uses: department-of-veterans-affairs/action-inject-ssm-secrets@latest
         with:
           ssm_parameter: /cms/prod/drupal_api_users/content_build_api/username
           env_variable_name: DRUPAL_USERNAME
@@ -236,7 +236,7 @@ jobs:
           jq '.series[].tags[4] = "trigger:${{env.BUILD_TRIGGER}}"' > metrics.json
 
       - name: Get Datadog api key from Parameter Store
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        uses: department-of-veterans-affairs/action-inject-ssm-secrets@latest
         with:
           ssm_parameter: /dsva-vagov/content-build/GHA_CONTENT_BUILD_DATADOG_API_KEY
           env_variable_name: GHA_CONTENT_BUILD_DATADOG_API_KEY
@@ -261,21 +261,21 @@ jobs:
           aws-region: us-gov-west-1
 
       - name: Get Slack app token
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        uses: department-of-veterans-affairs/action-inject-ssm-secrets@latest
         if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
         with:
           ssm_parameter: /devops/github_actions_slack_socket_token
           env_variable_name: SLACK_APP_TOKEN
 
       - name: Get Slack bot token
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        uses: department-of-veterans-affairs/action-inject-ssm-secrets@latest
         if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
         with:
           ssm_parameter: /devops/github_actions_slack_bot_user_token
           env_variable_name: SLACK_BOT_TOKEN
 
       - name: Get role from Parameter Store
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        uses: department-of-veterans-affairs/action-inject-ssm-secrets@latest
         if: ${{ steps.get-broken-link-info.outputs.UPLOAD_AND_NOTIFY == '1' && always() }}
         with:
           ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
@@ -347,7 +347,7 @@ jobs:
           aws-region: us-gov-west-1
 
       - name: Get role from Parameter Store
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        uses: department-of-veterans-affairs/action-inject-ssm-secrets@latest
         with:
           ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
           env_variable_name: AWS_FRONTEND_NONPROD_ROLE
@@ -391,7 +391,7 @@ jobs:
           aws-region: us-gov-west-1
 
       - name: Get role from Parameter Store
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        uses: department-of-veterans-affairs/action-inject-ssm-secrets@latest
         with:
           ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_PROD_ROLE
           env_variable_name: AWS_FRONTEND_PROD_ROLE
@@ -489,7 +489,7 @@ jobs:
           method: GET
 
       - name: Get Datadog token from Parameter Store
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        uses: department-of-veterans-affairs/action-inject-ssm-secrets@latest
         with:
           ssm_parameter: /dsva-vagov/content-build/GHA_CONTENT_BUILD_DATADOG_API_KEY
           env_variable_name: GHA_CONTENT_BUILD_DATADOG_API_KEY
@@ -579,13 +579,13 @@ jobs:
           aws-region: us-gov-west-1
 
       - name: Get Datadog api key from Parameter Store
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        uses: department-of-veterans-affairs/action-inject-ssm-secrets@latest
         with:
           ssm_parameter: /dsva-vagov/content-build/GHA_CONTENT_BUILD_DATADOG_API_KEY
           env_variable_name: GHA_CONTENT_BUILD_DATADOG_API_KEY
 
       - name: Get Datadog app key from Parameter Store
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        uses: department-of-veterans-affairs/action-inject-ssm-secrets@latest
         with:
           ssm_parameter: /dsva-vagov/content-build/GHA_CONTENT_BUILD_DATADOG_APP_KEY
           env_variable_name: GHA_CONTENT_BUILD_DATADOG_APP_KEY


### PR DESCRIPTION
## Description
relates to https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12640

This updates Content Release to use updated actions that were outdated. We are only updating Content Release here as a trial of the updated actions on an active workflow.

## Testing done & Screenshots
This was run in a test workflow with the department-of-veterans-affairs/action-inject-ssm-secrets@latest action added:

https://github.com/department-of-veterans-affairs/content-build/actions/runs/4813362548/jobs/8569822352

## Acceptance criteria
- [ ] Action runs successfully

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
