### PR TITLE
testing abTestSurveyNumber

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1487,7 +1487,7 @@ module.exports = function registerFilters() {
     ) {
       return stagingSurveys[url]
         ? stagingSurveys[url]
-        : abTestSurveyNumber(11, 29);
+        : abTestSurveyNumber(11, 37);
     }
     if (buildtype === 'vagovprod') {
       return prodSurveys[url] ? prodSurveys[url] : 17;

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1476,12 +1476,18 @@ module.exports = function registerFilters() {
   };
 
   liquid.filters.getSurvey = (buildtype, url) => {
+    const abTestSurveyNumber = (num1, num2) => {
+      return Math.random() < 0.5 ? num1 : num2;
+    };
+
     if (
       buildtype === 'localhost' ||
       buildtype === 'vagovstaging' ||
       buildtype === 'vagovdev'
     ) {
-      return stagingSurveys[url] ? stagingSurveys[url] : 11;
+      return stagingSurveys[url]
+        ? stagingSurveys[url]
+        : abTestSurveyNumber(11, 29);
     }
     if (buildtype === 'vagovprod') {
       return prodSurveys[url] ? prodSurveys[url] : 17;

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1476,8 +1476,8 @@ module.exports = function registerFilters() {
   };
 
   liquid.filters.getSurvey = (buildtype, url) => {
-    const abTestSurvey = (num1, num2) => {
-      return Math.random() < 0.5 ? num1 : num2;
+    const abTestSurvey = (surveyA, surveyB) => {
+      return Math.random() < 0.5 ? surveyA : surveyB;
     };
 
     if (

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1476,7 +1476,7 @@ module.exports = function registerFilters() {
   };
 
   liquid.filters.getSurvey = (buildtype, url) => {
-    const abTestSurveyNumber = (num1, num2) => {
+    const abTestSurvey = (num1, num2) => {
       return Math.random() < 0.5 ? num1 : num2;
     };
 
@@ -1485,9 +1485,7 @@ module.exports = function registerFilters() {
       buildtype === 'vagovstaging' ||
       buildtype === 'vagovdev'
     ) {
-      return stagingSurveys[url]
-        ? stagingSurveys[url]
-        : abTestSurveyNumber(11, 37);
+      return stagingSurveys[url] ? stagingSurveys[url] : abTestSurvey(11, 37);
     }
     if (buildtype === 'vagovprod') {
       return prodSurveys[url] ? prodSurveys[url] : 17;

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -2470,14 +2470,19 @@ describe('getSurvey', () => {
       '/contact-us/virtual-agent',
     ];
     const testBuildTypes = ['vagovprod', 'vagovstaging', 'localhost'];
+    const stagingAbTest = [11, 37];
+
+    const stagingDefault = liquid.filters.getSurvey(
+      testBuildTypes[1],
+      testUrls[1],
+      stagingSurveys,
+    );
+
+    expect(stagingAbTest.includes(stagingDefault)).to.be.true;
 
     expect(
       liquid.filters.getSurvey(testBuildTypes[1], testUrls[2], stagingSurveys),
     ).to.equal(20);
-
-    expect(
-      liquid.filters.getSurvey(testBuildTypes[1], testUrls[1], stagingSurveys),
-    ).to.equal(11);
 
     expect(
       liquid.filters.getSurvey(testBuildTypes[1], testUrls[3], stagingSurveys),


### PR DESCRIPTION
## Description

This PR adds the ability to A/B test the Medallia VFS survey. When you scroll to the bottom of the main content on any page and click the FEEDBACK button, there's a 50% chance you will receive one of two Medallia surveys.
relates to [#62606](https://github.com/department-of-veterans-affairs/va.gov-team/issues/62605)

Note: These changes are for staging only to demo for stakeholders.

## Testing done & Screenshots
Tested on review instance

## QA steps

What needs to be checked to prove this works? 
Scroll to the bottom of the main content on 5-10 pages and click FEEDBACK button. Determine you receive one of two different survey modals each time. 


## Acceptance criteria

- [x] One of two Medallia surveys show up when you click FEEDBACK

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
