### PR TITLE
VA-11848: Open facility social links in same tab

### DIFF
--- a/src/site/facilities/facility_social_links.drupal.liquid
+++ b/src/site/facilities/facility_social_links.drupal.liquid
@@ -7,7 +7,7 @@
                 {% if fieldGovdeliveryIdNews != empty %}
                         <div class="social-links-email vads-u-margin-bottom--2">
                             <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none"
-                                target="_blank" href="https://public.govdelivery.com/accounts/USVHA/subscriber/new?topic_id={{ fieldGovdeliveryIdNews }}">
+                             data-same-tab href="https://public.govdelivery.com/accounts/USVHA/subscriber/new?topic_id={{ fieldGovdeliveryIdNews }}">
                                 <i class="fas fa-envelope vads-u-margin-right--1"></i>
                                 <span class="vads-u-text-decoration--underline">Subscribe to
                                     {{ regionNickname }} news and announcements</span>
@@ -17,7 +17,7 @@
 
                 {% if fieldGovdeliveryIdEmerg != empty %}
                         <div class="social-links-email vads-u-margin-bottom--2">
-                            <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" target="_blank" href="https://public.govdelivery.com/accounts/USVHA/subscriber/new?topic_id={{ fieldGovdeliveryIdEmerg }}">
+                            <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" data-same-tab href="https://public.govdelivery.com/accounts/USVHA/subscriber/new?topic_id={{ fieldGovdeliveryIdEmerg }}">
                                 <i class="fas fa-envelope vads-u-margin-right--1"></i>
                                 <span class="vads-u-text-decoration--underline">Subscribe to {{ regionNickname }} emergency notifications</span>
                             </a>
@@ -27,7 +27,7 @@
                 {% if fieldOperatingStatus.url.path %}
                         <div class="social-links-email vads-u-margin-bottom--2">
                             <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none"
-                                target="_blank" href="{{ fieldOperatingStatus.url.path}}">
+                             data-same-tab href="{{ fieldOperatingStatus.url.path}}">
                                 <i class="fas fa-dot-circle vads-u-margin-right--1"></i>
                                 <span class="vads-u-text-decoration--underline">{{ regionNickname }} operating status</span>
                             </a>
@@ -41,7 +41,7 @@
                 <div class="">
                     {% if fieldFacebook != empty %}
                         <div class="social-links social-links-facebook vads-u-margin-bottom--2">
-                            <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" target="_blank" href="{{ fieldFacebook.uri }}">
+                            <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" data-same-tab href="{{ fieldFacebook.uri }}">
                                 <i class="fab fa-facebook-square vads-u-margin-right--1"></i>
                                 <span class="vads-u-text-decoration--underline">{{ fieldFacebook.title }}</span>
                             </a>
@@ -50,7 +50,7 @@
 
                     {% if fieldTwitter != empty %}
                         <div class="social-links social-links-twitter vads-u-margin-bottom--2">
-                            <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" target="_blank" href="{{ fieldTwitter.uri }}">
+                            <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" data-same-tab href="{{ fieldTwitter.uri }}">
                                 <i class="fab fa-twitter vads-u-text-decoration--none vads-u-margin-right--1"></i>
                                 <span class="vads-u-text-decoration--underline">{{ fieldTwitter.title }}</span>
                             </a>
@@ -58,7 +58,7 @@
                     {% endif %}
                     {% if fieldFlickr != empty %}
                         <div class="social-links social-links-flickr vads-u-margin-bottom--2">
-                            <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" target="_blank" href="{{ fieldFlickr.uri }}">
+                            <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" data-same-tab href="{{ fieldFlickr.uri }}">
                                 <i class="fab fa-flickr vads-u-text-decoration--none vads-u-margin-right--1"></i>
                                 <span class="vads-u-text-decoration--underline">{{ fieldFlickr.title }}</span>
                             </a>
@@ -67,7 +67,7 @@
 
                     {% if fieldInstagram != empty %}
                         <div class="social-links social-links-instagram vads-u-margin-bottom--2">
-                            <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" target="_blank" href="{{ fieldInstagram.uri }}">
+                            <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" data-same-tab href="{{ fieldInstagram.uri }}">
                                 <i class="fab fa-instagram vads-u-text-decoration--none vads-u-margin-right--1"></i>
                                 <span class="vads-u-text-decoration--underline">{{ fieldInstagram.title }}</span>
                             </a>

--- a/src/site/facilities/facility_social_links.drupal.liquid
+++ b/src/site/facilities/facility_social_links.drupal.liquid
@@ -7,7 +7,7 @@
                 {% if fieldGovdeliveryIdNews != empty %}
                         <div class="social-links-email vads-u-margin-bottom--2">
                             <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none"
