### PR TITLE
Adds certs for newer RCAs to Dockerfiles.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -44,6 +44,7 @@ ENV AWS_CA_BUNDLE /etc/ssl/certs/ca-certificates.crt
 # Add VA Root CA to Docker Certificate Authority (CA) Store so that NODE can use it for requests.
 ADD http://crl.pki.va.gov/PKI/AIA/VA/VA-Internal-S2-RCA1-v1.cer /usr/local/share/ca-certificates/
 RUN mv /usr/local/share/ca-certificates/VA-Internal-S2-RCA1-v1.cer /usr/local/share/ca-certificates/VA-Internal-S2-RCA1-v1.cer.crt
+ADD http://crl.pki.va.gov/PKI/AIA/VA/VA-Internal-S2-RCA2.cer /usr/local/share/ca-certificates/VA-Internal-S2-RCA2.cer.crt
 RUN update-ca-certificates
 # Display VA Internal certificates that are now trusted
 RUN awk -v cmd='openssl x509 -noout -subject' '/BEGIN/{close(cmd)};{print | cmd}' < /etc/ssl/certs/ca-certificates.crt | grep -i 'VA-Internal'

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ ENV AWS_CA_BUNDLE /etc/ssl/certs/ca-certificates.crt
 # Add VA Root CA to Docker Certificate Authority (CA) Store so that NODE can use it for requests.
 ADD https://raw.githubusercontent.com/department-of-veterans-affairs/platform-va-ca-certificate/main/VA-Internal-S2-RCA1-v1.cer /usr/local/share/ca-certificates/
 RUN openssl x509 -inform DER -in /usr/local/share/ca-certificates/VA-Internal-S2-RCA1-v1.cer -out /usr/local/share/ca-certificates/VA-Internal-S2-RCA1-v1.crt
+ADD https://raw.githubusercontent.com/department-of-veterans-affairs/platform-va-ca-certificate/main/VA-Internal-S2-RCA2.cer /usr/local/share/ca-certificates/VA-Internal-S2-RCA2.cer.crt
 RUN update-ca-certificates
 
 RUN mkdir -p /application/content-build


### PR DESCRIPTION
I'm not sure that this is pressing. I'm not sure the root Dockerfile is even in use. I don't know how the other one is used.

So this PR might be stupid. It's a risk I'm willing to take, to stand up for what is good and true and consistent in Dockerfiles.
