### PR TITLE
Fix codespaces build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -43,8 +43,10 @@ ENV AWS_CA_BUNDLE /etc/ssl/certs/ca-certificates.crt
 
 # Add VA Root CA to Docker Certificate Authority (CA) Store so that NODE can use it for requests.
 ADD http://crl.pki.va.gov/PKI/AIA/VA/VA-Internal-S2-RCA1-v1.cer /usr/local/share/ca-certificates/
-RUN openssl x509 -inform DER -in /usr/local/share/ca-certificates/VA-Internal-S2-RCA1-v1.cer -out /usr/local/share/ca-certificates/VA-Internal-S2-RCA1-v1.crt
+RUN mv /usr/local/share/ca-certificates/VA-Internal-S2-RCA1-v1.cer /usr/local/share/ca-certificates/VA-Internal-S2-RCA1-v1.cer.crt
 RUN update-ca-certificates
+# Display VA Internal certificates that are now trusted
+RUN awk -v cmd='openssl x509 -noout -subject' '/BEGIN/{close(cmd)};{print | cmd}' < /etc/ssl/certs/ca-certificates.crt | grep -i 'VA-Internal'
 
 RUN mkdir -p /application
 WORKDIR /application


### PR DESCRIPTION
This fixes codespace creation (The VA internal certificate installation step was failing and breaking codespaces builds). A [similar PR](https://github.com/department-of-veterans-affairs/vets-website/pull/24582) was recently merged into vets-website.

