### PR TITLE
VACMS-11448 Fix accessibility issue (dupe IDs) on reusable Q&A

### DIFF
--- a/src/site/layouts/faq_multiple_q_a.drupal.liquid
+++ b/src/site/layouts/faq_multiple_q_a.drupal.liquid
@@ -72,15 +72,16 @@
 
               {% if fieldQAGroup.entity.fieldAccordionDisplay %}
                 <va-accordion bordered>
+                {% assign groupId = fieldQAGroup.entity.entityId %}
                   {% for fieldQA in fieldQAGroup.entity.fieldQAs %}
                     {% if fieldQA.entity %}
                       <va-accordion-item
                         data-faq-entity-id="{{ fieldQA.entity.entityId }}"
                       >
-                      <h3 slot="headline">
-                        {{ fieldQA.entity.title }}
-                    </h3>
-                        <div id="{{ fieldQA.entity.entityBundle }}-{{ fieldQA.entity.entityId }}">
+                        <h3 slot="headline">
+                          {{ fieldQA.entity.title }}
+                        </h3>
+                        <div id="{{ fieldQA.entity.entityBundle }}-{{ fieldQA.entity.entityId }}-{{ groupId }}">
                           {% assign fieldAnswer = fieldQA.entity.fieldAnswer %}
                           {% assign bundleComponent = "src/site/paragraphs/" | append: fieldAnswer.entity.entityBundle %}
                           {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}

--- a/src/site/stages/build/drupal/graphql/faqMultipleQa.graphql.js
+++ b/src/site/stages/build/drupal/graphql/faqMultipleQa.graphql.js
@@ -16,6 +16,7 @@ fragment faqMultipleQA on NodeFaqMultipleQA {
   fieldQAGroups {
     entity {
       ... on ParagraphQAGroup {
+        entityId
         fieldSectionHeader
         fieldAccordionDisplay
         fieldQAs {


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11448

When duplicate Q&A accordions are used, their IDs are the same (for the `faq_multiple_q_a.drupal.liquid` template). This causes accessibility issues and conflicts when linking directly to an accordion's answer from another page.

The solution was to retrieve the group ID via GraphQL and concatenate that with the existing ID.

## Testing done & Screenshots

Tested locally with `/resources/the-pact-act-and-your-va-benefits`

1 of 2 duplicated content blocks
<img width="1713" alt="Screenshot 2023-04-27 at 12 12 58 PM" src="https://user-images.githubusercontent.com/19175324/234938708-cc584b8b-892e-4800-b756-3b51ccac161a.png">

2 of 2 duplicated content blocks
<img width="1713" alt="Screenshot 2023-04-27 at 12 13 08 PM" src="https://user-images.githubusercontent.com/19175324/234938772-86cbec5a-5fe3-4edd-b470-51487a724e44.png">

## QA steps

What needs to be checked to prove this works?  
1) navigate to `/resources/the-pact-act-and-your-va-benefits`
2) scroll to the section for Gulf War era and Vietnam era Veteran eligibility
3) note that there is a question in the Gulf War era section that is duplicated in the Vietnam era section (`Are there more exposure related presumptive conditions?`)

What needs to be checked to prove it didn't break any related things? 
Other accordions on this page

## Acceptance criteria

- [x] Update generated ID to combine group ID with element ID
- [x] Fix here doesn't worse the problem in https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11354, (because reusable Q&As can be created as a group of Accordions on FAQ content, e.g.)
https://prod.cms.va.gov/node/8233/edit
https://www.va.gov/resources/verifying-your-identity-on-vagov/
- [ ] Accessibility Review

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)