### PR TITLE
Add continue-on-error to CI workflow.

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -430,7 +430,7 @@ jobs:
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           url: ${{ env.DRUPAL_ADDRESS }}/api/govdelivery_bulletins/queue?EndTime=${{ needs.build.outputs.vagovprod_buildtime }}&src=gha&runId=${{ github.run_id }}&runNumber=${{ github.run_number }}
           method: GET
-        # This should not prevent the job from continuing.
+        # A failure here should not prevent the workflow from continuing.
         continue-on-error: true
 
       - name: Export deploy end time

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -670,6 +670,8 @@ jobs:
           username: api
           password: ${{ env.CALLBACK_TOKEN }}
           timeout: 10000
+        # A failure here should not prevent the workflow from continuing.
+        continue-on-error: true
 
   jenkins:
     name: Run Jenkins CI


### PR DESCRIPTION
## Description

In response to this workflow run: https://github.com/department-of-veterans-affairs/content-build/actions/runs/5465140738/jobs/9955066284#step:9:1

If this callback fails, it is not cause for failing the entire workflow. 