### PR TITLE
Schedule the prune-self-hosted-runner script.

### DIFF
--- a/.github/workflows/prune-self-hosted-runners.yml
+++ b/.github/workflows/prune-self-hosted-runners.yml
@@ -3,7 +3,7 @@ name: Prune Self-Hosted Runners
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 * * * *' # Hourly
+    - cron: '27 2 * * *' # Daily, @ ~2:27AM
 
 jobs:
 

--- a/.github/workflows/prune-self-hosted-runners.yml
+++ b/.github/workflows/prune-self-hosted-runners.yml
@@ -2,6 +2,8 @@ name: Prune Self-Hosted Runners
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 * * * *' # Hourly
 
 jobs:
 

--- a/.github/workflows/prune-self-hosted-runners.yml
+++ b/.github/workflows/prune-self-hosted-runners.yml
@@ -3,7 +3,7 @@ name: Prune Self-Hosted Runners
 on:
   workflow_dispatch:
   schedule:
-    - cron: '27 2 * * *' # Daily, @ ~2:27AM
+    - cron: '27 * * * *' # Hourly at 27 minutes past the hour
 
 jobs:
 

--- a/script/prune-self-hosted-runners.js
+++ b/script/prune-self-hosted-runners.js
@@ -38,6 +38,9 @@ const DEBUG = process.env.DEBUG === 'true';
 // value to allow for scheduling vagaries, long-running jobs, etc.
 const THRESHOLD_DAYS = process.env.THRESHOLD_DAYS || 5;
 
+// The maximum number of runners to terminate at a time.
+const TERMINATE_LIMIT = process.env.TERMINATE_LIMIT || 3;
+
 // The owner of the repository.
 const GITHUB_OWNER =
   process.env.GITHUB_OWNER || 'department-of-veterans-affairs';
@@ -320,6 +323,11 @@ async function getOldIdleInstances(instances, runners, thresholdDays) {
   if (oldIdleInstances.length === 0) {
     debug('No old, idle instances to delete!');
   } else {
+    // Don't kill more than _n_ runners at a time.
+    if (oldIdleInstances.length > TERMINATE_LIMIT) {
+      oldIdleInstances.length = TERMINATE_LIMIT;
+    }
+
     // Determine the runners we should delete, and delete them.
     const doomedRunners = getDoomedRunners(oldIdleInstances, runners);
     debug('Deleting doomed runners:', doomedRunners);

--- a/script/prune-self-hosted-runners.js
+++ b/script/prune-self-hosted-runners.js
@@ -123,10 +123,13 @@ async function getRunners(token, owner, repo) {
   const octokit = new Octokit({
     auth: token,
   });
-  const response = await octokit.actions.listSelfHostedRunnersForRepo({
-    owner,
-    repo,
-  });
+  const response = await octokit.request(
+    'GET /repos/{owner}/{repo}/actions/runners?per_page=100',
+    {
+      owner,
+      repo,
+    },
+  );
   const result = response.data.runners;
   debug('Runners:', result);
   return result;


### PR DESCRIPTION
## Description

I made a tweak to the prune-self-hosted-runners script to retrieve up to 100 runners (bugfix!) and also to schedule it for regular execution. I've been using the script locally to prune old, idle runners for a few days and haven't encountered any unexpected issues.

I don't want to merge this just yet, though, as I'd like to see how stable the runners are in their current arrangement.