### PR TITLE
Use VSP GitHub token, not default token, for managing runners.

### DIFF
--- a/.github/workflows/prune-self-hosted-runners.yml
+++ b/.github/workflows/prune-self-hosted-runners.yml
@@ -21,6 +21,12 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-gov-west-1
 
+      - name: Get va-vsp-bot token
+        uses: department-of-veterans-affairs/action-inject-ssm-secrets@d8e6de3bde4dd728c9d732baef58b3c854b8c4bb # latest
+        with:
+          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+
       - name: Install dependencies
         uses: ./.github/workflows/install
         with:
@@ -33,7 +39,7 @@ jobs:
       - name: Run the prune script
         run: yarn prune-self-hosted-runners
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: 'us-gov-west-1'


### PR DESCRIPTION
Normal GitHub token doesn't seem to have sufficient privileges for pruning self-hosted runners (see #1676). I believe what I need is the VSP GitHub bot token.

Pls lemme know if I should use a different one.
