### PR TITLE
Updated gh-actions for set-output deprecation

### DIFF
--- a/.github/workflows/preview-environment-cleanup.yml
+++ b/.github/workflows/preview-environment-cleanup.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Add and Commit change(s)
         if: ${{ env.FILES_TO_DELETE == 'true'}}
-        uses: EndBug/add-and-commit@v7
+        uses: EndBug/add-and-commit@1bad3abcf0d6ec49a5857d124b0bfb52dc7bb081 # 9.1.3
         with:
           author_name: va-vsp-bot
           author_email: devops@va.gov
@@ -63,7 +63,7 @@ jobs:
 
       - name: Add and Commit change(s)
         if: ${{ env.ENVS_TO_DELETE == 'true'}}
-        uses: EndBug/add-and-commit@v7
+        uses: EndBug/add-and-commit@1bad3abcf0d6ec49a5857d124b0bfb52dc7bb081 # 9.1.3
         with:
           author_name: va-vsp-bot
           author_email: devops@va.gov


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

1. [ ]  ~~[`aws-actions/configure-aws-credentials@v1`](https://github.com/aws-actions/configure-aws-credentials) - Can be replaced with `@v2`; see https://github.com/aws-actions/configure-aws-credentials/issues/489~~
    Already correct
3. [ ] ~~[`marvinpinto/action-inject-ssm-secrets`](https://github.com/marvinpinto/action-inject-ssm-secrets) - [No apparent updates forthcoming](https://github.com/marvinpinto/actions/issues/543); the maintainer appears to be absent. This is **widely** used: https://github.com/search?q=org%3Adepartment-of-veterans-affairs+action-inject-ssm-secrets&type=code~~
    Already correct
5. [ ] ~~[`slackapi/slack-github-action`](https://github.com/slackapi/slack-github-action) - Fixable by moving to version 1.23.0~~
    Already correct
7. [x] [`EndBug/add-and-commit`](https://github.com/EndBug/add-and-commit/issues/448#issuecomment-1297742564) - Fixable by moving to `v9`
8. [ ] ~~Add entry to dependabot.yml for gh-actions updates~~
    Already correct


## Related issue(s)
- department-of-veterans-affairs/va.gov-team/issues/55037

## Testing done

## Screenshots
_Note: Optional_
