### PR TITLE
Medallia - Add A/B test for rating scale in production surveys

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1487,8 +1487,9 @@ module.exports = function registerFilters() {
     ) {
       return stagingSurveys[url] ? stagingSurveys[url] : abTestSurvey(11, 37);
     }
+
     if (buildtype === 'vagovprod') {
-      return prodSurveys[url] ? prodSurveys[url] : 17;
+      return prodSurveys[url] ? prodSurveys[url] : abTestSurvey(17, 39);
     }
     return null;
   };

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -2471,7 +2471,9 @@ describe('getSurvey', () => {
     ];
     const testBuildTypes = ['vagovprod', 'vagovstaging', 'localhost'];
     const stagingAbTest = [11, 37];
+    const prodAbTest = [17, 39];
 
+    // Staging survey tests
     const stagingDefault = liquid.filters.getSurvey(
       testBuildTypes[1],
       testUrls[1],
@@ -2479,6 +2481,8 @@ describe('getSurvey', () => {
     );
 
     expect(stagingAbTest.includes(stagingDefault)).to.be.true;
+
+    expect(prodAbTest.includes(stagingDefault)).to.be.false;
 
     expect(
       liquid.filters.getSurvey(testBuildTypes[1], testUrls[2], stagingSurveys),
@@ -2488,6 +2492,17 @@ describe('getSurvey', () => {
       liquid.filters.getSurvey(testBuildTypes[1], testUrls[3], stagingSurveys),
     ).to.equal(26);
 
+    // Prod survey tests
+    const prodDefault = liquid.filters.getSurvey(
+      testBuildTypes[0],
+      testUrls[1],
+      prodSurveys,
+    );
+
+    expect(prodAbTest.includes(prodDefault)).to.be.true;
+
+    expect(stagingAbTest.includes(prodDefault)).to.be.false;
+
     expect(
       liquid.filters.getSurvey(testBuildTypes[0], testUrls[2], prodSurveys),
     ).to.equal(21);
@@ -2495,10 +2510,6 @@ describe('getSurvey', () => {
     expect(
       liquid.filters.getSurvey(testBuildTypes[0], testUrls[3], prodSurveys),
     ).to.equal(25);
-
-    expect(
-      liquid.filters.getSurvey(testBuildTypes[0], testUrls[1], prodSurveys),
-    ).to.equal(17);
   });
 });
 


### PR DESCRIPTION
## Description

This PR adds the ability to A/B test the Medallia VFS survey on production. When you scroll to the bottom of the main content on any page and click the FEEDBACK button, there's a 50% chance you will receive one of two Medallia surveys.
relates to [#62606](https://github.com/department-of-veterans-affairs/va.gov-team/issues/62605)

## Testing done & Screenshots
Updated unit tests.

## QA steps

What needs to be checked to prove this works?  
Scroll to the bottom of the main content on 5-10 pages and click FEEDBACK button. Determine you receive one of two different survey modals each time. 

## Acceptance criteria

- [x] One of two Medallia surveys show up when you click FEEDBACK

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
