### PR TITLE
Adds preview support for most Lovell pages.

### DIFF
--- a/script/preview.js
+++ b/script/preview.js
@@ -23,6 +23,9 @@ const HOSTNAMES = require('../src/site/constants/hostnames');
 const bucketsContent = require('../src/site/constants/buckets-content');
 const singlePageDiff = require('./preview-routes/single-page-diff');
 const createMetalSmithSymlink = require('../src/site/stages/build/plugins/create-symlink');
+const {
+  processLovellPages,
+} = require('../src/site/stages/build/drupal/process-lovell-pages');
 
 const defaultBuildtype = ENVIRONMENTS.LOCALHOST;
 const defaultHost = HOSTNAMES[defaultBuildtype];
@@ -280,7 +283,11 @@ app.get('/preview', async (req, res, next) => {
 
     Object.assign(drupalData.data, nonNodeContent.content.data);
 
-    const drupalPage = drupalData.data.nodes.entities[0];
+    drupalData.data.nodeQuery = drupalData.data.nodes;
+    processLovellPages(drupalData);
+    const pageIndex = req.query?.lovellVariant === 'va' ? 1 : 0;
+
+    const drupalPage = drupalData.data.nodes.entities[pageIndex];
     const drupalPath = `${req.path.substring(1)}/index.html`;
 
     if (!drupalPage.entityBundle) {


### PR DESCRIPTION
## Description
Adds preview support for Lovell pages, with some exceptions:
- Listing pages will not work. These require merging with Federal listing pages, which will not be fetched when building only a single page.
- Homepages will work but will not include umbrella featured items. Getting those items is done by grabbing them from the listing pages, which will not be built when building only the single page.

Note: There's a [related draft PR](https://github.com/department-of-veterans-affairs/content-build/pull/1576) that gets most or all of the way to adding support for these other pages. I've opted for the simpler solution to satisfy this issue, as the larger solution feels like some scope creep. The more robust solution can be considered for a later date if there is a strong need for this support.

closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13289

## Testing done & QA steps
What needs to be checked to prove this works?  
### Ensure Lovell pages can be previewed
1. `yarn preview`
2. http://localhost:3002/preview?nodeId=56142
   - [x] Ensure page loads
   - [ ] Ensure TRICARE version (default)
3. http://localhost:3002/preview?nodeId=56142&lovellVariant=tricare
   - [x] Ensure page loads
   - [x] Ensure TRICARE version (explicit)
4. http://localhost:3002/preview?nodeId=56142&lovellVariant=va
   - [x] Ensure page loads
   - [x] Ensure VA version (explicit)
   
What needs to be checked to prove it didn't break any related things?  
### Ensure non-Lovell pages can _still_ be previewed.
1. http://localhost:3002/preview?nodeId=8127
   - [x] Ensure page loads


## Acceptance criteria
See original ticket.
