### PR TITLE
VACMS-13222: Display new 'Where' format for events

### DIFF
--- a/src/site/includes/directions-google-maps.liquid
+++ b/src/site/includes/directions-google-maps.liquid
@@ -1,9 +1,9 @@
 {% comment %}
-  parameters:
-    directionsLinkTitle
-    directionsLinkAddress
-    directionsLinkOnClickPropName
-    directionsLinkOnClickPropValue
+parameters:
+directionsLinkTitle
+directionsLinkAddress
+directionsLinkOnClickPropName
+directionsLinkOnClickPropValue
 {% endcomment %}
 
 {% assign onClick = "" %}
@@ -16,7 +16,9 @@
 <div>
   <a
     {{ onClick | strip }}
-    href="https://maps.google.com?saddr=Current+Location&amp;daddr={{ directionsLinkAddress | strip }}">
-    Get directions on Google Maps <span class="sr-only">to {{ directionsLinkTitle | strip }}</span>
+    href="https://maps.google.com?saddr=Current+Location&amp;daddr={{ directionsLinkAddress | strip }}"
+    target="_blank">
+    Get directions on Google Maps
+    <span class="sr-only">to {{ directionsLinkTitle | strip }}</span>
   </a>
 </div>

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -62,13 +62,13 @@
 
             <!-- Where -->
             {% if fieldFacilityLocation or fieldAddress.addressLine1 or fieldLocationType == "online" %}
-            {% assign fieldFacilityAddress = fieldFacilityLocation.entity.fieldAddress  %}
               <div class="vads-u-display--flex vads-u-flex-direction--row vads-u-margin-top--1">
                 <p class="vads-u-margin--0 vads-u-margin-right--0p5">
                   <strong>Where:</strong>
                 </p>
 
                 {% if fieldFacilityLocation %}
+                {% assign fieldFacilityAddress = fieldFacilityLocation.entity.fieldAddress  %}
                   <div class="vads-u-display--flex vads-u-flex-direction--column">
                     <p class="vads-u-margin--0">
                       <a href="{{ fieldFacilityLocation.entity.entityUrl.path }}">
@@ -115,21 +115,21 @@
                     {% if fieldLocationHumanreadable != empty %}
                       <p class="vads-u-margin--0">{{ fieldLocationHumanreadable }}</p>
                     {% endif %}
-                    {% if fieldAddress.addressLine1  %}
-                      <p class="vads-u-margin--0">{{ fieldAddress.addressLine1  }}</p>
+                    {% if fieldAddress.addressLine1 %}
+                      <p class="vads-u-margin--0">{{ fieldAddress.addressLine1 }}</p>
                     {% endif %}
 
-                    {% if fieldAddress.addressLine2  %}
-                      <p class="vads-u-margin--0">{{ fieldAddress.addressLine2  }}</p>
+                    {% if fieldAddress.addressLine2 %}
+                      <p class="vads-u-margin--0">{{ fieldAddress.addressLine2 }}</p>
                     {% endif %}
 
                     <p class="vads-u-margin--0">
-                      {% if fieldAddress.locality   %}
-                        {{ fieldAddress.locality  | strip }},
+                      {% if fieldAddress.locality %}
+                        {{ fieldAddress.locality | strip }},
                       {% endif %}
 
-                      {% if fieldAddress.administrativeArea   %}
-                        {{ fieldAddress.administrativeArea  }}
+                      {% if fieldAddress.administrativeArea %}
+                        {{ fieldAddress.administrativeArea }}
                       {% endif %}
                     </p>
                     {% capture fullAddress %}

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -2,7 +2,10 @@
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" with deriveBreadcrumbsFromUrl = true replaceLastItem = true %}
 
-<div class="interior" id="content" data-template="layouts/event.drupal.liquid">
+<div
+  class="interior"
+  id="content"
+  data-template="layouts/event.drupal.liquid">
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">
       {% unless entityUrl.path contains "/outreach-and-events" %}
@@ -11,8 +14,7 @@
 
       <div class="usa-width-three-fourths vads-u-display--flex vads-u-flex-direction--column vads-u-padding-x--1p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--2">
         {% include "src/site/includes/lovell-switch-link.drupal.liquid" with
-          entityUrl = entityUrl
-        %}
+         entityUrl = entityUrl %}
 
         <!-- Title -->
         <h1>{{ title }}</h1>
@@ -22,8 +24,7 @@
           <img
             alt="{{ fieldMedia.entity.image.alt }}"
             class="event-detail-img vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4"
-            src="{{ fieldMedia.entity.image.derivative.url }}"
-          />
+            src="{{ fieldMedia.entity.image.derivative.url }}" />
         {% endif %}
 
         <!-- Intro text -->
@@ -54,7 +55,8 @@
                 {% if fieldDatetimeRangeTimezone.length > 1 %}
                   <!-- Repeats -->
                   <p class="vads-u-margin--0">
