### PR TITLE
VACMS-14814: Add new functionality for QA groups to allow for accordions

### DIFF
--- a/src/site/layouts/faq_multiple_q_a.drupal.liquid
+++ b/src/site/layouts/faq_multiple_q_a.drupal.liquid
@@ -71,7 +71,7 @@
               {% endif %}
 
               {% if fieldQAGroup.entity.fieldAccordionDisplay %}
-                <va-accordion bordered>
+                <va-accordion>
                 {% assign groupId = fieldQAGroup.entity.entityId %}
                   {% for fieldQA in fieldQAGroup.entity.fieldQAs %}
                     {% if fieldQA.entity %}

--- a/src/site/layouts/page.drupal.liquid
+++ b/src/site/layouts/page.drupal.liquid
@@ -51,12 +51,16 @@
 
           {% for block in fieldContentBlock %}
             {% if block.entity.entityBundle == "q_a_group" %}
-            {% include "src/site/paragraphs/q_a_group_content.drupal.liquid" with entity = block.entity %}
-          {% else %}
-            {% assign bundleComponent = "src/site/paragraphs/" | append: block.entity.entityBundle %}
-            {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
-            {% include {{ bundleComponentWithExtension }} with entity = block.entity %}
-          {% endif %}  
+              {% if block.entity.fieldAccordionDisplay %}
+                {% include "src/site/paragraphs/q_a_group_collapsible_content.drupal.liquid" with entity = block.entity %}
+              {% else %}
+                {% include "src/site/paragraphs/q_a_group_content.drupal.liquid" with entity = block.entity %}
+              {% endif %}  
+            {% else %}
+              {% assign bundleComponent = "src/site/paragraphs/" | append: block.entity.entityBundle %}
+              {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
+              {% include {{ bundleComponentWithExtension }} with entity = block.entity %}
+            {% endif %}  
           {% endfor %}
           {% if fieldRelatedLinks != empty %}
             <div class="row">

--- a/src/site/layouts/support_resources_detail_page.drupal.liquid
+++ b/src/site/layouts/support_resources_detail_page.drupal.liquid
@@ -46,7 +46,11 @@
             <!-- Content blocks -->
             {% for block in fieldContentBlock %}
               {% if block.entity.entityBundle == "q_a_group" %}
-                {% include "src/site/paragraphs/q_a_group_content.drupal.liquid" with entity = block.entity %}
+                {% if block.entity.fieldAccordionDisplay %}
+                  {% include "src/site/paragraphs/q_a_group_collapsible_content.drupal.liquid" with entity = block.entity %}
+                {% else %}
+                  {% include "src/site/paragraphs/q_a_group_content.drupal.liquid" with entity = block.entity %}
+                {% endif %}
               {% else %}
                 {% assign bundleComponent = "src/site/paragraphs/" | append: block.entity.entityBundle %}
                 {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}

--- a/src/site/paragraphs/q_a.collapsible_panel.drupal.liquid
+++ b/src/site/paragraphs/q_a.collapsible_panel.drupal.liquid
@@ -1,6 +1,6 @@
 <div data-template="paragraphs/q_a.collapsible_panel">
   <va-accordion>
-
+    
     {% assign questions = entity.fieldQuestions %}
     {% assign sectionHeader = entity.fieldSectionHeader %}
 
@@ -12,16 +12,18 @@
         header="{{ item.fieldQuestion }}"
         id="{{ item.fieldQuestion | hashReference: 30 }}"
         {% if level %}
-        level="{{ level }}"
-        {% else %}
-        level=3
-        {% endif %}>
+          level="{{ level }}"
+          {% else %}
+          level=3
+        {% endif %}
+      >
         <div
           id={{ id }}
           data-template="paragraphs/q_a.collapsible_panel__qa"
           data-entity-id="{{ id }}"
           data-analytics-faq-section="{{ sectionHeader | escape }}"
-          data-analytics-faq-text="{{ item.fieldQuestion | escape }}">
+          data-analytics-faq-text="{{ item.fieldQuestion | escape }}"
+        >
           <div id="{{ item.entityBundle }}-{{ id }}">
             {% for answer in item.fieldAnswer %}
               {% assign bundleComponent = "src/site/paragraphs/" | append: answer.entity.entityBundle | append: ".drupal.liquid" %}

--- a/src/site/paragraphs/q_a.collapsible_panel.drupal.liquid
+++ b/src/site/paragraphs/q_a.collapsible_panel.drupal.liquid
@@ -1,6 +1,6 @@
 <div data-template="paragraphs/q_a.collapsible_panel">
   <va-accordion>
-    
+
     {% assign questions = entity.fieldQuestions %}
     {% assign sectionHeader = entity.fieldSectionHeader %}
 
@@ -12,18 +12,16 @@
         header="{{ item.fieldQuestion }}"
         id="{{ item.fieldQuestion | hashReference: 30 }}"
         {% if level %}
-          level="{{ level }}"
-          {% else %}
-          level=3
-        {% endif %}
-      >
+        level="{{ level }}"
+        {% else %}
+        level=3
+        {% endif %}>
         <div
           id={{ id }}
           data-template="paragraphs/q_a.collapsible_panel__qa"
           data-entity-id="{{ id }}"
           data-analytics-faq-section="{{ sectionHeader | escape }}"
-          data-analytics-faq-text="{{ item.fieldQuestion | escape }}"
-        >
+          data-analytics-faq-text="{{ item.fieldQuestion | escape }}">
           <div id="{{ item.entityBundle }}-{{ id }}">
             {% for answer in item.fieldAnswer %}
               {% assign bundleComponent = "src/site/paragraphs/" | append: answer.entity.entityBundle | append: ".drupal.liquid" %}

--- a/src/site/paragraphs/q_a_group_collapsible_content.drupal.liquid
+++ b/src/site/paragraphs/q_a_group_collapsible_content.drupal.liquid
@@ -10,20 +10,18 @@
   {{ entity.fieldRichWysiwyg.processed }}
 {% endif %}
 
-<div>
-  <va-accordion>
-    {% for item in fieldQAs %}
-      {% assign id = item.entityId %}
-      <va-accordion-item header="{{ item.entityLabel }}" id="{{ item.entityLabel | hashReference: 30 }}">
-        <div id={{ id }} data-entity-id="{{ id }}">
-          <div id="{{ item.fieldAnswer.entity.entityBundle }}-{{ item.fieldAnswer.entity.entityId }}">
-            {% if item.fieldAnswer %}
-              {% assign bundleComponent = "src/site/paragraphs/" | append: item.fieldAnswer.entity.entityBundle | append: ".drupal.liquid" %}
-              {% include {{ bundleComponent }} with entity = item.fieldAnswer.entity %}
-            {% endif %}
-          </div>
+<va-accordion>
+  {% for item in fieldQAs %}
+    {% assign id = item.entityId %}
+    <va-accordion-item header="{{ item.entityLabel }}" id="{{ item.entityLabel | hashReference: 30 }}">
+      <div id={{ id }} data-entity-id="{{ id }}">
+        <div id="{{ item.fieldAnswer.entity.entityBundle }}-{{ item.fieldAnswer.entity.entityId }}">
+          {% if item.fieldAnswer %}
+            {% assign bundleComponent = "src/site/paragraphs/" | append: item.fieldAnswer.entity.entityBundle | append: ".drupal.liquid" %}
+            {% include {{ bundleComponent }} with entity = item.fieldAnswer.entity %}
+          {% endif %}
         </div>
-      </va-accordion-item>
-    {% endfor %}
-  </va-accordion>
-</div>
+      </div>
+    </va-accordion-item>
+  {% endfor %}
+</va-accordion>

--- a/src/site/paragraphs/q_a_group_collapsible_content.drupal.liquid
+++ b/src/site/paragraphs/q_a_group_collapsible_content.drupal.liquid
@@ -16,7 +16,7 @@
       {% assign id = item.entityId %}
       <va-accordion-item header="{{ item.entityLabel }}" id="{{ item.entityLabel | hashReference: 30 }}">
         <div id={{ id }} data-entity-id="{{ id }}">
-          <div id="{{ entity.entitiyBundle }}-{{ id }}">
+          <div id="{{ entity.entityBundle }}-{{ id }}">
             {% for answer in item.fieldAnswer %}
               {% assign bundleComponent = "src/site/paragraphs/" | append: answer.entity.entityBundle | append: ".drupal.liquid" %}
               {% include {{ bundleComponent }} with entity = answer.entity %}

--- a/src/site/paragraphs/q_a_group_collapsible_content.drupal.liquid
+++ b/src/site/paragraphs/q_a_group_collapsible_content.drupal.liquid
@@ -16,11 +16,11 @@
       {% assign id = item.entityId %}
       <va-accordion-item header="{{ item.entityLabel }}" id="{{ item.entityLabel | hashReference: 30 }}">
         <div id={{ id }} data-entity-id="{{ id }}">
-          <div id="{{ entity.entityBundle }}-{{ id }}">
-            {% for answer in item.fieldAnswer %}
-              {% assign bundleComponent = "src/site/paragraphs/" | append: answer.entity.entityBundle | append: ".drupal.liquid" %}
-              {% include {{ bundleComponent }} with entity = answer.entity %}
-            {% endfor %}
+          <div id="{{ item.fieldAnswer.entity.entityBundle }}-{{ item.fieldAnswer.entity.entityId }}">
+            {% if item.fieldAnswer %}
+              {% assign bundleComponent = "src/site/paragraphs/" | append: item.fieldAnswer.entity.entityBundle | append: ".drupal.liquid" %}
+              {% include {{ bundleComponent }} with entity = item.fieldAnswer.entity %}
+            {% endif %}
           </div>
         </div>
       </va-accordion-item>

--- a/src/site/paragraphs/q_a_group_collapsible_content.drupal.liquid
+++ b/src/site/paragraphs/q_a_group_collapsible_content.drupal.liquid
@@ -1,59 +1,29 @@
 {% assign fieldQAs = entity.queryFieldQAs.entities %}
-    
-    <!-- Optional section header -->
-    {% if entity.fieldSectionHeader %}
-        <h2>{{ entity.fieldSectionHeader }}</h2>
-    {% endif %}
 
-    <!-- Optional QA Group Introduction -->
-    {% if entity.fieldRichWysiwyg.processed %}
-        {{ entity.fieldRichWysiwyg.processed }}
-    {% endif %}
+<!-- Optional section header -->
+{% if entity.fieldSectionHeader %}
+  <h2>{{ entity.fieldSectionHeader }}</h2>
+{% endif %}
 
-    <div>
-    <va-accordion>  
-      {% for accordionItem in fieldQAs %}
-        {% assign item = accordionItem.entity %}
-        {% assign id = item.entityId %}
-        <va-accordion-item
-          header="{{ item.entityLabel }}"
-          id="{{ item.entityLabel | hashReference: 30 }}"
-        >
-          <div
-            id={{ id }}
-            data-entity-id="{{ id }}"
-          >
-            <div id="{{ entity.entitiyBundle }}-{{ id }}">
-              {% for answer in item.fieldAnswer %}
-                {% assign bundleComponent = "src/site/paragraphs/" | append: answer.entity.entityBundle | append: ".drupal.liquid" %}
-                {% include {{ bundleComponent }} with entity = answer.entity %}
-              {% endfor %}
-            </div>
+<!-- Optional QA Group Introduction -->
+{% if entity.fieldRichWysiwyg.processed %}
+  {{ entity.fieldRichWysiwyg.processed }}
+{% endif %}
+
+<div>
+  <va-accordion>
+    {% for item in fieldQAs %}
+      {% assign id = item.entityId %}
+      <va-accordion-item header="{{ item.entityLabel }}" id="{{ item.entityLabel | hashReference: 30 }}">
+        <div id={{ id }} data-entity-id="{{ id }}">
+          <div id="{{ entity.entitiyBundle }}-{{ id }}">
+            {% for answer in item.fieldAnswer %}
+              {% assign bundleComponent = "src/site/paragraphs/" | append: answer.entity.entityBundle | append: ".drupal.liquid" %}
+              {% include {{ bundleComponent }} with entity = answer.entity %}
+            {% endfor %}
           </div>
-        </va-accordion-item>
-      {% endfor %}
-    </va-accordion>
-  </div>
-  
-
-
-
-
-
-
-
-                  
-    {% assign fieldSectionHeaderTag = 'h2' %}
-    {% if entity.fieldSectionHeader %}
-        {% assign fieldSectionHeaderTag = 'h3' %}
-    {% endif %}
-    {% for fieldQA in fieldQAs %}
-        <{{ fieldSectionHeaderTag }}>{{ fieldQA.entityLabel }}</{{ fieldSectionHeaderTag }}>
-            {% if fieldQA.fieldAnswer %}
-                {% assign fieldAnswer = fieldQA.fieldAnswer %}
-                {% assign bundleComponent = "src/site/paragraphs/" | append: fieldAnswer.entity.entityBundle %}
-                {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
-                {% include {{ bundleComponentWithExtension }} with entity = fieldAnswer.entity %}
-            {% endif %}
-        </ul>
+        </div>
+      </va-accordion-item>
     {% endfor %}
+  </va-accordion>
+</div>

--- a/src/site/paragraphs/q_a_group_collapsible_content.drupal.liquid
+++ b/src/site/paragraphs/q_a_group_collapsible_content.drupal.liquid
@@ -9,6 +9,39 @@
     {% if entity.fieldRichWysiwyg.processed %}
         {{ entity.fieldRichWysiwyg.processed }}
     {% endif %}
+
+    <div>
+    <va-accordion>  
+      {% for accordionItem in fieldQAs %}
+        {% assign item = accordionItem.entity %}
+        {% assign id = item.entityId %}
+        <va-accordion-item
+          header="{{ item.entityLabel }}"
+          id="{{ item.entityLabel | hashReference: 30 }}"
+        >
+          <div
+            id={{ id }}
+            data-entity-id="{{ id }}"
+          >
+            <div id="{{ entity.entitiyBundle }}-{{ id }}">
+              {% for answer in item.fieldAnswer %}
+                {% assign bundleComponent = "src/site/paragraphs/" | append: answer.entity.entityBundle | append: ".drupal.liquid" %}
+                {% include {{ bundleComponent }} with entity = answer.entity %}
+              {% endfor %}
+            </div>
+          </div>
+        </va-accordion-item>
+      {% endfor %}
+    </va-accordion>
+  </div>
+  
+
+
+
+
+
+
+
                   
     {% assign fieldSectionHeaderTag = 'h2' %}
     {% if entity.fieldSectionHeader %}
@@ -24,6 +57,3 @@
             {% endif %}
         </ul>
     {% endfor %}
-
-                  
-                  

--- a/src/site/stages/build/drupal/graphql/paragraph-fragments/qaGroup.paragraph.graphql.js
+++ b/src/site/stages/build/drupal/graphql/paragraph-fragments/qaGroup.paragraph.graphql.js
@@ -1,6 +1,7 @@
 module.exports = `
 fragment qaGroup on ParagraphQAGroup {
     fieldSectionHeader
+    fieldAccordionDisplay
     fieldRichWysiwyg {
       value
       format


### PR DESCRIPTION
## Description
For this ticket we encountered a defect where the accordion option for reusable Q&As was not adding the feature properly across all implementations. This PR will account for the accordion display flag and also will account for the QA group introduction that was also not included in initial implementation. 

- Updated graphQL to pass in `fieldAccodionDisplay` flag
- Added accordion specific template for reusable QAs

Relates to [#14814](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14814)

## Testing done & Screenshots

Tugboat Instances: 
https://web-nooftw96f8qss9vj2uw4a78vfp0ukbkv.ci.cms.va.gov/resources/qa-group-for-rs-page/
https://web-nooftw96f8qss9vj2uw4a78vfp0ukbkv.ci.cms.va.gov/qa-group-with-accordions/

![QA_GROUP_FOR_RS_PAGE___Veterans_Affairs](https://github.com/department-of-veterans-affairs/content-build/assets/42885441/510da79e-131e-45ac-98f7-5cf9f6aab5a7)

![QA_GROUP_WITH_ACCORDIONS___Veterans_Affairs](https://github.com/department-of-veterans-affairs/content-build/assets/42885441/5ee9728f-1df5-4bc5-a6d4-ea6679d06040)




## QA steps

What needs to be checked to prove this works?  
Verify on R&S and Benefit Detail Pages that Reusable QAs will show in accordions when flag is checked in CMS
 
What needs to be checked to prove it didn't break any related things?  
Verify other detail pages are not affected by this change.


## Acceptance criteria
- [x] FAQ Review
- [x] R&S Detail Page Review
- [x] Benefit Detail Page Review
- [x] A11y Review

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
