### PR TITLE
Refactors Google Maps directions links

### DIFF
--- a/src/site/includes/directions-google-maps.liquid
+++ b/src/site/includes/directions-google-maps.liquid
@@ -1,0 +1,22 @@
+{% comment %}
+  parameters:
+    directionsLinkTitle
+    directionsLinkAddress
+    directionsLinkOnClickPropName
+    directionsLinkOnClickPropValue
+{% endcomment %}
+
+{% assign onClick = "" %}
+{% if directionsLinkOnClickPropName != empty and directionsLinkOnClickPropValue != empty %}
+  {% capture onClick %}
+    onclick="recordEvent({ event: 'directions-link-click', '{{ directionsLinkOnClickPropName }}': '{{ directionsLinkOnClickPropValue }}'});"
+  {% endcapture %}
+{% endif %}
+
+<div>
+  <a
+    {{ onClick | strip }}
+    href="https://maps.google.com?saddr=Current+Location&amp;daddr={{ directionsLinkAddress | strip }}">
+    Get directions on Google Maps <span class="sr-only">to {{ directionsLinkTitle | strip }}</span>
+  </a>
+</div>

--- a/src/site/includes/facilityListing.drupal.liquid
+++ b/src/site/includes/facilityListing.drupal.liquid
@@ -20,11 +20,14 @@
             {{ entity.fieldAddress.postalCode }}
           </div>
         </address>
-        <directions>
-          <a href="https://maps.google.com?saddr=Current+Location&amp;daddr={{ entity.fieldAddress.addressLine1 }}, {{ entity.fieldAddress.locality }}, {{ entity.fieldAddress.administrativeArea }} {{ entity.fieldAddress.postalCode }}">
-            Directions (Google Maps)
-          </a>
-        </directions>
+
+        {% capture fullAddress %}
+          {{ entity.fieldAddress.addressLine1 }}, {{ entity.fieldAddress.locality }}, {{ entity.fieldAddress.administrativeArea }} {{ entity.fieldAddress.postalCode }}
+        {% endcapture %}
+        {% include "src/site/includes/directions-google-maps.liquid" with
+          directionsLinkTitle = entity.title
+          directionsLinkAddress = fullAddress
+        %}
       </div>
     {% endunless %}
     <div class="vads-u-margin-bottom--0">

--- a/src/site/includes/vet_centers/address_phone_image.liquid
+++ b/src/site/includes/vet_centers/address_phone_image.liquid
@@ -35,13 +35,16 @@
             {{ vetCenter.fieldAddress.postalCode }}
           </div>
         </address>
-        <div>
-          <a onclick="recordEvent({ event: 'directions-link-click', 'vet-center-facility-name': '{{ vetCenter.title }}'})"
-             href="https://maps.google.com?saddr=Current+Location&amp;daddr={{ vetCenter.fieldAddress.addressLine1 }}, {{ vetCenter.fieldAddress.locality }}, {{ vetCenter.fieldAddress.administrativeArea }} {{ vetCenter.fieldAddress.postalCode }}"
-             aria-label="Directions to {{ vetCenter.title }} on Google Maps">
-            Directions (Google Maps)
-          </a>
-        </div>
+
+        {% capture fullAddress %}
+          {{ vetCenter.fieldAddress.addressLine1 }}, {{ vetCenter.fieldAddress.locality }}, {{ vetCenter.fieldAddress.administrativeArea }} {{ vetCenter.fieldAddress.postalCode }}
+        {% endcapture %}
+        {% include "src/site/includes/directions-google-maps.liquid" with
+          directionsLinkTitle = vetCenter.title
+          directionsLinkAddress = fullAddress
+          directionsLinkOnClickPropName = "vet-center-facility-name"
+          directionsLinkOnClickPropValue = vetCenter.title
+        %}
       </div>
     {% endif %}
     <div class="vads-u-margin-bottom--3">

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -91,11 +91,15 @@
                       {{ fieldAddress.locality }},
                       {{ fieldAddress.administrativeArea }}
                       {{ fieldAddress.postalCode }}
