### PR TITLE
VACMS-13955 Clean up homepage code post-launch

### DIFF
--- a/src/site/layouts/home-sandbox.drupal.liquid
+++ b/src/site/layouts/home-sandbox.drupal.liquid
@@ -1,5 +1,5 @@
 {% include "src/site/includes/header.html" %}
-<main data-template="layouts/home-preview" id="content">
+<main data-template="layouts/home-sandbox" id="content">
 
   {% include "src/site/includes/hero.drupal.liquid" with hero %}
   {% include "src/site/includes/common-tasks.drupal.liquid" with commonTasks %}

--- a/src/site/layouts/home.drupal.liquid
+++ b/src/site/layouts/home.drupal.liquid
@@ -1,158 +1,26 @@
 {% include "src/site/includes/header.html" %}
 <main data-template="layouts/home" id="content">
 
-  <!-- the hub -->
-  <section class="homepage-hub">
-
-    <div class="homepage-hub-container">
-
-      <h1 class="heading-level-2 homepage-heading">Access and manage your VA benefits and health care</h1>
-
-      <!-- top row -->
-      <div class="hub-links-row">
-      {% for card in cards %}
-        <div class="hub-links-container" data-e2e="bucket">
-          <h2 class="heading-level-3 vads-u-margin-top--0"><i class="icon-large-baseline icon-heading hub-icon-{{ card.label | downcase | replace: ' ', '-' }} hub-color-{{ card.label | downcase | replace: ' ', '-' }} vads-u-margin-right--0p5"></i>{{ card.label }}</h2>
-          <ul class="hub-links-list vads-u-margin-bottom--0">
-            {% assign card_label = card.label %}
-            {% for link in card.links %}
-              <li>
-                <a href="{{ link.url.path }}"
-                  onclick="recordEvent({
-                    event: 'nav-zone-one',
-                    'nav-path': '->{% if link.url.path != empty %}{{ link.url.path }}{% else %}{{ link.label }}{% endif %}',
-                    'click-text': '{{ link.label | strip }}',
-                    heading: '{{ card_label | strip }}',
-                  });"
-                  >
-                  {{ link.label }}
-                </a>
-              </li>
-            {% endfor %}
-          </ul>
+  {% include "src/site/includes/hero.drupal.liquid" with hero %}
+  {% include "src/site/includes/common-tasks.drupal.liquid" with commonTasks %}
+  {% include "src/site/includes/news-spotlight.drupal.liquid" with newsSpotlight %}
+  {% include "src/site/includes/homepage-benefits.drupal.liquid" with hubs %}
+  <!-- Medallia feedback button-->
+  <div class="usa-grid usa-grid-full">
+    <div class="last-updated vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
+      <div class="vads-u-display--flex above-footer-elements-container">
+        <div class="vads-u-flex--1 vads-u-text-align--right">
+          <span class="vads-u-text-align--right">
+              {% include "src/site/includes/medallia-feedback-button.drupal.liquid" %}
+          </span>
         </div>
-        {% comment %} Close row and start new row after 2nd card. {% endcomment %}
-        {% if forloop.index == 2 %}
-        </div>
-        <div class="hub-links-row">
-        {% endif %}
-      {% endfor %}
       </div>
     </div>
