### PR TITLE
[VA-13808] Add underlines to links in Spotlight sections

### DIFF
--- a/src/site/includes/vet_centers/featured_content.liquid
+++ b/src/site/includes/vet_centers/featured_content.liquid
@@ -11,7 +11,7 @@
     {% if entity.fieldCta.entity.fieldButtonLink %}
         {% assign fieldButtonUri = entity.fieldCta.entity.fieldButtonLink.uri | hasCharacterOtherThanSpace %}
         {% if fieldButtonUri %}
-            <a class="vads-u-display--block vads-u-padding-top--1 vads-u-text-decoration--none" href="{{ entity.fieldCta.entity.fieldButtonLink.uri }}" >
+            <a class="vads-u-display--block vads-u-padding-top--1" href="{{ entity.fieldCta.entity.fieldButtonLink.uri }}" >
                 <span> {{  entity.fieldCta.entity.fieldButtonLabel }} <i class="fa fa-chevron-right vads-facility-hub-cta-arrow" aria-hidden="true"></i></span>
             </a>
         {%endif%}

--- a/src/site/paragraphs/link_teaser_featured_content.drupal.liquid
+++ b/src/site/paragraphs/link_teaser_featured_content.drupal.liquid
@@ -8,7 +8,7 @@
     {% if linkTeaser.fieldLinkSummary != empty %}
         <p class="va-nav-linkslist-description">{{ linkTeaser.fieldLinkSummary }}</p>
     {% endif %}
-    <a onClick="recordEvent({ event: 'nav-featured-content-link-click', 'featured-content-header': '{{link.title}}' });" class="vads-u-display--block vads-u-padding-top--1 vads-u-text-decoration--none" href="{{link.url.path}}" {% if linkTeaser.options["target"] %}target="{{ linkTeaser.options["target"] }}"{% endif %} onClick="recordEvent({ event: 'nav-linkslist' });">
+    <a onClick="recordEvent({ event: 'nav-featured-content-link-click', 'featured-content-header': '{{link.title}}' });" class="vads-u-display--block vads-u-padding-top--1" href="{{link.url.path}}" {% if linkTeaser.options["target"] %}target="{{ linkTeaser.options["target"] }}"{% endif %} onClick="recordEvent({ event: 'nav-linkslist' });">
         <span>Read more<i class="fa fa-chevron-right vads-facility-hub-cta-arrow"></i></span>
     </a>
 </li>


### PR DESCRIPTION
## Description

Spotlight section links don't have underlines, and they need to be underlined more in line (no pun intended) with accessibility and design system guidelines.

relates to [#13808](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13808)

## Testing done & Screenshots

Visual, checked below local pages.

[VA Dublin Health Care](http://localhost:3002/dublin-health-care/health-services/)

<img width="721" alt="Screen Shot 2023-06-13 at 2 36 25 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10790736/116f5d20-67b5-4c4d-8208-284a1af9737b">

[Los Angeles Vet Center](http://localhost:3002/los-angeles-vet-center/)

<img width="729" alt="Screen Shot 2023-06-13 at 2 36 20 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10790736/949882f9-e30e-4e97-a2b9-5422a892a8e3">

## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

1. Check Spotlight on a VAMC page
   - [ ] Check that the Spotlight links on the above VA Dublin Health Care page are underlined
2. Then check Spotlight on a Vet Center page
   - [ ] Check that the Spotlight links on the above Los Angeles Vet Center page are underlined

## Acceptance criteria

- [ ] Above QA steps pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