-                      <div>
-                        <a href="https://maps.google.com?saddr=Current+Location&daddr={{ fieldAddress.addressLine1 }}, {{ fieldAddress.locality }}, {{ fieldAddress.postalCode }}">
-                          Directions (Google Maps)
-                        </a>
-                      </div>
+
+                      {% capture fullAddress %}
+                        {{ fieldAddress.addressLine1 }}, {{ fieldAddress.locality }}, {{ fieldAddress.administrativeArea }} {{ fieldAddress.postalCode }}
+                      {% endcapture %}
+                      {% include "src/site/includes/directions-google-maps.liquid" with
+                        directionsLinkTitle = title
+                        directionsLinkAddress = fullAddress
+                      %}
+
                     </div>
                     <h3
                         class="vads-u-font-size--lg vads-u-margin-top--0 vads-u-line-height--1 vads-u-margin-bottom--1">

--- a/src/site/layouts/vet_center.drupal.liquid
+++ b/src/site/layouts/vet_center.drupal.liquid
@@ -88,14 +88,16 @@
                         {{ fieldAddress.administrativeArea }}
                         {{ fieldAddress.postalCode }}
                       </address>
-                      <div>
-                        <a onclick="recordEvent({ event: 'directions-link-click', 'vet-center-facility-name': '{{ entityLabel }}'});"
-                           href="https://maps.google.com?saddr=Current+Location&daddr={{ fieldAddress.addressLine1 }}, {{ fieldAddress.locality }}, {{ fieldAddress.postalCode }}"
-                           aria-label="Directions to {{ entityLabel }} on Google Maps"
-                        >
-                          Directions (Google Maps)
-                        </a>
-                      </div>
+
+                      {% capture fullAddress %}
+                        {{ fieldAddress.addressLine1 }}, {{ fieldAddress.locality }}, {{ fieldAddress.administrativeArea}} {{ fieldAddress.postalCode }}
+                      {% endcapture %}
+                      {% include "src/site/includes/directions-google-maps.liquid" with
+                        directionsLinkTitle = title
+                        directionsLinkAddress = fullAddress
+                        directionsLinkOnClickPropName = "vet-center-facility-name"
+                        directionsLinkOnClickPropValue = title
+                      %}
                     </div>
                     <h4 class="vads-u-font-size--lg vads-u-margin-top--0 vads-u-line-height--1 vads-u-margin-bottom--1">
                       Direct line</h4>

--- a/src/site/layouts/vet_center.drupal.liquid
+++ b/src/site/layouts/vet_center.drupal.liquid
@@ -93,10 +93,10 @@
                         {{ fieldAddress.addressLine1 }}, {{ fieldAddress.locality }}, {{ fieldAddress.administrativeArea}} {{ fieldAddress.postalCode }}
                       {% endcapture %}
                       {% include "src/site/includes/directions-google-maps.liquid" with
-                        directionsLinkTitle = title
+                        directionsLinkTitle = entityLabel
                         directionsLinkAddress = fullAddress
                         directionsLinkOnClickPropName = "vet-center-facility-name"
-                        directionsLinkOnClickPropValue = title
+                        directionsLinkOnClickPropValue = entityLabel
                       %}
                     </div>
                     <h4 class="vads-u-font-size--lg vads-u-margin-top--0 vads-u-line-height--1 vads-u-margin-bottom--1">


### PR DESCRIPTION
## Description

closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12085
closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13837

- Google Maps directions links are implemented in multiple places. This adds a reusable abstraction (template) for this component.
- The links themselves needed two tweaks:
   - Visually, they now read, "Get directions on Google Maps"
   - For screen readers, they add the title of the facility that the directions are to

These changes allows consistency across the website. Previously, these were being handled in multiple ways.


