### PR TITLE
Turn on 21-10210 form-app in Prod

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1384,7 +1384,7 @@
     "rootUrl": "/supporting-forms-for-claims/lay-witness-statement-form-21-10210",
     "productId": "f8117c9f-0d57-486f-91ee-89c806b84d65",
     "template": {
-      "vagovprod": false,
+      "vagovprod": true,
       "layout": "page-react.html",
       "includeBreadcrumbs": true,
       "breadcrumbs_override": [


### PR DESCRIPTION
## Description

Set `vagovprod` to true in `src/applications/registry.json` for form-app 21-10210, to [enable this form in Prod](https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/307).

NOTE: Flipper `form2110210` is currently OFF in Prod, so this PR can be safely merged without accidental publication.

## Testing done & Screenshots

N/A -- this a config for an external React app.  The app itself [in vets-website repo] has been successfully tested and reviewed by Platform.
