### PR TITLE
VACMS-11990: Remove Lovell disallow lines for full state

### DIFF
--- a/src/site/assets/robots.txt
+++ b/src/site/assets/robots.txt
@@ -17,8 +17,6 @@ Disallow: /covid19screen
 # to prevent sub-directories from being indexed
 # see https://developers.google.com/search/docs/advanced/robots/create-robots-txt#useful-robots.txt-rules
 
-Disallow: /lovell-federal-health-care-va/
-Disallow: /lovell-federal-health-care-tricare/
 
 # sitemap index
 Sitemap: https://www.va.gov/sitemap.xml


### PR DESCRIPTION
## Description

closes [VACMS-11990](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11990)   

## Testing done & Screenshots
N/A


## QA steps
- [x] Validate that the Lovell VA disallow has been removed
- [x] Validate that the Lovell TRICARE disallow has been removed


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
