### PR TITLE
Update content-release.yml

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -476,6 +476,9 @@ jobs:
     needs: deploy
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
         with:


### PR DESCRIPTION
A recent PR added some steps to the notify-cms-on-failure bit, but didn't add a checkout step. Consequently notifying the CMS of failure is not functioning correctly right now.