## Screenshots
### VAMC-facility page:
![image](https://github.com/department-of-veterans-affairs/content-build/assets/6863534/fed4ea9b-dbc7-4d1e-b6c7-0390d941a4f4)
```
<div>
  <a href="https://maps.google.com?saddr=Current+Location&amp;daddr=113 Comanche Road, Fort Meade, SD 57741-1002" hreflang="en">
    Get directions on Google Maps <span class="sr-only">to Fort Meade VA Medical Center</span>
  </a>
</div>
```

### VAMC-region page:
![image](https://github.com/department-of-veterans-affairs/content-build/assets/6863534/3f97cd84-bd15-4de4-84d0-f7ca9ce99ed0)
```
<div>
  <a href="https://maps.google.com?saddr=Current+Location&amp;daddr=1500 East Woodrow Wilson Avenue, Jackson, MS 39216-5116" hreflang="en">
    Get directions on Google Maps <span class="sr-only">to G.V. (Sonny) Montgomery Department of Veterans Affairs Medical Center</span>
  </a>
</div>
```

### VAMC-locations-list page:
![image](https://github.com/department-of-veterans-affairs/content-build/assets/6863534/188e2e6c-ba91-414a-a80b-17cbca096fa1)
```
<div>
  <a href="https://maps.google.com?saddr=Current+Location&amp;daddr=500 East Veterans Street, Tomah, WI 54660-3105" hreflang="en">
    Get directions on Google Maps <span class="sr-only">to Tomah VA Medical Center</span>
  </a>
</div>

<div>
  <a href="https://maps.google.com?saddr=Current+Location&amp;daddr=8 Johnson Street, Owen, WI 54460-9534" hreflang="en">
    Get directions on Google Maps <span class="sr-only">to Clark County VA Clinic</span>
  </a>
</div>
```

### Vet-center page:
![image](https://github.com/department-of-veterans-affairs/content-build/assets/6863534/0c81b152-42f0-404f-b2c8-6140347802b1)
```
<div>
  <a href="https://maps.google.com?saddr=Current+Location&amp;daddr=5139 Deer Park Drive, New Port Richey, FL 34653" id="6f210ebe7570987a9ddc2d906917a874" hreflang="en">
    Get directions on Google Maps <span class="sr-only">to Pasco County Vet Center</span>
  </a>
</div>
```

### Vet-center-locations-list page:
![image](https://github.com/department-of-veterans-affairs/content-build/assets/6863534/e2c5812b-f510-4781-82f8-a08d89f8d26e)
```
<div>
  <a href="https://maps.google.com?saddr=Current+Location&amp;daddr=2114 Ben Craig Drive, Charlotte, NC 28262" id="a61388506e598f2630b759282e3e6c1a" hreflang="en">
    Get directions on Google Maps <span class="sr-only">to Charlotte Vet Center</span>
  </a>
</div>

<div>
  <a href="https://maps.google.com?saddr=Current+Location&amp;daddr=1050 Devore Lane, Matthews, NC 28105" id="680defd2ac8f15bc07ef4aaa3f4b837b" hreflang="en">
    Get directions on Google Maps <span class="sr-only">to Charlotte Vet Center - Matthews</span>
  </a>
</div>
```


## Testing done & QA steps
### VAMC pages
On review instance, visit the following pages, and on each page, follow remaining QA steps:
   - [VAMC Facility page](http://6ca49b0cac4e0c88b66e647e6099cdf5.review.vetsgov-internal/black-hills-health-care/locations/fort-meade-va-medical-center/)
   - [VAMC Region page](http://6ca49b0cac4e0c88b66e647e6099cdf5.review.vetsgov-internal/jackson-health-care/)
   - [VAMC Locations List page](http://6ca49b0cac4e0c88b66e647e6099cdf5.review.vetsgov-internal/tomah-health-care/locations/)
1. - [ ] Validate that all directions links read "Get directions on Google Maps"
2. - [ ] Inspect the directions link and validate that there is an `sr-only` element that includes the facility title
3. - [ ] Inspect the directions link and validate that an address is properly included
4. - [ ] Click the link and ensure you're taken to Google Maps _in the same tab_.

### Vet Center pages
On review instance, visit the following pages, and on each page, follow remaining QA steps:
   - [Vet Center page](http://6ca49b0cac4e0c88b66e647e6099cdf5.review.vetsgov-internal/pasco-county-vet-center/)
   - [Vet Center Locations List page](http://6ca49b0cac4e0c88b66e647e6099cdf5.review.vetsgov-internal/charlotte-vet-center/locations/)
1. - [ ] Validate that all directions links read "Get directions on Google Maps"
2. - [ ] Inspect the directions link and validate that there is an `sr-only` element that includes the facility title
3. - [ ] Inspect the directions link and validate that an address is properly included
4. - [ ] Click the link and ensure you're taken to Google Maps _in the same tab_.
5. - [ ] Return to previous page and ensure `onclick` handler works to record the click event:
       - Get ready to click the link again, but _immediately_ after clicking the link, hit the `esc` key on your keyboard.
       - In the developer tools console, type `window.dataLayer`.
       - Expand the returned object and ensure there is an object in the array with property: `event: "directions-link-click"`

## Acceptance criteria
See original tickets.
