### PR TITLE
Add breadcrumbs and update URL for form 21-0972

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1433,11 +1433,22 @@
   {
     "appName": "Sign for benefits on behalf of another person",
     "entryName": "21-0972-alternate-signer",
-    "rootUrl": "/alternate-signer",
+    "rootUrl": "/supporting-forms-for-claims/alternate-signer-form-21-0972",
     "productId": "38f07696-546f-4c9a-a6f0-16348bde4d33",
     "template": {
       "vagovprod": false,
-      "layout": "page-react.html"
+      "layout": "page-react.html",
+      "includeBreadcrumbs": true,
+      "breadcrumbs_override": [
+        {
+          "name": "Supporting forms for VA claims",
+          "path": "supporting-forms-for-claims"
+        },
+        {
+          "name": "Sign for benefits on behalf of another person",
+          "path": "supporting-forms-for-claims/alternate-signer-form-21-0972"
+        }
+      ]
     }
   },
   {


### PR DESCRIPTION
## Summary

- Update route for form 21-0972 and add breadcrumbs

[devops PR](https://github.com/department-of-veterans-affairs/devops/pull/13256)
[vets-website PR](https://github.com/department-of-veterans-affairs/vets-website/pull/24959)

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/425

## What areas of the site does it impact?
Form 21-0972