-
-    {% include "src/site/includes/veteran-banner.html" %}
-
-  </section>
-  <!-- /the hub -->
-
-  <section>
-    <section id="homepage-benefits">
-      <div class="usa-grid usa-grid-full homepage-benefits-row">
-      {% for hub in hubs %}
-        <div class="usa-width-one-third" data-e2e="hub" data-entity-id="{{ hub.entity.entityId }}">
-          <h2 class="heading-level-4"><a href="{{ hub.entity.entityUrl.path }}" onclick="recordEvent({ event: 'nav-linkslist' });"><i class="icon-small icon-heading hub-icon-{{ hub.entity.fieldTitleIcon }} hub-background-{{ hub.entity.fieldTitleIcon }} white vads-u-margin-right--0p5"></i>{{ hub.entity.fieldHomePageHubLabel }}</a></h2>
-          <p class="vads-u-margin-top--0">{{ hub.entity.fieldTeaserText }}</p>
-        </div>
-        {% comment %} Close this row and open a new one when needed. {% endcomment %}
-        {% if hub.endRow and forloop.last != true %}
-        </div>
-        <div class="usa-grid usa-grid-full homepage-benefits-row">
-        {% endif %}
-      {% endfor %}
-      </div>
-    </section>
-
-    <section id="homepage-popular">
-      <div class="usa-grid usa-grid-full">
-        <div class="usa-width-one-third">
-          <a href="/find-locations/"
-            onclick="recordEvent({ event: 'nav-main-health', 'homepage-cta-action': 'Homepage CTA - Find a location' });"
-            class="homepage-button">
-            <div class="icon-wrapper">
-              <i class="fa fa-map-marker-alt homepage-button-icon"></i>
-            </div>
-            <!-- div required for alignment -->
-            <div class="button-inner">
-              <span>Find a VA health facility, regional office, or cemetery</span>
-            </div>
-          </a>
-        </div>
-
-        <div class="usa-width-one-third">
-          <button onclick="recordEvent({ event: 'nav-main-vcl', 'homepage-cta-action': 'Homepage CTA - Crisis Line' });"
-            class="homepage-button vcl va-overlay-trigger" data-show="#modal-crisisline">
-            <div class="icon-wrapper vcl"></div>
-            <div class="button-inner">
-              <span>Talk to a Veterans Crisis Line responder now</span>
-            </div>
-          </button>
-        </div>
-
-        <div class="usa-width-one-third" id="myva-login">
-          <button onclick="recordEvent({ event: 'nav-main-sign-in', 'homepage-cta-action': 'Homepage CTA - Sign In' });"
-            class="homepage-button signin-signup-modal-trigger">
-            <div class="icon-wrapper">
-              <i class="fas fa-user-circle homepage-button-icon"></i>
-            </div>
-            <div class="button-inner">
-              <span>Sign in or create an account to use more tools</span>
-            </div>
-          </button>
-        </div>
-
-      </div>
-    </section>
-    <!-- end triple column -->
   </div>
-
-  <section class="usa-grid usa-grid-full">
-    <div class="va-h-ruled--stars"></div>
-  </section>
-
-  <section id="homepage-news">
-    <div class="usa-grid usa-grid-full">
-    {% comment %} Promos is an array of Drupal promo block entities. See /src/site/stages/build/drupal/home.js. {% endcomment %}
-    {% for promo in promos %}
-      <div data-entity-id="{{ promo.entity.entityId }}" class="usa-width-one-third homepage-news-story" data-e2e="news">
-        <div class="homepage-image-wrapper">
-          <img class="lazy" width="552" data-src="{{ promo.entity.fieldImage.entity.image.url }}" alt="{{ promo.entity.fieldImage.entity.image.alt }}"/>
-        </div>
-        <h3 class="homepage-news-story-title vads-u-font-size--h4">
-          <a
-            class="no-external-icon"
-            href="{{ promo.entity.fieldPromoLink.entity.fieldLink.uri }}"
-            onClick="recordEvent({ event: 'nav-footer-news-story' });"
-          >
-            {{ promo.entity.fieldPromoLink.entity.fieldLink.title }}
-          </a>
-        </h3>
-        <p class="homepage-news-story-desc">{{ promo.entity.fieldPromoLink.entity.fieldLinkSummary }}</p>
-      </div>
-      {% if hub.end_row == true and forloop.last != true %}
-      </div>
-      <div class="usa-grid usa-grid-full">
-      {% endif %}
-    {% endfor %}
-    </div>
-  </section>
-
-  <div data-widget-type="shifted-vets-banner"></div>
+  {% include "src/site/includes/email-update-signup.drupal.liquid" %}
 
 </main> <!-- end #content -->
 
-<!-- Medallia feedback button-->
-<div class="usa-grid usa-grid-full">
-  <div class="last-updated vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
-    <div class="vads-u-display--flex above-footer-elements-container">
-      <div class="vads-u-flex--1 vads-u-text-align--right">
-        <span class="vads-u-text-align--right">
-            {% include "src/site/includes/medallia-feedback-button.drupal.liquid" %}
-        </span>
-      </div>
-    </div>
-  </div>
-</div>
-<!-- end Medallia feedback button-->
 
 {% include "src/site/includes/footer.html" %}
 {% include "src/site/includes/debug.drupal.liquid" %}

