### PR TITLE
add new mock form for patterns

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1388,6 +1388,16 @@
     }
   },
   {
+    "appName": "Mock Form Patterns",
+    "entryName": "mock-form-patterns-v3",
+    "rootUrl": "/mock-form-patterns",
+    "productId": "46a3411a-7a98-4527-bcd8-b0cd71226bff",
+    "template": {
+      "vagovprod": false,
+      "layout": "page-react.html"
+    }
+  },
+  {
     "appName": "21-10210 Lay/Witness Statement",
     "entryName": "10210-lay-witness-statement",
     "rootUrl": "/supporting-forms-for-claims/lay-witness-statement-form-21-10210",


### PR DESCRIPTION
## Description

closes https://github.com/department-of-veterans-affairs/vets-website/pull/25089
relates to https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/287

## Testing done & Screenshots

browser testing and comparison vs mocks

![image](https://github.com/department-of-veterans-affairs/content-build/assets/123402053/398f0528-c9ab-456f-bf35-d50778466165)


## QA steps

What needs to be checked to prove this works?  
new address should work http://localhost:3001/mock-form-patterns/

What needs to be checked to prove it didn't break any related things?  
should not be activated in production

What variations of circumstances (users, actions, values) need to be checked?  


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
