### PR TITLE
Update form 21-4142 breadcrumbs and url per IA

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1339,7 +1339,7 @@
   {
     "appName": "Authorize the release of medical information to the VA",
     "entryName": "21-4142-medical-release",
-    "rootUrl": "/supporting-forms-for-claims/release-records-to-va-form-21-4142",
+    "rootUrl": "/supporting-forms-for-claims/release-information-to-va-form-21-4142",
     "productId": "56438c7b-e586-490d-a7f6-7e3c92136564",
     "template": {
       "vagovprod": false,
@@ -1347,8 +1347,12 @@
       "includeBreadcrumbs": true,
       "breadcrumbs_override": [
         {
-          "name": "Authorize the release of medical information to the VA",
-          "path": "supporting-forms-for-claims/release-records-to-va-form-21-4142"
+          "name": "Supporting forms for VA claims",
+          "path": "supporting-forms-for-claims"
+        },
+        {
+          "name": "Authorize the release of non-VA medical information to VA",
+          "path": "supporting-forms-for-claims/release-information-to-va-form-21-4142"
         }
       ]
     }


### PR DESCRIPTION
## Description
Update breadcrumbs and URL per final IA review

[Ticket](https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/315)

## Testing done & Screenshots
Ran locally with [vets-website changes](https://github.com/department-of-veterans-affairs/vets-website/pull/24430). Verified the new route worked.

## Acceptance criteria
Pull vets-website branch linked above. Run with `yarn watch --env entry=21-4142-medical-release`.
Navigate to `http://localhost:3001/supporting-forms-for-claims/release-information-to-va-form-21-4142` and verify it loads.
