### PR TITLE
VACMS-13593 Update Income Limits URL

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1412,7 +1412,7 @@
   {
     "appName": "Income Limits",
     "entryName": "income-limits",
-    "rootUrl": "/health-care/income-limits-temp",
+    "rootUrl": "/health-care/income-limits",
     "template": {
       "title": "Income Limits",
       "layout": "page-react.html",


### PR DESCRIPTION
## Description
I am making some changes to prevent deep-linking to parts of the Income Limits form (i.e. navigating directly to `/health-care/income-limits/zip`). This requires an entry in the `devops` repository to enable client-side routing. I'm adding the up-to-date URL (`/health-care/income-limits` rather than `/health-care/income-limits-temp`) there so I need to make the update here.