### PR TITLE
VACMS-14747 Fix duplicate ID issue on va-accordion-item

### DIFF
--- a/src/site/stages/build/plugins/modify-dom/add-id-to-subheadings.js
+++ b/src/site/stages/build/plugins/modify-dom/add-id-to-subheadings.js
@@ -46,11 +46,18 @@ module.exports = {
         const heading = dom(el);
         const parent = heading.parents();
         const isInAccordionButton = parent.hasClass('usa-accordion-button');
+        const isInAccordionItem = dom('va-accordion-item [slot="headline"]');
+
         const isInAlert = parent.hasClass('usa-alert-body');
 
         // skip heading if it already has an id
         // skip heading if it's in an accordion button or an alert
-        if (!heading.attr('id') && !isInAccordionButton && !isInAlert) {
+        if (
+          !heading.attr('id') &&
+          !isInAccordionButton &&
+          !isInAlert &&
+          !isInAccordionItem
+        ) {
           const headingID = createUniqueId(heading, headingOptions);
           heading.attr('id', headingID);
           idAdded = true;


### PR DESCRIPTION
## Description

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14747

When we added unique IDs to `va-accordion-item`s for linking to fragments (i.e. `/resources/the-pact-act-and-your-va-benefits/#can-i-apply-now`), it created a duplicate ID issue. The `h3`s inside of the `va-accordion-item` were automatically getting IDs assigned by `add-id-to-subheadings.js`.

Since we do not need IDs on the `h3`s inside `va-accordion-item`s, this code removes that automatic ID addition.

## Testing done & Screenshots

Before, in production
<br/>
<img width="590" alt="Screenshot 2023-08-14 at 9 27 00 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/a1cc7fc8-d8de-4258-9901-fbfa66ec26e2">

<br/>
After
<br/>
<img width="591" alt="Screenshot 2023-08-14 at 9 26 37 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/bc4d2b68-f7fc-45aa-ad8b-81950255a494">

## QA steps
1. Go to one of the URLs below
2. Inspect one of the accordions
3. Note the ID value on the `va-accordion-item`
4. Inspect the `h3` (may or may not have `slot="headline"`) in the `va-accordion-item`
5. Note the `h3` (with or without `slot="headline"`) should not have an ID assigned to it

```
facility_health_service
/durham-health-care/locations/durham-va-medical-center/?_ga=2.234279389.2136479616.1692026339-137499793.1687529688

vet_centers/services
/boston-vet-center

campaign_landing_page
/initiatives/sign-in-securely-with-logingov

faq_multiple_q_a
/resources/connected-apps-faqs/

health_care_local_facility
/tennessee-valley-health-care/locations/nashville-va-medical-center/

landing_page
/decision-reviews/

vet_center
/boston-vet-center/

health_service
/durham-health-care/health-services/ 

collapsible_panel
/health-care/covid-19-vaccine/

q_a.collapsible_panel
/health-care/eligibility/ 
```