### PR TITLE
VACMS-11941: Lovell featured items on homepages

### DIFF
--- a/src/site/filters/events.js
+++ b/src/site/filters/events.js
@@ -1,0 +1,62 @@
+const _ = require('lodash');
+const moment = require('moment-timezone');
+
+const deriveMostRecentDate = (
+  fieldDatetimeRangeTimezone,
+  now = moment().unix(), // This is done so that we can mock the current time in tests.
+) => {
+  // Escape early if no fieldDatetimeRangeTimezone was passed.
+  if (!fieldDatetimeRangeTimezone) return fieldDatetimeRangeTimezone;
+
+  // Return back fieldDatetimeRangeTimezone if it is already a singular most recent date.
+  if (!_.isArray(fieldDatetimeRangeTimezone)) {
+    return fieldDatetimeRangeTimezone;
+  }
+
+  // Return back fieldDatetimeRangeTimezone's first item if it only has 1 item.
+  if (fieldDatetimeRangeTimezone?.length === 1) {
+    return fieldDatetimeRangeTimezone[0];
+  }
+
+  // Derive date times relative to now.
+  const dates = _.sortBy(fieldDatetimeRangeTimezone, 'endValue');
+  const futureDates = _.filter(dates, date => date?.endValue - now > 0);
+
+  // Return the most recent past date if there are no future dates.
+  if (_.isEmpty(futureDates)) {
+    return dates[dates?.length - 1];
+  }
+
+  // Return the most recent future date if there are future dates.
+  return futureDates[0];
+};
+
+const filterPastEvents = data => {
+  if (!data) return null;
+  const currentTimestamp = new Date().getTime();
+  return data.filter(event => {
+    const mostRecentEvent = deriveMostRecentDate(
+      event.fieldDatetimeRangeTimezone[0]
+        ? event.fieldDatetimeRangeTimezone[0]
+        : event.fieldDatetimeRangeTimezone,
+    );
+    return mostRecentEvent.value * 1000 < currentTimestamp;
+  });
+};
+
+const filterUpcomingEvents = data => {
+  if (!data) return null;
+  const currentTimestamp = new Date().getTime();
+  return data.filter(event => {
+    const mostRecentEvent = deriveMostRecentDate(
+      event.fieldDatetimeRangeTimezone,
+    );
+    return mostRecentEvent?.value * 1000 >= currentTimestamp;
+  });
+};
+
+module.exports = {
+  deriveMostRecentDate,
+  filterPastEvents,
+  filterUpcomingEvents,
+};

