### PR TITLE
VACMS-14729 Add PACT Act to application registry

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1543,5 +1543,16 @@
       "vagovprod": false,
       "layout": "page-react.html"
     }
+  },
+  {
+    "appName": "PACT Act",
+    "entryName": "pact-act",
+    "rootUrl": "/test/pact-act",
+    "template": {
+      "title": "PACT Act",
+      "layout": "page-react.html",
+      "description": "PACT Act application",
+      "vagovprod": false
+    }
   }
 ]


### PR DESCRIPTION
## Description
Add PACT Act wizard to the application registry.

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14729

### Acceptance Criteria
- [x] This URL is hidden from production visibility using the app registry in content-build [like we did for Income Limits](https://github.com/department-of-veterans-affairs/content-build/blob/7c7a8984b85ce900e0f98393be07216e4562b0b5/src/applications/registry.json#L1439)