### PR TITLE
VACMS-13137 Conditional List for template

### DIFF
--- a/src/site/paragraphs/contact_information.drupal.liquid
+++ b/src/site/paragraphs/contact_information.drupal.liquid
@@ -5,67 +5,73 @@
         <div class="usa-content vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
           <section class="vads-u-display--flex vads-u-flex-direction--column vads-u-padding-y--2" data-template="paragraphs/contact_information">
             <h2 class="vads-u-font-size--h3 vads-u-border-bottom--4px vads-u-border-color--primary vads-u-margin--0 vads-u-margin-y--1 vads-u-padding-bottom--1">Need more help?</h2>
+            {% if 
+              entity.fieldContactInfoSwitch == 'DC' and
+              entity.fieldContactDefault != empty and
+              !entity.fieldAdditionalContact.entity.fieldEmailLabel and
+              !entity.fieldAdditionalContact.entity.fieldEmailAddress 
+            %}
+              <p>{% include "src/site/paragraphs/default_contact.drupal.liquid" with entity = entity %}</p>
+            {% else %}
+              <ul class="usa-unstyled-list vads-u-display--flex vads-u-flex-direction--column" role="list">
 
-            <ul class="usa-unstyled-list vads-u-display--flex vads-u-flex-direction--column" role="list">
-              <!-- Default contact -->
-              {% if entity.fieldContactInfoSwitch == 'DC' and entity.fieldContactDefault != empty %}
-                <li class="vads-u-margin-top--1">
-                  <strong>{{ entity.fieldContactDefault.entity.title }} </strong>
-                  {% if entity.fieldContactDefault.entity.fieldLink %}
-                    <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ entity.fieldContactDefault.entity.fieldPhoneNumber }}', 'links-list-section-header': 'Need more help?' })"
-                        href="{{ entity.fieldContactDefault.entity.fieldLink.url.path }}"
-                        rel="noreferrer noopener">
-                      {{ entity.fieldContactDefault.entity.fieldPhoneNumber }}
-                    </a>
-                  {% endif %}
-                </li>
-              {% endif %}
-
-              <!-- Additional contact -->
-              {% if entity.fieldAdditionalContact != empty %}
-                <li class="vads-u-margin-top--1">
-                  <!-- Email -->
-                  {% if entity.fieldAdditionalContact.entity.fieldEmailLabel and entity.fieldAdditionalContact.entity.fieldEmailAddress %}
-                    <strong>{{ entity.fieldAdditionalContact.entity.fieldEmailLabel }}: </strong>
-                    {% if entity.fieldAdditionalContact.entity.fieldEmailAddress %}
-                      <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ entity.fieldAdditionalContact.entity.fieldEmailAddress | escape }}', 'links-list-section-header': 'Need more help?' })"
-                          href="mailto:{{ entity.fieldAdditionalContact.entity.fieldEmailAddress }}"
-                          rel="noreferrer noopener">
-                        {{ entity.fieldAdditionalContact.entity.fieldEmailAddress }}
-                      </a>
-                    {% endif %}
-                  {% endif %}
-
-                  <!-- Phone number -->
-                  {% if entity.fieldAdditionalContact.entity.fieldPhoneLabel and entity.fieldAdditionalContact.entity.fieldPhoneNumber %}
-                    <strong>{{ entity.fieldAdditionalContact.entity.fieldPhoneLabel }}: </strong>
-                    {% if entity.fieldAdditionalContact.entity.fieldPhoneNumber %}
-                      <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ entity.fieldAdditionalContact.entity.fieldPhoneNumber | escape }}{% if fieldPhoneExtension %}p{{ fieldPhoneExtension }}{% endif %}', 'links-list-section-header': 'Need more help?' })"
-                          href="tel:{{ entity.fieldAdditionalContact.entity.fieldPhoneNumber }}{% if fieldPhoneExtension %}p{{ fieldPhoneExtension }}{% endif %}"
-                          rel="noreferrer noopener">
-                        {{ entity.fieldAdditionalContact.entity.fieldPhoneNumber }}{% if fieldPhoneExtension %}p{{ fieldPhoneExtension }}{% endif %}
-                      </a>
-                    {% endif %}
-                  {% endif %}
-                </li>
-              {% endif %}
-
-              <!-- Benefit hub contacts -->
-              {% if entity.fieldContactInfoSwitch == 'BHC' and entity.fieldBenefitHubContacts != empty %}
-                {% for supportService in entity.fieldBenefitHubContacts.entity.fieldSupportServices %}
+                <!-- Default contact -->
+                {% if entity.fieldContactInfoSwitch == 'DC' and entity.fieldContactDefault != empty %}
                   <li class="vads-u-margin-top--1">
-                    <strong>{{ supportService.entity.title }} </strong>
-                    {% if supportService.entity.fieldLink %}
-                      <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ supportService.entity.fieldPhoneNumber | escape }}', 'links-list-section-header': 'Need more help?' })"
-                          href="{{ supportService.entity.fieldLink.url.path }}"
-                          rel="noreferrer noopener">
-                        {{ supportService.entity.fieldPhoneNumber }}
-                      </a>
-                    {% endif %}
+                    <p>{% include "src/site/paragraphs/default_contact.drupal.liquid" with entity = entity %}</p>
                   </li>
