### PR TITLE
Add appeals testing app

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1574,5 +1574,21 @@
       "description": "PACT Act application",
       "vagovprod": false
     }
+  },
+  {
+    "appName": "Appeals Testing",
+    "entryName": "appeals-testing",
+    "rootUrl": "/decision-reviews/appeals-testing",
+    "productId": "5dd32517-00fd-4e97-afed-e6db1f1f54f9",
+    "template": {
+      "layout": "page-react.html",
+      "description": "Testing new layout for Appeals forms",
+      "vagovprod": false,
+      "includeBreadcrumbs": false,
+      "noNavOrLogin": true,
+      "noMegamenu": true,
+      "includeFeedbackButton": false,
+      "minimalFooter": true
+    }
   }
 ]


### PR DESCRIPTION
## Description

We plan to build an app to allow our team to more easily perform user testing in staging. This app will _never_ be released into production. 

See [#64388](https://github.com/department-of-veterans-affairs/va.gov-team/issues/64388)

## Testing done & Screenshots

N/A

## Acceptance criteria

- [x] Add registry entry for new app

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