--- a/src/site/filters/events.js
+++ b/src/site/filters/events.js
@@ -34,7 +34,7 @@ const deriveMostRecentDate = (
 const filterPastEvents = data => {
   if (!data) return null;
   const currentTimestamp = new Date().getTime();
-  return data.filter(event => {
+  return data.filter?.(event => {
     const mostRecentEvent = deriveMostRecentDate(
       event.fieldDatetimeRangeTimezone[0]
         ? event.fieldDatetimeRangeTimezone[0]
@@ -47,7 +47,7 @@ const filterPastEvents = data => {
 const filterUpcomingEvents = data => {
   if (!data) return null;
   const currentTimestamp = new Date().getTime();
-  return data.filter(event => {
+  return data.filter?.(event => {
     const mostRecentEvent = deriveMostRecentDate(
       event.fieldDatetimeRangeTimezone,
     );

--- a/src/site/stages/build/drupal/lovell/featured-items.js
+++ b/src/site/stages/build/drupal/lovell/featured-items.js
@@ -1,20 +1,20 @@
 const { filterUpcomingEvents } = require('../../../../filters/events');
 const { ENTITY_BUNDLES } = require('../../../../constants/content-modeling');
 
+/*
+ * Event listings need to filter out past events.
+ * Other listings just return all entities.
+ */
+const getCurrentListingItems = listingPage => {
+  const listingItems = listingPage?.reverseFieldListingNode?.entities;
+  if (listingPage.entityBundle !== ENTITY_BUNDLES.EVENT_LISTING) {
+    return listingItems;
+  }
+
+  return filterUpcomingEvents(listingItems);
+};
+
 const getFeaturedListingItems = (listingPages, listingType) => {
-  /*
-   * Event listings need to filter out past events.
-   * Other listings just return all entities.
-   */
-  const getCurrentListingItems = listingPage => {
-    const listingItems = listingPage?.reverseFieldListingNode?.entities;
-    if (listingPage.entityBundle !== ENTITY_BUNDLES.EVENT_LISTING) {
-      return listingItems;
-    }
-
-    return filterUpcomingEvents(listingItems);
-  };
-
   const listingPage = listingPages.find(
     page => page.entityBundle === listingType,
   );

--- a/src/site/stages/build/drupal/lovell/featured-items.js
+++ b/src/site/stages/build/drupal/lovell/featured-items.js
@@ -1,0 +1,34 @@
+const { filterUpcomingEvents } = require('../../../../filters/events');
+const { ENTITY_BUNDLES } = require('../../../../constants/content-modeling');
+
+const getFeaturedListingItems = (listingPages, listingType) => {
+  /*
+   * Event listings need to filter out past events.
+   * Other listings just return all entities.
+   */
+  const getCurrentListingItems = listingPage => {
+    const listingItems = listingPage?.reverseFieldListingNode?.entities;
+    if (listingPage.entityBundle !== ENTITY_BUNDLES.EVENT_LISTING) {
+      return listingItems;
+    }
+
+    return filterUpcomingEvents(listingItems);
+  };
+
+  const listingPage = listingPages.find(
+    page => page.entityBundle === listingType,
+  );
+  const listingItems = getCurrentListingItems(listingPage);
+  const featuredItems = listingItems?.filter?.(item => item?.fieldFeatured);
+  const sortedFeaturedItems = featuredItems?.sort?.(
+    (a, b) =>
+      (a?.fieldAdministration?.entity?.entityId || Number.MAX_SAFE_INTEGER) -
+      (b?.fieldAdministration?.entity?.entityId || Number.MAX_SAFE_INTEGER),
+  );
+
+  return sortedFeaturedItems || [];
+};
+
+module.exports = {
+  getFeaturedListingItems,
+};

--- a/src/site/stages/build/drupal/lovell/featured-items.js
+++ b/src/site/stages/build/drupal/lovell/featured-items.js
@@ -37,6 +37,43 @@ const getFeaturedListingItems = (listingPages, listingType) => {
     : getFeaturedListingStories(listingItems);
 };
 
+const getTeasersFeaturedObject = featuredItems => ({
+  entities: [
+    {
+      reverseFieldListingNode: {
+        entities: featuredItems,
+      },
+    },
+  ],
+});
+
+/**
+ * Returns a new page object with featured events and stories added to it
+ *
+ * @param {*} page
+ * @param {*} listingPages
+ */
+const lovellHomepageWithFeaturedListingItems = (page, listingPages) => {
+  if (!page) {
+    return null;
+  }
+
+  const featuredEvents = getFeaturedListingItems(
+    listingPages,
+    ENTITY_BUNDLES.EVENT_LISTING,
+  );
+  const featuredStories = getFeaturedListingItems(
+    listingPages,
+    ENTITY_BUNDLES.STORY_LISTING,
+  );
+
+  return {
+    ...page,
+    eventTeasersFeatured: getTeasersFeaturedObject(featuredEvents),
+    newsStoryTeasersFeatured: getTeasersFeaturedObject(featuredStories),
+  };
+};
+
 module.exports = {
-  getFeaturedListingItems,
+  lovellHomepageWithFeaturedListingItems,
 };

--- a/src/site/stages/build/drupal/lovell/helpers.js
+++ b/src/site/stages/build/drupal/lovell/helpers.js
@@ -37,6 +37,21 @@ function isListingPage(page) {
   return listingPageTypes.includes(page.entityBundle);
 }
 
+function getFeaturedListingItems(listingPages, listingType) {
+  const listingPage = listingPages.find(
+    page => page.entityBundle === listingType,
+  );
+  const listingItems = listingPage?.reverseFieldListingNode?.entities;
+  const featuredItems = listingItems?.filter?.(item => item?.fieldFeatured);
+  const sortedFeaturedItems = featuredItems?.sort?.(
+    (a, b) =>
+      (a?.fieldAdministration?.entity?.entityId || Number.MAX_SAFE_INTEGER) -
+      (b?.fieldAdministration?.entity?.entityId || Number.MAX_SAFE_INTEGER),
+  );
+
+  return sortedFeaturedItems || [];
+}
+
 function isFederalRegionHomepage(page) {
   return (
     isLovellFederalPage(page) &&
@@ -94,6 +109,7 @@ module.exports = {
   isLovellTricarePage,
   isLovellVaPage,
   isListingPage,
+  getFeaturedListingItems,
   isFederalRegionHomepage,
   isTricareRegionHomepage,
   isVaRegionHomepage,

--- a/src/site/stages/build/drupal/lovell/helpers.js
+++ b/src/site/stages/build/drupal/lovell/helpers.js
@@ -1,5 +1,4 @@
 const { ENTITY_BUNDLES } = require('../../../../constants/content-modeling');
-const { filterUpcomingEvents } = require('../../../../filters/events');
 
 const LOVELL_TITLE_STRING = 'Lovell Federal';
 const LOVELL_FEDERAL_ENTITY_ID = '347';
@@ -80,34 +79,6 @@ function getLovellVariantOfUrl(path, linkVar) {
   );
 }
 
-function getFeaturedListingItems(listingPages, listingType) {
-  /*
-   * Event listings need to filter out past events.
-   * Other listings just return all entities.
-   */
-  const getCurrentListingItems = listingPage => {
-    const listingItems = listingPage?.reverseFieldListingNode?.entities;
-    if (listingPage.entityBundle !== ENTITY_BUNDLES.EVENT_LISTING) {
-      return listingItems;
-    }
-
-    return filterUpcomingEvents(listingItems);
-  };
-
-  const listingPage = listingPages.find(
-    page => page.entityBundle === listingType,
-  );
-  const listingItems = getCurrentListingItems(listingPage);
-  const featuredItems = listingItems?.filter?.(item => item?.fieldFeatured);
-  const sortedFeaturedItems = featuredItems?.sort?.(
-    (a, b) =>
-      (a?.fieldAdministration?.entity?.entityId || Number.MAX_SAFE_INTEGER) -
-      (b?.fieldAdministration?.entity?.entityId || Number.MAX_SAFE_INTEGER),
-  );
-
-  return sortedFeaturedItems || [];
-}
-
 module.exports = {
   LOVELL_TITLE_STRING,
   LOVELL_FEDERAL_ENTITY_ID,
@@ -130,5 +101,4 @@ module.exports = {
   getLovellTitleVariation,
   getLovellUrl,
   getLovellVariantOfUrl,
-  getFeaturedListingItems,
 };

--- a/src/site/stages/build/drupal/lovell/helpers.js
+++ b/src/site/stages/build/drupal/lovell/helpers.js
@@ -1,3 +1,5 @@
+const { ENTITY_BUNDLES } = require('../../../../constants/content-modeling');
+
 const LOVELL_TITLE_STRING = 'Lovell Federal';
 const LOVELL_FEDERAL_ENTITY_ID = '347';
 const LOVELL_TRICARE_ENTITY_ID = '1039';
@@ -27,9 +29,9 @@ function isLovellVaPage(page) {
 
 function isListingPage(page) {
   const listingPageTypes = [
-    'event_listing',
-    'press_releases_listing',
-    'story_listing',
+    ENTITY_BUNDLES.EVENT_LISTING,
+    ENTITY_BUNDLES.PRESS_RELEASES_LISTING,
+    ENTITY_BUNDLES.STORY_LISTING,
   ];
 
   return listingPageTypes.includes(page.entityBundle);
@@ -37,7 +39,22 @@ function isListingPage(page) {
 
 function isFederalRegionHomepage(page) {
   return (
-    isLovellFederalPage(page) && page.entityBundle === 'health_care_region_page'
+    isLovellFederalPage(page) &&
+    page.entityBundle === ENTITY_BUNDLES.HEALTH_CARE_REGION_PAGE
+  );
+}
+
+function isTricareRegionHomepage(page) {
+  return (
+    isLovellTricarePage(page) &&
+    page.entityBundle === ENTITY_BUNDLES.HEALTH_CARE_REGION_PAGE
+  );
+}
+
+function isVaRegionHomepage(page) {
+  return (
+    isLovellVaPage(page) &&
+    page.entityBundle === ENTITY_BUNDLES.HEALTH_CARE_REGION_PAGE
   );
 }
 
@@ -78,6 +95,8 @@ module.exports = {
   isLovellVaPage,
   isListingPage,
   isFederalRegionHomepage,
+  isTricareRegionHomepage,
+  isVaRegionHomepage,
   getLovellTitle,
   getLovellTitleVariation,
   getLovellUrl,

--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -2,7 +2,6 @@
 /* eslint-disable no-param-reassign, no-console */
 
 const cloneDeep = require('lodash/cloneDeep');
-const { ENTITY_BUNDLES } = require('../../../constants/content-modeling');
 const { camelize } = require('../../../utilities/stringHelpers');
 
 const {
@@ -24,7 +23,9 @@ const {
   isVaRegionHomepage,
 } = require('./lovell/helpers');
 
-const { getFeaturedListingItems } = require('./lovell/featured-items');
+const {
+  lovellHomepageWithFeaturedListingItems,
+} = require('./lovell/featured-items');
 
 const {
   getLovellPageVariables,
@@ -282,43 +283,6 @@ function combineLovellListingPages(tricareOrVaPages, federalPages, variant) {
       },
     };
   });
-}
-
-/**
- * Returns a new page object with featured events and stories added to it
- *
- * @param {*} page
- * @param {*} listingPages
- */
-function lovellHomepageWithFeaturedListingItems(page, listingPages) {
-  if (!page) {
-    return null;
-  }
-
-  const getTeasersFeaturedObject = featuredItems => ({
-    entities: [
-      {
-        reverseFieldListingNode: {
-          entities: featuredItems,
-        },
-      },
-    ],
-  });
-
-  const featuredEvents = getFeaturedListingItems(
-    listingPages,
-    ENTITY_BUNDLES.EVENT_LISTING,
-  );
-  const featuredStories = getFeaturedListingItems(
-    listingPages,
-    ENTITY_BUNDLES.STORY_LISTING,
-  );
-
-  return {
-    ...page,
-    eventTeasersFeatured: getTeasersFeaturedObject(featuredEvents),
-    newsStoryTeasersFeatured: getTeasersFeaturedObject(featuredStories),
-  };
 }
 
 function processLovellPages(drupalData) {

--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -208,20 +208,53 @@ function combineLovellListingPages(tricareOrVaPages, federalPages, variant) {
       };
     };
 
+    const entityWithFieldAdministration = fieldAdminEntityId => entity => ({
+      ...entity,
+      fieldAdministration: {
+        entity: {
+          entityId: fieldAdminEntityId,
+        },
+      },
+    });
+
     const {
       [pastObjectLabel]: pastListItemsToCombine,
       reverseFieldListingNode: reverseFieldListingNodeToCombine,
     } = listingPageToCombine;
 
-    const pastListItemEntities = pastListItems?.entities || [];
-    const allListItemEntities = reverseFieldListingNode?.entities || [];
+    // When merging listing pages, we need to track from which page an item originated,
+    //  so we add the listing page's fieldAdministration value to the item itself (entityWithFieldAdministration).
+    // When the item originates from the federal listing page, we update the item's url to reflect
+    //  the VA/TRICARE listing page it will end up on (updateEntityUrlForVariant).
+    const pastListItemEntities =
+      pastListItems?.entities?.map?.(
+        entityWithFieldAdministration(
+          listingPage?.fieldAdministration?.entity?.entityId,
+        ),
+      ) || [];
+    const allListItemEntities =
+      reverseFieldListingNode?.entities.map?.(
+        entityWithFieldAdministration(
+          listingPage?.fieldAdministration?.entity?.entityId,
+        ),
+      ) || [];
 
     const pastListItemEntitiesToCombine =
-      pastListItemsToCombine?.entities.map(updateEntityUrlForVariant) || [];
+      pastListItemsToCombine?.entities
+        .map?.(updateEntityUrlForVariant)
+        .map?.(
+          entityWithFieldAdministration(
+            listingPageToCombine?.fieldAdministration?.entity?.entityId,
+          ),
+        ) || [];
     const allListItemEntitiesToCombine =
-      reverseFieldListingNodeToCombine?.entities.map(
-        updateEntityUrlForVariant,
-      ) || [];
+      reverseFieldListingNodeToCombine?.entities
+        .map?.(updateEntityUrlForVariant)
+        .map?.(
+          entityWithFieldAdministration(
+            listingPageToCombine?.fieldAdministration?.entity?.entityId,
+          ),
+        ) || [];
 
     const combinedPastListItemEntities = [
       ...pastListItemEntities,

--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -15,7 +15,6 @@ const {
   isLovellTricarePage,
   isLovellVaPage,
   isListingPage,
-  getFeaturedListingItems,
   isFederalRegionHomepage,
   getLovellTitle,
   getLovellTitleVariation,
@@ -24,6 +23,8 @@ const {
   isTricareRegionHomepage,
   isVaRegionHomepage,
 } = require('./lovell/helpers');
+
+const { getFeaturedListingItems } = require('./lovell/featured-items');
 
 const {
   getLovellPageVariables,

--- a/src/site/stages/build/drupal/process-lovell-pages.js
+++ b/src/site/stages/build/drupal/process-lovell-pages.js
@@ -290,6 +290,10 @@ function combineLovellListingPages(tricareOrVaPages, federalPages, variant) {
  * @param {*} listingPages
  */
 function lovellHomepageWithFeaturedListingItems(page, listingPages) {
+  if (!page) {
+    return null;
+  }
+
   const getTeasersFeaturedObject = featuredItems => ({
     entities: [
       {
@@ -400,22 +404,27 @@ function processLovellPages(drupalData) {
 
   // modify all tricare pages
   const lovellTricarePages = [
-    lovellTricareHomepageWithFeatured,
     ...lovellTricareListingPagesWithFederal,
     ...lovellTricareNonListingPages,
   ];
+  if (lovellTricareHomepageWithFeatured) {
+    lovellTricarePages.push(lovellTricareHomepageWithFeatured);
+  }
   const modifiedLovellTricarePages = lovellTricarePages.map(page =>
     getModifiedLovellPage(page, 'tricare'),
   );
   // modify all va pages
   const lovellVaPages = [
-    lovellVaHomepageWithFeatured,
     ...lovellVaListingPagesWithFederal,
     ...lovellVaNonListingPages,
   ];
+  if (lovellVaHomepageWithFeatured) {
+    lovellVaPages.push(lovellVaHomepageWithFeatured);
+  }
   const modifiedLovellVaPages = lovellVaPages.map(page =>
     getModifiedLovellPage(page, 'va'),
   );
+
   // Each federal page needs to be duplicated and modified once each for tricare/va
   const lovellFederalPagesClonedTricare = lovellFederalNonListingPages.map(
     page => getModifiedLovellPage(cloneDeep(page), 'tricare'),

--- a/src/site/stages/build/drupal/tests/lovell/featuredItems.unit.spec.js
+++ b/src/site/stages/build/drupal/tests/lovell/featuredItems.unit.spec.js
@@ -1,0 +1,221 @@
+/* eslint-disable @department-of-veterans-affairs/axe-check-required */
+/* eslint-disable camelcase */
+import { expect, assert } from 'chai';
+import { processLovellPages } from '../../process-lovell-pages';
+import {
+  deriveMostRecentDate,
+  filterUpcomingEvents,
+} from '../../../../../filters/events';
+// Mock Data
+import tricareHomepage from './fixtures/homepages/tricare.json';
+import vaHomepage from './fixtures/homepages/va.json';
+import federalStories from './fixtures/listing-pages/federal/stories.json';
+import federalEvents from './fixtures/listing-pages/federal/events.json';
+import tricareStories from './fixtures/listing-pages/tricare/stories.json';
+import tricareEvents from './fixtures/listing-pages/tricare/events.json';
+import vaStories from './fixtures/listing-pages/va/stories.json';
+import vaEvents from './fixtures/listing-pages/va/events.json';
+import lovellFederalHealthCareFacilitySidebarQuery from './fixtures/sidebar.json';
+import {
+  isTricareRegionHomepage,
+  isVaRegionHomepage,
+} from '../../lovell/helpers';
+
+const isFeatured = entity => entity.fieldFeatured === true;
+
+const getFeaturedItems = (drupalData, lovellVariant, listingVariant) => {
+  const homepage = drupalData.data.nodeQuery.entities.find(page => {
+    if (lovellVariant === 'tricare') {
+      return isTricareRegionHomepage(page);
+    }
+    if (lovellVariant === 'va') {
+      return isVaRegionHomepage(page);
+    }
+    return false;
+  });
+
+  return (
+    homepage?.[`${listingVariant}TeasersFeatured`]?.entities[0]
+      ?.reverseFieldListingNode?.entities || []
+  );
+};
+
+const isSortedAscendingByFieldAdministration = featuredStories =>
+  featuredStories.reduce(
+    (acc, featuredStory) => {
+      const currentEntityId =
+        featuredStory?.fieldAdministration?.entity?.entityId ??
+        Number.MAX_SAFE_INTEGER;
+      return {
+        lastEntityId: currentEntityId,
+        isSorted:
+          acc.isSorted &&
+          parseInt(currentEntityId, 10) >= parseInt(acc.lastEntityId, 10),
+      };
+    },
+    {
+      lastEntityId: 0,
+      isSorted: true,
+    },
+  ).isSorted;
+
+const isSortedAscendingByDate = featuredEvents =>
+  featuredEvents.reduce(
+    (acc, featuredEvent) => {
+      const currentTimestamp = deriveMostRecentDate(
+        featuredEvent?.fieldDatetimeRangeTimezone,
+      )?.value;
+      return {
+        lastTimestamp: currentTimestamp,
+        isSorted: acc.isSorted && currentTimestamp >= acc.lastTimestamp,
+      };
+    },
+    {
+      lastTimestamp: 0,
+      isSorted: true,
+    },
+  ).isSorted;
+
+describe('processLovellPages (featured items)', () => {
+  const listingPages = [
+    federalStories,
+    federalEvents,
+    tricareStories,
+    tricareEvents,
+    vaStories,
+    vaEvents,
+  ];
+  let featuredCounts;
+  let drupalDataWithoutHomepages;
+  let drupalDataWithHomepages;
+
+  before(() => {
+    featuredCounts = {
+      federal: {
+        stories: federalStories.reverseFieldListingNode.entities.filter(
+          isFeatured,
+        ).length,
+        events: filterUpcomingEvents(
+          federalEvents.reverseFieldListingNode.entities,
+        ).filter(isFeatured).length,
+      },
+      tricare: {
+        stories: tricareStories.reverseFieldListingNode.entities.filter(
+          isFeatured,
+        ).length,
+        events: filterUpcomingEvents(
+          tricareEvents.reverseFieldListingNode.entities,
+        ).filter(isFeatured).length,
+      },
+      va: {
+        stories: vaStories.reverseFieldListingNode.entities.filter(isFeatured)
+          .length,
+        events: filterUpcomingEvents(
+          vaEvents.reverseFieldListingNode.entities,
+        ).filter(isFeatured).length,
+      },
+    };
+
+    drupalDataWithoutHomepages = {
+      data: {
+        lovellFederalHealthCareFacilitySidebarQuery,
+        nodeQuery: {
+          entities: [...listingPages],
+        },
+      },
+    };
+    drupalDataWithHomepages = {
+      data: {
+        lovellFederalHealthCareFacilitySidebarQuery,
+        nodeQuery: {
+          entities: [...listingPages, vaHomepage, tricareHomepage],
+        },
+      },
+    };
+
+    processLovellPages(drupalDataWithHomepages);
+  });
+
+  describe('homepages do not exist', () => {
+    it('processes without errors when homepage objects do not exist', () => {
+      try {
+        processLovellPages(drupalDataWithoutHomepages);
+      } catch (_err) {
+        assert.fail(
+          '`processLovellPages` should finish without errors if VA/TRICARE homeapge data is not present, but it fails.',
+        );
+      }
+    });
+  });
+
+  describe('homepages do exist', () => {
+    describe('TRICARE homepage', () => {
+      let tricareFeaturedStories;
+      let tricareFeaturedEvents;
+      before(() => {
+        tricareFeaturedStories = getFeaturedItems(
+          drupalDataWithHomepages,
+          'tricare',
+          'newsStory',
+        );
+        tricareFeaturedEvents = getFeaturedItems(
+          drupalDataWithHomepages,
+          'tricare',
+          'event',
+        );
+      });
+      it('correctly populates featured stories on TRICARE homepage', () => {
+        expect(tricareFeaturedStories.length).to.equal(
+          featuredCounts.federal.stories + featuredCounts.tricare.stories,
+        );
+      });
+      it('correctly sorts featured stories on TRICARE homepage', () => {
+        expect(isSortedAscendingByFieldAdministration(tricareFeaturedStories))
+          .to.be.true;
+      });
+      it('correctly populates featured events on TRICARE homepage', () => {
+        expect(tricareFeaturedEvents.length).to.equal(
+          featuredCounts.federal.events + featuredCounts.tricare.events,
+        );
+      });
+      it('correctly sorts featured events on TRICARE homepage', () => {
+        expect(isSortedAscendingByDate(tricareFeaturedEvents)).to.be.true;
+      });
+    });
+
+    describe('VA homepage', () => {
+      let vaFeaturedStories;
+      let vaFeaturedEvents;
+
+      before(() => {
+        vaFeaturedStories = getFeaturedItems(
+          drupalDataWithHomepages,
+          'va',
+          'newsStory',
+        );
+        vaFeaturedEvents = getFeaturedItems(
+          drupalDataWithHomepages,
+          'va',
+          'event',
+        );
+      });
+      it('correctly populates featured stories on VA homepage', () => {
+        expect(vaFeaturedStories.length).to.equal(
+          featuredCounts.federal.stories + featuredCounts.va.stories,
+        );
+      });
+      it('correctly sorts featured stories on VA homepage', () => {
+        expect(isSortedAscendingByFieldAdministration(vaFeaturedStories)).to.be
+          .true;
+      });
+      it('correctly populates featured events on VA homepage', () => {
+        expect(vaFeaturedEvents.length).to.equal(
+          featuredCounts.federal.events + featuredCounts.va.events,
+        );
+      });
+      it('correctly sorts featured events on VA homepage', () => {
+        expect(isSortedAscendingByDate(vaFeaturedEvents)).to.be.true;
+      });
+    });
+  });
+});

--- a/src/site/stages/build/drupal/tests/lovell/fixtures/homepages/tricare.json
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/homepages/tricare.json
@@ -1,0 +1,65 @@
+{
+  "entityBundle": "health_care_region_page",
+  "entityId": "49011",
+  "entityPublished": true,
+  "title": "Lovell Federal health care - TRICARE",
+  "vid": 761449,
+  "entityUrl": {
+      "breadcrumb": [
+          {
+              "url": {
+                  "path": "/",
+                  "routed": true
+              },
+              "text": "Home"
+          },
+          {
+              "url": {
+                  "path": "",
+                  "routed": true
+              },
+              "text": "Lovell Federal health care - TRICARE"
+          }
+      ],
+      "path": "/lovell-federal-health-care-tricare",
+      "switchPath": "/lovell-federal-health-care-va"
+  },
+  "newsStoryTeasers": {
+      "entities": []
+  },
+  "allNewsStoryTeasers": {
+      "entities": []
+  },
+  "eventTeasers": {
+      "entities": []
+  },
+  "allEventTeasers": {
+      "entities": []
+  },
+  "allPressReleaseTeasers": {
+      "entities": []
+  },
+  "eventTeasersFeatured": {
+      "entities": [
+          {
+              "reverseFieldListingNode": {
+                  "entities": []
+              }
+          }
+      ]
+  },
+  "newsStoryTeasersFeatured": {
+      "entities": [
+          {
+              "reverseFieldListingNode": {
+                  "entities": []
+              }
+          }
+      ]
+  },
+  "fieldAdministration": {
+      "entity": {
+          "entityId": "1039"
+      }
+  }
+}

--- a/src/site/stages/build/drupal/tests/lovell/fixtures/homepages/va.json
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/homepages/va.json
@@ -1,0 +1,64 @@
+{
+  "entityBundle": "health_care_region_page",
+  "entityId": "49451",
+  "entityPublished": true,
+  "title": "Lovell Federal health care - VA",
+  "entityUrl": {
+      "breadcrumb": [
+          {
+              "url": {
+                  "path": "/",
+                  "routed": true
+              },
+              "text": "Home"
+          },
+          {
+              "url": {
+                  "path": "",
+                  "routed": true
+              },
+              "text": "Lovell Federal health care - VA"
+          }
+      ],
+      "path": "/lovell-federal-health-care-va",
+      "switchPath": "/lovell-federal-health-care-tricare"
+  },
+  "newsStoryTeasers": {
+      "entities": []
+  },
+  "allNewsStoryTeasers": {
+      "entities": []
+  },
+  "eventTeasers": {
+      "entities": []
+  },
+  "allEventTeasers": {
+      "entities": []
+  },
+  "allPressReleaseTeasers": {
+      "entities": []
+  },
+  "eventTeasersFeatured": {
+      "entities": [
+          {
+              "reverseFieldListingNode": {
+                  "entities": []
+              }
+          }
+      ]
+  },
+  "newsStoryTeasersFeatured": {
+      "entities": [
+          {
+              "reverseFieldListingNode": {
+                  "entities": []
+              }
+          }
+      ]
+  },
+  "fieldAdministration": {
+      "entity": {
+          "entityId": "1040"
+      }
+  }
+}

--- a/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/federal/events.json
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/federal/events.json
@@ -158,6 +158,39 @@
         "entityBundle": "event",
         "entityId": "14",
         "entityPublished": true,
+        "title": "Lovell Federal - Featured - Future - 3",
+        "fieldDatetimeRangeTimezone": [
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 2524644000,
+            "rrule": null,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/Chicago",
+            "value": 2524640400
+          },
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 2650874400,
+            "rrule": null,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/Chicago",
+            "value": 2650870800
+          }
+        ],
+        "fieldFeatured": true,
+        "entityUrl": {
+          "path": "/lovell-federal-health-care/events/14"
+        }
+      },
+      {
+        "changed": 1671038416,
+        "entityBundle": "event",
+        "entityId": "15",
+        "entityPublished": true,
         "title": "Lovell Federal - Not Featured - Future - 1",
         "fieldDatetimeRangeTimezone": [
           {
@@ -183,7 +216,7 @@
         ],
         "fieldFeatured": false,
         "entityUrl": {
-          "path": "/lovell-federal-health-care/events/14"
+          "path": "/lovell-federal-health-care/events/15"
         }
       }
     ]

--- a/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/federal/events.json
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/federal/events.json
@@ -37,926 +37,6 @@
     ],
     "path": "/lovell-federal-health-care/events"
   },
-  "entityMetatags": [
-    {
-      "__typename": "MetaLink",
-      "key": "image_src",
-      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "title",
-      "value": "Events | Lovell Federal health care | Veterans Affairs"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "description",
-      "value": "Check early and often to see upcoming events at Lovell Federal health care and regional events."
-    },
-    {
-      "__typename": "MetaProperty",
-      "key": "og:site_name",
-      "value": "Veterans Affairs"
-    },
-    {
-      "__typename": "MetaProperty",
-      "key": "og:title",
-      "value": "Events | Veterans Affairs"
-    },
-    {
-      "__typename": "MetaProperty",
-      "key": "og:description",
-      "value": "Check early and often to see upcoming events at Lovell Federal health care and regional events."
-    },
-    {
-      "__typename": "MetaProperty",
-      "key": "og:image",
-      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
-    },
-    {
-      "__typename": "MetaProperty",
-      "key": "og:image:alt",
-      "value": "U.S. Department of Veterans Affairs"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:card",
-      "value": "summary_large_image"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:site",
-      "value": "@DeptVetAffairs"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:description",
-      "value": "Check early and often to see upcoming events at Lovell Federal health care and regional events."
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:title",
-      "value": "Events | Lovell Federal health care | Veterans Affairs"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:image:alt",
-      "value": "U.S. Department of Veterans Affairs"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:image",
-      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
-    }
-  ],
-  "changed": 1671038410,
-  "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care and regional events.",
-  "pastEvents": {
-    "entities": [
-      {
-        "changed": 1671038416,
-        "entityBundle": "event",
-        "entityId": "36405",
-        "entityPublished": true,
-        "entityMetatags": [
-          {
-            "__typename": "MetaLink",
-            "key": "image_src",
-            "value": "https://www.va.gov/img/design/logo/va-og-image.png"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "title",
-            "value": "Lovell Federal health care | Lovell Federal health care Placeholder - Event | Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:site_name",
-            "value": "Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:title",
-            "value": "Lovell Federal health care Placeholder - Event | Lovell Federal health care | Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:image",
-            "value": "/img/styles/3_2_medium_thumbnail/public/2021-03/Placeholder%20image%20-%20VA%20logo.png"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:image:height",
-            "value": "314"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:image:alt",
-            "value": "VA logo"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:card",
-            "value": "summary_large_image"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:site",
-            "value": "@DeptVetAffairs"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:title",
-            "value": "Lovell Federal health care Placeholder - Event | Lovell Federal health care | Veterans Affairs"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:image:alt",
-            "value": "VA logo"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:image",
-            "value": "/img/styles/3_2_medium_thumbnail/public/2021-03/Placeholder%20image%20-%20VA%20logo.png"
-          }
-        ],
-        "entityUrl": {
-          "path": "/lovell-federal-health-care-va/events/36405"
-        },
-        "title": "Lovell Federal health care Placeholder - Event",
-        "vid": 736023,
-        "fieldAdditionalInformationAbo": null,
-        "fieldAddress": null,
-        "fieldBody": null,
-        "fieldDatetimeRangeTimezone": [
-          {
-            "duration": 60,
-            "endTime": null,
-            "endValue": 1633119000,
-            "rrule": null,
-            "rruleIndex": null,
-            "startTime": null,
-            "timezone": "America/Chicago",
-            "value": 1633115400
-          }
-        ],
-        "fieldDescription": null,
-        "fieldEventCost": null,
-        "fieldEventCta": null,
-        "fieldEventRegistrationrequired": false,
-        "fieldFacilityLocation": null,
-        "fieldFeatured": false,
-        "fieldLink": null,
-        "fieldListing": {
-          "entity": {
-            "entityBundle": "event_listing",
-            "entityId": "36319",
-            "entityType": "node",
-            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal health care and regional events.",
-            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care and regional events.",
-            "fieldOffice": {
-              "entity": {
-                "entityType": "node",
-                "entityBundle": "health_care_region_page",
-                "entityId": "15007"
-              }
-            }
-          }
-        },
-        "fieldLocationHumanreadable": null,
-        "fieldLocationType": "online",
-        "fieldMedia": {
-          "entity": {
-            "entityBundle": "image",
-            "entityId": "2858",
-            "entityType": "media",
-            "image": {
-              "alt": "VA logo",
-              "title": "",
-              "derivative": {
-                "height": 300,
-                "url": "/img/styles/7_2_medium_thumbnail/public/2021-03/Placeholder%20image%20-%20VA%20logo.png",
-                "width": 1050
-              }
-            },
-            "thumbnail": {
-              "alt": "VA logo",
-              "height": 320,
-              "targetId": 3145,
-              "title": null,
-              "url": "/img/2021-03/Placeholder%20image%20-%20VA%20logo.png",
-              "width": 320
-            }
-          }
-        },
-        "fieldMetaTags": null,
-        "fieldOrder": null,
-        "fieldUrlOfAnOnlineEvent": null,
-        "uid": {
-          "targetId": 1282,
-          "entity": {
-            "name": "lisa.trombley@va.gov",
-            "timezone": null
-          }
-        },
-        "fieldAdministration": {
-          "entity": {
-            "entityId": "347"
-          }
-        }
-      },
-      {
-        "changed": 1671038406,
-        "entityBundle": "event",
-        "entityId": "49919",
-        "entityPublished": true,
-        "entityMetatags": [
-          {
-            "__typename": "MetaLink",
-            "key": "image_src",
-            "value": "https://www.va.gov/img/design/logo/va-og-image.png"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "title",
-            "value": "Lovell Federal health care | Test Event 1 Both | Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:site_name",
-            "value": "Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:title",
-            "value": "Test Event 1 Both | Lovell Federal health care | Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:image:height",
-            "value": "314"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:card",
-            "value": "summary_large_image"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:site",
-            "value": "@DeptVetAffairs"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:title",
-            "value": "Test Event 1 Both | Lovell Federal health care | Veterans Affairs"
-          }
-        ],
-        "entityUrl": {
-          "path": "/lovell-federal-health-care-va/events/49919"
-        },
-        "title": "Test Event 1 Both",
-        "vid": 735968,
-        "fieldAdditionalInformationAbo": null,
-        "fieldAddress": {
-          "additionalName": null,
-          "addressLine1": "",
-          "addressLine2": "",
-          "administrativeArea": "",
-          "countryCode": "US",
-          "dependentLocality": null,
-          "familyName": null,
-          "givenName": null,
-          "langcode": null,
-          "locality": "",
-          "organization": null,
-          "postalCode": null,
-          "sortingCode": null
-        },
-        "fieldBody": {
-          "format": "rich_text",
-          "processed": "<html><head></head><body><p>This is an event that should appear in both Lovells.</p></body></html>",
-          "value": "<p>This is an event that should appear in both Lovells.</p>\r\n"
-        },
-        "fieldDatetimeRangeTimezone": [
-          {
-            "duration": 60,
-            "endTime": null,
-            "endValue": 1666402200,
-            "rrule": null,
-            "rruleIndex": null,
-            "startTime": null,
-            "timezone": "America/New_York",
-            "value": 1666398600
-          }
-        ],
-        "fieldDescription": null,
-        "fieldEventCost": "Free",
-        "fieldEventCta": null,
-        "fieldEventRegistrationrequired": false,
-        "fieldFacilityLocation": {
-          "entity": {
-            "entityBundle": "health_care_local_facility",
-            "entityId": "1480",
-            "entityType": "node",
-            "entityUrl": {
-              "path": "/lovell-federal-health-care-va/locations/captain-james-a-lovell-federal-health-care-center"
-            },
-            "title": "Captain James A. Lovell Federal Health Care Center"
-          }
-        },
-        "fieldFeatured": false,
-        "fieldLink": null,
-        "fieldListing": {
-          "entity": {
-            "entityBundle": "event_listing",
-            "entityId": "36319",
-            "entityType": "node",
-            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal health care and regional events.",
-            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care and regional events.",
-            "fieldOffice": {
-              "entity": {
-                "entityType": "node",
-                "entityBundle": "health_care_region_page",
-                "entityId": "15007"
-              }
-            }
-          }
-        },
-        "fieldLocationHumanreadable": null,
-        "fieldLocationType": "facility",
-        "fieldMedia": null,
-        "fieldMetaTags": null,
-        "fieldOrder": null,
-        "fieldUrlOfAnOnlineEvent": null,
-        "uid": {
-          "targetId": 1215,
-          "entity": {
-            "name": "Steve.Wirt@civicactions.com",
-            "timezone": null
-          }
-        },
-        "fieldAdministration": {
-          "entity": {
-            "entityId": "347"
-          }
-        }
-      },
-      {
-        "changed": 1671038406,
-        "entityBundle": "event",
-        "entityId": "49920",
-        "entityPublished": true,
-        "entityMetatags": [
-          {
-            "__typename": "MetaLink",
-            "key": "image_src",
-            "value": "https://www.va.gov/img/design/logo/va-og-image.png"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "title",
-            "value": "Lovell Federal health care | Test Event 2 Both | Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:site_name",
-            "value": "Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:title",
-            "value": "Test Event 2 Both | Lovell Federal health care | Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:image:height",
-            "value": "314"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:card",
-            "value": "summary_large_image"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:site",
-            "value": "@DeptVetAffairs"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:title",
-            "value": "Test Event 2 Both | Lovell Federal health care | Veterans Affairs"
-          }
-        ],
-        "entityUrl": {
-          "path": "/lovell-federal-health-care-va/events/49920"
-        },
-        "title": "Test Event 2 Both",
-        "vid": 735967,
-        "fieldAdditionalInformationAbo": null,
-        "fieldAddress": {
-          "additionalName": null,
-          "addressLine1": "",
-          "addressLine2": "",
-          "administrativeArea": "",
-          "countryCode": "US",
-          "dependentLocality": null,
-          "familyName": null,
-          "givenName": null,
-          "langcode": null,
-          "locality": "",
-          "organization": null,
-          "postalCode": null,
-          "sortingCode": null
-        },
-        "fieldBody": {
-          "format": "rich_text",
-          "processed": "<html><head></head><body><p>This is another event that should appear in both Lovells.</p></body></html>",
-          "value": "<p>This is another event that should appear in both Lovells.</p>\r\n"
-        },
-        "fieldDatetimeRangeTimezone": [
-          {
-            "duration": 60,
-            "endTime": null,
-            "endValue": 1666589400,
-            "rrule": null,
-            "rruleIndex": null,
-            "startTime": null,
-            "timezone": "America/New_York",
-            "value": 1666585800
-          }
-        ],
-        "fieldDescription": null,
-        "fieldEventCost": "Free",
-        "fieldEventCta": null,
-        "fieldEventRegistrationrequired": false,
-        "fieldFacilityLocation": null,
-        "fieldFeatured": false,
-        "fieldLink": null,
-        "fieldListing": {
-          "entity": {
-            "entityBundle": "event_listing",
-            "entityId": "36319",
-            "entityType": "node",
-            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal health care and regional events.",
-            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care and regional events.",
-            "fieldOffice": {
-              "entity": {
-                "entityType": "node",
-                "entityBundle": "health_care_region_page",
-                "entityId": "15007"
-              }
-            }
-          }
-        },
-        "fieldLocationHumanreadable": null,
-        "fieldLocationType": "online",
-        "fieldMedia": null,
-        "fieldMetaTags": null,
-        "fieldOrder": null,
-        "fieldUrlOfAnOnlineEvent": {
-          "uri": "https://google.com",
-          "title": ""
-        },
-        "uid": {
-          "targetId": 1215,
-          "entity": {
-            "name": "Steve.Wirt@civicactions.com",
-            "timezone": null
-          }
-        },
-        "fieldAdministration": {
-          "entity": {
-            "entityId": "347"
-          }
-        }
-      }
-    ]
-  },
-  "reverseFieldListingNode": {
-    "entities": [
-      {
-        "changed": 1671038416,
-        "entityBundle": "event",
-        "entityId": "36405",
-        "entityPublished": true,
-        "entityMetatags": [
-          {
-            "__typename": "MetaLink",
-            "key": "image_src",
-            "value": "https://www.va.gov/img/design/logo/va-og-image.png"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "title",
-            "value": "Lovell Federal health care | Lovell Federal health care Placeholder - Event | Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:site_name",
-            "value": "Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:title",
-            "value": "Lovell Federal health care Placeholder - Event | Lovell Federal health care | Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:image",
-            "value": "/img/styles/3_2_medium_thumbnail/public/2021-03/Placeholder%20image%20-%20VA%20logo.png"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:image:height",
-            "value": "314"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:image:alt",
-            "value": "VA logo"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:card",
-            "value": "summary_large_image"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:site",
-            "value": "@DeptVetAffairs"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:title",
-            "value": "Lovell Federal health care Placeholder - Event | Lovell Federal health care | Veterans Affairs"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:image:alt",
-            "value": "VA logo"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:image",
-            "value": "/img/styles/3_2_medium_thumbnail/public/2021-03/Placeholder%20image%20-%20VA%20logo.png"
-          }
-        ],
-        "entityUrl": {
-          "path": "/lovell-federal-health-care-va/events/36405"
-        },
-        "title": "Lovell Federal health care Placeholder - Event",
-        "vid": 736023,
-        "fieldAdditionalInformationAbo": null,
-        "fieldAddress": null,
-        "fieldBody": null,
-        "fieldDatetimeRangeTimezone": [
-          {
-            "duration": 60,
-            "endTime": null,
-            "endValue": 1633119000,
-            "rrule": null,
-            "rruleIndex": null,
-            "startTime": null,
-            "timezone": "America/Chicago",
-            "value": 1633115400
-          }
-        ],
-        "fieldDescription": null,
-        "fieldEventCost": null,
-        "fieldEventCta": null,
-        "fieldEventRegistrationrequired": false,
-        "fieldFacilityLocation": null,
-        "fieldFeatured": false,
-        "fieldLink": null,
-        "fieldListing": {
-          "entity": {
-            "entityBundle": "event_listing",
-            "entityId": "36319",
-            "entityType": "node",
-            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal health care and regional events.",
-            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care and regional events.",
-            "fieldOffice": {
-              "entity": {
-                "entityType": "node",
-                "entityBundle": "health_care_region_page",
-                "entityId": "15007"
-              }
-            }
-          }
-        },
-        "fieldLocationHumanreadable": null,
-        "fieldLocationType": "online",
-        "fieldMedia": {
-          "entity": {
-            "entityBundle": "image",
-            "entityId": "2858",
-            "entityType": "media",
-            "image": {
-              "alt": "VA logo",
-              "title": "",
-              "derivative": {
-                "height": 300,
-                "url": "/img/styles/7_2_medium_thumbnail/public/2021-03/Placeholder%20image%20-%20VA%20logo.png",
-                "width": 1050
-              }
-            },
-            "thumbnail": {
-              "alt": "VA logo",
-              "height": 320,
-              "targetId": 3145,
-              "title": null,
-              "url": "/img/2021-03/Placeholder%20image%20-%20VA%20logo.png",
-              "width": 320
-            }
-          }
-        },
-        "fieldMetaTags": null,
-        "fieldOrder": null,
-        "fieldUrlOfAnOnlineEvent": null,
-        "uid": {
-          "targetId": 1282,
-          "entity": {
-            "name": "lisa.trombley@va.gov",
-            "timezone": null
-          }
-        },
-        "fieldAdministration": {
-          "entity": {
-            "entityId": "347"
-          }
-        }
-      },
-      {
-        "changed": 1671038406,
-        "entityBundle": "event",
-        "entityId": "49919",
-        "entityPublished": true,
-        "entityMetatags": [
-          {
-            "__typename": "MetaLink",
-            "key": "image_src",
-            "value": "https://www.va.gov/img/design/logo/va-og-image.png"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "title",
-            "value": "Lovell Federal health care | Test Event 1 Both | Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:site_name",
-            "value": "Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:title",
-            "value": "Test Event 1 Both | Lovell Federal health care | Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:image:height",
-            "value": "314"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:card",
-            "value": "summary_large_image"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:site",
-            "value": "@DeptVetAffairs"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:title",
-            "value": "Test Event 1 Both | Lovell Federal health care | Veterans Affairs"
-          }
-        ],
-        "entityUrl": {
-          "path": "/lovell-federal-health-care-va/events/49919"
-        },
-        "title": "Test Event 1 Both",
-        "vid": 735968,
-        "fieldAdditionalInformationAbo": null,
-        "fieldAddress": {
-          "additionalName": null,
-          "addressLine1": "",
-          "addressLine2": "",
-          "administrativeArea": "",
-          "countryCode": "US",
-          "dependentLocality": null,
-          "familyName": null,
-          "givenName": null,
-          "langcode": null,
-          "locality": "",
-          "organization": null,
-          "postalCode": null,
-          "sortingCode": null
-        },
-        "fieldBody": {
-          "format": "rich_text",
-          "processed": "<html><head></head><body><p>This is an event that should appear in both Lovells.</p></body></html>",
-          "value": "<p>This is an event that should appear in both Lovells.</p>\r\n"
-        },
-        "fieldDatetimeRangeTimezone": [
-          {
-            "duration": 60,
-            "endTime": null,
-            "endValue": 1666402200,
-            "rrule": null,
-            "rruleIndex": null,
-            "startTime": null,
-            "timezone": "America/New_York",
-            "value": 1666398600
-          }
-        ],
-        "fieldDescription": null,
-        "fieldEventCost": "Free",
-        "fieldEventCta": null,
-        "fieldEventRegistrationrequired": false,
-        "fieldFacilityLocation": {
-          "entity": {
-            "entityBundle": "health_care_local_facility",
-            "entityId": "1480",
-            "entityType": "node",
-            "entityUrl": {
-              "path": "/lovell-federal-health-care-va/locations/captain-james-a-lovell-federal-health-care-center"
-            },
-            "title": "Captain James A. Lovell Federal Health Care Center"
-          }
-        },
-        "fieldFeatured": false,
-        "fieldLink": null,
-        "fieldListing": {
-          "entity": {
-            "entityBundle": "event_listing",
-            "entityId": "36319",
-            "entityType": "node",
-            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal health care and regional events.",
-            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care and regional events.",
-            "fieldOffice": {
-              "entity": {
-                "entityType": "node",
-                "entityBundle": "health_care_region_page",
-                "entityId": "15007"
-              }
-            }
-          }
-        },
-        "fieldLocationHumanreadable": null,
-        "fieldLocationType": "facility",
-        "fieldMedia": null,
-        "fieldMetaTags": null,
-        "fieldOrder": null,
-        "fieldUrlOfAnOnlineEvent": null,
-        "uid": {
-          "targetId": 1215,
-          "entity": {
-            "name": "Steve.Wirt@civicactions.com",
-            "timezone": null
-          }
-        },
-        "fieldAdministration": {
-          "entity": {
-            "entityId": "347"
-          }
-        }
-      },
-      {
-        "changed": 1671038406,
-        "entityBundle": "event",
-        "entityId": "49920",
-        "entityPublished": true,
-        "entityMetatags": [
-          {
-            "__typename": "MetaLink",
-            "key": "image_src",
-            "value": "https://www.va.gov/img/design/logo/va-og-image.png"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "title",
-            "value": "Lovell Federal health care | Test Event 2 Both | Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:site_name",
-            "value": "Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:title",
-            "value": "Test Event 2 Both | Lovell Federal health care | Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:image:height",
-            "value": "314"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:card",
-            "value": "summary_large_image"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:site",
-            "value": "@DeptVetAffairs"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:title",
-            "value": "Test Event 2 Both | Lovell Federal health care | Veterans Affairs"
-          }
-        ],
-        "entityUrl": {
-          "path": "/lovell-federal-health-care-va/events/49920"
-        },
-        "title": "Test Event 2 Both",
-        "vid": 735967,
-        "fieldAdditionalInformationAbo": null,
-        "fieldAddress": {
-          "additionalName": null,
-          "addressLine1": "",
-          "addressLine2": "",
-          "administrativeArea": "",
-          "countryCode": "US",
-          "dependentLocality": null,
-          "familyName": null,
-          "givenName": null,
-          "langcode": null,
-          "locality": "",
-          "organization": null,
-          "postalCode": null,
-          "sortingCode": null
-        },
-        "fieldBody": {
-          "format": "rich_text",
-          "processed": "<html><head></head><body><p>This is another event that should appear in both Lovells.</p></body></html>",
-          "value": "<p>This is another event that should appear in both Lovells.</p>\r\n"
-        },
-        "fieldDatetimeRangeTimezone": [
-          {
-            "duration": 60,
-            "endTime": null,
-            "endValue": 1666589400,
-            "rrule": null,
-            "rruleIndex": null,
-            "startTime": null,
-            "timezone": "America/New_York",
-            "value": 1666585800
-          }
-        ],
-        "fieldDescription": null,
-        "fieldEventCost": "Free",
-        "fieldEventCta": null,
-        "fieldEventRegistrationrequired": false,
-        "fieldFacilityLocation": null,
-        "fieldFeatured": false,
-        "fieldLink": null,
-        "fieldListing": {
-          "entity": {
-            "entityBundle": "event_listing",
-            "entityId": "36319",
-            "entityType": "node",
-            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal health care and regional events.",
-            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care and regional events.",
-            "fieldOffice": {
-              "entity": {
-                "entityType": "node",
-                "entityBundle": "health_care_region_page",
-                "entityId": "15007"
-              }
-            }
-          }
-        },
-        "fieldLocationHumanreadable": null,
-        "fieldLocationType": "online",
-        "fieldMedia": null,
-        "fieldMetaTags": null,
-        "fieldOrder": null,
-        "fieldUrlOfAnOnlineEvent": {
-          "uri": "https://google.com",
-          "title": ""
-        },
-        "uid": {
-          "targetId": 1215,
-          "entity": {
-            "name": "Steve.Wirt@civicactions.com",
-            "timezone": null
-          }
-        },
-        "fieldAdministration": {
-          "entity": {
-            "entityId": "347"
-          }
-        }
-      }
-    ]
-  },
   "fieldOffice": {
     "entity": {
       "entityLabel": "Lovell Federal health care"
@@ -966,5 +46,146 @@
     "entity": {
       "entityId": "347"
     }
+  },
+  "pastEvents": {
+    "entities": [
+      {
+        "changed": 1671038416,
+        "entityBundle": "event",
+        "entityId": "11",
+        "entityPublished": true,
+        "title": "Lovell Federal - Featured - Past - 1",
+        "fieldDatetimeRangeTimezone": [
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 1262336400,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/Chicago",
+            "value": 1262332800
+          }
+        ],
+        "fieldFeatured": true,
+        "entityUrl": {
+          "path": "/lovell-federal-health-care/events/11"
+        }
+      }
+    ]
+  },
+  "reverseFieldListingNode": {
+    "entities": [
+      {
+        "changed": 1671038416,
+        "entityBundle": "event",
+        "entityId": "11",
+        "entityPublished": true,
+        "title": "Lovell Federal - Featured - Past - 1",
+        "fieldDatetimeRangeTimezone": [
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 1262336400,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/Chicago",
+            "value": 1262332800
+          }
+        ],
+        "fieldFeatured": true,
+        "entityUrl": {
+          "path": "/lovell-federal-health-care/events/11"
+        }
+      },
+      {
+        "changed": 1671038416,
+        "entityBundle": "event",
+        "entityId": "12",
+        "entityPublished": true,
+        "title": "Lovell Federal - Featured - Future - 1",
+        "fieldDatetimeRangeTimezone": [
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 2633119000,
+            "rrule": null,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/Chicago",
+            "value": 2633115400
+          }
+        ],
+        "fieldFeatured": true,
+        "entityUrl": {
+          "path": "/lovell-federal-health-care/events/12"
+        }
+      },
+      {
+        "changed": 1671038416,
+        "entityBundle": "event",
+        "entityId": "13",
+        "entityPublished": true,
+        "title": "Lovell Federal - Featured - Future - 2",
+        "fieldDatetimeRangeTimezone": [
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 2633119000,
+            "rrule": null,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/Chicago",
+            "value": 2633115400
+          },
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 2650874400,
+            "rrule": null,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/Chicago",
+            "value": 2650870800
+          }
+        ],
+        "fieldFeatured": true,
+        "entityUrl": {
+          "path": "/lovell-federal-health-care/events/13"
+        }
+      },
+      {
+        "changed": 1671038416,
+        "entityBundle": "event",
+        "entityId": "14",
+        "entityPublished": true,
+        "title": "Lovell Federal - Not Featured - Future - 1",
+        "fieldDatetimeRangeTimezone": [
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 2633119000,
+            "rrule": null,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/Chicago",
+            "value": 2633115400
+          },
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 2650874400,
+            "rrule": null,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/Chicago",
+            "value": 2650870800
+          }
+        ],
+        "fieldFeatured": false,
+        "entityUrl": {
+          "path": "/lovell-federal-health-care/events/14"
+        }
+      }
+    ]
   }
 }

--- a/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/federal/stories.json
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/federal/stories.json
@@ -37,108 +37,31 @@
     ],
     "path": "/lovell-federal-health-care/stories"
   },
-  "entityMetatags": [
-    {
-      "__typename": "MetaLink",
-      "key": "image_src",
-      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "title",
-      "value": "Stories | Lovell Federal health care | Veterans Affairs"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "description",
-      "value": "Lovell Federal health care top stories."
-    },
-    {
-      "__typename": "MetaProperty",
-      "key": "og:site_name",
-      "value": "Veterans Affairs"
-    },
-    {
-      "__typename": "MetaProperty",
-      "key": "og:title",
-      "value": "Stories | Lovell Federal health care | Veterans Affairs"
-    },
-    {
-      "__typename": "MetaProperty",
-      "key": "og:description",
-      "value": "Lovell Federal health care top stories."
-    },
-    {
-      "__typename": "MetaProperty",
-      "key": "og:image",
-      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
-    },
-    {
-      "__typename": "MetaProperty",
-      "key": "og:image:alt",
-      "value": "U.S. Department of Veterans Affairs"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:card",
-      "value": "summary_large_image"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:site",
-      "value": "@DeptVetAffairs"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:description",
-      "value": "Lovell Federal health care top stories."
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:title",
-      "value": "Stories | Lovell Federal health care | Veterans Affairs"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:image:alt",
-      "value": "U.S. Department of Veterans Affairs"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:image",
-      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
-    }
-  ],
   "fieldIntroText": "Lovell Federal health care top stories.",
   "reverseFieldListingNode": {
     "entities": [
       {
-        "entityId": "49929",
-        "title": "TEST story for BOTH Lovell",
+        "entityId": "101",
+        "title": "Lovell Federal Story - Featured - 1",
+        "fieldFeatured": true,
+        "entityUrl": {
+          "path": "/lovell-federal-health-care-va/stories/lovell-federal-story-featured-1"
+        }
+      },
+      {
+        "entityId": "102",
+        "title": "Lovell Federal Story - Featured - 2",
+        "fieldFeatured": true,
+        "entityUrl": {
+          "path": "/lovell-federal-health-care-va/stories/lovell-federal-story-featured-2"
+        }
+      },
+      {
+        "entityId": "103",
+        "title": "Lovell Federal Story - Not Featured - 1",
         "fieldFeatured": false,
         "entityUrl": {
-          "path": "/lovell-federal-health-care-va/stories/test-story-for-both-lovell"
-        },
-        "uid": {
-          "targetId": 1215,
-          "entity": {
-            "name": "Steve.Wirt@civicactions.com",
-            "timezone": null
-          }
-        },
-        "promote": false,
-        "created": 1664741402,
-        "fieldAuthor": {
-          "entity": {
-            "title": "Steven Winslow",
-            "fieldDescription": "Caregiver Support Social Worker (Manhattan Campus)"
-          }
-        },
-        "fieldImageCaption": null,
-        "fieldIntroText": "This is a story for the ages.",
-        "fieldMedia": null,
-        "fieldFullStory": {
-          "processed": "<html><head></head><body><p>The story of this story can not be surpassed.</p></body></html>"
+          "path": "/lovell-federal-health-care-va/stories/lovell-federal-story-not-featured-1"
         }
       }
     ]

--- a/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/tricare/events.json
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/tricare/events.json
@@ -130,12 +130,12 @@
           {
             "duration": 60,
             "endTime": null,
-            "endValue": 2633119000,
+            "endValue": 2366877600,
             "rrule": null,
             "rruleIndex": null,
             "startTime": null,
             "timezone": "America/Chicago",
-            "value": 2633115400
+            "value": 2366874000
           },
           {
             "duration": 60,

--- a/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/tricare/events.json
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/tricare/events.json
@@ -37,622 +37,6 @@
     ],
     "path": "/lovell-federal-health-care-tricare/events"
   },
-  "entityMetatags": [
-    {
-      "__typename": "MetaLink",
-      "key": "image_src",
-      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "title",
-      "value": "Events | Lovell Federal health care - TRICARE | Veterans Affairs"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "description",
-      "value": "Check early and often to see upcoming events at Lovell Federal health care - TRICARE and regional events."
-    },
-    {
-      "__typename": "MetaProperty",
-      "key": "og:site_name",
-      "value": "Veterans Affairs"
-    },
-    {
-      "__typename": "MetaProperty",
-      "key": "og:title",
-      "value": "Events | Veterans Affairs"
-    },
-    {
-      "__typename": "MetaProperty",
-      "key": "og:description",
-      "value": "Check early and often to see upcoming events at Lovell Federal health care - TRICARE and regional events."
-    },
-    {
-      "__typename": "MetaProperty",
-      "key": "og:image",
-      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
-    },
-    {
-      "__typename": "MetaProperty",
-      "key": "og:image:alt",
-      "value": "U.S. Department of Veterans Affairs"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:card",
-      "value": "summary_large_image"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:site",
-      "value": "@DeptVetAffairs"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:description",
-      "value": "Check early and often to see upcoming events at Lovell Federal health care - TRICARE and regional events."
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:title",
-      "value": "Events | Lovell Federal health care - TRICARE | Veterans Affairs"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:image:alt",
-      "value": "U.S. Department of Veterans Affairs"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:image",
-      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
-    }
-  ],
-  "changed": 1671038416,
-  "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care - TRICARE and regional events.",
-  "pastEvents": {
-    "entities": [
-      {
-        "changed": 1671038406,
-        "entityBundle": "event",
-        "entityId": "49921",
-        "entityPublished": true,
-        "entityMetatags": [
-          {
-            "__typename": "MetaLink",
-            "key": "image_src",
-            "value": "https://www.va.gov/img/design/logo/va-og-image.png"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "title",
-            "value": "Lovell Federal health care - TRICARE | Test Event A TRICARE | Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:site_name",
-            "value": "Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:title",
-            "value": "Test Event A TRICARE | Lovell Federal health care - TRICARE | Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:image:height",
-            "value": "314"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:card",
-            "value": "summary_large_image"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:site",
-            "value": "@DeptVetAffairs"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:title",
-            "value": "Test Event A TRICARE | Lovell Federal health care - TRICARE | Veterans Affairs"
-          }
-        ],
-        "entityUrl": {
-          "path": "/lovell-federal-health-care-tricare/events/49921"
-        },
-        "title": "Test Event A TRICARE",
-        "vid": 735966,
-        "fieldAdditionalInformationAbo": null,
-        "fieldAddress": {
-          "additionalName": null,
-          "addressLine1": "",
-          "addressLine2": "",
-          "administrativeArea": "",
-          "countryCode": "US",
-          "dependentLocality": null,
-          "familyName": null,
-          "givenName": null,
-          "langcode": null,
-          "locality": "",
-          "organization": null,
-          "postalCode": null,
-          "sortingCode": null
-        },
-        "fieldBody": {
-          "format": "rich_text",
-          "processed": "<html><head></head><body><p>This is another event that should appear in TRICARE lovell.</p></body></html>",
-          "value": "<p>This is another event that should appear in TRICARE lovell.</p>\r\n"
-        },
-        "fieldDatetimeRangeTimezone": [
-          {
-            "duration": 60,
-            "endTime": null,
-            "endValue": 1666251000,
-            "rrule": null,
-            "rruleIndex": null,
-            "startTime": null,
-            "timezone": "America/New_York",
-            "value": 1666247400
-          }
-        ],
-        "fieldDescription": null,
-        "fieldEventCost": "Free",
-        "fieldEventCta": null,
-        "fieldEventRegistrationrequired": false,
-        "fieldFacilityLocation": null,
-        "fieldFeatured": false,
-        "fieldLink": null,
-        "fieldListing": {
-          "entity": {
-            "entityBundle": "event_listing",
-            "entityId": "49454",
-            "entityType": "node",
-            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal health care - TRICARE and regional events.",
-            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care - TRICARE and regional events.",
-            "fieldOffice": {
-              "entity": {
-                "entityType": "node",
-                "entityBundle": "health_care_region_page",
-                "entityId": "49011"
-              }
-            }
-          }
-        },
-        "fieldLocationHumanreadable": null,
-        "fieldLocationType": "online",
-        "fieldMedia": null,
-        "fieldMetaTags": null,
-        "fieldOrder": null,
-        "fieldUrlOfAnOnlineEvent": {
-          "uri": "https://google.com",
-          "title": ""
-        },
-        "uid": {
-          "targetId": 1215,
-          "entity": {
-            "name": "Steve.Wirt@civicactions.com",
-            "timezone": null
-          }
-        },
-        "fieldAdministration": {
-          "entity": {
-            "entityId": "1039"
-          }
-        }
-      },
-      {
-        "changed": 1671038406,
-        "entityBundle": "event",
-        "entityId": "49922",
-        "entityPublished": true,
-        "entityMetatags": [
-          {
-            "__typename": "MetaLink",
-            "key": "image_src",
-            "value": "https://www.va.gov/img/design/logo/va-og-image.png"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "title",
-            "value": "Lovell Federal health care - TRICARE | Test Event B TRICARE | Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:site_name",
-            "value": "Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:title",
-            "value": "Test Event B TRICARE | Lovell Federal health care - TRICARE | Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:image:height",
-            "value": "314"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:card",
-            "value": "summary_large_image"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:site",
-            "value": "@DeptVetAffairs"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:title",
-            "value": "Test Event B TRICARE | Lovell Federal health care - TRICARE | Veterans Affairs"
-          }
-        ],
-        "entityUrl": {
-          "path": "/lovell-federal-health-care-tricare/events/49922"
-        },
-        "title": "Test Event B TRICARE",
-        "vid": 735965,
-        "fieldAdditionalInformationAbo": null,
-        "fieldAddress": {
-          "additionalName": null,
-          "addressLine1": "",
-          "addressLine2": "",
-          "administrativeArea": "",
-          "countryCode": "US",
-          "dependentLocality": null,
-          "familyName": null,
-          "givenName": null,
-          "langcode": null,
-          "locality": "",
-          "organization": null,
-          "postalCode": null,
-          "sortingCode": null
-        },
-        "fieldBody": {
-          "format": "rich_text",
-          "processed": "<html><head></head><body><p>This is another event that should appear in TRICARE lovell.</p></body></html>",
-          "value": "<p>This is another event that should appear in TRICARE lovell.</p>\r\n"
-        },
-        "fieldDatetimeRangeTimezone": [
-          {
-            "duration": 60,
-            "endTime": null,
-            "endValue": 1666269300,
-            "rrule": null,
-            "rruleIndex": null,
-            "startTime": null,
-            "timezone": "America/New_York",
-            "value": 1666265700
-          }
-        ],
-        "fieldDescription": null,
-        "fieldEventCost": "Free",
-        "fieldEventCta": null,
-        "fieldEventRegistrationrequired": false,
-        "fieldFacilityLocation": {
-          "entity": {
-            "entityBundle": "health_care_local_facility",
-            "entityId": "49055",
-            "entityType": "node",
-            "entityUrl": {
-              "path": "/lovell-federal-health-care-tricare/locations/captain-james-a-lovell-federal-health-care-center"
-            },
-            "title": "Captain James A. Lovell Federal Health Care Center"
-          }
-        },
-        "fieldFeatured": false,
-        "fieldLink": null,
-        "fieldListing": {
-          "entity": {
-            "entityBundle": "event_listing",
-            "entityId": "49454",
-            "entityType": "node",
-            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal health care - TRICARE and regional events.",
-            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care - TRICARE and regional events.",
-            "fieldOffice": {
-              "entity": {
-                "entityType": "node",
-                "entityBundle": "health_care_region_page",
-                "entityId": "49011"
-              }
-            }
-          }
-        },
-        "fieldLocationHumanreadable": null,
-        "fieldLocationType": "facility",
-        "fieldMedia": null,
-        "fieldMetaTags": null,
-        "fieldOrder": null,
-        "fieldUrlOfAnOnlineEvent": null,
-        "uid": {
-          "targetId": 1215,
-          "entity": {
-            "name": "Steve.Wirt@civicactions.com",
-            "timezone": null
-          }
-        },
-        "fieldAdministration": {
-          "entity": {
-            "entityId": "1039"
-          }
-        }
-      }
-    ]
-  },
-  "reverseFieldListingNode": {
-    "entities": [
-      {
-        "changed": 1671038406,
-        "entityBundle": "event",
-        "entityId": "49921",
-        "entityPublished": true,
-        "entityMetatags": [
-          {
-            "__typename": "MetaLink",
-            "key": "image_src",
-            "value": "https://www.va.gov/img/design/logo/va-og-image.png"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "title",
-            "value": "Lovell Federal health care - TRICARE | Test Event A TRICARE | Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:site_name",
-            "value": "Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:title",
-            "value": "Test Event A TRICARE | Lovell Federal health care - TRICARE | Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:image:height",
-            "value": "314"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:card",
-            "value": "summary_large_image"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:site",
-            "value": "@DeptVetAffairs"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:title",
-            "value": "Test Event A TRICARE | Lovell Federal health care - TRICARE | Veterans Affairs"
-          }
-        ],
-        "entityUrl": {
-          "path": "/lovell-federal-health-care-tricare/events/49921"
-        },
-        "title": "Test Event A TRICARE",
-        "vid": 735966,
-        "fieldAdditionalInformationAbo": null,
-        "fieldAddress": {
-          "additionalName": null,
-          "addressLine1": "",
-          "addressLine2": "",
-          "administrativeArea": "",
-          "countryCode": "US",
-          "dependentLocality": null,
-          "familyName": null,
-          "givenName": null,
-          "langcode": null,
-          "locality": "",
-          "organization": null,
-          "postalCode": null,
-          "sortingCode": null
-        },
-        "fieldBody": {
-          "format": "rich_text",
-          "processed": "<html><head></head><body><p>This is another event that should appear in TRICARE lovell.</p></body></html>",
-          "value": "<p>This is another event that should appear in TRICARE lovell.</p>\r\n"
-        },
-        "fieldDatetimeRangeTimezone": [
-          {
-            "duration": 60,
-            "endTime": null,
-            "endValue": 1666251000,
-            "rrule": null,
-            "rruleIndex": null,
-            "startTime": null,
-            "timezone": "America/New_York",
-            "value": 1666247400
-          }
-        ],
-        "fieldDescription": null,
-        "fieldEventCost": "Free",
-        "fieldEventCta": null,
-        "fieldEventRegistrationrequired": false,
-        "fieldFacilityLocation": null,
-        "fieldFeatured": false,
-        "fieldLink": null,
-        "fieldListing": {
-          "entity": {
-            "entityBundle": "event_listing",
-            "entityId": "49454",
-            "entityType": "node",
-            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal health care - TRICARE and regional events.",
-            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care - TRICARE and regional events.",
-            "fieldOffice": {
-              "entity": {
-                "entityType": "node",
-                "entityBundle": "health_care_region_page",
-                "entityId": "49011"
-              }
-            }
-          }
-        },
-        "fieldLocationHumanreadable": null,
-        "fieldLocationType": "online",
-        "fieldMedia": null,
-        "fieldMetaTags": null,
-        "fieldOrder": null,
-        "fieldUrlOfAnOnlineEvent": {
-          "uri": "https://google.com",
-          "title": ""
-        },
-        "uid": {
-          "targetId": 1215,
-          "entity": {
-            "name": "Steve.Wirt@civicactions.com",
-            "timezone": null
-          }
-        },
-        "fieldAdministration": {
-          "entity": {
-            "entityId": "1039"
-          }
-        }
-      },
-      {
-        "changed": 1671038406,
-        "entityBundle": "event",
-        "entityId": "49922",
-        "entityPublished": true,
-        "entityMetatags": [
-          {
-            "__typename": "MetaLink",
-            "key": "image_src",
-            "value": "https://www.va.gov/img/design/logo/va-og-image.png"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "title",
-            "value": "Lovell Federal health care - TRICARE | Test Event B TRICARE | Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:site_name",
-            "value": "Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:title",
-            "value": "Test Event B TRICARE | Lovell Federal health care - TRICARE | Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:image:height",
-            "value": "314"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:card",
-            "value": "summary_large_image"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:site",
-            "value": "@DeptVetAffairs"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:title",
-            "value": "Test Event B TRICARE | Lovell Federal health care - TRICARE | Veterans Affairs"
-          }
-        ],
-        "entityUrl": {
-          "path": "/lovell-federal-health-care-tricare/events/49922"
-        },
-        "title": "Test Event B TRICARE",
-        "vid": 735965,
-        "fieldAdditionalInformationAbo": null,
-        "fieldAddress": {
-          "additionalName": null,
-          "addressLine1": "",
-          "addressLine2": "",
-          "administrativeArea": "",
-          "countryCode": "US",
-          "dependentLocality": null,
-          "familyName": null,
-          "givenName": null,
-          "langcode": null,
-          "locality": "",
-          "organization": null,
-          "postalCode": null,
-          "sortingCode": null
-        },
-        "fieldBody": {
-          "format": "rich_text",
-          "processed": "<html><head></head><body><p>This is another event that should appear in TRICARE lovell.</p></body></html>",
-          "value": "<p>This is another event that should appear in TRICARE lovell.</p>\r\n"
-        },
-        "fieldDatetimeRangeTimezone": [
-          {
-            "duration": 60,
-            "endTime": null,
-            "endValue": 1666269300,
-            "rrule": null,
-            "rruleIndex": null,
-            "startTime": null,
-            "timezone": "America/New_York",
-            "value": 1666265700
-          }
-        ],
-        "fieldDescription": null,
-        "fieldEventCost": "Free",
-        "fieldEventCta": null,
-        "fieldEventRegistrationrequired": false,
-        "fieldFacilityLocation": {
-          "entity": {
-            "entityBundle": "health_care_local_facility",
-            "entityId": "49055",
-            "entityType": "node",
-            "entityUrl": {
-              "path": "/lovell-federal-health-care-tricare/locations/captain-james-a-lovell-federal-health-care-center"
-            },
-            "title": "Captain James A. Lovell Federal Health Care Center"
-          }
-        },
-        "fieldFeatured": false,
-        "fieldLink": null,
-        "fieldListing": {
-          "entity": {
-            "entityBundle": "event_listing",
-            "entityId": "49454",
-            "entityType": "node",
-            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal health care - TRICARE and regional events.",
-            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care - TRICARE and regional events.",
-            "fieldOffice": {
-              "entity": {
-                "entityType": "node",
-                "entityBundle": "health_care_region_page",
-                "entityId": "49011"
-              }
-            }
-          }
-        },
-        "fieldLocationHumanreadable": null,
-        "fieldLocationType": "facility",
-        "fieldMedia": null,
-        "fieldMetaTags": null,
-        "fieldOrder": null,
-        "fieldUrlOfAnOnlineEvent": null,
-        "uid": {
-          "targetId": 1215,
-          "entity": {
-            "name": "Steve.Wirt@civicactions.com",
-            "timezone": null
-          }
-        },
-        "fieldAdministration": {
-          "entity": {
-            "entityId": "1039"
-          }
-        }
-      }
-    ]
-  },
   "fieldOffice": {
     "entity": {
       "entityLabel": "Lovell Federal health care - TRICARE"
@@ -662,5 +46,146 @@
     "entity": {
       "entityId": "1039"
     }
+  },
+  "pastEvents": {
+    "entities": [
+      {
+        "changed": 1671038416,
+        "entityBundle": "event",
+        "entityId": "21",
+        "entityPublished": true,
+        "title": "Lovell Tricare - Featured - Past - 1",
+        "fieldDatetimeRangeTimezone": [
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 1262336400,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/Chicago",
+            "value": 1262332800
+          }
+        ],
+        "fieldFeatured": true,
+        "entityUrl": {
+          "path": "/lovell-federal-health-care-tricare/events/21"
+        }
+      }
+    ]
+  },
+  "reverseFieldListingNode": {
+    "entities": [
+      {
+        "changed": 1671038416,
+        "entityBundle": "event",
+        "entityId": "21",
+        "entityPublished": true,
+        "title": "Lovell Tricare - Featured - Past - 1",
+        "fieldDatetimeRangeTimezone": [
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 1262336400,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/Chicago",
+            "value": 1262332800
+          }
+        ],
+        "fieldFeatured": true,
+        "entityUrl": {
+          "path": "/lovell-federal-health-care-tricare/events/21"
+        }
+      },
+      {
+        "changed": 1671038416,
+        "entityBundle": "event",
+        "entityId": "22",
+        "entityPublished": true,
+        "title": "Lovell Tricare - Featured - Future - 1",
+        "fieldDatetimeRangeTimezone": [
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 2633119000,
+            "rrule": null,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/Chicago",
+            "value": 2633115400
+          }
+        ],
+        "fieldFeatured": true,
+        "entityUrl": {
+          "path": "/lovell-federal-health-care-tricare/events/22"
+        }
+      },
+      {
+        "changed": 1671038416,
+        "entityBundle": "event",
+        "entityId": "23",
+        "entityPublished": true,
+        "title": "Lovell Federal - Featured - Future - 2",
+        "fieldDatetimeRangeTimezone": [
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 2633119000,
+            "rrule": null,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/Chicago",
+            "value": 2633115400
+          },
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 2650874400,
+            "rrule": null,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/Chicago",
+            "value": 2650870800
+          }
+        ],
+        "fieldFeatured": true,
+        "entityUrl": {
+          "path": "/lovell-federal-health-care-tricare/events/23"
+        }
+      },
+      {
+        "changed": 1671038416,
+        "entityBundle": "event",
+        "entityId": "24",
+        "entityPublished": true,
+        "title": "Lovell Tricare - Not Featured - Future - 1",
+        "fieldDatetimeRangeTimezone": [
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 2633119000,
+            "rrule": null,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/Chicago",
+            "value": 2633115400
+          },
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 2650874400,
+            "rrule": null,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/Chicago",
+            "value": 2650870800
+          }
+        ],
+        "fieldFeatured": false,
+        "entityUrl": {
+          "path": "/lovell-federal-health-care-tricare/events/24"
+        }
+      }
+    ]
   }
 }

--- a/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/tricare/stories.json
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/tricare/stories.json
@@ -37,108 +37,31 @@
     ],
     "path": "/lovell-federal-health-care-tricare/stories"
   },
-  "entityMetatags": [
-    {
-      "__typename": "MetaLink",
-      "key": "image_src",
-      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "title",
-      "value": "Stories | Lovell Federal health care - TRICARE | Veterans Affairs"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "description",
-      "value": "Lovell Federal health care - TRICARE top stories."
-    },
-    {
-      "__typename": "MetaProperty",
-      "key": "og:site_name",
-      "value": "Veterans Affairs"
-    },
-    {
-      "__typename": "MetaProperty",
-      "key": "og:title",
-      "value": "Stories | Lovell Federal health care - TRICARE | Veterans Affairs"
-    },
-    {
-      "__typename": "MetaProperty",
-      "key": "og:description",
-      "value": "Lovell Federal health care - TRICARE top stories."
-    },
-    {
-      "__typename": "MetaProperty",
-      "key": "og:image",
-      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
-    },
-    {
-      "__typename": "MetaProperty",
-      "key": "og:image:alt",
-      "value": "U.S. Department of Veterans Affairs"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:card",
-      "value": "summary_large_image"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:site",
-      "value": "@DeptVetAffairs"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:description",
-      "value": "Lovell Federal health care - TRICARE top stories."
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:title",
-      "value": "Stories | Lovell Federal health care - TRICARE | Veterans Affairs"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:image:alt",
-      "value": "U.S. Department of Veterans Affairs"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:image",
-      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
-    }
-  ],
   "fieldIntroText": "Lovell Federal health care - TRICARE top stories.",
   "reverseFieldListingNode": {
     "entities": [
       {
-        "entityId": "49930",
-        "title": "TEST story for TRICARE Lovell",
+        "entityId": "201",
+        "title": "Lovell Tricare Story - Featured - 1",
         "fieldFeatured": true,
         "entityUrl": {
-          "path": "/lovell-federal-health-care-tricare/stories/test-story-for-tricare-lovell"
-        },
-        "uid": {
-          "targetId": 1215,
-          "entity": {
-            "name": "Steve.Wirt@civicactions.com",
-            "timezone": null
-          }
-        },
-        "promote": false,
-        "created": 1664741414,
-        "fieldAuthor": {
-          "entity": {
-            "title": "Steven Winslow",
-            "fieldDescription": "Caregiver Support Social Worker (Manhattan Campus)"
-          }
-        },
-        "fieldImageCaption": null,
-        "fieldIntroText": "This is a smallish story for now.",
-        "fieldMedia": null,
-        "fieldFullStory": {
-          "processed": "<html><head></head><body><p>This is a meager story, but still important.</p></body></html>"
+          "path": "/lovell-federal-health-care-tricare/stories/lovell-tricare-story-featured-1"
+        }
+      },
+      {
+        "entityId": "202",
+        "title": "Lovell Tricare Story - Featured - 2",
+        "fieldFeatured": true,
+        "entityUrl": {
+          "path": "/lovell-federal-health-care-tricare/stories/lovell-tricare-story-featured-2"
+        }
+      },
+      {
+        "entityId": "203",
+        "title": "Lovell Tricare Story - Not Featured - 1",
+        "fieldFeatured": false,
+        "entityUrl": {
+          "path": "/lovell-federal-health-care-tricare/stories/lovell-tricare-story-not-featured-1"
         }
       }
     ]

--- a/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/va/events.json
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/va/events.json
@@ -16,622 +16,155 @@
     ],
     "path": "/lovell-federal-health-care-va/events"
   },
-  "entityMetatags": [
-    {
-      "__typename": "MetaLink",
-      "key": "image_src",
-      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "title",
-      "value": "Events | Lovell Federal health care - VA | Veterans Affairs"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "description",
-      "value": "Check early and often to see upcoming events at Lovell Federal health care - VA and regional events."
-    },
-    {
-      "__typename": "MetaProperty",
-      "key": "og:site_name",
-      "value": "Veterans Affairs"
-    },
-    {
-      "__typename": "MetaProperty",
-      "key": "og:title",
-      "value": "Events | Veterans Affairs"
-    },
-    {
-      "__typename": "MetaProperty",
-      "key": "og:description",
-      "value": "Check early and often to see upcoming events at Lovell Federal health care - VA and regional events."
-    },
-    {
-      "__typename": "MetaProperty",
-      "key": "og:image",
-      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
-    },
-    {
-      "__typename": "MetaProperty",
-      "key": "og:image:alt",
-      "value": "U.S. Department of Veterans Affairs"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:card",
-      "value": "summary_large_image"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:site",
-      "value": "@DeptVetAffairs"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:description",
-      "value": "Check early and often to see upcoming events at Lovell Federal health care - VA and regional events."
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:title",
-      "value": "Events | Lovell Federal health care - VA | Veterans Affairs"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:image:alt",
-      "value": "U.S. Department of Veterans Affairs"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:image",
-      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+  "fieldOffice": {
+    "entity": {
+      "entityLabel": "Lovell Federal health care - VA"
     }
-  ],
-  "changed": 1671038416,
-  "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care - VA and regional events.",
+  },
+  "fieldAdministration": {
+    "entity": {
+      "entityId": "1040"
+    }
+  },
   "pastEvents": {
     "entities": [
       {
-        "changed": 1671038406,
+        "changed": 1671038416,
         "entityBundle": "event",
-        "entityId": "49923",
+        "entityId": "31",
         "entityPublished": true,
-        "entityMetatags": [
-          {
-            "__typename": "MetaLink",
-            "key": "image_src",
-            "value": "https://www.va.gov/img/design/logo/va-og-image.png"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "title",
-            "value": "Lovell Federal health care - VA | Test Event X VA | Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:site_name",
-            "value": "Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:title",
-            "value": "Test Event X VA | Lovell Federal health care - VA | Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:image:height",
-            "value": "314"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:card",
-            "value": "summary_large_image"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:site",
-            "value": "@DeptVetAffairs"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:title",
-            "value": "Test Event X VA | Lovell Federal health care - VA | Veterans Affairs"
-          }
-        ],
-        "entityUrl": {
-          "path": "/lovell-federal-health-care-va/events/49923"
-        },
-        "title": "Test Event X VA",
-        "vid": 735964,
-        "fieldAdditionalInformationAbo": null,
-        "fieldAddress": {
-          "additionalName": null,
-          "addressLine1": "",
-          "addressLine2": "",
-          "administrativeArea": "",
-          "countryCode": "US",
-          "dependentLocality": null,
-          "familyName": null,
-          "givenName": null,
-          "langcode": null,
-          "locality": "",
-          "organization": null,
-          "postalCode": null,
-          "sortingCode": null
-        },
-        "fieldBody": {
-          "format": "rich_text",
-          "processed": "<html><head></head><body><p>This is another event that should appear in VA lovell.</p></body></html>",
-          "value": "<p>This is another event that should appear in VA lovell.</p>\r\n"
-        },
+        "title": "Lovell VA - Featured - Past - 1",
         "fieldDatetimeRangeTimezone": [
           {
             "duration": 60,
             "endTime": null,
-            "endValue": 1666269300,
-            "rrule": null,
+            "endValue": 1262336400,
             "rruleIndex": null,
             "startTime": null,
-            "timezone": "America/New_York",
-            "value": 1666265700
+            "timezone": "America/Chicago",
+            "value": 1262332800
           }
         ],
-        "fieldDescription": null,
-        "fieldEventCost": "Free",
-        "fieldEventCta": null,
-        "fieldEventRegistrationrequired": false,
-        "fieldFacilityLocation": {
-          "entity": {
-            "entityBundle": "health_care_local_facility",
-            "entityId": "49055",
-            "entityType": "node",
-            "entityUrl": {
-              "path": "/lovell-federal-health-care-tricare/locations/captain-james-a-lovell-federal-health-care-center"
-            },
-            "title": "Captain James A. Lovell Federal Health Care Center"
-          }
-        },
-        "fieldFeatured": false,
-        "fieldLink": null,
-        "fieldListing": {
-          "entity": {
-            "entityBundle": "event_listing",
-            "entityId": "49455",
-            "entityType": "node",
-            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal health care - VA and regional events.",
-            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care - VA and regional events.",
-            "fieldOffice": {
-              "entity": {
-                "entityType": "node",
-                "entityBundle": "health_care_region_page",
-                "entityId": "49451"
-              }
-            }
-          }
-        },
-        "fieldLocationHumanreadable": null,
-        "fieldLocationType": "facility",
-        "fieldMedia": null,
-        "fieldMetaTags": null,
-        "fieldOrder": null,
-        "fieldUrlOfAnOnlineEvent": null,
-        "uid": {
-          "targetId": 1215,
-          "entity": {
-            "name": "Steve.Wirt@civicactions.com",
-            "timezone": null
-          }
-        },
-        "fieldAdministration": { "entity": { "entityId": "1040" } }
-      },
-      {
-        "changed": 1671038400,
-        "entityBundle": "event",
-        "entityId": "49924",
-        "entityPublished": true,
-        "entityMetatags": [
-          {
-            "__typename": "MetaLink",
-            "key": "image_src",
-            "value": "https://www.va.gov/img/design/logo/va-og-image.png"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "title",
-            "value": "Lovell Federal health care - VA | Test Event Y VA | Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:site_name",
-            "value": "Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:title",
-            "value": "Test Event Y VA | Lovell Federal health care - VA | Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:image:height",
-            "value": "314"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:card",
-            "value": "summary_large_image"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:site",
-            "value": "@DeptVetAffairs"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:title",
-            "value": "Test Event Y VA | Lovell Federal health care - VA | Veterans Affairs"
-          }
-        ],
+        "fieldFeatured": true,
         "entityUrl": {
-          "path": "/lovell-federal-health-care-va/events/49924"
-        },
-        "title": "Test Event Y VA",
-        "vid": 735963,
-        "fieldAdditionalInformationAbo": null,
-        "fieldAddress": {
-          "additionalName": null,
-          "addressLine1": "",
-          "addressLine2": "",
-          "administrativeArea": "",
-          "countryCode": "US",
-          "dependentLocality": null,
-          "familyName": null,
-          "givenName": null,
-          "langcode": null,
-          "locality": "",
-          "organization": null,
-          "postalCode": null,
-          "sortingCode": null
-        },
-        "fieldBody": {
-          "format": "rich_text",
-          "processed": "<html><head></head><body><p>This is another event that should appear in VA lovell.</p></body></html>",
-          "value": "<p>This is another event that should appear in VA lovell.</p>\r\n"
-        },
-        "fieldDatetimeRangeTimezone": [
-          {
-            "duration": 60,
-            "endTime": null,
-            "endValue": 1666370100,
-            "rrule": null,
-            "rruleIndex": null,
-            "startTime": null,
-            "timezone": "America/New_York",
-            "value": 1666366500
-          }
-        ],
-        "fieldDescription": null,
-        "fieldEventCost": "Free",
-        "fieldEventCta": null,
-        "fieldEventRegistrationrequired": false,
-        "fieldFacilityLocation": {
-          "entity": {
-            "entityBundle": "health_care_local_facility",
-            "entityId": "49055",
-            "entityType": "node",
-            "entityUrl": {
-              "path": "/lovell-federal-health-care-tricare/locations/captain-james-a-lovell-federal-health-care-center"
-            },
-            "title": "Captain James A. Lovell Federal Health Care Center"
-          }
-        },
-        "fieldFeatured": false,
-        "fieldLink": null,
-        "fieldListing": {
-          "entity": {
-            "entityBundle": "event_listing",
-            "entityId": "49455",
-            "entityType": "node",
-            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal health care - VA and regional events.",
-            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care - VA and regional events.",
-            "fieldOffice": {
-              "entity": {
-                "entityType": "node",
-                "entityBundle": "health_care_region_page",
-                "entityId": "49451"
-              }
-            }
-          }
-        },
-        "fieldLocationHumanreadable": null,
-        "fieldLocationType": "facility",
-        "fieldMedia": null,
-        "fieldMetaTags": null,
-        "fieldOrder": null,
-        "fieldUrlOfAnOnlineEvent": null,
-        "uid": {
-          "targetId": 1215,
-          "entity": {
-            "name": "Steve.Wirt@civicactions.com",
-            "timezone": null
-          }
-        },
-        "fieldAdministration": { "entity": { "entityId": "1040" } }
+          "path": "/lovell-federal-health-care-va/events/31"
+        }
       }
     ]
   },
   "reverseFieldListingNode": {
     "entities": [
       {
-        "changed": 1671038406,
+        "changed": 1671038416,
         "entityBundle": "event",
-        "entityId": "49923",
+        "entityId": "31",
         "entityPublished": true,
-        "entityMetatags": [
-          {
-            "__typename": "MetaLink",
-            "key": "image_src",
-            "value": "https://www.va.gov/img/design/logo/va-og-image.png"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "title",
-            "value": "Lovell Federal health care - VA | Test Event X VA | Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:site_name",
-            "value": "Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:title",
-            "value": "Test Event X VA | Lovell Federal health care - VA | Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:image:height",
-            "value": "314"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:card",
-            "value": "summary_large_image"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:site",
-            "value": "@DeptVetAffairs"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:title",
-            "value": "Test Event X VA | Lovell Federal health care - VA | Veterans Affairs"
-          }
-        ],
-        "entityUrl": {
-          "path": "/lovell-federal-health-care-va/events/49923"
-        },
-        "title": "Test Event X VA",
-        "vid": 735964,
-        "fieldAdditionalInformationAbo": null,
-        "fieldAddress": {
-          "additionalName": null,
-          "addressLine1": "",
-          "addressLine2": "",
-          "administrativeArea": "",
-          "countryCode": "US",
-          "dependentLocality": null,
-          "familyName": null,
-          "givenName": null,
-          "langcode": null,
-          "locality": "",
-          "organization": null,
-          "postalCode": null,
-          "sortingCode": null
-        },
-        "fieldBody": {
-          "format": "rich_text",
-          "processed": "<html><head></head><body><p>This is another event that should appear in VA lovell.</p></body></html>",
-          "value": "<p>This is another event that should appear in VA lovell.</p>\r\n"
-        },
+        "title": "Lovell VA - Featured - Past - 1",
         "fieldDatetimeRangeTimezone": [
           {
             "duration": 60,
             "endTime": null,
-            "endValue": 1666269300,
-            "rrule": null,
+            "endValue": 1262336400,
             "rruleIndex": null,
             "startTime": null,
-            "timezone": "America/New_York",
-            "value": 1666265700
+            "timezone": "America/Chicago",
+            "value": 1262332800
           }
         ],
-        "fieldDescription": null,
-        "fieldEventCost": "Free",
-        "fieldEventCta": null,
-        "fieldEventRegistrationrequired": false,
-        "fieldFacilityLocation": {
-          "entity": {
-            "entityBundle": "health_care_local_facility",
-            "entityId": "49055",
-            "entityType": "node",
-            "entityUrl": {
-              "path": "/lovell-federal-health-care-tricare/locations/captain-james-a-lovell-federal-health-care-center"
-            },
-            "title": "Captain James A. Lovell Federal Health Care Center"
-          }
-        },
-        "fieldFeatured": false,
-        "fieldLink": null,
-        "fieldListing": {
-          "entity": {
-            "entityBundle": "event_listing",
-            "entityId": "49455",
-            "entityType": "node",
-            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal health care - VA and regional events.",
-            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care - VA and regional events.",
-            "fieldOffice": {
-              "entity": {
-                "entityType": "node",
-                "entityBundle": "health_care_region_page",
-                "entityId": "49451"
-              }
-            }
-          }
-        },
-        "fieldLocationHumanreadable": null,
-        "fieldLocationType": "facility",
-        "fieldMedia": null,
-        "fieldMetaTags": null,
-        "fieldOrder": null,
-        "fieldUrlOfAnOnlineEvent": null,
-        "uid": {
-          "targetId": 1215,
-          "entity": {
-            "name": "Steve.Wirt@civicactions.com",
-            "timezone": null
-          }
-        },
-        "fieldAdministration": { "entity": { "entityId": "1040" } }
+        "fieldFeatured": true,
+        "entityUrl": {
+          "path": "/lovell-federal-health-care-va/events/31"
+        }
       },
       {
-        "changed": 1671038400,
+        "changed": 1671038416,
         "entityBundle": "event",
-        "entityId": "49924",
+        "entityId": "32",
         "entityPublished": true,
-        "entityMetatags": [
-          {
-            "__typename": "MetaLink",
-            "key": "image_src",
-            "value": "https://www.va.gov/img/design/logo/va-og-image.png"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "title",
-            "value": "Lovell Federal health care - VA | Test Event Y VA | Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:site_name",
-            "value": "Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:title",
-            "value": "Test Event Y VA | Lovell Federal health care - VA | Veterans Affairs"
-          },
-          {
-            "__typename": "MetaProperty",
-            "key": "og:image:height",
-            "value": "314"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:card",
-            "value": "summary_large_image"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:site",
-            "value": "@DeptVetAffairs"
-          },
-          {
-            "__typename": "MetaValue",
-            "key": "twitter:title",
-            "value": "Test Event Y VA | Lovell Federal health care - VA | Veterans Affairs"
-          }
-        ],
-        "entityUrl": {
-          "path": "/lovell-federal-health-care-va/events/49924"
-        },
-        "title": "Test Event Y VA",
-        "vid": 735963,
-        "fieldAdditionalInformationAbo": null,
-        "fieldAddress": {
-          "additionalName": null,
-          "addressLine1": "",
-          "addressLine2": "",
-          "administrativeArea": "",
-          "countryCode": "US",
-          "dependentLocality": null,
-          "familyName": null,
-          "givenName": null,
-          "langcode": null,
-          "locality": "",
-          "organization": null,
-          "postalCode": null,
-          "sortingCode": null
-        },
-        "fieldBody": {
-          "format": "rich_text",
-          "processed": "<html><head></head><body><p>This is another event that should appear in VA lovell.</p></body></html>",
-          "value": "<p>This is another event that should appear in VA lovell.</p>\r\n"
-        },
+        "title": "Lovell VA - Featured - Future - 1",
         "fieldDatetimeRangeTimezone": [
           {
             "duration": 60,
             "endTime": null,
-            "endValue": 1666370100,
+            "endValue": 2633119000,
             "rrule": null,
             "rruleIndex": null,
             "startTime": null,
-            "timezone": "America/New_York",
-            "value": 1666366500
+            "timezone": "America/Chicago",
+            "value": 2633115400
           }
         ],
-        "fieldDescription": null,
-        "fieldEventCost": "Free",
-        "fieldEventCta": null,
-        "fieldEventRegistrationrequired": false,
-        "fieldFacilityLocation": {
-          "entity": {
-            "entityBundle": "health_care_local_facility",
-            "entityId": "49055",
-            "entityType": "node",
-            "entityUrl": {
-              "path": "/lovell-federal-health-care-tricare/locations/captain-james-a-lovell-federal-health-care-center"
-            },
-            "title": "Captain James A. Lovell Federal Health Care Center"
+        "fieldFeatured": true,
+        "entityUrl": {
+          "path": "/lovell-federal-health-care-va/events/32"
+        }
+      },
+      {
+        "changed": 1671038416,
+        "entityBundle": "event",
+        "entityId": "33",
+        "entityPublished": true,
+        "title": "Lovell VA - Featured - Future - 2",
+        "fieldDatetimeRangeTimezone": [
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 2633119000,
+            "rrule": null,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/Chicago",
+            "value": 2633115400
+          },
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 2650874400,
+            "rrule": null,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/Chicago",
+            "value": 2650870800
           }
-        },
+        ],
+        "fieldFeatured": true,
+        "entityUrl": {
+          "path": "/lovell-federal-health-care-va/events/33"
+        }
+      },
+      {
+        "changed": 1671038416,
+        "entityBundle": "event",
+        "entityId": "34",
+        "entityPublished": true,
+        "title": "Lovell VA - Not Featured - Future - 1",
+        "fieldDatetimeRangeTimezone": [
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 2633119000,
+            "rrule": null,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/Chicago",
+            "value": 2633115400
+          },
+          {
+            "duration": 60,
+            "endTime": null,
+            "endValue": 2650874400,
+            "rrule": null,
+            "rruleIndex": null,
+            "startTime": null,
+            "timezone": "America/Chicago",
+            "value": 2650870800
+          }
+        ],
         "fieldFeatured": false,
-        "fieldLink": null,
-        "fieldListing": {
-          "entity": {
-            "entityBundle": "event_listing",
-            "entityId": "49455",
-            "entityType": "node",
-            "fieldDescription": "Check early and often to see upcoming events at Lovell Federal health care - VA and regional events.",
-            "fieldIntroText": "Check early and often to see upcoming events at Lovell Federal health care - VA and regional events.",
-            "fieldOffice": {
-              "entity": {
-                "entityType": "node",
-                "entityBundle": "health_care_region_page",
-                "entityId": "49451"
-              }
-            }
-          }
-        },
-        "fieldLocationHumanreadable": null,
-        "fieldLocationType": "facility",
-        "fieldMedia": null,
-        "fieldMetaTags": null,
-        "fieldOrder": null,
-        "fieldUrlOfAnOnlineEvent": null,
-        "uid": {
-          "targetId": 1215,
-          "entity": {
-            "name": "Steve.Wirt@civicactions.com",
-            "timezone": null
-          }
-        },
-        "fieldAdministration": { "entity": { "entityId": "1040" } }
+        "entityUrl": {
+          "path": "/lovell-federal-health-care-va/events/34"
+        }
       }
     ]
-  },
-  "fieldOffice": {
-    "entity": { "entityLabel": "Lovell Federal health care - VA" }
-  },
-  "fieldAdministration": { "entity": { "entityId": "1040" } }
+  }
 }

--- a/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/va/events.json
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/va/events.json
@@ -86,12 +86,12 @@
           {
             "duration": 60,
             "endTime": null,
-            "endValue": 2633119000,
+            "endValue": 2998029600,
             "rrule": null,
             "rruleIndex": null,
             "startTime": null,
             "timezone": "America/Chicago",
-            "value": 2633115400
+            "value": 2998026000
           }
         ],
         "fieldFeatured": true,

--- a/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/va/stories.json
+++ b/src/site/stages/build/drupal/tests/lovell/fixtures/listing-pages/va/stories.json
@@ -16,108 +16,31 @@
     ],
     "path": "/lovell-federal-health-care-va/stories"
   },
