### PR TITLE
Transitions the Lovell VA/TRICARE banner switcher from info->warning status

### DIFF
--- a/src/site/includes/lovell-switch-link.drupal.liquid
+++ b/src/site/includes/lovell-switch-link.drupal.liquid
@@ -7,7 +7,7 @@
     {% assign switchPageVariation = "VA" %}
   {% endif %}
 
-  <va-alert status="info" class="vads-u-margin-bottom--2" id="va-info-alert">
+  <va-alert status="warning" class="vads-u-margin-bottom--2" id="va-info-alert">
     <div class="vads-u-margin-top--0">
       <strong>You are viewing this page as a {{ currentPageVariation }} beneficiary.</strong> <a href="{{ entityUrl.switchPath }}">View this page as a {{ switchPageVariation }} beneficiary <i aria-hidden="true" class="fas fa-angle-right"></i></a>
     </div>


### PR DESCRIPTION
## Description
This PR makes the info banner conform to the desired warning style banner for the Lovell liquid  switch link.

closes #14479

## Testing done & Screenshots

old:
<img width="969" alt="Screenshot 2023-08-08 at 12 11 38 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/e4a954f9-7f38-4521-96a2-c8a76cd5b78a">

new "warning":
<img width="962" alt="Screenshot 2023-08-08 at 12 13 55 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/12bf9283-8508-4325-87e6-907273db1070">

new "warning" as VA beneficiary
<img width="961" alt="Screenshot 2023-08-08 at 12 18 45 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/a60c6ed5-9317-44f1-91c7-988c82e31599">


## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

1. Do this
   - [ ] Validate that when navigating to any [Lovell page on localhost](http://localhost:3002/lovell-federal-health-care-tricare).
2. Then
   - [ ] Validate that you see the first image's banner with the warning icon, color, and text. 
3. Then validate Acceptance Criteria from issue

## Acceptance criteria

- [ ] I expect that the switch link on [Lovell pages](https://www.va.gov/lovell-federal-health-care-tricare/) on Production uses the [warning alert style](https://design.va.gov/components/alert#warning-alert) (in font, styling, color, and iconography)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
