### PR TITLE
Adds a GHA workflow and JS script to delete old, idle self-hosted runners.

### DIFF
--- a/.github/workflows/prune-self-hosted-runners.yml
+++ b/.github/workflows/prune-self-hosted-runners.yml
@@ -1,0 +1,40 @@
+name: Prune Self-Hosted Runners
+
+on:
+  workflow_dispatch:
+
+jobs:
+
+  prune-self-hosted-runners:
+    name: Prune Old and Idle Self-Hosted Runners
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Install dependencies
+        uses: ./.github/workflows/install
+        with:
+          key: ${{ hashFiles('yarn.lock') }}
+          yarn_cache_folder: ~/.cache/yarn
+          path: |
+            ~/.cache/yarn
+            node_modules
+
+      - name: Run the prune script
+        run: yarn prune-self-hosted-runners
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: 'us-gov-west-1'
+          DEBUG: 'true'

--- a/.github/workflows/prune-self-hosted-runners.yml
+++ b/.github/workflows/prune-self-hosted-runners.yml
@@ -37,4 +37,4 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: 'us-gov-west-1'
-          DEBUG: 'true'
+          DEBUG: ${{ secrets.ACTIONS_RUNNER_DEBUG }}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "watch:css-sourcemaps": "node --max-old-space-size=5000 --expose-gc script/build-content.js --watch --local-css-sourcemaps",
     "watch:review": "node ./script/run-review-instance-api.js",
     "list-heading-order-violations": "node script/heading-order-violations.js --dir ./build/vagovdev",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "prune-self-hosted-runners": "export DEBUG=true; node script/prune-self-hosted-runners.js",