-                             data-same-tab href="https://public.govdelivery.com/accounts/USVHA/subscriber/new?topic_id={{ fieldGovdeliveryIdNews }}">
+                             href="https://public.govdelivery.com/accounts/USVHA/subscriber/new?topic_id={{ fieldGovdeliveryIdNews }}">
                                 <i class="fas fa-envelope vads-u-margin-right--1"></i>
                                 <span class="vads-u-text-decoration--underline">Subscribe to
                                     {{ regionNickname }} news and announcements</span>
@@ -17,7 +17,7 @@
 
                 {% if fieldGovdeliveryIdEmerg != empty %}
                         <div class="social-links-email vads-u-margin-bottom--2">
-                            <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" data-same-tab href="https://public.govdelivery.com/accounts/USVHA/subscriber/new?topic_id={{ fieldGovdeliveryIdEmerg }}">
+                            <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" href="https://public.govdelivery.com/accounts/USVHA/subscriber/new?topic_id={{ fieldGovdeliveryIdEmerg }}">
                                 <i class="fas fa-envelope vads-u-margin-right--1"></i>
                                 <span class="vads-u-text-decoration--underline">Subscribe to {{ regionNickname }} emergency notifications</span>
                             </a>
@@ -27,7 +27,7 @@
                 {% if fieldOperatingStatus.url.path %}
                         <div class="social-links-email vads-u-margin-bottom--2">
                             <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none"
-                             data-same-tab href="{{ fieldOperatingStatus.url.path}}">
+                             href="{{ fieldOperatingStatus.url.path}}">
                                 <i class="fas fa-dot-circle vads-u-margin-right--1"></i>
                                 <span class="vads-u-text-decoration--underline">{{ regionNickname }} operating status</span>
                             </a>
@@ -41,7 +41,7 @@
                 <div class="">
                     {% if fieldFacebook != empty %}
                         <div class="social-links social-links-facebook vads-u-margin-bottom--2">
-                            <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" data-same-tab href="{{ fieldFacebook.uri }}">
+                            <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" href="{{ fieldFacebook.uri }}">
                                 <i class="fab fa-facebook-square vads-u-margin-right--1"></i>
                                 <span class="vads-u-text-decoration--underline">{{ fieldFacebook.title }}</span>
                             </a>
@@ -50,7 +50,7 @@
 
                     {% if fieldTwitter != empty %}
                         <div class="social-links social-links-twitter vads-u-margin-bottom--2">
-                            <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" data-same-tab href="{{ fieldTwitter.uri }}">
+                            <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" href="{{ fieldTwitter.uri }}">
                                 <i class="fab fa-twitter vads-u-text-decoration--none vads-u-margin-right--1"></i>
                                 <span class="vads-u-text-decoration--underline">{{ fieldTwitter.title }}</span>
                             </a>
@@ -58,7 +58,7 @@
                     {% endif %}
                     {% if fieldFlickr != empty %}
                         <div class="social-links social-links-flickr vads-u-margin-bottom--2">
-                            <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" data-same-tab href="{{ fieldFlickr.uri }}">
+                            <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" href="{{ fieldFlickr.uri }}">
                                 <i class="fab fa-flickr vads-u-text-decoration--none vads-u-margin-right--1"></i>
                                 <span class="vads-u-text-decoration--underline">{{ fieldFlickr.title }}</span>
                             </a>
@@ -67,7 +67,7 @@
 
                     {% if fieldInstagram != empty %}
                         <div class="social-links social-links-instagram vads-u-margin-bottom--2">
-                            <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" data-same-tab href="{{ fieldInstagram.uri }}">
+                            <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" href="{{ fieldInstagram.uri }}">
                                 <i class="fab fa-instagram vads-u-text-decoration--none vads-u-margin-right--1"></i>
                                 <span class="vads-u-text-decoration--underline">{{ fieldInstagram.title }}</span>
                             </a>


### PR DESCRIPTION
## Description

The "get updates from <system>" links should open in the same tabs, but instead open in new ones. This edits the anchor tags to fix this.

relates to [#11848](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11848)

## Testing done & Screenshots

Visual, see below QA steps

<img width="1358" alt="Screen Shot 2023-06-15 at 5 24 28 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10790736/02549acb-02f4-4abb-b36c-4ae4752a56f2">

## QA steps

1. Do a local build and [visit "VA Sheridan health care"](http://localhost:3002/sheridan-health-care/) to check links are updated
   - [ ] Validate that the two email notification links open in the same tab
   - [ ] Validate that the status link opens in the same tab
   - [ ] Validate that the Facebook and Twitter links open in the same tab

## Acceptance criteria

- [ ] All QA steps pass.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
