### PR TITLE
VACMS-14670: Fix centralized content Alert and Expander Text 

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -811,11 +811,30 @@ module.exports = function registerFilters() {
 
     // Converts all complex key/value pairs in obj to simple strings
     // e.g. key: [{ value: 'foo' }] => key: 'foo'
-    const flattenArrayValues = obj => {
+    // Recursion is used to flatten pairs in entity objects deeper in the data
+    const flattenArrayValues = (obj, flattenContentType) => {
+      const isEntityArray = a => {
+        const uniqKeyValues = a.filter((item, pos) => a.indexOf(item) === pos);
+        return uniqKeyValues.length === 1 && uniqKeyValues[0] === 'entity';
+      };
+
       const newObj = {};
       for (const [key] of Object.entries(obj)) {
-        if (Array.isArray(obj[key]) && obj[key][0]?.value) {
+        if (
+          Array.isArray(obj[key]) &&
+          obj[key][0]?.value &&
+          (Object.keys(obj[key][0]).length === 1 ||
+            flattenContentType === 'react_widget')
+        ) {
           newObj[key] = obj[key][0].value;
+        } else if (
+          Array.isArray(obj[key]) &&
+          isEntityArray(obj[key].map(objKey => Object.keys(objKey)[0]))
+        ) {
+          // Recursively flattens nested entity arrays
+          newObj[key] = obj[key].map(nestedObj => {
+            return { entity: flattenArrayValues(nestedObj.entity) };
+          });
         } else {
           newObj[key] = obj[key];
         }
@@ -867,7 +886,7 @@ module.exports = function registerFilters() {
         };
       }
       case 'react_widget': {
-        const normalizedData = flattenArrayValues(entity);
+        const normalizedData = flattenArrayValues(entity, 'react_widget');
         if (!normalizedData.fieldErrorMessage.value) {
           return {
             ...normalizedData,

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -1685,6 +1685,61 @@ describe('processCentralizedContent', () => {
                   ],
                 },
               },
+              {
+                entity: {
+                  targetId: '135322',
+                  targetRevisionId: '1025879',
+                  entityType: 'paragraph',
+                  entityBundle: 'alert',
+                  pid: '135322',
+                  label:
+                    'National Vet Center content > Content > Questions > Answer',
+                  status: true,
+                  langcode: 'en',
+                  fieldAlertBlockReference: [],
+                  fieldAlertHeading: [
+                    {
+                      value:
+                        'What are the covered educational assistance benefits?',
+                    },
+                  ],
+                  fieldAlertType: [
+                    {
+                      value: 'information',
+                    },
+                  ],
+                  fieldVaParagraphs: [
+                    {
+                      entity: {
+                        targetId: '135321',
+                        targetRevisionId: '1025878',
+                        entityType: 'paragraph',
+                        entityBundle: 'expandable_text',
+                        pid: '135321',
+                        label:
+                          'National Vet Center content > Content > Questions > Answer > Alert content',
+                        status: true,
+                        langcode: 'en',
+                        fieldTextExpander: [
+                          {
+                            value:
+                              'What are the covered educational assistance benefits?',
+                          },
+                        ],
+                        fieldWysiwyg: [
+                          {
+                            value:
+                              '<p>The covered educational assistance benefits are benefits from any of these programs:&nbsp;</p>\r\n\r\n<ul>\r\n\t<li>Montgomery GI Bill Active Duty</li>\r\n\t<li>Montgomery GI Bill Selected Reserve</li>\r\n\t<li>Post-9/11 GI Bill</li>\r\n\t<li>Reserve Educational Assistance Program (REAP)</li>\r\n\t<li>Veteran Rapid Retraining Assistance Program (VRRAP)</li>\r\n\t<li>Veteran Readiness and Employment (VR&amp;E)</li>\r\n\t<li>Veterans’ Educational Assistance Program (VEAP)</li>\r\n\t<li>Veteran Employment Through Technology Education Courses (VET TEC)</li>\r\n</ul>\r\n',
+                            format: 'rich_text',
+                            processed:
+                              '<html><head></head><body><p>The covered educational assistance benefits are benefits from any of these programs:&#xA0;</p>\n\n<ul><li>Montgomery GI Bill Active Duty</li>\n\t<li>Montgomery GI Bill Selected Reserve</li>\n\t<li>Post-9/11 GI Bill</li>\n\t<li>Reserve Educational Assistance Program (REAP)</li>\n\t<li>Veteran Rapid Retraining Assistance Program (VRRAP)</li>\n\t<li>Veteran Readiness and Employment (VR&amp;E)</li>\n\t<li>Veterans&#x2019; Educational Assistance Program (VEAP)</li>\n\t<li>Veteran Employment Through Technology Education Courses (VET TEC)</li>\n</ul></body></html>',
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
             ],
             fieldQuestion: [
               {
@@ -1727,6 +1782,49 @@ describe('processCentralizedContent', () => {
                       format: 'rich_text_limited',
                       processed:
                         "<p>Vet Centers are small, non-medical, counseling centers conveniently located in your community. They're staffed by highly trained counselors and team members dedicated to seeing you through the challenges that come with managing life during and after the military.</p>\n<p>Whether you come in for one-on-one counseling or to participate in a group session, at Vet Centers you can form social connections, try new things, and build a support system with people who understand you and want to help you succeed.</p>\n",
+                    },
+                  ],
+                },
+              },
+              {
+                entity: {
+                  targetId: '135322',
+                  targetRevisionId: '1025879',
+                  entityType: 'paragraph',
+                  entityBundle: 'alert',
+                  pid: '135322',
+                  label:
+                    'National Vet Center content > Content > Questions > Answer',
+                  status: true,
+                  langcode: 'en',
+                  fieldAlertBlockReference: [],
+                  fieldAlertHeading:
+                    'What are the covered educational assistance benefits?',
+                  fieldAlertType: 'information',
+                  fieldVaParagraphs: [
+                    {
+                      entity: {
+                        targetId: '135321',
+                        targetRevisionId: '1025878',
+                        entityType: 'paragraph',
+                        entityBundle: 'expandable_text',
+                        pid: '135321',
+                        label:
+                          'National Vet Center content > Content > Questions > Answer > Alert content',
+                        status: true,
+                        langcode: 'en',
+                        fieldTextExpander:
+                          'What are the covered educational assistance benefits?',
+                        fieldWysiwyg: [
+                          {
+                            value:
+                              '<p>The covered educational assistance benefits are benefits from any of these programs:&nbsp;</p>\r\n\r\n<ul>\r\n\t<li>Montgomery GI Bill Active Duty</li>\r\n\t<li>Montgomery GI Bill Selected Reserve</li>\r\n\t<li>Post-9/11 GI Bill</li>\r\n\t<li>Reserve Educational Assistance Program (REAP)</li>\r\n\t<li>Veteran Rapid Retraining Assistance Program (VRRAP)</li>\r\n\t<li>Veteran Readiness and Employment (VR&amp;E)</li>\r\n\t<li>Veterans’ Educational Assistance Program (VEAP)</li>\r\n\t<li>Veteran Employment Through Technology Education Courses (VET TEC)</li>\r\n</ul>\r\n',
+                            format: 'rich_text',
+                            processed:
+                              '<html><head></head><body><p>The covered educational assistance benefits are benefits from any of these programs:&#xA0;</p>\n\n<ul><li>Montgomery GI Bill Active Duty</li>\n\t<li>Montgomery GI Bill Selected Reserve</li>\n\t<li>Post-9/11 GI Bill</li>\n\t<li>Reserve Educational Assistance Program (REAP)</li>\n\t<li>Veteran Rapid Retraining Assistance Program (VRRAP)</li>\n\t<li>Veteran Readiness and Employment (VR&amp;E)</li>\n\t<li>Veterans&#x2019; Educational Assistance Program (VEAP)</li>\n\t<li>Veteran Employment Through Technology Education Courses (VET TEC)</li>\n</ul></body></html>',
+                          },
+                        ],
+                      },
                     },
                   ],
                 },

--- a/src/site/layouts/basic_landing_page.drupal.liquid
+++ b/src/site/layouts/basic_landing_page.drupal.liquid
@@ -42,17 +42,19 @@
       </div>
 
       <!-- Content blocks -->
-      <article class="vads-u-padding-bottom--4">
-        {% for block in fieldContentBlock %}
-          {% if block.entity.entityBundle == 'lists_of_links' and block.entity.fieldSectionHeader == 'Browse by audience' %}
-            {% include 'src/site/components/browse-by-audience.drupal.liquid' %}
-          {% else %}
-              {% assign bundleComponent = "src/site/paragraphs/" | append: block.entity.entityBundle %}
-              {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
-              {% include {{ bundleComponentWithExtension }} with entity = block.entity %}
-          {% endif %}
+      <article class="usa-width-three-fourths vads-u-padding-bottom--4">
+        <div class="usa-content">
+          {% for block in fieldContentBlock %}
+            {% if block.entity.entityBundle == 'lists_of_links' and block.entity.fieldSectionHeader == 'Browse by audience' %}
+              {% include 'src/site/components/browse-by-audience.drupal.liquid' %}
+            {% else %}
+                {% assign bundleComponent = "src/site/paragraphs/" | append: block.entity.entityBundle %}
+                {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
+                {% include {{ bundleComponentWithExtension }} with entity = block.entity %}
+            {% endif %}
 
-        {% endfor %}
+          {% endfor %}
+        </div>
       </article>
 
       <div class="usa-width-three-fourths">

--- a/src/site/paragraphs/alert.drupal.liquid
+++ b/src/site/paragraphs/alert.drupal.liquid
@@ -28,7 +28,7 @@
   {% assign alertType = "info" %}
 {% endif %}
 
-{% if entity.fieldAlertBlockReference.length > 0 %}
+{% if entity.fieldAlertBlockReference.length > 0 or entity.fieldAlertBlockReference.entity %}
   {% assign alertBlock = entity.fieldAlertBlockReference.entity %}
   {% include "src/site/blocks/alert.drupal.liquid" with alert = alertBlock %}
 <!-- hide ghost alerts -->

--- a/src/site/paragraphs/alert.drupal.liquid
+++ b/src/site/paragraphs/alert.drupal.liquid
@@ -28,11 +28,11 @@
   {% assign alertType = "info" %}
 {% endif %}
 
-{% if entity.fieldAlertBlockReference != empty %}
+{% if entity.fieldAlertBlockReference.length > 0 %}
   {% assign alertBlock = entity.fieldAlertBlockReference.entity %}
   {% include "src/site/blocks/alert.drupal.liquid" with alert = alertBlock %}
 <!-- hide ghost alerts -->
-{% elsif entity.fieldAlertHeading != empty and entity.fieldVaParagraphs != empty %}
+{% elsif entity.fieldAlertHeading.length > 0 and entity.fieldVaParagraphs.length > 0 %}
   <va-alert date-template="paragraphs/alert" data-entity-id="{{ entity.entityId }}" status="{{ alertType }}" class="vads-u-margin-top--3" role="alert">
     <h2 slot="headline" class="vads-u-font-size--h3">
       {{ entity.fieldAlertHeading }}
@@ -44,4 +44,3 @@
     {% endfor %}
   </va-alert>
 {% endif %}
-

--- a/src/site/paragraphs/expandable_text.drupal.liquid
+++ b/src/site/paragraphs/expandable_text.drupal.liquid
@@ -16,7 +16,13 @@ Example data:
         <div class="additional-info-title">{{ entity.fieldTextExpander }}</div>
 
         {% if entity.fieldWysiwyg %}
-            <div class="additional-info-content usa-alert-text" hidden>{{ entity.fieldWysiwyg.processed }}</div>
+            <div class="additional-info-content usa-alert-text" hidden>
+                {% if entity.fieldWysiwyg.processed %}
+                    {{ entity.fieldWysiwyg.processed }}
+                {% elsif entity.fieldWysiwyg.0.processed %}
+                    {{ entity.fieldWysiwyg.0.processed }}
+                {% endif %}
+            </div>
         {% endif %}
     </div>
 {% endif %}


### PR DESCRIPTION
## Description

The Vet Center centralized content alert and expandable text content aren't rendering the content from the CMS properly. These changes to the front-end template should get the content rendering properly.

relates to [#14647](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14647)

## Testing done & Screenshots

#### With Errors

<img width="714" alt="Screen Shot 2023-08-08 at 10 38 42 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10790736/0b4e4522-733a-4330-9e57-7d3edba53703">

#### Without Errors

<img width="836" alt="Screen Shot 2023-08-11 at 12 11 42 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10790736/11a3487e-d3d1-4af7-ac53-9945720a7885">

## QA steps

**What needs to be checked to prove this works?** That the alert and expandable text render properly with the expected content.
**What needs to be checked to prove it didn't break any related things?** The entire page where this content is rendered.  
**What variations of circumstances (users, actions, values) need to be checked?** None 

### Check Centralized Content
1. Go to the [White Oak Vet Center page](https://web-spvbjheoe12isfu1maky120fjrnm7ivg.demo.cms.va.gov/brooklyn-vet-center/) and check that the alert and expansion content renders properly (2nd dropdown in FAQ section Click "Am I eligible for Vet Center services as a Veteran?" to expand).
   - [x] Validate that the content renders  as a blue alert properly
   
![image](https://github.com/department-of-veterans-affairs/content-build/assets/5752113/65b0bc96-84ea-4b12-b5de-68ac422c03f6)

   - [x] validate that the alert can be expanded
   
![image](https://github.com/department-of-veterans-affairs/content-build/assets/5752113/77a665a7-8abc-4d69-b448-66d6f6eca4ce)

2. Check that other Centralized Content on Vet Center is unaffected Links: [PR](https://web-spvbjheoe12isfu1maky120fjrnm7ivg.demo.cms.va.gov/brooklyn-vet-center/) -> [Prod](https://www.va.gov/brooklyn-vet-center/)
   - [x] Validate that the content and display of the expanded content on PR and Prod match
4. Check Centralized content on VAMC policy page is unaffected Links: [PR](https://web-spvbjheoe12isfu1maky120fjrnm7ivg.demo.cms.va.gov/black-hills-health-care/policies/) -> [Prod](https://www.va.gov/black-hills-health-care/policies/)
    - [x] Validate that PR and Prod match
5. Check Centralized content on VAMC medical records page is unaffected Links: [PR](https://web-spvbjheoe12isfu1maky120fjrnm7ivg.demo.cms.va.gov/black-hills-health-care/medical-records-office/) -> [Prod](https://www.va.gov/black-hills-health-care/medical-records-office/)
   - [x] Validate that PR and Prod match
6. Check Centralized content on VAMC register for care page is unaffected Links: [PR](https://web-spvbjheoe12isfu1maky120fjrnm7ivg.demo.cms.va.gov/black-hills-health-care/register-for-care/) -> [Prod](https://www.va.gov/black-hills-health-care/register-for-care/)
   - [x] Validate that PR and Prod match
7. Check Centralized content on VAMC billing and insurance page is unaffected Links: [PR](https://web-spvbjheoe12isfu1maky120fjrnm7ivg.demo.cms.va.gov/black-hills-health-care/billing-and-insurance/) -> [Prod](https://www.va.gov/black-hills-health-care/billing-and-insurance/)
    - [x] Validate that PR and Prod match
### Check Alerts
8. Check a page that has an alert that is NOT coming from centralized content and is a reusable alert  [CMS](https://prod.cms.va.gov/education/other-va-education-benefits)  -> [PR](https://web-spvbjheoe12isfu1maky120fjrnm7ivg.demo.cms.va.gov/education/other-va-education-benefits/) -> [Prod](https://www.va.gov/education/other-va-education-benefits/)
   - [x] Validate that PR and Prod match for the appearance of the light blue alert block for "The Veteran Rapid Retraining Assistance Program (VRRAP) has closed"
9. Check a page that has an alert that is NOT coming from centralized content and is NOT reusuable (comes with its own heading and text)  CMS  -> [PR](https://web-spvbjheoe12isfu1maky120fjrnm7ivg.demo.cms.va.gov/disability/eligibility/hazardous-materials-exposure/agent-orange/) -> [Prod](https://www.va.gov/disability/eligibility/hazardous-materials-exposure/agent-orange/) 
    - [x] Validate that PR and Prod match for the light blue alert titled "New PACT Act-related presumptive conditions and locations"


## Acceptance criteria

- [x] All QA steps pass
- [x] No other elements in the page render improperly

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