-  "entityMetatags": [
-    {
-      "__typename": "MetaLink",
-      "key": "image_src",
-      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "title",
-      "value": "Stories | Lovell Federal health care - VA | Veterans Affairs"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "description",
-      "value": "Lovell Federal health care - VA top stories."
-    },
-    {
-      "__typename": "MetaProperty",
-      "key": "og:site_name",
-      "value": "Veterans Affairs"
-    },
-    {
-      "__typename": "MetaProperty",
-      "key": "og:title",
-      "value": "Stories | Lovell Federal health care - VA | Veterans Affairs"
-    },
-    {
-      "__typename": "MetaProperty",
-      "key": "og:description",
-      "value": "Lovell Federal health care - VA top stories."
-    },
-    {
-      "__typename": "MetaProperty",
-      "key": "og:image",
-      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
-    },
-    {
-      "__typename": "MetaProperty",
-      "key": "og:image:alt",
-      "value": "U.S. Department of Veterans Affairs"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:card",
-      "value": "summary_large_image"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:site",
-      "value": "@DeptVetAffairs"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:description",
-      "value": "Lovell Federal health care - VA top stories."
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:title",
-      "value": "Stories | Lovell Federal health care - VA | Veterans Affairs"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:image:alt",
-      "value": "U.S. Department of Veterans Affairs"
-    },
-    {
-      "__typename": "MetaValue",
-      "key": "twitter:image",
-      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
-    }
-  ],
   "fieldIntroText": "Lovell Federal health care - VA top stories.",
   "reverseFieldListingNode": {
     "entities": [
       {
-        "entityId": "49931",
-        "title": "TEST story for VA Lovell",
+        "entityId": "301",
+        "title": "Lovell VA Story - Featured - 1",
         "fieldFeatured": true,
         "entityUrl": {
-          "path": "/lovell-federal-health-care-va/stories/test-story-for-va-lovell"
-        },
-        "uid": {
-          "targetId": 1215,
-          "entity": {
-            "name": "Steve.Wirt@civicactions.com",
-            "timezone": null
-          }
-        },
-        "promote": false,
-        "created": 1664741589,
-        "fieldAuthor": {
-          "entity": {
-            "title": "Jill Vinge",
-            "fieldDescription": "Caregiver Support Coordinator"
-          }
-        },
-        "fieldImageCaption": null,
-        "fieldIntroText": "This is a goodish story for now.",
-        "fieldMedia": null,
-        "fieldFullStory": {
-          "processed": "<html><head></head><body><p>This is a fun little story, but still important.</p></body></html>"
+          "path": "/lovell-federal-health-care-va/stories/lovell-va-story-featured-1"
+        }
+      },
+      {
+        "entityId": "302",
+        "title": "Lovell VA Story - Featured - 2",
+        "fieldFeatured": true,
+        "entityUrl": {
+          "path": "/lovell-federal-health-care-va/stories/lovell-va-story-featured-2"
+        }
+      },
+      {
+        "entityId": "303",
+        "title": "Lovell VA Story - Not Featured - 1",
+        "fieldFeatured": false,
+        "entityUrl": {
+          "path": "/lovell-federal-health-care-va/stories/lovell-va-story-not-featured-1"
         }
       }
     ]

--- a/src/site/stages/build/drupal/tests/lovell/helpers.unit.spec.js
+++ b/src/site/stages/build/drupal/tests/lovell/helpers.unit.spec.js
@@ -10,7 +10,6 @@ import {
   getLovellTitleVariation,
   getLovellUrl,
   getLovellVariantOfUrl,
-  getFeaturedListingItems,
 } from '../../lovell/helpers';
 
 describe('getLovellTitle', () => {
@@ -91,85 +90,5 @@ describe('getLovellVariantOfUrl', () => {
       LOVELL_TRICARE_LINK_VARIATION,
       '/lovell-federal-health-care-tricare/some-page',
     );
-  });
-});
-
-describe('getFeaturedListingItems', () => {
-  const listingPages = [
-    {
-      entityBundle: 'type1-expected',
-      reverseFieldListingNode: {
-        entities: [
-          {
-            title: 'Featured 1',
-            fieldFeatured: true,
-            fieldAdministration: {
-              entity: {
-                entityId: 2,
-              },
-            },
-          },
-          {
-            title: 'Featured 2',
-            fieldFeatured: true,
-            fieldAdministration: {
-              entity: {
-                entityId: 1,
-              },
-            },
-          },
-          {
-            title: 'Not Featured 1',
-            fieldFeatured: false,
-          },
-        ],
-      },
-    },
-    {
-      entityBundle: 'type2-malformed',
-    },
-  ];
-
-  it('returns an empty array when listingType is not found', () => {
-    const featuredItems = getFeaturedListingItems(
-      listingPages,
-      'nonExistentType',
-    );
-    expect(featuredItems).to.deep.eq([]);
-  });
-
-  it('returns an empty array when listing page is malformed', () => {
-    const featuredItems = getFeaturedListingItems(
-      listingPages,
-      'type2-malformed',
-    );
-    expect(featuredItems).to.deep.eq([]);
-  });
-
-  it('returns featured items sorted by fieldAdministration', () => {
-    const featuredItems = getFeaturedListingItems(
-      listingPages,
-      'type1-expected',
-    );
-    expect(featuredItems).to.deep.eq([
-      {
-        title: 'Featured 2',
-        fieldFeatured: true,
-        fieldAdministration: {
-          entity: {
-            entityId: 1,
-          },
-        },
-      },
-      {
-        title: 'Featured 1',
-        fieldFeatured: true,
-        fieldAdministration: {
-          entity: {
-            entityId: 2,
-          },
-        },
-      },
-    ]);
   });
 });

