### PR TITLE
VACMS-13843: Use the square image style for homepage news promo block query

### DIFF
--- a/src/site/stages/build/drupal/graphql/homePage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/homePage.graphql.js
@@ -167,7 +167,7 @@ const query = `
                 ... on MediaImage {
                   image {
                     alt
-                    derivative(style: LARGE) {
+                    derivative(style: CROPSQUARE) {
                       url
                     }
                   }


### PR DESCRIPTION
## Description
Changes the image style for the V2 (new) home page news promo block. The current design expects a 1:1 aspect ratio, but today we are using the 'large' Drupal image style which maintains the existing aspect ratio of the image.

relates to #13843

## Testing done & Screenshots
Manual testing locally. Will also test in Tugboat and RI (if RI is functional).

## QA steps

1. Visit /new-home-page on the FE
   - [ ] Validate that the news promo image is using a 1:1 aspect ratio (by inspecting the html)

## Acceptance criteria

- [ ] 1:1 image style is used for new-home-page alert promo block image

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