--- a/src/site/stages/build/drupal/home-sandbox.js
+++ b/src/site/stages/build/drupal/home-sandbox.js
@@ -17,7 +17,7 @@ function divideHubRows(hubs) {
   });
 }
 
-const addHomePreviewContent = (
+const addHomeSandboxContent = (
   contentData,
   files,
   metalsmith,
@@ -70,7 +70,7 @@ const addHomePreviewContent = (
     title: 'New VA.gov Home Page',
   };
 
-  const homePreviewPath = '/new-home-page';
+  const homeSandboxPath = '/new-home-page';
   const hero =
     homePageHeroQuery?.itemsOfEntitySubqueueHomePageHero?.[0]?.entity || {};
   hero.createAccountBlock =
@@ -85,7 +85,7 @@ const addHomePreviewContent = (
   // Filter hub menu links. We do this here instead of in the template because the
   // grouping of hubs also happens here, and we need to filter before we group in
   // order to preserve the intended grouping. See divideHubRows().
-  const homePreviewHubs = homePageHubListMenuQuery.links.filter(link => {
+  const homeSandboxHubs = homePageHubListMenuQuery.links.filter(link => {
     // Any disabled links should not be displayed.
     if (!link.enabled) {
       return false;
@@ -98,7 +98,7 @@ const addHomePreviewContent = (
     );
   });
 
-  const homePreviewEntityObj = {
+  const homeSandboxEntityObj = {
     ...homeEntityObj,
     canonicalLink: '/', // Match current homepage to avoid 'duplicate content' SEO demerit
     hero,
@@ -107,20 +107,20 @@ const addHomePreviewContent = (
       popularLinks,
     },
     newsSpotlight,
-    path: homePreviewPath,
+    path: homeSandboxPath,
     entityUrl: {
-      path: homePreviewPath,
+      path: homeSandboxPath,
     },
-    hubs: divideHubRows(homePreviewHubs),
+    hubs: divideHubRows(homeSandboxHubs),
     title: 'New VA.gov home page',
   };
 
-  files[`.${homePreviewPath}.html`] = createFileObj(
-    homePreviewEntityObj,
-    'home-preview.drupal.liquid',
+  files[`.${homeSandboxPath}.html`] = createFileObj(
+    homeSandboxEntityObj,
+    'home-sandbox.drupal.liquid',
   );
 };
 
 module.exports = {
-  addHomePreviewContent,
+  addHomeSandboxContent,
 };

--- a/src/site/stages/build/drupal/home.js
+++ b/src/site/stages/build/drupal/home.js
@@ -1,9 +1,6 @@
 /* eslint-disable no-param-reassign, no-continue */
-const fs = require('fs-extra');
-const path = require('path');
-const yaml = require('js-yaml');
 const { createEntityUrlObj, createFileObj } = require('./page');
-const { addHomePreviewContent } = require('./home-preview');
+const { addHomeSandboxContent } = require('./home-sandbox');
 
 function divideHubRows(hubs) {
   return hubs.map((hub, i) => {
@@ -23,8 +20,6 @@ function addHomeContent(contentData, files, metalsmith, buildOptions) {
   // We cannot limit menu items in Drupal, so we must do it here.
   const menuLength = 4;
 
-  const { cmsFeatureFlags } = buildOptions;
-
   // Make sure that we have content for the home page.
   if (contentData.data.homePageMenuQuery) {
     let homeEntityObj = createEntityUrlObj('/');
@@ -32,40 +27,11 @@ function addHomeContent(contentData, files, metalsmith, buildOptions) {
       data: {
         banners,
         homePageMenuQuery,
-        homePageHubListQuery,
         homePagePromoBlockQuery,
         promoBanners,
       },
     } = contentData;
 
-    // Liquid does not have a good modulo operator, so we let the template know when to end a row.
-    const hubs = divideHubRows(
-      homePageHubListQuery.itemsOfEntitySubqueueHomePageHubList,
-    );
-
-    const fragmentsRoot = metalsmith.path(buildOptions.contentFragments);
-    const bannerLocation = path.join(fragmentsRoot, 'home/banner.yml');
-    const bannerFile = fs.readFileSync(bannerLocation);
-    const banner = yaml.safeLoad(bannerFile);
-
-    homeEntityObj = {
-      ...homeEntityObj,
-      banners,
-      cards: homePageMenuQuery.links.slice(0, menuLength),
-      description:
-        'Apply for and manage the VA benefits and services you’ve earned as a Veteran, Servicemember, or family member—like health care, disability, education, and more.',
-      entityUrl: { path: '/' },
-      hubs,
-      // eslint-disable-next-line camelcase
-      legacy_homepage_banner: banner,
-      promoBanners,
-      promos: homePagePromoBlockQuery.itemsOfEntitySubqueueHomePagePromos,
-      title: 'VA.gov Home',
-    };
-
-    /**
-     * Below is the code responsible for generating the new Homepage experience.
-     * */
     const {
       data: {
         homePageHeroQuery,
@@ -76,8 +42,7 @@ function addHomeContent(contentData, files, metalsmith, buildOptions) {
         homePageCreateAccountQuery,
       },
     } = contentData;
-
-    const homePreviewPath = '/';
+    const homePath = '/';
 
     const hero =
       homePageHeroQuery?.itemsOfEntitySubqueueHomePageHero?.[0]?.entity || {};
@@ -93,7 +58,7 @@ function addHomeContent(contentData, files, metalsmith, buildOptions) {
     // Filter hub menu links. We do this here instead of in the template because the
     // grouping of hubs also happens here, and we need to filter before we group in
     // order to preserve the intended grouping. See divideHubRows().
-    const homePreviewHubs = homePageHubListMenuQuery.links.filter(link => {
+    const homeHubs = homePageHubListMenuQuery.links.filter(link => {
       // Any disabled links should not be displayed.
       if (!link.enabled) {
         return false;
@@ -106,37 +71,27 @@ function addHomeContent(contentData, files, metalsmith, buildOptions) {
       );
     });
 
-    const homePreviewEntityObj = {
-      ...homeEntityObj,
+    homeEntityObj = {
+      banners,
       canonicalLink: '/',
-      hero,
+      cards: homePageMenuQuery.links.slice(0, menuLength),
       commonTasks: {
         searchLinks,
         popularLinks,
       },
+      entityUrl: { path: homePath },
+      hero,
+      hubs: divideHubRows(homeHubs),
       newsSpotlight,
-      path: homePreviewPath,
-      entityUrl: {
-        path: homePreviewPath,
-      },
-      hubs: divideHubRows(homePreviewHubs),
+      promoBanners,
+      promos: homePagePromoBlockQuery.itemsOfEntitySubqueueHomePagePromos,
+      path: homePath,
       title: 'VA.gov Home',
     };
 
-    addHomePreviewContent(contentData, files, metalsmith, buildOptions);
+    addHomeSandboxContent(contentData, files, metalsmith, buildOptions);
 
-    // Create correct home page based on feature flag.
-    if (cmsFeatureFlags?.FEATURE_HOMEPAGE_V2) {
-      files[`./index.html`] = createFileObj(
-        homePreviewEntityObj,
-        'home-preview.drupal.liquid',
-      );
-    } else {
-      files[`./index.html`] = createFileObj(
-        homeEntityObj,
-        'home.drupal.liquid',
-      );
-    }
+    files[`./index.html`] = createFileObj(homeEntityObj, 'home.drupal.liquid');
   }
 }
 


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13955

- Cleans up feature toggle logic for the home page
- Removes all old home page code
- Renames all home preview things to "home sandbox." 

## Testing done & Screenshots
Tested locally.

<img width="800" alt="Screenshot 2023-06-06 at 9 32 48 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/698f5c4b-2cb1-431b-89fc-7af01e5e570c">
<img width="800" alt="Screenshot 2023-06-06 at 9 32 57 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/1959c5cb-5d20-4216-a637-c80b1a3d2d21">

## QA steps
- Check `/` and ensure features are working such as search typeahead, links & buttons in hub, footer, news spotlight, header.
- Check `/new-home-page` and ensure features are working such as search typeahead, links & buttons in hub, footer, news spotlight, header.

## Acceptance criteria

- [ ] Removed conditional template code, including markup for Old Homepage which we left in case of rollback
- [ ] Namespace cleanup – updated variable names, file names, etc to align around "2023-homepage" or similar, so that future homepage iterations will be easy to disambiguate