-                    <i aria-hidden="true" class="fa fa-sync vads-u-font-size--sm vads-u-margin-right--0p5"></i> Repeats
+                    <i aria-hidden="true" class="fa fa-sync vads-u-font-size--sm vads-u-margin-right--0p5"></i>
+                    Repeats
                   </p>
                 {% endif %}
               </div>
@@ -68,7 +70,7 @@
                 </p>
 
                 {% if fieldFacilityLocation %}
-                {% assign fieldFacilityAddress = fieldFacilityLocation.entity.fieldAddress  %}
+                  {% assign fieldFacilityAddress = fieldFacilityLocation.entity.fieldAddress %}
                   <div class="vads-u-display--flex vads-u-flex-direction--column">
                     <p class="vads-u-margin--0">
                       <a href="{{ fieldFacilityLocation.entity.entityUrl.path }}">
@@ -76,40 +78,43 @@
                       </a>
                     </p>
                     <p class="vads-u-margin--0">{{ fieldLocationHumanreadable }}</p>
-                      {% if fieldFacilityAddress.addressLine1 != empty %}
-                    <p class="vads-u-margin--0">{{ fieldFacilityAddress.addressLine1  }}</p>
-                  {% endif %}
-                  {% if fieldFacilityAddress.addressLine2 != empty %}
-                  <p class="vads-u-margin--0">{{ fieldFacilityAddress.addressLine2 }}</p>
-                {% endif %}
+                    {% if fieldFacilityAddress.addressLine1 != empty %}
+                      <p class="vads-u-margin--0">{{ fieldFacilityAddress.addressLine1 }}</p>
+                    {% endif %}
+                    {% if fieldFacilityAddress.addressLine2 != empty %}
+                      <p class="vads-u-margin--0">{{ fieldFacilityAddress.addressLine2 }}</p>
+                    {% endif %}
 
-                <p class="vads-u-margin--0">
-                  {% if fieldFacilityAddress.locality != empty  %}
-                    {{ fieldFacilityAddress.locality | strip }},
-                  {% endif %}
+                    <p class="vads-u-margin--0">
+                      {% if fieldFacilityAddress.locality != empty %}
+                        {{ fieldFacilityAddress.locality | strip }},
+                      {% endif %}
 
-                  {% if fieldFacilityAddress.administrativeArea != empty  %}
-                    {{ fieldFacilityAddress.administrativeArea }}
-                  {% endif %}
-                  </p>
-                  {% if fieldFacilityAddress.addressLine1 %}
-                    {% capture fullAddress %}
-                      {{ fieldFacilityAddress.addressLine1 }}, {{ fieldFacilityAddress.locality }}, {{ fieldFacilityAddress.administrativeArea}} {{ fieldFacilityAddress.postalCode }}
-                    {% endcapture %}
-                    {% include "src/site/includes/directions-google-maps.liquid" with
-                      directionsLinkTitle = fieldFacilityLocation.entity.title
-                      directionsLinkAddress = fullAddress
-                      directionsLinkOnClickPropName = "vet-center-facility-name"
-                      directionsLinkOnClickPropValue = fieldFacilityLocation.entity.title
-                    %}
-                  {% endif %}
+                      {% if fieldFacilityAddress.administrativeArea != empty %}
+                        {{ fieldFacilityAddress.administrativeArea }}
+                      {% endif %}
+                    </p>
+                    {% if fieldFacilityAddress.addressLine1 %}
+                      {% capture fullAddress %}
+                        {{ fieldFacilityAddress.addressLine1 }}, {{ fieldFacilityAddress.locality }}, {{ fieldFacilityAddress.administrativeArea }} {{ fieldFacilityAddress.postalCode }}
+                      {% endcapture %}
+                      {% include "src/site/includes/directions-google-maps.liquid" with
+                       directionsLinkTitle = fieldFacilityLocation.entity.title
+                       directionsLinkAddress = fullAddress
+                       directionsLinkOnClickPropName = "vet-center-facility-name"
+                       directionsLinkOnClickPropValue = fieldFacilityLocation.entity.title %}
+                    {% endif %}
                   </div>
 
                 {% elsif fieldLocationType == "online" %}
                   <p class="vads-u-margin--0 vads-u-margin-bottom--2">
-                    {% if fieldUrlOfAnOnlineEvent %}<a href="{{ fieldUrlOfAnOnlineEvent.uri }}">{% endif %}
+                    {% if fieldUrlOfAnOnlineEvent %}
+                      <a href="{{ fieldUrlOfAnOnlineEvent.uri }}">
+                      {% endif %}
                       This is an online event.
-                    {% if fieldUrlOfAnOnlineEvent %}</a>{% endif %}
+                      {% if fieldUrlOfAnOnlineEvent %}
+                      </a>
+                    {% endif %}
                   </p>
                 {% else %}
 
@@ -136,18 +141,16 @@
                     </p>
                     {% if fieldAddress.addressLine1 %}
                       {% capture fullAddress %}
