### PR TITLE
VACMS-13705: Fixes phone number bugs on health services

### DIFF
--- a/src/site/components/phone-number.drupal.liquid
+++ b/src/site/components/phone-number.drupal.liquid
@@ -1,11 +1,7 @@
-{% if number.fieldPhoneLabel != empty %}
-  {% assign phoneLabel = number.fieldPhoneLabel %}
-{% endif %}
-{% if phoneLabel == empty %}
-  {% assign phoneLabel = 'Phone' %}
-{% endif %}
-<h{{ phoneHeaderLevel }}>{{ phoneLabel }}</h{{ phoneHeaderLevel }}>
-<a class="vads-u-margin-bottom--1" aria-label="{{ number.fieldPhoneNumber | accessibleNumber }}{% if number.fieldPhoneExtension %} extension: {{ number.fieldPhoneExtension | accessibleNumber }}{% endif %}"
-   href="tel:{{ number.fieldPhoneNumber }}{% if number.fieldPhoneExtension %}p{{ number.fieldPhoneExtension }}{% endif %}">
-  {{ number.fieldPhoneNumber }}{% if number.fieldPhoneExtension %}x {{ number.fieldPhoneExtension }}{% endif %}
-</a>
+<h{{ phoneHeaderLevel }}>{{ phoneLabel | default: 'Phone' }}</h{{ phoneHeaderLevel }}>
+<div>
+  <va-telephone
+    contact="{{ phoneNumber | removeDashes }}"
+    extension="{{ phoneExtension | default: '' }}"
+  />
+</div>

--- a/src/site/components/phone.drupal.liquid
+++ b/src/site/components/phone.drupal.liquid
@@ -4,8 +4,9 @@
     {% if phoneNumberObj.tel %}
       {% for number in phoneNumberObj.tel %}
         {% include "src/site/components/phone-number.drupal.liquid" with
-          number = number
-          phoneLabel = 'Phone'
+          phoneNumber = number.fieldPhoneNumber
+          phoneExtension = number.fieldPhoneExtension
+          phoneLabel = number.fieldPhoneLabel | default: 'Phone'
           phoneHeaderLevel = phoneHeaderLevel
         %}
       {% endfor %}
@@ -14,8 +15,9 @@
     {% if phoneNumberObj.fax %}
       {% for number in phoneNumberObj.fax %}
         {% include "src/site/components/phone-number.drupal.liquid" with
-          number = number
-          phoneLabel = 'Fax'
+          phoneNumber = number.fieldPhoneNumber
+          phoneExtension = number.fieldPhoneExtension
+          phoneLabel = number.fieldPhoneLabel | default: 'Fax'
           phoneHeaderLevel = phoneHeaderLevel
         %}
       {% endfor %}
@@ -24,8 +26,9 @@
     {% if phoneNumberObj.sms %}
       {% for number in phoneNumberObj.sms %}
         {% include "src/site/components/phone-number.drupal.liquid" with
-          number = number
-          phoneLabel = 'SMS'
+          phoneNumber = number.fieldPhoneNumber
+          phoneExtension = number.fieldPhoneExtension
+          phoneLabel = number.fieldPhoneLabel | default: 'SMS'
           phoneHeaderLevel = phoneHeaderLevel
         %}
       {% endfor %}
@@ -34,8 +37,9 @@
     {% if phoneNumberObj.tty %}
       {% for number in phoneNumberObj.tty %}
         {% include "src/site/components/phone-number.drupal.liquid" with
-          number = number
-          phoneLabel = 'TTY'
+          phoneNumber = number.fieldPhoneNumber
+          phoneExtension = number.fieldPhoneExtension
+          phoneLabel = number.fieldPhoneLabel | default: 'TTY'
           phoneHeaderLevel = phoneHeaderLevel
         %}
       {% endfor %}

--- a/src/site/facilities/health_care_local_health_service.drupal.liquid
+++ b/src/site/facilities/health_care_local_health_service.drupal.liquid
@@ -50,7 +50,7 @@
     <div class="vads-u-display--flex vads-u-flex-direction--column vads-u-margin-bottom--1" data-template="facilities/health_care_local_health_service">
       {% include "src/site/components/phone-number.drupal.liquid" with
         phoneNumber = fieldPhoneNumber
-        phoneLabel = 'Phone'
+        phoneLabel = 'Main Phone'
         phoneHeaderLevel = 5
       %}
     </div>

