### PR TITLE
Add note to keep parity with CMS on heading ids.

### DIFF
--- a/src/site/stages/build/plugins/modify-dom/add-id-to-subheadings.js
+++ b/src/site/stages/build/plugins/modify-dom/add-id-to-subheadings.js
@@ -6,7 +6,7 @@
 
 function createUniqueId(headingEl, headingOptions) {
   const headingString = headingEl.text();
-  // Any changes to srting processing here must also be made in va.gov-cms
+  // Any changes to string processing here must also be made in va.gov-cms
   // docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityBase.php getFrontEndFragment().
   const length = 30;
   let anchor = headingString

--- a/src/site/stages/build/plugins/modify-dom/add-id-to-subheadings.js
+++ b/src/site/stages/build/plugins/modify-dom/add-id-to-subheadings.js
@@ -6,6 +6,8 @@
 
 function createUniqueId(headingEl, headingOptions) {
   const headingString = headingEl.text();
+  // Any changes to srting processing here must also be made in va.gov-cms
+  // docroot/modules/custom/va_gov_post_api/src/Service/PostFacilityBase.php getFrontEndFragment().
   const length = 30;
   let anchor = headingString
     .trim()


### PR DESCRIPTION
## Description
 
relates to https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13769

## Testing done & Screenshots
## QA steps

No functional changes, only adding comments.

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  


## Acceptance criteria

- [ ] A person altering the method that generates heading ids, is adequately warned to keep parity with CMS side code.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
