### PR TITLE
Remove trailing whitespace from event locality

### DIFF
--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -100,7 +100,7 @@
 
                     <p class="vads-u-margin--0">
                       {% if fieldAddress.locality %}
-                        {{ fieldAddress.locality }}
+                        {{ fieldAddress.locality -}}
                       {% endif %}
 
                       {% if fieldAddress.administrativeArea %}

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -100,11 +100,11 @@
 
                     <p class="vads-u-margin--0">
                       {% if fieldAddress.locality %}
-                        {{ fieldAddress.locality -}}
+                        {{ fieldAddress.locality | strip }},
                       {% endif %}
 
                       {% if fieldAddress.administrativeArea %}
-                        , {{ fieldAddress.administrativeArea }}
+                        {{ fieldAddress.administrativeArea }}
                       {% endif %}
                     </p>
                   </div>


### PR DESCRIPTION
## Description

Event pages have extra whitespace between the city and state in the **Where** block, see e.g. https://www.va.gov/outreach-and-events/events/57259/ which looks like this:

![image](https://github.com/department-of-veterans-affairs/content-build/assets/101649/2b5aaf36-761c-4c5e-927b-022f7fb94ee9)

## Testing done & Screenshots

Tested on review instance, see e.g.:

- /outreach-and-events/events/57259/
- /outreach-and-events/events/57122/
- /outreach-and-events/events/57384/

## QA steps

### What needs to be checked to prove this works?  

Event pages at `outreach-and-events/events/*/`

### What needs to be checked to prove it didn't break any related things?  

Also event pages, not aware of anything else.

### What variations of circumstances (users, actions, values) need to be checked?  

Content does not vary for logged in users.

3. Then validate Acceptance Criteria from issue


## Acceptance criteria

- [ ] no whitespace after city name and before comma 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
