### PR TITLE
VACMS-13199: Adds node-status filter to subqueries for non-clinical services

### DIFF
--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionNonClinicialServices.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionNonClinicialServices.node.graphql.js
@@ -15,7 +15,15 @@ module.exports = `
   entity {
     entityId
     entityLabel
-    reverseFieldRegionPageNode(limit: 50, filter: {conditions: [{field: "type", value: ["health_care_local_facility"]}]}) {
+    reverseFieldRegionPageNode(
+      limit: 50,
+      filter: {
+        conditions: [
+          { field: "type", value: ["health_care_local_facility"] },
+          { field: "status", value: ["1"], enabled: $onlyPublishedContent }
+        ]
+      }
+    ) {
       entities {
         ... on NodeHealthCareLocalFacility {
           entityLabel
@@ -31,9 +39,8 @@ module.exports = `
           ${FIELD_ADDRESS}
           reverseFieldFacilityLocationNode(limit: 50, filter: {
             conditions: [
-              {
-                field: "type", value: ["vha_facility_nonclinical_service"]
-              }
+              { field: "type", value: ["vha_facility_nonclinical_service"] },
+              { field: "status", value: ["1"], enabled: $onlyPublishedContent }
             ]
           }) {
             entities {


### PR DESCRIPTION
## Description
closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13199

Archived non-clinical services are showing on VAMC top-task pages. They shouldn't be showing. This PR fixes that.

## Screenshots
In the [CMS data used to test](https://main-ogvo5d8kyveonzymjllajdl4credcmvw.demo.cms.va.gov/), there are two archived pieces of content to note:
1. [O'Neill VA Clinic VAMC Facility node](https://main-ogvo5d8kyveonzymjllajdl4credcmvw.demo.cms.va.gov/nebraska-western-iowa-health-care/locations/oneill-va-clinic) is archived
2. [The billing-and-insurance VAMC Facility Non-clinical Service node tied to Omaha VA Medical Center](https://main-ogvo5d8kyveonzymjllajdl4credcmvw.demo.cms.va.gov/nebraska-western-iowa-health-care/locations/omaha-va-medical-center/billing-and-insurance) is archived.

As a result, the Billing and Insurance page for VA Nebraska-Western Iowa health care should exclude O'Neill VA Clinic _and_ Omaha VA Medical Center. Currently, before this PR, the page shows both.

### Before
![image](https://github.com/department-of-veterans-affairs/content-build/assets/6863534/3b3b752e-12c3-45d0-b813-1b0a505f56e5)

### After
![image](https://github.com/department-of-veterans-affairs/content-build/assets/6863534/9749a87d-285e-4155-b3cc-d4e39fe1cc4a)

## Testing done & QA steps
1. `yarn build --pull-drupal --drupal-address=https://main-ogvo5d8kyveonzymjllajdl4credcmvw.demo.cms.va.gov --use-cached-assets`
4. http://localhost:3002/nebraska-western-iowa-health-care/billing-and-insurance/
   - [ ] Under "Pay in person", validate that "O'Neill VA Clinic" is not present.
   - [ ] Under "Pay in person", validate that "Omaha VA Medical Center" is not present.

## Acceptance criteria
See original issue