-                        {{ fieldAddress.addressLine1 }}, {{ fieldAddress.locality }}, {{ fieldAddress.administrativeArea}} {{ fieldAddress.postalCode }}
+                        {{ fieldAddress.addressLine1 }}, {{ fieldAddress.locality }}, {{ fieldAddress.administrativeArea }} {{ fieldAddress.postalCode }}
                       {% endcapture %}
                       {% include "src/site/includes/directions-google-maps.liquid" with
-                      directionsLinkTitle = title
-                      directionsLinkAddress = fullAddress
-                      directionsLinkOnClickPropName = "facility-name"
-                      directionsLinkOnClickPropValue = title
-                      %}
+                       directionsLinkTitle = title
+                       directionsLinkAddress = fullAddress
+                       directionsLinkOnClickPropName = "facility-name"
+                       directionsLinkOnClickPropValue = title %}
                     {% endif %}
                   </div>
-                  </div>
-                {% endif %}
+                </div>
               </div>
             {% endif %}
 
@@ -207,17 +210,17 @@
             class="vads-u-background-color--gray-lightest vads-u-color--primary-darkest vads-u-font-weight--bold vads-u-display--flex vads-u-align-items--center vads-u-justify-content--space-between vads-u-height--full vads-u-padding--2 vads-u-margin--0 vads-u-margin-top--1"
             id="expand-recurring-events"
             style="z-index: 1;"
-            type="button"
-          >
-            View other times for this event <i aria-hidden="true" class="fa fa-plus" id="expand-recurring-events-icon"></i>
+            type="button">
+            View other times for this event
+            <i
+              aria-hidden="true"
+              class="fa fa-plus"
+              id="expand-recurring-events-icon"></i>
           </button>
-          <div
-            class="vads-u-display--none vads-u-flex-direction--column vads-u-background-color--white vads-u-border--2px vads-u-border-color--gray-lightest vads-u-padding--2"
-            id="recurring-events"
-          >
+          <div class="vads-u-display--none vads-u-flex-direction--column vads-u-background-color--white vads-u-border--2px vads-u-border-color--gray-lightest vads-u-padding--2" id="recurring-events">
             <!-- Recurring events list. -->
             {% for recurringEventDatetimeRangeTimezone in fieldDatetimeRangeTimezone %}
-            <div class="recurring-event {% if forloop.index > 6 %}vads-u-display--none{% endif %} vads-u-margin-bottom--2">
+              <div class="recurring-event {% if forloop.index > 6 %}vads-u-display--none{% endif %} vads-u-margin-bottom--2">
                 <p class="vads-u-margin--0">
                   {{ recurringEventDatetimeRangeTimezone | deriveFormattedTimestamp }}
                 </p>
@@ -230,9 +233,11 @@
                   data-subject="{{ title }}"
                   href="{{ entityUrl.path }}"
                   rel="noreferrer noopener"
-                  style="max-width: 140px;"
-                >
-                  <i aria-hidden="true" class="va-c-social-icon fas fa-calendar-check vads-u-margin-right--0p5" role="presentation"></i>
+                  style="max-width: 140px;">
+                  <i
+                    aria-hidden="true"
+                    class="va-c-social-icon fas fa-calendar-check vads-u-margin-right--0p5"
+                    role="presentation"></i>
                   Add to Calendar
                 </a>
               </div>
@@ -244,8 +249,7 @@
                 <button
                   class="usa-button-secondary vads-u-width--full medium-screen:vads-u-width--auto"
                   id="show-all-recurring-events"
-                  type="button"
-                >
+                  type="button">
                   Show all times
                 </button>
               </div>
@@ -258,10 +262,12 @@
         <a
           class="vads-u-padding-bottom--3 vads-u-margin-top--1 vads-u-font-weight--bold"
           href="{{ entityUrl.breadcrumb | getValueFromArrayObjPath: index, 'url.path' }}"
-          onclick="recordEvent({ event: 'nav-secondary-button-click' });"
-        >
+          onclick="recordEvent({ event: 'nav-secondary-button-click' });">
           See more events
-          <i aria-hidden="true" class='vads-u-font-size--sm vads-u-margin-left--1 fa fa-chevron-right' role="presentation"></i>
+          <i
+            aria-hidden="true"
+            class='vads-u-font-size--sm vads-u-margin-left--1 fa fa-chevron-right'
+            role="presentation"></i>
         </a>
         <!-- Last updated & feedback button-->
         {% include "src/site/includes/above-footer-elements.drupal.liquid" %}
