### PR TITLE
VACMS-13588 Removing breadcrumbs configuration from Income Limits application

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1395,18 +1395,7 @@
       "title": "Income Limits",
       "layout": "page-react.html",
       "description": "Income Limits application",
-      "vagovprod": false,
-      "includeBreadcrumbs": true,
-      "breadcrumbs_override": [
-        {
-          "path": "health-care",
-          "name": "Health Care"
-        },
-        {
-          "path": "health-care/income-limits-temp/zip",
-          "name": "Check income limits"
-        }
-      ]
+      "vagovprod": false
     }
   },
   {


### PR DESCRIPTION
## Description
Removing breadcrumb configuration in the application registry as it is preferred to use the design system component in the application side (vets-website) instead.

## Screenshot
<img width="900" alt="Screenshot 2023-06-06 at 4 29 56 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/1b04d4e2-fc7a-439e-aeba-9a38798619f3">


## QA steps
This is just removing code for an application that is not in production yet. You can test that everything still works at `/health-care/income-limits-temp` locally (without breadcrumbs).