-                {% endfor %}
-              {% endif %}
-            </ul>
+                {% endif %}
+
+                <!-- Additional contact -->
+                {% if entity.fieldContactDefault != empty %}
+                  {% if entity.fieldAdditionalContact.entity.fieldEmailLabel or entity.fieldAdditionalContact.entity.fieldPhoneLabel %}
+                    <li class="vads-u-margin-top--1">
+
+                      <!-- Email -->
+                      {% if entity.fieldAdditionalContact.entity.fieldEmailLabel and entity.fieldAdditionalContact.entity.fieldEmailAddress %}
+                        <strong>{{ entity.fieldAdditionalContact.entity.fieldEmailLabel }}: </strong>
+                        {% if entity.fieldAdditionalContact.entity.fieldEmailAddress %}
+                          <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ entity.fieldAdditionalContact.entity.fieldEmailAddress | escape }}', 'links-list-section-header': 'Need more help?' })"
+                              href="mailto:{{ entity.fieldAdditionalContact.entity.fieldEmailAddress }}"
+                              rel="noreferrer noopener">
+                            {{ entity.fieldAdditionalContact.entity.fieldEmailAddress }}
+                          </a>
+                        {% endif %}
+                      {% endif %}
+
+                      <!-- Phone number -->
+                      {% if entity.fieldAdditionalContact.entity.fieldPhoneLabel and entity.fieldAdditionalContact.entity.fieldPhoneNumber %}
+                        <strong>{{ entity.fieldAdditionalContact.entity.fieldPhoneLabel }}: </strong>
+                        {% if entity.fieldAdditionalContact.entity.fieldPhoneNumber %}
+                          <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ entity.fieldAdditionalContact.entity.fieldPhoneNumber | escape }}{% if fieldPhoneExtension %}p{{ fieldPhoneExtension }}{% endif %}', 'links-list-section-header': 'Need more help?' })"
+                              href="tel:{{ entity.fieldAdditionalContact.entity.fieldPhoneNumber }}{% if fieldPhoneExtension %}p{{ fieldPhoneExtension }}{% endif %}"
+                              rel="noreferrer noopener">
+                            {{ entity.fieldAdditionalContact.entity.fieldPhoneNumber }}{% if fieldPhoneExtension %}p{{ fieldPhoneExtension }}{% endif %}
+                          </a>
+                        {% endif %}
+                      {% endif %}
+                    </li>
+                  {% endif %}
+                {% endif %}
+
+                <!-- Benefit hub contacts -->
+                {% if entity.fieldContactInfoSwitch == 'BHC' and entity.fieldBenefitHubContacts != empty %}
+                  {% for supportService in entity.fieldBenefitHubContacts.entity.fieldSupportServices %}
+                    <li class="vads-u-margin-top--1">
+                      <strong>{{ supportService.entity.title }} </strong>
+                      {% if supportService.entity.fieldLink %}
+                        <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ supportService.entity.fieldPhoneNumber | escape }}', 'links-list-section-header': 'Need more help?' })"
+                            href="{{ supportService.entity.fieldLink.url.path }}"
+                            rel="noreferrer noopener">
+                          {{ supportService.entity.fieldPhoneNumber }}
+                        </a>
+                      {% endif %}
+                    </li>
+                  {% endfor %}
+                {% endif %}
+
+              </ul>
+            {% endif %}
           </section>
         </div>
       </div>

--- a/src/site/paragraphs/default_contact.drupal.liquid
+++ b/src/site/paragraphs/default_contact.drupal.liquid
@@ -1,0 +1,9 @@
+<strong>{{ entity.fieldContactDefault.entity.title }} </strong>
+{% if entity.fieldContactDefault.entity.fieldLink %}
+  <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ entity.fieldContactDefault.entity.fieldPhoneNumber }}', 'links-list-section-header': 'Need more help?' })"
+    href="{{ entity.fieldContactDefault.entity.fieldLink.url.path }}"
+    rel="noreferrer noopener"
+  >
+    {{ entity.fieldContactDefault.entity.fieldPhoneNumber }}
+  </a>
+{% endif %}


### PR DESCRIPTION
## Description
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13137

On the Resources & Support pages, there is a Contact Information widget used to add phone numbers to the bottom of those pages. When there's only the default (MyVA411) contact information provided, we needed to render a paragraph instead of an unordered list.

I saw that we were also rendering an `<li>` regardless of whether the default contact information for email and phone number is provided, resulting in a blank `<li>` that is still read by the screen reader. This is fixed as well.

## Testing done & Screenshots

### Multiple Contact Numbers
```
/resources/can-i-plan-ahead-for-my-burial-in-a-va-national-cemetery/
/resources/compare-va-education-benefits/
```
<img width="736" alt="Screenshot 2023-08-30 at 10 41 22 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/2e51c60d-9f54-4165-801b-b53f8d42ee7f">
<br />
<br />
<img width="514" alt="Screenshot 2023-08-30 at 10 41 39 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/5278486a-6165-4a8b-af60-dbd50043eb93">

### Default Contact Only
```
/resources/how-to-get-free-language-assistance-from-va/
```
<img width="737" alt="Screenshot 2023-08-30 at 10 39 42 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/ac1d7f43-2161-4c8a-ad88-c87b15faf9dc">
<br />
<br />
<img width="430" alt="Screenshot 2023-08-30 at 10 39 51 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/9d00b7e8-16dd-4418-b206-b60150ed2898">


## QA steps
1. Navigate to one of the 3 URLs above
2. If there are multiple contact numbers, validate that they are contained within a `<ul>` with an `<li>` for each element.
3. If there is only the default contact number, validate that it is contained within a `<p>` and there is no `<ul>` in this section.

## Acceptance criteria
- [x] Check for other places (besides R&S Detail template below) where a need-more-help section exists, as this will drive the decision of whether to componentize or just one-off code
- [x] Need more help's content is a `<p>` if there is only 1 item
- [x] Need more help's content is a `<ul>` with `<li>` option if there is more than one item