--- a/src/site/stages/build/drupal/tests/lovell/helpers.unit.spec.js
+++ b/src/site/stages/build/drupal/tests/lovell/helpers.unit.spec.js
@@ -10,6 +10,7 @@ import {
   getLovellTitleVariation,
   getLovellUrl,
   getLovellVariantOfUrl,
+  getFeaturedListingItems,
 } from '../../lovell/helpers';
 
 describe('getLovellTitle', () => {
@@ -90,5 +91,85 @@ describe('getLovellVariantOfUrl', () => {
       LOVELL_TRICARE_LINK_VARIATION,
       '/lovell-federal-health-care-tricare/some-page',
     );
+  });
+});
+
+describe('getFeaturedListingItems', () => {
+  const listingPages = [
+    {
+      entityBundle: 'type1-expected',
+      reverseFieldListingNode: {
+        entities: [
+          {
+            title: 'Featured 1',
+            fieldFeatured: true,
+            fieldAdministration: {
+              entity: {
+                entityId: 2,
+              },
+            },
+          },
+          {
+            title: 'Featured 2',
+            fieldFeatured: true,
+            fieldAdministration: {
+              entity: {
+                entityId: 1,
+              },
+            },
+          },
+          {
+            title: 'Not Featured 1',
+            fieldFeatured: false,
+          },
+        ],
+      },
+    },
+    {
+      entityBundle: 'type2-malformed',
+    },
+  ];
+
+  it('returns an empty array when listingType is not found', () => {
+    const featuredItems = getFeaturedListingItems(
+      listingPages,
+      'nonExistentType',
+    );
+    expect(featuredItems).to.deep.eq([]);
+  });
+
+  it('returns an empty array when listing page is malformed', () => {
+    const featuredItems = getFeaturedListingItems(
+      listingPages,
+      'type2-malformed',
+    );
+    expect(featuredItems).to.deep.eq([]);
+  });
+
+  it('returns featured items sorted by fieldAdministration', () => {
+    const featuredItems = getFeaturedListingItems(
+      listingPages,
+      'type1-expected',
+    );
+    expect(featuredItems).to.deep.eq([
+      {
+        title: 'Featured 2',
+        fieldFeatured: true,
+        fieldAdministration: {
+          entity: {
+            entityId: 1,
+          },
+        },
+      },
+      {
+        title: 'Featured 1',
+        fieldFeatured: true,
+        fieldAdministration: {
+          entity: {
+            entityId: 2,
+          },
+        },
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## Description
See https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11941

This PR adds featured stories and events to the Lovell VA and TRICARE homepages.

## Testing done & Screenshots
### TRICARE Homepage
#### Stories
**Sorted Federal then TRICARE**
![image](https://github.com/department-of-veterans-affairs/content-build/assets/6863534/f58d2dbc-3e19-437b-9da5-f7ccddb5ae58)
#### Events
**Sorted by date (next upcoming event listed first)**
![image](https://github.com/department-of-veterans-affairs/content-build/assets/6863534/35850a30-af1a-410c-837e-d4392d646866)

### VA Homepage
#### Stories
**Sorted Federal then VA**
![image](https://github.com/department-of-veterans-affairs/content-build/assets/6863534/acceee6c-781c-4c0b-95b0-7d900ba702ce)
#### Events
**Sorted by date (next upcoming event listed first)**
![image](https://github.com/department-of-veterans-affairs/content-build/assets/6863534/dada2466-1f94-491d-8334-1b060a643714)

## QA steps
1. `yarn build --pull-drupal --drupal-address=https://main-ogvo5d8kyveonzymjllajdl4credcmvw.demo.cms.va.gov/ --use-cached-assets`
2. http://localhost:3002/lovell-federal-health-care-tricare/
  - [ ] Ensure featured stories and events match screenshots above
  - [ ] Ensure stories are sorted by Federal and then TRICARE
  - [ ] Ensure events are sorted by date, with next upcoming event first
3. http://localhost:3002/lovell-federal-health-care-va/
  - [ ] Ensure featured stories and events match screenshots above
  - [ ] Ensure stories are sorted by Federal and then VA
  - [ ] Ensure events are sorted by date, with next upcoming event first


## Acceptance criteria
See original ticket.