+    "prune-self-hosted-runners:dry-run": "export DEBUG=true; export DRY_RUN=true; node script/prune-self-hosted-runners.js"
   },
   "repository": {
     "type": "git",
@@ -205,6 +207,7 @@
   "private": true,
   "dependencies": {
     "@department-of-veterans-affairs/vagov-platform": "^0.0.1",
+    "aws-sdk": "^2.1441.0",
     "blob-polyfill": "^4.0.20200601",
     "core-js": "^3.17.3",
     "diff2html": "^3.4.11",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "watch:review": "node ./script/run-review-instance-api.js",
     "list-heading-order-violations": "node script/heading-order-violations.js --dir ./build/vagovdev",
     "prepare": "husky install",
-    "prune-self-hosted-runners": "export DEBUG=true; node script/prune-self-hosted-runners.js",
-    "prune-self-hosted-runners:dry-run": "export DEBUG=true; export DRY_RUN=true; node script/prune-self-hosted-runners.js"
+    "prune-self-hosted-runners": "node script/prune-self-hosted-runners.js",
+    "prune-self-hosted-runners:dry-run": "export DRY_RUN=true; node script/prune-self-hosted-runners.js"
   },
   "repository": {
     "type": "git",

--- a/script/prune-self-hosted-runners.js
+++ b/script/prune-self-hosted-runners.js
@@ -1,0 +1,335 @@
+/* eslint-disable prefer-destructuring */
+/* eslint-disable camelcase */
+/* eslint-disable no-await-in-loop */
+/* eslint-disable no-console */
+
+/**
+ * This script performs some lifecycle management tasks on self-hosted runners.
+ *
+ * It is intended to be run as a scheduled cron job in a GHA workflow, though
+ * it can also be run locally.
+ *
+ * Briefly, the problem is this: We have an issue with our self-hosted runners,
+ * which are deployed to EC2 instances controlled by an ASG. If left alone,
+ * they sometimes run out of disk space, or lose connection, or in some other
+ * way lose their usefulness. If we have the max-lifetime of the ASG set, then
+ * they will be killed unceremoniously as soon as they reach that age, without
+ * any regard for jobs that may be running on them at the time.
+ *
+ * It's easier to determine a runner's state, connectivity, idleness, health,
+ * etc from GitHub than it is from within the runner itself, so my solution is
+ * to use that information to prune aging, ailing runners in a safe way, and
+ * rely upon the ASG's lifecycle management only as a last resort.
+ */
+
+const { Octokit } = require('@octokit/rest');
+const AWS = require('aws-sdk');
+
+// Prevent any changes to the infrastructure.
+const DRY_RUN = process.env.DRY_RUN === 'true';
+
+// Increased debugging information.
+const DEBUG = process.env.DEBUG === 'true';
+
+// Number of days an instance is allowed to run before termination.
+//
+// The ASG's max-lifetime is set (as of August 2023) to a value comfortably in
+// excess of this, and it should always at least, say, 5-6 hours more than this
+// value to allow for scheduling vagaries, long-running jobs, etc.
+const THRESHOLD_DAYS = process.env.THRESHOLD_DAYS || 5;
+
+// The owner of the repository.
+const GITHUB_OWNER =
+  process.env.GITHUB_OWNER || 'department-of-veterans-affairs';
+const GITHUB_REPO = process.env.GITHUB_REPO || 'content-build';
+
+// The GitHub token.
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+
+// The name of the ASG.
+const ASG_NAME = 'dsva-vagov-content-build-gha-runners-asg';
+
+// Milliseconds-to-days conversion factor.
+const MILLISECONDS_PER_DAY = 1000 * 60 * 60 * 24;
+
+// Set the default AWS region.
+const AWS_DEFAULT_REGION = 'us-gov-west-1';
+AWS.config.update({ region: AWS_DEFAULT_REGION });
+
+// The current time.
+const NOW = new Date();
+
+/**
+ * Log some debugging information.
+ */
+function debug(...args) {
+  if (DEBUG) {
+    console.log(...args);
+  }
+}
+
+/**
+ * Get the current instances in the given ASG.
+ *
+ * A given instance data structure looks like this:
+ *
+ * Instance: {
+ *   InstanceId: 'i-0fe66f30785a4190e',
+ *   InstanceType: 'm6i.4xlarge',
+ *   AvailabilityZone: 'us-gov-west-1c',
+ *   LifecycleState: 'InService',
+ *   HealthStatus: 'Healthy',
+ *   LaunchTemplate: {
+ *     LaunchTemplateId: 'lt-001a10f785f2aeafd',
+ *     LaunchTemplateName: 'dsva-vagov-content-build-gha-runner-lt',
+ *     Version: '81'
+ *   },
+ *   ProtectedFromScaleIn: true
+ * }
+ */
+async function getASGInstances(asgName) {
+  const asg = new AWS.AutoScaling();
+  const response = await asg
+    .describeAutoScalingGroups({
+      AutoScalingGroupNames: [asgName],
+    })
+    .promise();
+  const result = response.AutoScalingGroups[0].Instances;
+  debug('ASG instances:', result);
+  return result;
+}
+
+/**
+ * Get the current self-hosted runners.
+ *
+ * A given runner data structure looks like this:
+ *
+ * Runner: {
+ *   id: 37902,
+ *   name: '0WUqD2i-01cfc6179d3ca8ca3',
+ *   os: 'Linux',
+ *   status: 'online',
+ *   busy: true,
+ *   labels: [
+ *     { id: 1, name: 'self-hosted', type: 'read-only' },
+ *     { id: 2, name: 'Linux', type: 'read-only' },
+ *     { id: 3, name: 'X64', type: 'read-only' },
+ *     { id: 16273, name: 'Ubuntu20', type: 'custom' },
+ *     { id: 16274, name: 'asg', type: 'custom' }
+ *   ]
+ * }
+ */
+async function getRunners(token, owner, repo) {
+  const octokit = new Octokit({
+    auth: token,
+  });
+  const response = await octokit.actions.listSelfHostedRunnersForRepo({
+    owner,
+    repo,
+  });
+  const result = response.data.runners;
+  debug('Runners:', result);
+  return result;
+}
+
+/**
+ * Get the details of the EC2 instances.
+ */
+async function getInstancesDetails(instances) {
+  const ec2 = new AWS.EC2();
+  const response = await ec2
+    .describeInstances({
+      InstanceIds: instances.map(instance => instance.InstanceId),
+    })
+    .promise();
+  // Merge the instances of all of the reservations into a single array.
+  const instanceDetails = response.Reservations.reduce(
+    (accumulator, reservation) => {
+      return accumulator.concat(reservation.Instances);
+    },
+    [],
+  );
+  // Merge the instance details into the instances.
+  const result = instances.map(instance => {
+    const instanceDetail = instanceDetails.find(
+      details => instance.InstanceId === details.InstanceId,
+    );
+    return {
+      ...instance,
+      ...instanceDetail,
+    };
+  });
+  debug('Instances details:', result);
+  return result;
+}
+
+/**
+ * Determine the list of runners on a given instance.
+ *
+ * Each runner has a name that is composed of (as of 08/2023):
+ * - a random string
+ * - a hyphen
+ * - the instance ID
+ *
+ * Thus any runner containing the instance ID is running on that instance.
+ */
+function getRunnersOnInstance(runners, instanceId) {
+  const result = runners.filter(runner => runner.name.includes(instanceId));
+  debug('Runners on instance:', result);
+  return result;
+}
+
+/**
+ * Determine whether a given instance is old.
+ */
+function isOldInstance(instance, thresholdDays) {
+  const launchTime = instance.LaunchTime;
+  const age = NOW - new Date(launchTime);
+  const result = age > thresholdDays * MILLISECONDS_PER_DAY;
+  debug('Instance age:', age, 'Old?', result);
+  return result;
+}
+
+/**
+ * Determine whether a given instance is idle.
+ */
+function isIdleInstance(instance, runners) {
+  const { InstanceId: instanceId } = instance;
+  const myRunners = getRunnersOnInstance(runners, instanceId);
+  const isBusy = myRunners.some(runner => runner.busy);
+  return !isBusy;
+}
+
+/**
+ * Determine the list of doomed runners.
+ */
+function getDoomedRunners(instances, runners) {
+  const result = [];
+  for (const instance of instances) {
+    const { InstanceId: instanceId } = instance;
+    const myRunners = getRunnersOnInstance(runners, instanceId);
+    result.push(...myRunners);
+  }
+  debug('Doomed runners:', result);
+  return result;
+}
+
+/**
+ * Delete the given runners.
+ */
+async function deleteRunners(runners, token, owner, repo, dryRun) {
+  if (dryRun) {
+    console.log('Dry run: Not deleting runners.');
+    return;
+  }
+  const octokit = new Octokit({
+    auth: GITHUB_TOKEN,
+  });
+  for (const runner of runners) {
+    const { id: runnerId } = runner;
+    const response = await octokit
+      .request('DELETE /repos/{owner}/{repo}/actions/runners/{runner_id}', {
+        owner,
+        repo,
+        runner_id: runnerId,
+      })
+      .catch(err => {
+        console.log(err);
+      });
+    debug('Delete runner response:', response);
+  }
+}
+
+/**
+ * Remove the given instances.
+ *
+ * We do this by setting their health status to Unhealthy, which will cause the
+ * ASG to terminate them.
+ */
+async function removeInstances(instances, dryRun) {
+  if (dryRun) {
+    console.log('Dry run: Not marking instances as unhealthy.');
+    return;
+  }
+  const asg = new AWS.AutoScaling();
+  for (const instance of instances) {
+    await asg
+      .setInstanceHealth({
+        InstanceId: instance.InstanceId,
+        HealthStatus: 'Unhealthy',
+        ShouldRespectGracePeriod: true,
+      })
+      .promise();
+  }
+}
+
+/**
+ * Determine the list of old, idle instances.
+ *
+ * An instance is considered:
+ * - old if it is older than the threshold age
+ * - busy if it has any busy runners
+ * - idle if it has no busy runners
+ *
+ * Given the instances and runners, we can determine the list of old, idle
+ * instances with the following algorithm:
+ *
+ * 1. For each instance:
+ *  a. If the instance is older than the threshold age:
+ *   i. If the instance has any busy runners:
+ *    - Do nothing.
+ *  ii. If the instance has no busy runners:
+ *    - Add the instance to the list of old, idle instances.
+ * 2. Return the list of old, idle instances.
+ */
+async function getOldIdleInstances(instances, runners, thresholdDays) {
+  const result = [];
+  for (const instance of instances) {
+    const isOld = isOldInstance(instance, thresholdDays);
+    if (isOld) {
+      const isIdle = isIdleInstance(instance, runners);
+      if (isIdle) {
+        result.push(instance);
+      }
+    }
+  }
+  debug('Old idle instances:', result);
+  return result;
+}
+
+(async () => {
+  // Get all of the instances on the ASG...
+  let instances = await getASGInstances(ASG_NAME);
+
+  // ... and add their details.
+  instances = await getInstancesDetails(instances);
+
+  // Get all of the runners from GitHub.
+  const runners = await getRunners(GITHUB_TOKEN, GITHUB_OWNER, GITHUB_REPO);
+
+  // Determine the old, idle instances.
+  const oldIdleInstances = await getOldIdleInstances(
+    instances,
+    runners,
+    THRESHOLD_DAYS,
+  );
+
+  if (oldIdleInstances.length === 0) {
+    debug('No old, idle instances to delete!');
+  } else {
+    // Determine the runners we should delete, and delete them.
+    const doomedRunners = getDoomedRunners(oldIdleInstances, runners);
+    debug('Deleting doomed runners:', doomedRunners);
+    deleteRunners(
+      doomedRunners,
+      GITHUB_TOKEN,
+      GITHUB_OWNER,
+      GITHUB_REPO,
+      DRY_RUN,
+    );
+
+    // Mark the instances as unhealthy.
+    debug('Setting old idle instances unhealthy:', oldIdleInstances);
+    removeInstances(oldIdleInstances, DRY_RUN);
+  }
+})();

--- a/script/prune-self-hosted-runners.js
+++ b/script/prune-self-hosted-runners.js
@@ -219,7 +219,7 @@ function getDoomedRunners(instances, runners) {
  */
 async function deleteRunners(runners, token, owner, repo, dryRun) {
   if (dryRun) {
-    console.log('Dry run: Not deleting runners.');
+    debug('Dry run: Not deleting runners.');
     return;
   }
   const octokit = new Octokit({
@@ -234,7 +234,7 @@ async function deleteRunners(runners, token, owner, repo, dryRun) {
         runner_id: runnerId,
       })
       .catch(err => {
-        console.log(err);
+        console.error(err);
       });
     debug('Delete runner response:', response);
   }
@@ -248,7 +248,7 @@ async function deleteRunners(runners, token, owner, repo, dryRun) {
  */
 async function removeInstances(instances, dryRun) {
   if (dryRun) {
-    console.log('Dry run: Not marking instances as unhealthy.');
+    debug('Dry run: Not marking instances as unhealthy.');
     return;
   }
   const asg = new AWS.AutoScaling();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2347,6 +2347,27 @@ autoprefixer@^9.6.1:
     postcss "^7.0.32"
     postcss-value-parser "^4.1.0"
 
+available-typed-arrays@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
+  integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
+
+aws-sdk@^2.1441.0:
+  version "2.1441.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1441.0.tgz#bce13790f0bc7364a33bafd83f7e77a08b682313"
+  integrity sha512-qMmFt7jyBoe9HsS0o9YoY/zGfURM/rD8DYR1VFzsJKKb8UMnjZrUfDX+fb+rQKK1WLp0+k9dBVFhU09EcSJTKQ==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.16.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    util "^0.12.4"
+    uuid "8.0.0"
+    xml2js "0.5.0"
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -2470,7 +2491,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base64-js@^1.3.1:
+base64-js@^1.0.2, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -2628,6 +2649,15 @@ buffer-indexof@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-indexof/-/buffer-indexof-1.1.1.tgz#52fabcc6a606d1a00302802648ef68f639da268c"
   integrity sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==
+
+buffer@4.9.2:
+  version "4.9.2"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
+  integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+    isarray "^1.0.0"
 
 buffer@^5.5.0, buffer@^5.6.0, buffer@^5.7.0:
   version "5.7.1"
@@ -4862,6 +4892,11 @@ eventemitter3@^4.0.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
+events@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+  integrity sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==
+
 events@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
@@ -5262,6 +5297,13 @@ follow-redirects@^1.0.0, follow-redirects@^1.14.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.8.tgz#016996fb9a11a100566398b1c6839337d7bfa8fc"
   integrity sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==
 
+for-each@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
+  integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
+  dependencies:
+    is-callable "^1.1.3"
+
 foreground-child@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-2.0.0.tgz#71b32800c9f15aa8f2f83f4a6bd9bff35d861a53"
@@ -5478,6 +5520,16 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
     has "^1.0.3"
     has-symbols "^1.0.1"
 
+get-intrinsic@^1.1.3:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.1.tgz#d295644fed4505fc9cde952c37ee12b477a83d82"
+  integrity sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-proto "^1.0.1"
+    has-symbols "^1.0.3"
+
 get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz#b5fde77f22cbe35f390b4e089922c50bce6ef664"
@@ -5631,6 +5683,13 @@ gonzales-pe-sl@^4.2.3:
   dependencies:
     minimist "1.1.x"
 
+gopd@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
+  integrity sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==
+  dependencies:
+    get-intrinsic "^1.1.3"
+
 graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.3, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.8:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
@@ -5714,10 +5773,20 @@ has-generators@^1.0.1:
   resolved "https://registry.yarnpkg.com/has-generators/-/has-generators-1.0.1.tgz#a6a2e55486011940482e13e2c93791c449acf449"
   integrity sha1-pqLlVIYBGUBILhPiyTeRxEms9Ek=
 
+has-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-proto/-/has-proto-1.0.1.tgz#1885c1305538958aff469fef37937c22795408e0"
+  integrity sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==
+
 has-symbols@^1.0.1, has-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
   integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
+
+has-symbols@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
+  integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
 
 has-tostringtag@^1.0.0:
   version "1.0.0"
@@ -5959,7 +6028,12 @@ icss-utils@^5.0.0, icss-utils@^5.1.0:
   resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-5.1.0.tgz#c6be6858abd013d768e98366ae47e25d5887b1ae"
   integrity sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==
 
-ieee754@^1.1.13:
+ieee754@1.1.13:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
+  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
+
+ieee754@^1.1.13, ieee754@^1.1.4:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -6182,6 +6256,11 @@ is-builtin-module@^3.1.0:
   dependencies:
     builtin-modules "^3.0.0"
 
+is-callable@^1.1.3:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
+  integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
+
 is-callable@^1.1.4, is-callable@^1.1.5, is-callable@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.2.tgz#c7c6715cd22d4ddb48d3e19970223aceabb080d9"
@@ -6251,6 +6330,13 @@ is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
+
+is-generator-function@^1.0.7:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.0.10.tgz#f1558baf1ac17e0deea7c0415c438351ff2b3c72"
+  integrity sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==
+  dependencies:
+    has-tostringtag "^1.0.0"
 
 is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   version "4.0.3"
@@ -6418,6 +6504,13 @@ is-symbol@^1.0.2, is-symbol@^1.0.3:
   dependencies:
     has-symbols "^1.0.2"
 
+is-typed-array@^1.1.3:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.12.tgz#d0bab5686ef4a76f7a73097b95470ab199c57d4a"
+  integrity sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==
+  dependencies:
+    which-typed-array "^1.1.11"
+
 is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
@@ -6559,6 +6652,11 @@ jest-worker@^27.0.6:
     "@types/node" "*"
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
+
+jmespath@0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.16.0.tgz#b15b0a85dfd4d930d43e69ed605943c802785076"
+  integrity sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==
 
 jpeg-js@^0.4.0:
   version "0.4.4"
@@ -10142,6 +10240,16 @@ sass-loader@^12.1.0:
     klona "^2.0.4"
     neo-async "^2.6.2"
 
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  integrity sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==
+
+sax@>=0.6.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
 saxes@^3.1.9:
   version "3.1.11"
   resolved "https://registry.yarnpkg.com/saxes/-/saxes-3.1.11.tgz#d59d1fd332ec92ad98a2e0b2ee644702384b1c5b"
@@ -11431,6 +11539,14 @@ url-parse@^1.5.10:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
+url@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+  integrity sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
+
 url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
@@ -11458,6 +11574,17 @@ util@^0.10.3:
   dependencies:
     inherits "2.0.3"
 
+util@^0.12.4:
+  version "0.12.5"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.12.5.tgz#5f17a6059b73db61a875668781a1c2b136bd6fbc"
+  integrity sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==
+  dependencies:
+    inherits "^2.0.3"
+    is-arguments "^1.0.4"
+    is-generator-function "^1.0.7"
+    is-typed-array "^1.1.3"
+    which-typed-array "^1.1.2"
+
 utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
@@ -11467,6 +11594,11 @@ uuid@3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
+
+uuid@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.0.0.tgz#bc6ccf91b5ff0ac07bbcdbf1c7c4e150db4dbb6c"
+  integrity sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==
 
 uuid@^3.3.2, uuid@^3.3.3, uuid@^3.4.0:
   version "3.4.0"
@@ -11738,6 +11870,17 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
+which-typed-array@^1.1.11, which-typed-array@^1.1.2:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.11.tgz#99d691f23c72aab6768680805a271b69761ed61a"
+  integrity sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    for-each "^0.3.3"
+    gopd "^1.0.1"
+    has-tostringtag "^1.0.0"
+
 which@2.0.2, which@^2.0.1, which@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
@@ -11894,10 +12037,23 @@ xml-name-validator@^3.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
+xml2js@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.5.0.tgz#d9440631fbb2ed800203fad106f2724f62c493b7"
+  integrity sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
+
 xml@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
   integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
+
+xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
 xmlchars@^2.1.1:
   version "2.2.0"


### PR DESCRIPTION
## Description

Closes department-of-veterans-affairs/va.gov-cms#14693.

This PR introduces a script and associated GitHub Actions workflow to manage the lifecycle of our self-hosted runners on EC2 instances controlled by an ASG. The primary goal is to gracefully handle runners that might run out of resources or become unresponsive over time.

Node.js Script (`prune-self-hosted-runners.js`):
- Queries GitHub to determine the status of each runner.
- Interacts with AWS to fetch the age of each EC2 instance.
- Identifies old, idle instances (those that have been running for more than a set threshold and have no busy runners).
- Deregisters runners from GitHub and marks the associated EC2 instances as unhealthy.

GitHub Actions Workflow (`prune-runners.yml`):
- Scheduled to run on a manual trigger (`workflow_dispatch`). I'll update this later to add a scheduled invocation if the workflow runs and works as expected.
- Sets up AWS credentials and Node.js environment.
- Executes the pruning script.

`package.json` Updates:
- Added two new scripts for running the pruning script, one for regular execution and another for a dry-run mode.

Safety Measures:
- A dry-run mode has been implemented to simulate the pruning process without making actual changes. This is useful for testing and verification.
- Detailed logging has been added for monitoring and debugging purposes, but only in the detailed debug logging mode. I don't think this will log any sensitive information. Certainly no PHI/PII, but it's possible that something misconfigured somewhere else could be exposed.

Next Steps:
- After merging, monitor the initial runs of the workflow to ensure everything operates as expected.
- Adjust the age threshold if necessary based on observations and requirements.

## Testing done & Screenshots

Ran in dry-run mode locally many times while developing.

