### PR TITLE
deactivate PE workflow til content build is supported

### DIFF
--- a/.github/workflows/preview-environment-deployment.yml
+++ b/.github/workflows/preview-environment-deployment.yml
@@ -1,43 +1,43 @@
-name: Preview Environment Deployment
+# name: Preview Environment Deployment
 
-on:
-  push:
-    branches:
-      - '**'
+# on:
+#   push:
+#     branches:
+#       - '**'
 
-jobs:
-  deploy-preview-environment:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+# jobs:
+#   deploy-preview-environment:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Checkout
+#         uses: actions/checkout@v3
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
+#       - name: Configure AWS credentials
+#         uses: aws-actions/configure-aws-credentials@v2
+#         with:
+#           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#           aws-region: us-gov-west-1
 
-      - name: Get va-vsp-bot token
-        uses: department-of-veterans-affairs/action-inject-ssm-secrets@latest
-        with:
-          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
-          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+#       - name: Get va-vsp-bot token
+#         uses: department-of-veterans-affairs/action-inject-ssm-secrets@latest
+#         with:
+#           ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+#           env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
 
-      - name: Start Deployment
-        uses: bobheadxi/deployments@v1
-        id: deployment
-        with:
-          step: start
-          token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
-          env: master/main/${{ github.ref_name }}
-          ref: ${{ github.ref_name }}
+#       - name: Start Deployment
+#         uses: bobheadxi/deployments@v1
+#         id: deployment
+#         with:
+#           step: start
+#           token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
+#           env: master/main/${{ github.ref_name }}
+#           ref: ${{ github.ref_name }}
 
-      - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v2
-        with:
-          token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
-          event-type: deploy_review_instance
-          repository: department-of-veterans-affairs/vets-website
-          client-payload: '{"source_repo": "content-build", "source_ref": "${{ github.ref_name }}", "deployment_id": "${{ steps.deployment.outputs.deployment_id }}" }'
+#       - name: Repository Dispatch
+#         uses: peter-evans/repository-dispatch@v2
+#         with:
+#           token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
+#           event-type: deploy_review_instance
+#           repository: department-of-veterans-affairs/vets-website
+#           client-payload: '{"source_repo": "content-build", "source_ref": "${{ github.ref_name }}", "deployment_id": "${{ steps.deployment.outputs.deployment_id }}" }'


### PR DESCRIPTION
## Description

Preview environments will not support content-build at MVP for a variety of infrastructure-related reasons. While support will be added later, having this workflow active in the interim is creating failed dispatches to vets-website that we'd like to disable for the time being. Code is being left commented as it will be needed post-MVP.

## Testing done & Screenshots
N/A


## QA steps

N/A


## Acceptance criteria

- [ ] Workflow will no longer run on push.

## Definition of done

