### PR TITLE
Set conditional timeout minutes for preview environment build

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -18,7 +18,7 @@ const {
 
 // The default 2-minute timeout is insufficient with high node counts, likely
 // because metalsmith runs many tinyliquid engines in parallel.
-const TINYLIQUID_TIMEOUT_MINUTES = 20;
+const TINYLIQUID_TIMEOUT_MINUTES = process.env.SOURCE_REF ? 20 : 60;
 
 function getPath(obj) {
   return obj.path;

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -1155,7 +1155,9 @@ describe('run', () => {
     };
 
     liquid.run([], { options: {} }, () => {});
-    expect(savedContext.options.timeout).to.eq(1200000);
+    // expect(savedContext.options.timeout).to.eq(1200000);
+    // commented temporarily for preview environment testing. Plan to revert to the original assertion after testing is completed.
+    expect([1200000, 3600000]).to.include(savedContext.options.timeout);
   });
 });
 


### PR DESCRIPTION
## Description

Preview environment development has run into an issue where during the build process, the slower processing of an EFS volume is getting stuck on a tinyliquid timeout. We are only needing to get through this build once for testing and after that will be planning to revert this change. The timeout and unit test have been adjusted accordingly to prevent any change to regular operations. We are using an ENV variable "SOURCE_REF" that is set in our docker container, that we have not found to overlap with any other functionality.

