### PR TITLE
VACMS-11354 Add IDs to accordions

### DIFF
--- a/src/site/facilities/facility_health_service.drupal.liquid
+++ b/src/site/facilities/facility_health_service.drupal.liquid
@@ -7,6 +7,7 @@
       data-label="{{ serviceTaxonomy.name }}"
       data-childlabel="{{ serviceTaxonomy.fieldAlsoKnownAs }}"
       data-template="facilities/facilities_health_service"
+      id="{{serviceTaxonomy.name | hashReference: 30 }}"
     >
       <h3 slot="headline">
         {{ serviceTaxonomy.name }}

--- a/src/site/facilities/health_service.drupal.liquid
+++ b/src/site/facilities/health_service.drupal.liquid
@@ -6,6 +6,7 @@
             {% endif %}
             data-label="{{ serviceTaxonomy.name }}"
             data-template="facilities/health_service"
+            id="{{serviceTaxonomy.name | hashReference: 30 }}"
         >
             <h3 slot="headline">
                 {{ serviceTaxonomy.name }}

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -466,6 +466,7 @@
                     header="{{ faqParagraph.entity.fieldQuestion }}"
                     level="3"
                     data-faq-entity-id="{{ faqParagraph.entity.entityId }}"
+                    id="{{ faqParagraph.entity.fieldQuestion | hashReference: 30 }}"
                   >
                     {% assign fieldAnswer = faqParagraph.entity.fieldAnswer | first %}
                     {% assign bundleComponent = "src/site/paragraphs/" | append: fieldAnswer.entity.entityBundle %}

--- a/src/site/layouts/faq_multiple_q_a.drupal.liquid
+++ b/src/site/layouts/faq_multiple_q_a.drupal.liquid
@@ -77,6 +77,7 @@
                     {% if fieldQA.entity %}
                       <va-accordion-item
                         data-faq-entity-id="{{ fieldQA.entity.entityId }}"
+                        id="{{ fieldQA.entity.title | hashReference: 30 }}"
                       >
                         <h3 slot="headline">
                           {{ fieldQA.entity.title }}

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -160,6 +160,7 @@
                     header="{{ item.fieldTitle }}"
                     level="3"
                     data-label="{{ item.fieldTitle }}"
+                    id="{{ item.fieldTitle | hashReference: 30 }}"
                   >
                     <div id="{{ item.entityBundle }}-{{ item.entityId }}">
                       {% include "src/site/paragraphs/wysiwyg.drupal.liquid" entity = item %}

--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -62,7 +62,7 @@
         {% endif %}
 
         <va-accordion bordered multi>
-          <va-accordion-item level="2" open="true" header="Ask questions">
+          <va-accordion-item level="2" open="true" header="Ask questions" id="{{ 'Message us' | hashReference: 30 }}">
             <section>
               <h3 class="vads-u-font-size--h4">Message us</h3>
               <ul class="va-nav-linkslist-list social">
@@ -108,7 +108,7 @@
           </va-accordion-item>
 
           {% if fieldLinks != empty and fieldLinks.length > 0 %}
-            <va-accordion-item level="2" open="true" header="Not a Veteran?">
+            <va-accordion-item level="2" open="true" header="Not a Veteran?" id="{{ 'Get information for' | hashReference: 30 }}">
               <section>
                 <h3 class="vads-u-font-size--h4">Get information for:</h3>
                 <ul class="va-nav-linkslist-list links">
@@ -126,7 +126,7 @@
 
         <!-- Connect with us -->
         {% if fieldRelatedOffice != empty and fieldRelatedOffice.entity.fieldExternalLink.title != "Records benefits hub" %}
-            <va-accordion-item level="2" header="Connect with us" open="true">
+            <va-accordion-item level="2" header="Connect with us" open="true" id="{{ fieldRelatedOffice.entity.fieldExternalLink.title | hashReference: 30 }}">
               {% if fieldRelatedOffice.entity.fieldExternalLink.url.path != empty %}
                 <h3 class="va-nav-linkslist-list vads-u-font-size--h4">
                   <a class="vads-u-text-decoration--underline" href="{{ fieldRelatedOffice.entity.fieldExternalLink.url.path }}" onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });">

--- a/src/site/paragraphs/q_a.collapsible_panel.drupal.liquid
+++ b/src/site/paragraphs/q_a.collapsible_panel.drupal.liquid
@@ -10,6 +10,7 @@
 
       <va-accordion-item
         header="{{ item.fieldQuestion }}"
+        id="{{ item.fieldQuestion | hashReference: 30 }}"
         {% if level %}
           level="{{ level }}"
           {% else %}


### PR DESCRIPTION
## Description
Ticket: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11354

When linking to an accordion using a fragment (e.g. `/health-care#what-are-my-benefit-options`), the page was not jumping to the correct content and opening the accordion. This was partly due to a Design System bug that is now fixed; the accordion was missing the `open` property when this scenario happened. But the reason the page wasn't jumping was because the `<va-accordion-item>`s were not labeled with the correct IDs.

## Testing done & Screenshots
`campaign_landing_page.drupal.liquid`
`health_care_local_facility.drupal.liquid`
`landing_page.drupal.liquid`
`faq_multiple_q_a.drupal.liquid`
`q_a.collapsible_panel.drupal.liquid`

<img width="1131" alt="Screenshot 2023-08-03 at 12 58 47 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/d795b983-662a-40a7-a03f-c85484f27c47">
<img width="1132" alt="Screenshot 2023-08-03 at 12 45 08 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/b7e93e3f-9feb-44a8-a921-4bd384ce5bb5">
<img width="1132" alt="Screenshot 2023-08-03 at 12 37 30 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/8cc005f1-6ba9-41c4-b98e-6a55742259f6">
<img width="1134" alt="Screenshot 2023-08-03 at 12 36 10 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/bf0231b3-db0f-4059-81d6-d8460ed05372">
<img width="1133" alt="Screenshot 2023-08-03 at 1 56 56 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/a8c0daee-0df1-40da-a61d-80ff467bff32">



## QA steps

What needs to be checked to prove this works?  Go to a page that uses one of these templates, copy an ID off the `va-accordion-item`, and go to the URL with that appended (with a `#`), and make sure it jumps to the accordion and opens it.

## Acceptance criteria
- [ ] Audit codebase for templates that render accordions, note which do not have ids
- [ ] All templates from audit open when url includes the appropriate fragment