--- a/src/site/facilities/health_care_local_health_service.drupal.liquid
+++ b/src/site/facilities/health_care_local_health_service.drupal.liquid
@@ -37,22 +37,22 @@
   {% endcomment %}
   {% if locationEntity.fieldPhoneNumbersParagraph.length > 0 %}
     <div class="vads-u-display--flex vads-u-flex-direction--column vads-u-margin-bottom--1" data-template="facilities/health_care_local_health_service">
-      <h5>Phone</h5>
-      {% if locationEntity.fieldPhoneNumbersParagraph %}
-        {% for number in locationEntity.fieldPhoneNumbersParagraph %}
-          <va-telephone
-            contact="{{ number.entity.fieldPhoneNumber | removeDashes }}"
-            extension="{{ number.entity.fieldPhoneExtension | default: '' }}"
-          />
-        {% endfor %}
-      {% endif %}
+      {% for number in locationEntity.fieldPhoneNumbersParagraph %}
+        {% include "src/site/components/phone-number.drupal.liquid" with
+          phoneNumber = number.entity.fieldPhoneNumber
+          phoneExtension = number.entity.fieldPhoneExtension
+          phoneLabel = number.entity.fieldPhoneLabel
+          phoneHeaderLevel = 5
+        %}
+      {% endfor %}
     </div>
   {% else %}
     <div class="vads-u-display--flex vads-u-flex-direction--column vads-u-margin-bottom--1" data-template="facilities/health_care_local_health_service">
-      <h5>Phone</h5>
-      <va-telephone
-        contact="{{ fieldPhoneNumber | removeDashes }}"
-      />
+      {% include "src/site/components/phone-number.drupal.liquid" with
+        phoneNumber = fieldPhoneNumber
+        phoneLabel = 'Phone'
+        phoneHeaderLevel = 5
+      %}
     </div>
   {% endif %}
 

--- a/src/site/paragraphs/service_location.drupal.liquid
+++ b/src/site/paragraphs/service_location.drupal.liquid
@@ -25,11 +25,24 @@
     {% endif %}
 {% endcase %}
 
-
 {% if single.fieldAdditionalHoursInfo %}
   <span data-template="paragraphs/service_location"><i>{{ single.fieldAdditionalHoursInfo }}</i></span>
 {% endif %}
 
+{% comment %}
+  Conditionally display facility phone number
+{% endcomment %}
+{% if single.fieldUseMainFacilityPhone %}
+  {% include "src/site/components/phone-number.drupal.liquid" with
+    phoneNumber = fieldPhoneNumber
+    phoneLabel = 'Phone'
+    phoneHeaderLevel = serviceLocationSubHeaderLevel
+  %}
+{% endif %}
+
+{% comment %}
+  Display each additional phone number provided
+{% endcomment %}
 {% include "src/site/components/phone.drupal.liquid" with
   numbers = single.fieldPhone
   phoneHeaderLevel = serviceLocationSubHeaderLevel

--- a/src/site/paragraphs/service_location.drupal.liquid
+++ b/src/site/paragraphs/service_location.drupal.liquid
@@ -35,7 +35,7 @@
 {% if single.fieldUseMainFacilityPhone %}
   {% include "src/site/components/phone-number.drupal.liquid" with
     phoneNumber = fieldPhoneNumber
-    phoneLabel = 'Phone'
+    phoneLabel = 'Main Phone'
     phoneHeaderLevel = serviceLocationSubHeaderLevel
   %}
 {% endif %}


### PR DESCRIPTION
## Description
closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13705

This PR resolves two problems with phone numbers on health-service accordions: 
1. Some phone number labels set in the CMS were not making their way to the front end.
2. When an editor selected to show the facility phone number, that phone number was not showing at all.

## Testing done & Screenshots
Before:
![image](https://github.com/department-of-veterans-affairs/content-build/assets/6863534/8423d03e-4b89-43ed-83ad-e383fdc119a6)

After:
![image](https://github.com/department-of-veterans-affairs/content-build/assets/6863534/01ddb9ac-ef97-489a-821a-cfd6064702d5)


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

1. `yarn preview --drupal-address=https://main-ogvo5d8kyveonzymjllajdl4credcmvw.demo.cms.va.gov`
2. http://localhost:3002/preview?nodeId=2030
3. - [ ] Expand 'Mental health care' accordion and confirm displayed data matches [CMS data](https://main-ogvo5d8kyveonzymjllajdl4credcmvw.demo.cms.va.gov/richmond-health-care/locations/richmond-va-medical-center/mental-health-care)
5. - [ ] Expand some other accordions and examine some other phone numbers to ensure nothing looks off.

## Acceptance criteria
See [original ticket](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13705).

## Definition of done
- [ ] ~Events are logged appropriately~
- [ ] ~Documentation has been updated, if applicable~
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
