### PR TITLE
VACMS-14697 Use footer label instead of description to populate footer titles

### DIFF
--- a/.github/workflows/close-stale-pull-requests.yml
+++ b/.github/workflows/close-stale-pull-requests.yml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
         with:
-          stale-pr-message: 'This PR is stale because it has been open 120 days with no activity. It will recieve a stale label every day for 14 days before being closed unless it recieves a comment or the stale label is removed.'
+          stale-pr-message: 'This PR is stale because it has been open 120 days with no activity. It will receive a stale label every day for 14 days before being closed unless it receives a comment or the stale label is removed.'
           days-before-pr-stale: 120
           days-before-pr-close: 14

--- a/src/site/stages/build/drupal/menus.js
+++ b/src/site/stages/build/drupal/menus.js
@@ -267,7 +267,7 @@ function formatHeaderData(buildOptions, contentData) {
   if (!contentData?.data?.menuLinkContentQuery?.entities) {
     // eslint-disable-next-line no-console
     throw new Error(
-      'contentData not recieved from Drupal, please check and restart SOCKS connection.',
+      'contentData not received from Drupal, please check and restart SOCKS connection.',
     );
   }
 

--- a/src/site/stages/build/plugins/create-header-footer.js
+++ b/src/site/stages/build/plugins/create-header-footer.js
@@ -13,7 +13,7 @@ const formatLink = (link, linkIndex, columnId, hostUrl) => {
     href: convertLinkToAbsolute(hostUrl, link?.url?.path),
     order: linkIndex + 1,
     target: null,
-    title: link?.description,
+    title: link?.label,
   };
 };
 

--- a/src/site/stages/build/plugins/tests/create-header-footer.unit.spec.js
+++ b/src/site/stages/build/plugins/tests/create-header-footer.unit.spec.js
@@ -7,20 +7,20 @@ describe('footer utilities', () => {
     description: 'bottom rail footer data',
     links: [
       {
-        description: 'Accessibility',
+        label: 'Accessibility',
         url: {
           path: 'https://www.va.gov/accessibility-at-va',
         },
       },
       {
-        description: 'Civil Rights',
+        label: 'Civil Rights',
         url: {
           path:
             'https://www.va.gov/resources/your-civil-rights-and-how-to-file-a-discrimination-complaint/',
         },
       },
       {
-        description: 'Partial Link Test',
+        label: 'Partial Link Test',
         url: {
           path: '/link-test-1',
         },
@@ -35,19 +35,19 @@ describe('footer utilities', () => {
         description: 'Column 1',
         links: [
           {
-            description: 'Homeless Veterans',
+            label: 'Homeless Veterans',
             url: {
               path: 'https://www.va.gov/homeless/',
             },
           },
           {
-            description: 'Women Veterans',
+            label: 'Women Veterans',
             url: {
               path: 'https://www.va.gov/womenvet/',
             },
           },
           {
-            description: 'Partial Link Test',
+            label: 'Partial Link Test',
             url: {
               path: '/link-test-2',
             },
@@ -58,19 +58,19 @@ describe('footer utilities', () => {
         description: 'Column 2',
         links: [
           {
-            description: 'VA forms',
+            label: 'VA forms',
             url: {
               path: '/find-forms',
             },
           },
           {
-            description: 'Careers at VA',
+            label: 'Careers at VA',
             url: {
               path: '/jobs',
             },
           },
           {
-            description: 'VA outreach materials',
+            label: 'VA outreach materials',
             url: {
               path: '/outreach-and-events/outreach-materials',
             },
@@ -81,7 +81,7 @@ describe('footer utilities', () => {
         description: 'Column 3',
         links: [
           {
-            description: 'Partial Link Test',
+            label: 'Partial Link Test',
             url: {
               path: '/link-test-3',
             },


### PR DESCRIPTION
## Description
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14697

When we built the Drupalized footer previously, we used `link.description` to populate the link title rather than `link.label`. This uses the `Menu link title` field instead so we can ensure that if the description is not filled out, the link will still be populated.

I also checked how the megamenu / header was being populated. It has a different GraphQL setup where the `title` field corresponds to the `Menu link title`. No issues there.

## Testing done & Screenshots
I created a test link in Drupal in the footer bottom rail. In the `Menu link title` field, I put `This is the menu link title` and in the description field, I put `This is the description`.

<img width="746" alt="Screenshot 2023-08-17 at 8 59 55 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/cffb3c74-6510-4803-ac8e-d289de2301b4">

I tested the build locally after pulling the data from Drupal. Note: `This is the menu link title` at the very bottom in the bottom rail.

<img width="886" alt="Screenshot 2023-08-17 at 9 09 32 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/5bb2f620-578c-460c-a60e-8509b33845e0">

<img width="430" alt="Screenshot 2023-08-17 at 8 59 36 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/b3327836-79cb-4d0a-9bc3-79e2221484a1">

This is how things look in the injected footer scenario.

<img width="850" alt="Screenshot 2023-08-21 at 2 22 15 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/3a8c4605-fdf9-4118-8c21-d3158f138cc1">


## QA steps

### To demo locally (today, while my link still exists):

1. In `content-build`, run `yarn build --pull-drupal --drupal-address=https://staging.cms.va.gov/`
2. Run `yarn watch`
3. In `vets-website` on `main`, run `yarn watch`.
4. If `vets-website` errors out on `main`, try running this in a separate terminal: `yarn mock-api --responses src/applications/personalization/profile/mocks/server.js`
5. Navigate to `localhost:3002`
6. Validate that the test link is in the footer and displaying the correct information

### Tugboat environment to test: https://web-ljrvavnooy7buqh9niszssez4lapulvi.demo.cms.va.gov/


## Acceptance criteria

- [x] Footer displays Menu link title field
- [x] Checked whether the other sections of the footer are using the correct fields to build links and fixed as needed
- [ ] Checked header for gut check on correct fields being utilized