### PR TITLE
VACMS-13147 Resources and Support breadcrumbs fix

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -921,7 +921,7 @@
         },
         {
           "path": "resources/search",
-          "name": "Search results"
+          "name": "Resources and Support Search Results"
         }
       ]
     }


### PR DESCRIPTION
## Description

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13147

The breadcrumbs on the Resources & Support search results should match the `h1`.

## Testing done & Screenshots

Before
<img width="735" alt="Screenshot 2023-08-14 at 12 20 29 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/652bf033-8347-481c-a854-61542115684b">

After
<img width="717" alt="Screenshot 2023-08-14 at 12 20 33 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/0096407d-bfc0-4525-a493-ba4c8e2ee2e3">

## QA steps
1. Go to `/resources/search/?query=disability`
2. Validate that the Breadcrumbs match the **After** screenshot from above.

## Acceptance criteria
- [x] Breadcrumbs for Resources and support matches respective h1