@@ -273,67 +279,63 @@
 <script nonce="**CSP_NONCE**" type="text/javascript">
 
   function onExpandRecurringEventsClick() {
-    var expandRecurringEventsButton = document.getElementById('expand-recurring-events');
-    var expandRecurringEventsIcon = document.getElementById('expand-recurring-events-icon');
-    var recurringEvents = document.getElementById('recurring-events');
-
-    // Escape early if we are not able to find the elements.
-    if (!expandRecurringEventsButton || !expandRecurringEventsIcon || !recurringEvents) {
-      return;
-    }
-
-    // Toggle the bottom borders of the button.
-    if (expandRecurringEventsButton.style.borderBottomLeftRadius === '0px') {
-      expandRecurringEventsButton.style.borderBottomLeftRadius = '5px';
-      expandRecurringEventsButton.style.borderBottomRightRadius = '5px';
-    } else {
-      expandRecurringEventsButton.style.borderBottomLeftRadius = '0px';
-      expandRecurringEventsButton.style.borderBottomRightRadius = '0px';
-    }
-
-    // Toggle the visibility of the recurring events.
-    recurringEvents.classList.toggle('vads-u-display--none');
-    recurringEvents.classList.toggle('vads-u-display--flex');
-
-    // Toggle the icon.
-    expandRecurringEventsIcon.classList.toggle('fa-plus');
-    expandRecurringEventsIcon.classList.toggle('fa-minus');
-  }
-
-  function onShowAllRecurringEventsClick() {
-    // Derive recurring event items.
-    var recurringEventItems = document.querySelectorAll('.recurring-event');
-
-    // Show all recurring events.
-    for (var index = 0; index < recurringEventItems.length; index++) {
-      if (recurringEventItems[index]) {
-        recurringEventItems[index].classList.remove('vads-u-display--none');
-      }
-    }
-
-    // Hide the show all recurring events button.
-    var showAllRecurringEventsButton = document.getElementById('show-all-recurring-events');
-
-    // Hide the button if we find it.
-    if (showAllRecurringEventsButton) {
-      showAllRecurringEventsButton.classList.add('vads-u-display--none');
-    }
-  }
-
-
   var expandRecurringEventsButton = document.getElementById('expand-recurring-events');
-  if (expandRecurringEventsButton) {
-    expandRecurringEventsButton.addEventListener('click', onExpandRecurringEventsClick);
-  }
-
-  var showAllRecurringEventsButton = document.getElementById('show-all-recurring-events');
-  if (showAllRecurringEventsButton) {
-    showAllRecurringEventsButton.addEventListener('click', onShowAllRecurringEventsClick);
-  }
-
-
-
-</script>
+            var expandRecurringEventsIcon = document.getElementById('expand-recurring-events-icon');
+            var recurringEvents = document.getElementById('recurring-events');
+        
+            // Escape early if we are not able to find the elements.
+            if (!expandRecurringEventsButton || !expandRecurringEventsIcon || !recurringEvents) {
+              return;
+            }
+        
+            // Toggle the bottom borders of the button.
+            if (expandRecurringEventsButton.style.borderBottomLeftRadius === '0px') {
+              expandRecurringEventsButton.style.borderBottomLeftRadius = '5px';
+              expandRecurringEventsButton.style.borderBottomRightRadius = '5px';
+            } else {
+              expandRecurringEventsButton.style.borderBottomLeftRadius = '0px';
+              expandRecurringEventsButton.style.borderBottomRightRadius = '0px';
+            }
+        
+            // Toggle the visibility of the recurring events.
+            recurringEvents.classList.toggle('vads-u-display--none');
+            recurringEvents.classList.toggle('vads-u-display--flex');
+        
+            // Toggle the icon.
+            expandRecurringEventsIcon.classList.toggle('fa-plus');
+            expandRecurringEventsIcon.classList.toggle('fa-minus');
+          }
+        
+          function onShowAllRecurringEventsClick() {
+            // Derive recurring event items.
+            var recurringEventItems = document.querySelectorAll('.recurring-event');
+        
+            // Show all recurring events.
+            for (var index = 0; index < recurringEventItems.length; index++) {
+              if (recurringEventItems[index]) {
+                recurringEventItems[index].classList.remove('vads-u-display--none');
+              }
+            }
+        
+            // Hide the show all recurring events button.
+            var showAllRecurringEventsButton = document.getElementById('show-all-recurring-events');
+        
+            // Hide the button if we find it.
+            if (showAllRecurringEventsButton) {
+              showAllRecurringEventsButton.classList.add('vads-u-display--none');
+            }
+          }
+        
+        
+          var expandRecurringEventsButton = document.getElementById('expand-recurring-events');
+          if (expandRecurringEventsButton) {
+            expandRecurringEventsButton.addEventListener('click', onExpandRecurringEventsClick);
+          }
+        
+          var showAllRecurringEventsButton = document.getElementById('show-all-recurring-events');
+          if (showAllRecurringEventsButton) {
+            showAllRecurringEventsButton.addEventListener('click', onShowAllRecurringEventsClick);
+          }</script>
 
 {% include "src/site/includes/footer.html" %}
 {% include "src/site/includes/debug.drupal.liquid" %}

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -33,7 +33,7 @@
           </p>
         {% endif %}
 
