### PR TITLE
[VA-12096] Reorganize Vet Center Satellite Locations

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1449,6 +1449,28 @@ module.exports = function registerFilters() {
     return `${formattedStartsAt} – ${formattedEndsAt} ${endsAtTimezone}`;
   };
 
+  liquid.filters.organizeSatelliteVetCenters = centers => {
+    const { outstations, CAPs } = centers.reduce(
+      (acc, center) => {
+        if (center.entityBundle === 'vet_center_outstation') {
+          acc.outstations.push(center);
+        } else if (center.entityBundle === 'vet_center_cap') {
+          acc.CAPs.push(center);
+        }
+        return acc;
+      },
+      {
+        outstations: [],
+        CAPs: [],
+      },
+    );
+
+    return [
+      ...liquid.filters.sortObjectsBy(outstations, 'title'),
+      ...liquid.filters.sortObjectsBy(CAPs, 'title'),
+    ];
+  };
+
   liquid.filters.dynamicVetCenterHoursKey = forloopindex => {
     return `vetCenterHoursKey_${forloopindex}`;
   };

--- a/src/site/layouts/vet_center_locations_list.drupal.liquid
+++ b/src/site/layouts/vet_center_locations_list.drupal.liquid
@@ -40,7 +40,7 @@
               confidentiality in a non-medical setting.
               Call us for more information about these locations.
             </p>
-            {% assign satelliteVetCenters = fieldOffice.entity.reverseFieldOfficeNode.entities | rejectBy: 'entityBundle', 'vet_center_mobile_vet_center' | sortObjectsBy: 'title' %}
+            {% assign satelliteVetCenters = fieldOffice.entity.reverseFieldOfficeNode.entities | rejectBy: 'entityBundle', 'vet_center_mobile_vet_center' | organizeSatelliteVetCenters %}
             {% for entityVetCenter in satelliteVetCenters %}
               {% assign myVetCenterHoursKeys = forloop.index | dynamicVetCenterHoursKey %}
               {% include "src/site/includes/vet_centers/address_phone_image.liquid" with


### PR DESCRIPTION
## Description

The Vet Center Satellite locations are organized alphabetically, but the outstations should be shown before the others. This makes the outstation vet centers appear first in the list (alphabetically), followed by the others (also alphabetically).

Closes [#12096](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12096)

## Testing done & Screenshots

### After Screenshots

<img width="993" alt="Screen Shot 2023-05-31 at 3 57 43 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10790736/dc5171c2-2319-4abd-a09e-226b071102cd">

<img width="733" alt="Screen Shot 2023-05-31 at 3 57 25 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10790736/fc7bf2d9-06bb-4528-8f6c-efe3c31e1d9c">

## QA steps

1. Run a local build of this branch
2. Check locations for Elken Vet Center at http://localhost:3002/elkton-vet-center/locations/
   - [ ] Confirm the two outstation locations appear first and alphabetically before the others
   - [ ] Confirm all vet centers are still present (compare to https://www.va.gov/elkton-vet-center/locations/)
3. Check locations for Great Falls Vet Center at http://localhost:3002/great-falls-vet-center/locations/
   - [ ] Confirm the outstation location appears before the others
   - [ ] Confirm all vet centers are still present (compare to https://www.va.gov/great-falls-vet-center/locations/)


## Acceptance criteria

- [ ] All QA steps and criteria pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
