### PR TITLE
Modify breadcrumbs and url per IA for form 21-4142 (non prod)

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1339,7 +1339,7 @@
   {
     "appName": "Authorize the release of medical information to the VA",
     "entryName": "21-4142-medical-release",
-    "rootUrl": "/health-care/medical-release-form",
+    "rootUrl": "/supporting-forms-for-claims/release-records-to-va-form-21-4142",
     "productId": "56438c7b-e586-490d-a7f6-7e3c92136564",
     "template": {
       "vagovprod": false,
@@ -1347,12 +1347,8 @@
       "includeBreadcrumbs": true,
       "breadcrumbs_override": [
         {
-          "name": "Health care",
-          "path": "health-care"
-        },
-        {
           "name": "Authorize the release of medical information to the VA",
-          "path": "health-care/medical-release-form"
+          "path": "supporting-forms-for-claims/release-records-to-va-form-21-4142"
         }
       ]
     }


### PR DESCRIPTION
## Description

Modify the URL per IA. Remove intermediate breadcrumb until that page is built by content team.

Closes: https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/279

## Testing done & Screenshots

Tested locally with vets-website. Shows proper breadcrumb (note: local does not display VA home breadcrumb)

<img width="281" alt="Screenshot 2023-05-16 at 9 23 25 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/57802560/a79eb499-032a-4191-9e68-9cb188876ff7">


## QA steps

(not necessary for non prod)

1. Pull down these changes and those in the [vets-website branch](https://github.com/department-of-veterans-affairs/vets-website/pull/24233). Run `yarn build` then `yarn watch` and navigate to `localhost:3001/supporting-forms-for-claims/release-records-to-va-form-21-4142`
   - [ ] Validate the breadcrumbs are `Authorize the release of medical information to the VA`

Note: The 'Home' Breadcrumb appears in deployed environments


## Acceptance criteria

- [ ] The above

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

## Related PRs
- [devops](https://github.com/department-of-veterans-affairs/devops/pull/13021)
- [vets-website](https://github.com/department-of-veterans-affairs/vets-website/pull/24233)