### PR TITLE
add mounting point for session sign out modal

### DIFF
--- a/src/site/includes/footer.html
+++ b/src/site/includes/footer.html
@@ -6,7 +6,7 @@
     ></div>
   </footer>
 </section>
-
+<div id="logout-modal-root"></div>
 <!--
 “To care for him who shall have borne the battle and for his widow, and his orphan.”
 - Abraham Lincoln


### PR DESCRIPTION
## Description

This PR adds a mounting div to the root context so that the session time out modal can always render above all other content. There is a [corresponding `vets-website` PR](https://github.com/department-of-veterans-affairs/vets-website/pull/24097). Also see [55731](https://app.zenhub.com/workspaces/platform-tech-team-2-633efe4ca5a428e5294d7ade/issues/gh/department-of-veterans-affairs/va.gov-team/55731).