-        <div class="vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row">
+        <div class="vads-u-display--flex vads-u-flex-direction--column">
           <div class="vads-u-display--flex vads-u-flex-direction--column vads-u-flex--1">
             <!-- When -->
             <div class="vads-u-display--flex vads-u-flex-direction--row vads-u-margin-bottom--1">
@@ -62,7 +62,7 @@
 
             <!-- Where -->
             {% if fieldFacilityLocation or fieldAddress.addressLine1 or fieldLocationType == "online" %}
-              <div class="vads-u-display--flex vads-u-flex-direction--row vads-u-margin-top--1">
+              <div class="vads-u-display--flex vads-u-flex-direction--row vads-u-margin-top--1 vads-u-margin-bottom--1">
                 <p class="vads-u-margin--0 vads-u-margin-right--0p5">
                   <strong>Where:</strong>
                 </p>

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -62,6 +62,7 @@
 
             <!-- Where -->
             {% if fieldFacilityLocation or fieldAddress.addressLine1 or fieldLocationType == "online" %}
+            {% assign fieldFacilityAddress = fieldFacilityLocation.entity.fieldAddress  %}
               <div class="vads-u-display--flex vads-u-flex-direction--row vads-u-margin-top--1">
                 <p class="vads-u-margin--0 vads-u-margin-right--0p5">
                   <strong>Where:</strong>
@@ -90,23 +91,24 @@
                     {% if fieldLocationHumanreadable != empty %}
                       <p class="vads-u-margin--0">{{ fieldLocationHumanreadable }}</p>
                     {% endif %}
-                    {% if fieldAddress.addressLine1 %}
-                      <p class="vads-u-margin--0">{{ fieldAddress.addressLine1 }}</p>
+                    {% if fieldAddress.addressLine1 or fieldFacilityAddress.addressLine1 %}
+                      <p class="vads-u-margin--0">{{ fieldAddress.addressLine1 or fieldFacilityAddress.addressLine1 }}</p>
                     {% endif %}
 
-                    {% if fieldAddress.addressLine2 %}
-                      <p class="vads-u-margin--0">{{ fieldAddress.addressLine2 }}</p>
+                    {% if fieldAddress.addressLine2 or fieldFacilityAddress.addressLine2 %}
+                      <p class="vads-u-margin--0">{{ fieldAddress.addressLine2 or fieldFacilityAddress.addressLine2 }}</p>
                     {% endif %}
 
                     <p class="vads-u-margin--0">
-                      {% if fieldAddress.locality %}
-                        {{ fieldAddress.locality | strip }},
+                      {% if fieldAddress.locality or fieldFacilityAddress.locality  %}
+                        {{ fieldAddress.locality or fieldFacilityAddress.locality | strip }},
                       {% endif %}
 
-                      {% if fieldAddress.administrativeArea %}
-                        {{ fieldAddress.administrativeArea }}
+                      {% if fieldAddress.administrativeArea or fieldFacilityAddress.administrativeArea  %}
+                        {{ fieldAddress.administrativeArea or fieldFacilityAddress.administrativeArea }}
                       {% endif %}
                     </p>
+                  </div>
                   </div>
                 {% endif %}
               </div>

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -75,8 +75,32 @@
                         {{ fieldFacilityLocation.entity.title }}
                       </a>
                     </p>
-
                     <p class="vads-u-margin--0">{{ fieldLocationHumanreadable }}</p>
+                    {% if fieldFacilityAddress.addressLine1 != empty %}
+                    <p class="vads-u-margin--0">{{ fieldFacilityAddress.addressLine1  }}</p>
+                  {% endif %}
+                  {% if fieldFacilityAddress.addressLine2 != empty %}
+                  <p class="vads-u-margin--0">{{ fieldFacilityAddress.addressLine2 }}</p>
+                {% endif %}
+
+                <p class="vads-u-margin--0">
+                  {% if fieldFacilityAddress.locality != empty  %}
+                    {{ fieldFacilityAddress.locality | strip }},
+                  {% endif %}
+
+                  {% if fieldFacilityAddress.administrativeArea != empty  %}
+                    {{ fieldFacilityAddress.administrativeArea }}
+                  {% endif %}
+                  </p>
+                    {% capture fullAddress %}
+                      {{ fieldFacilityAddress.addressLine1 }}, {{ fieldFacilityAddress.locality }}, {{ fieldFacilityAddress.administrativeArea}} {{ fieldFacilityAddress.postalCode }}
+                    {% endcapture %}
+                    {% include "src/site/includes/directions-google-maps.liquid" with
+                      directionsLinkTitle = fieldFacilityLocation.entity.title
+                      directionsLinkAddress = fullAddress
+                      directionsLinkOnClickPropName = "vet-center-facility-name"
+                      directionsLinkOnClickPropValue = fieldFacilityLocation.entity.title
+                    %}
                   </div>
 
                 {% elsif fieldLocationType == "online" %}
@@ -91,23 +115,32 @@
                     {% if fieldLocationHumanreadable != empty %}
                       <p class="vads-u-margin--0">{{ fieldLocationHumanreadable }}</p>
                     {% endif %}
