### PR TITLE
add mock form for header testing

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1450,6 +1450,16 @@
     }
   },
   {
+    "appName": "Mock Form - Alternate header - 21-0845 Authorization to Disclose Personal Information to a Third Party",
+    "entryName": "mock-alternate-header-0845",
+    "rootUrl": "/authorization-to-disclose-alternate",
+    "productId": "f1075156-0d85-4a0e-bce6-3f053b6243b5",
+    "template": {
+      "vagovprod": false,
+      "layout": "page-react.html"
+    }
+  },
+  {
     "appName": "Sign for benefits on behalf of another person",
     "entryName": "21-0972-alternate-signer",
     "rootUrl": "/supporting-forms-for-claims/alternate-signer-form-21-0972",


### PR DESCRIPTION
## Description

closes https://github.com/department-of-veterans-affairs/vets-website/pull/25140
relates to https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/455
relates to https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/435

## Testing done & Screenshots

![image](https://github.com/department-of-veterans-affairs/content-build/assets/123402053/bdddac61-af54-4498-a36e-6cb42172eb99)


## QA steps

This should be checked in first: https://github.com/department-of-veterans-affairs/vets-website/pull/25140
yarn watch on the entry of this form should bring up the respective form app
