### PR TITLE
Enable form 21-4142 route and fix breadcrumb

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1342,7 +1342,7 @@
     "rootUrl": "/supporting-forms-for-claims/release-information-to-va-form-21-4142",
     "productId": "56438c7b-e586-490d-a7f6-7e3c92136564",
     "template": {
-      "vagovprod": false,
+      "vagovprod": true,
       "layout": "page-react.html",
       "includeBreadcrumbs": true,
       "breadcrumbs_override": [
@@ -1351,7 +1351,7 @@
           "path": "supporting-forms-for-claims"
         },
         {
-          "name": "Authorize the release of non-VA medical information to VA",
+          "name": "Authorize the release of non&#8208;VA medical information to VA",
           "path": "supporting-forms-for-claims/release-information-to-va-form-21-4142"
         }
       ]


### PR DESCRIPTION
## Description

- Change prod flag to true to enable form route in production (form visibility controlled by flipper, so it won't appear for everyone right away)
- Update breadcrumb to use hex code for dash since regular dash wasn't showing up in deployed environments (see screenshots)
  - This is based on what teams like [pre-need have done to get their breadcrumb dash to render](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json#L327)
  - [pre-need staging link](https://staging.va.gov/burials-and-memorials/pre-need/form-10007-apply-for-eligibility) for reference

[ticket](https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/339)   

## Testing done & Screenshots

Form 21-4142 in staging. Breadcrumb does not show hyphen
<img width="777" alt="Screenshot 2023-06-21 at 4 27 17 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/57802560/b9cbcdca-9eb0-4a76-a077-0e8dc6529887">

Updated breadcrumb locally. It shows up the way we expect (this worked with the old dash too, but just proving the new one renders correctly).
<img width="706" alt="Screenshot 2023-06-21 at 4 27 52 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/57802560/44e0f276-389c-43b9-b651-bb1f92ba213f">

Deployed environment shows hyphen correctly
<img width="796" alt="Screenshot 2023-06-22 at 1 21 08 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/57802560/d4d6222e-829c-45f2-8638-124c21e0301d">


## QA steps

1. Do this
   - [ ] Navigate to the [deployed environment](http://1ff7a09401bfb9fe57fd33fcef2ee803.review.vetsgov-internal/)
   - [ ] Go to the form url `supporting-forms-for-claims/release-information-to-va-form-21-4142`
   - [ ] Validate the "non-VA" text in the breadcrumb shows a hyphen


## Acceptance criteria

- [ ] The hyphen shows up