### PR TITLE
[VA-13673] Remove COVID tracker from VAMC pages

### DIFF
--- a/src/site/includes/facilityListing.drupal.liquid
+++ b/src/site/includes/facilityListing.drupal.liquid
@@ -11,15 +11,6 @@
         {% include "src/site/includes/operatingStatusFlagsLinks.drupal.liquid" with entity %}
       </div>
     {% endif %}
-    {% assign topMargin = '1' %}
-    {% assign bottomMargin = '2' %}
-    {% for covidStatus in fieldOffice.entity.reverseFieldRegionPageNode.entities %}
-      {% if covidStatus.entityId == entity.entityId %}
-      {% include "src/site/includes/covid-status.drupal.liquid" with covidStatus %}
-
-      {% endif %}
-    {% endfor %}
-
     {% unless type == 'mobile' %}
       <div class="vads-u-margin-bottom--1">
         <address class="vads-u-margin-bottom--0">

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -48,10 +48,6 @@
                     </div>
                   {% endif %}
 
-                  {% assign bottomMargin = '2' %}
-                  {% assign topMargin = '0p5' %}
-                  {% include "src/site/includes/covid-status.drupal.liquid" %}
-
                   <section class="vads-facility-detail">
                     <script type="application/ld+json">
                       {

--- a/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
+++ b/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
@@ -116,16 +116,6 @@
                         </div>
                       {% endif %}
 
-                      {% assign bottomMargin = '1' %}
-                      {% assign topMargin = '2' %}
-                      {% for covidStatus in fieldOffice.entity.reverseFieldRegionPageNode.entities %}
-                        {% if statusId == covidStatus.entityId %}
-                        {{facilityId}}
-                        {% include "src/site/includes/covid-status.drupal.liquid" with covidStatus %}
-
-                        {% endif %}
-                      {% endfor %}
-
                     </div>
                   </dd>
                 {% endfor %}


### PR DESCRIPTION
## Description

This removes the COVID health status from the needed VAMC pages on the content-build.

Related to [#13673](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13673)

## Testing done & Screenshots

Visual, confirmed the health status is gone on the following local pages after these steps:

1. Do a local build by running `yarn preview`
2. Check the page at http://localhost:3002/illiana-health-care/operating-status/

<img width="1122" alt="Screen Shot 2023-05-25 at 7 51 00 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10790736/eed73710-5486-4a43-a3c6-3cda65d6672e">

3. Check the page at http://localhost:3002/preview?nodeId=2802

<img width="1209" alt="Screen Shot 2023-05-25 at 7 57 37 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10790736/8f6a84f9-019e-4139-8eff-6b73f410d216">

4. Check the page at http://localhost:3002/illiana-health-care/locations/springfield-va-clinic/

<img width="1260" alt="Screen Shot 2023-05-25 at 7 50 46 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10790736/1962f9aa-3091-43b8-96f2-f699032e0783">

## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

1. Check all above local pages
   - [ ] Confirm that the COVID health status components are not there
   - [ ] Confirm that the pages don't look "broken" when the components are not there

## Acceptance criteria

- [ ] All local pages build properly
- [ ] All QA steps pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