-                    {% if fieldAddress.addressLine1 or fieldFacilityAddress.addressLine1 %}
-                      <p class="vads-u-margin--0">{{ fieldAddress.addressLine1 or fieldFacilityAddress.addressLine1 }}</p>
+                    {% if fieldAddress.addressLine1  %}
+                      <p class="vads-u-margin--0">{{ fieldAddress.addressLine1  }}</p>
                     {% endif %}
 
-                    {% if fieldAddress.addressLine2 or fieldFacilityAddress.addressLine2 %}
-                      <p class="vads-u-margin--0">{{ fieldAddress.addressLine2 or fieldFacilityAddress.addressLine2 }}</p>
+                    {% if fieldAddress.addressLine2  %}
+                      <p class="vads-u-margin--0">{{ fieldAddress.addressLine2  }}</p>
                     {% endif %}
 
                     <p class="vads-u-margin--0">
-                      {% if fieldAddress.locality or fieldFacilityAddress.locality  %}
-                        {{ fieldAddress.locality or fieldFacilityAddress.locality | strip }},
+                      {% if fieldAddress.locality   %}
+                        {{ fieldAddress.locality  | strip }},
                       {% endif %}
 
-                      {% if fieldAddress.administrativeArea or fieldFacilityAddress.administrativeArea  %}
-                        {{ fieldAddress.administrativeArea or fieldFacilityAddress.administrativeArea }}
+                      {% if fieldAddress.administrativeArea   %}
+                        {{ fieldAddress.administrativeArea  }}
                       {% endif %}
                     </p>
+                    {% capture fullAddress %}
+                      {{ fieldAddress.addressLine1 }}, {{ fieldAddress.locality }}, {{ fieldAddress.administrativeArea}} {{ fieldAddress.postalCode }}
+                    {% endcapture %}
+                    {% include "src/site/includes/directions-google-maps.liquid" with
+                      directionsLinkTitle = title
+                      directionsLinkAddress = fullAddress
+                      directionsLinkOnClickPropName = "facility-name"
+                      directionsLinkOnClickPropValue = title
+                    %}
                   </div>
                   </div>
                 {% endif %}

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -76,7 +76,7 @@
                       </a>
                     </p>
                     <p class="vads-u-margin--0">{{ fieldLocationHumanreadable }}</p>
-                    {% if fieldFacilityAddress.addressLine1 != empty %}
+                      {% if fieldFacilityAddress.addressLine1 != empty %}
                     <p class="vads-u-margin--0">{{ fieldFacilityAddress.addressLine1  }}</p>
                   {% endif %}
                   {% if fieldFacilityAddress.addressLine2 != empty %}
@@ -92,6 +92,7 @@
                     {{ fieldFacilityAddress.administrativeArea }}
                   {% endif %}
                   </p>
+                  {% if fieldFacilityAddress.addressLine1 %}
                     {% capture fullAddress %}
                       {{ fieldFacilityAddress.addressLine1 }}, {{ fieldFacilityAddress.locality }}, {{ fieldFacilityAddress.administrativeArea}} {{ fieldFacilityAddress.postalCode }}
                     {% endcapture %}
@@ -101,6 +102,7 @@
                       directionsLinkOnClickPropName = "vet-center-facility-name"
                       directionsLinkOnClickPropValue = fieldFacilityLocation.entity.title
                     %}
+                  {% endif %}
                   </div>
 
                 {% elsif fieldLocationType == "online" %}
@@ -132,15 +134,17 @@
                         {{ fieldAddress.administrativeArea }}
                       {% endif %}
                     </p>
-                    {% capture fullAddress %}
-                      {{ fieldAddress.addressLine1 }}, {{ fieldAddress.locality }}, {{ fieldAddress.administrativeArea}} {{ fieldAddress.postalCode }}
-                    {% endcapture %}
-                    {% include "src/site/includes/directions-google-maps.liquid" with
+                    {% if fieldAddress.addressLine1 %}
+                      {% capture fullAddress %}
+                        {{ fieldAddress.addressLine1 }}, {{ fieldAddress.locality }}, {{ fieldAddress.administrativeArea}} {{ fieldAddress.postalCode }}
+                      {% endcapture %}
+                      {% include "src/site/includes/directions-google-maps.liquid" with
                       directionsLinkTitle = title
                       directionsLinkAddress = fullAddress
                       directionsLinkOnClickPropName = "facility-name"
                       directionsLinkOnClickPropValue = title
-                    %}
+                      %}
+                    {% endif %}
                   </div>
                   </div>
                 {% endif %}

--- a/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
@@ -68,6 +68,14 @@ const nodeEvent = `
     fieldEventRegistrationrequired
     fieldFacilityLocation {
       entity {
+        ... on NodeVetCenter {
+          fieldAddress {
+            locality
+            administrativeArea
+            postalCode
+            addressLine1
+          }
+        }
         ...on NodeHealthCareLocalFacility {
           fieldAddress {
             locality
@@ -237,7 +245,7 @@ const nodeEventWithoutBreadcrumbs = `
             addressLine1
           }
         }
