### PR TITLE
VACMS-10944 Add Reusuable QAs to benefit detail pages

### DIFF
--- a/src/site/layouts/page.drupal.liquid
+++ b/src/site/layouts/page.drupal.liquid
@@ -50,9 +50,13 @@
           {% endif %}
 
           {% for block in fieldContentBlock %}
+            {% if block.entity.entityBundle == "q_a_group" %}
+            {% include "src/site/paragraphs/q_a_group_content.drupal.liquid" with entity = block.entity %}
+          {% else %}
             {% assign bundleComponent = "src/site/paragraphs/" | append: block.entity.entityBundle %}
             {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
             {% include {{ bundleComponentWithExtension }} with entity = block.entity %}
+          {% endif %}  
           {% endfor %}
           {% if fieldRelatedLinks != empty %}
             <div class="row">


### PR DESCRIPTION
## Description
Add new QA group content component to be used in benefit detail pages

## Testing done & Screenshots



## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue


## Acceptance criteria

- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