-        ...on NodeHealthCareLocalFacility
+        ...on NodeHealthCareLocalFacility {
           fieldAddress {
             locality
             administrativeArea

--- a/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
@@ -68,15 +68,18 @@ const nodeEvent = `
     fieldEventRegistrationrequired
     fieldFacilityLocation {
       entity {
+        ...on NodeVetCenter{
+          fieldAddress {
+            locality
+            administrativeArea
+            postalCode
+            addressLine1
+          }
+        }
         entityBundle
         entityId
         entityType
-        fieldAddress {
-          locality
-          administrativeArea
-          postalCode
-          addressLine1
-        }
+
         entityUrl {
           path
         }
@@ -226,15 +229,17 @@ const nodeEventWithoutBreadcrumbs = `
     fieldEventRegistrationrequired
     fieldFacilityLocation {
       entity {
+        ...on NodeVetCenter{
+          fieldAddress {
+            locality
+            administrativeArea
+            postalCode
+            addressLine1
+          }
+        }
         entityBundle
         entityId
         entityType
-        fieldAddress {         
-          locality
-          administrativeArea
-          postalCode
-          addressLine1
-        }
         entityUrl {
           path
         }

--- a/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
@@ -71,7 +71,12 @@ const nodeEvent = `
         entityBundle
         entityId
         entityType
-        fieldAddress
+        fieldAddress {
+          locality
+          administrativeArea
+          postalCode
+          addressLine1
+        }
         entityUrl {
           path
         }
@@ -224,7 +229,12 @@ const nodeEventWithoutBreadcrumbs = `
         entityBundle
         entityId
         entityType
-        fieldAddress
+        fieldAddress {         
+          locality
+          administrativeArea
+          postalCode
+          addressLine1
+        }
         entityUrl {
           path
         }

--- a/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
@@ -1,6 +1,15 @@
 // Relative imports.
 const { generatePaginatedQueries } = require('../individual-queries-helpers');
 
+const FIELD_ADDRESS = `
+fieldAddress {
+  addressLine1
+  addressLine2
+  postalCode
+  locality
+  administrativeArea
+}`;
+
 // Create NodeEvent fragment.
 const nodeEvent = `
   fragment nodeEvent on NodeEvent {
@@ -69,52 +78,22 @@ const nodeEvent = `
     fieldFacilityLocation {
       entity {
         ... on NodeVetCenter {
-          fieldAddress {
-            locality
-            administrativeArea
-            postalCode
-            addressLine1
-          }
+          ${FIELD_ADDRESS}
         }
         ...on NodeHealthCareLocalFacility {
-          fieldAddress {
-            locality
-            administrativeArea
-            postalCode
-            addressLine1
-          }
+          ${FIELD_ADDRESS}
         }
         ...on NodeNcaFacility {
-          fieldAddress {
-            locality
-            administrativeArea
-            postalCode
-            addressLine1
-          }
+          ${FIELD_ADDRESS}
         }
         ...on NodeVbaFacility {
-          fieldAddress {
-            locality
-            administrativeArea
-            postalCode
-            addressLine1
-          }
+          ${FIELD_ADDRESS}
         }
         ...on NodeVetCenterOutstation {
-          fieldAddress {
-            locality
-            administrativeArea
-            postalCode
-            addressLine1
-          }
+          ${FIELD_ADDRESS}
         }
         ...on NodeVetCenterCap {
-          fieldAddress {
-            locality
-            administrativeArea
-            postalCode
-            addressLine1
-          }
+          ${FIELD_ADDRESS}
         }
         entityBundle
         entityId
@@ -270,52 +249,22 @@ const nodeEventWithoutBreadcrumbs = `
     fieldFacilityLocation {
       entity {
         ... on NodeVetCenter {
-          fieldAddress {
-            locality
-            administrativeArea
-            postalCode
-            addressLine1
-          }
+          ${FIELD_ADDRESS}
         }
         ...on NodeHealthCareLocalFacility {
-          fieldAddress {
-            locality
-            administrativeArea
-            postalCode
-            addressLine1
-          }
+          ${FIELD_ADDRESS}
         }
         ...on NodeNcaFacility {
-          fieldAddress {
-            locality
-            administrativeArea
-            postalCode
-            addressLine1
-          }
+          ${FIELD_ADDRESS}
         }
         ...on NodeVbaFacility {
-          fieldAddress {
-            locality
-            administrativeArea
-            postalCode
-            addressLine1
-          }
+          ${FIELD_ADDRESS}
         }
         ...on NodeVetCenterOutstation {
-          fieldAddress {
-            locality
-            administrativeArea
-            postalCode
-            addressLine1
-          }
+          ${FIELD_ADDRESS}
         }
         ...on NodeVetCenterCap {
-          fieldAddress {
-            locality
-            administrativeArea
-            postalCode
-            addressLine1
-          }
+          ${FIELD_ADDRESS}
         }
         entityBundle
         entityId

--- a/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
@@ -71,6 +71,7 @@ const nodeEvent = `
         entityBundle
         entityId
         entityType
+        fieldAddress
         entityUrl {
           path
         }
@@ -223,6 +224,7 @@ const nodeEventWithoutBreadcrumbs = `
         entityBundle
         entityId
         entityType
+        fieldAddress
         entityUrl {
           path
         }

--- a/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
@@ -84,6 +84,38 @@ const nodeEvent = `
             addressLine1
           }
         }
+        ...on NodeNcaFacility {
+          fieldAddress {
+            locality
+            administrativeArea
+            postalCode
+            addressLine1
+          }
+        }
+        ...on NodeVbaFacility {
+          fieldAddress {
+            locality
+            administrativeArea
+            postalCode
+            addressLine1
+          }
+        }
+        ...on NodeVetCenterOutstation {
+          fieldAddress {
+            locality
+            administrativeArea
+            postalCode
+            addressLine1
+          }
+        }
+        ...on NodeVetCenterCap {
+          fieldAddress {
+            locality
+            administrativeArea
+            postalCode
+            addressLine1
+          }
+        }
         entityBundle
         entityId
         entityType
@@ -252,6 +284,39 @@ const nodeEventWithoutBreadcrumbs = `
             postalCode
             addressLine1
           }
+        }
+        ...on NodeNcaFacility {
+          fieldAddress {
+            locality
+            administrativeArea
+            postalCode
+            addressLine1
+          }
+        }
+        ...on NodeVbaFacility {
+          fieldAddress {
+            locality
+            administrativeArea
+            postalCode
+            addressLine1
+          }
+        }
+        ...on NodeVetCenterOutstation {
+          fieldAddress {
+            locality
+            administrativeArea
+            postalCode
+            addressLine1
+          }
+        }
+        ...on NodeVetCenterCap {
+          fieldAddress {
+            locality
+            administrativeArea
+            postalCode
+            addressLine1
+          }
+        }
         }
         entityBundle
         entityId

--- a/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
@@ -68,7 +68,7 @@ const nodeEvent = `
     fieldEventRegistrationrequired
     fieldFacilityLocation {
       entity {
-        ...on NodeVetCenter{
+        ...on NodeHealthCareLocalFacility {
           fieldAddress {
             locality
             administrativeArea
@@ -229,7 +229,15 @@ const nodeEventWithoutBreadcrumbs = `
     fieldEventRegistrationrequired
     fieldFacilityLocation {
       entity {
-        ...on NodeVetCenter{
+        ... on NodeVetCenter {
+          fieldAddress {
+            locality
+            administrativeArea
+            postalCode
+            addressLine1
+          }
+        }
+        ...on NodeHealthCareLocalFacility
           fieldAddress {
             locality
             administrativeArea

--- a/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
@@ -317,7 +317,6 @@ const nodeEventWithoutBreadcrumbs = `
             addressLine1
           }
         }
-        }
         entityBundle
         entityId
         entityType


### PR DESCRIPTION
## Description
For this ticket we are adding a new address format along with google maps link to direction. To accomplish this, we have added an update to the graphQL query to add the fieldAddress to the fieldFacilityLocation to pull the address into the event data obj. And we made the necessary changes on the FE drupal templates for events.

## Testing done & Screenshots

Testing URLs:
/outreach-and-events/events/60333/
/outreach-and-events/events/60524/

Before:
![Outreach_And_Events___Women_s_Resource_Fair_With_Veterans_Justice_Outreach_Program_-_Los_Angeles__CA___Veterans_Affairs_before](https://github.com/department-of-veterans-affairs/content-build/assets/42885441/bc094c38-6078-4c0d-9cb8-1489604aebb4)


After:
![Outreach_And_Events___Women_s_Resource_Fair_With_Veterans_Justice_Outreach_Program_-_Los_Angeles__CA___Veterans_Affairs](https://github.com/department-of-veterans-affairs/content-build/assets/42885441/f6e45585-453f-4be4-8317-2cd923d1ad42)


## QA steps

What needs to be checked to prove this works?  
Verify that event pages have new address format and link to google maps. 
Verify that VA and non VA facility events both show the new formatted address. 

What needs to be checked to prove it didn't break any related things?  
Verify that event pages are still working properly.


## Acceptance criteria
- [x] Address is presented as described above, including Directions link 
- [x] Optional building/floor/room text is displayed if provided by CMS
- [x] Google maps directions link is present / working for all addresses
- [x] VA facilities additionally display the name of the VA facility
  - [x] If the VA facility has a web page (eg VAMC), the facility name is hyperlinked to that page (see Eng Notes above)
  - [x] Otherwise, there is no hyperlink (eg VC Outstation)
- [ ] Design review required
- [ ] A11y review required

