### PR TITLE
VACMS-14967 Launch iOS mobile app banner

### DIFF
--- a/src/site/includes/metatags.drupal.liquid
+++ b/src/site/includes/metatags.drupal.liquid
@@ -24,7 +24,7 @@
 
 {% assign shouldShow = entityUrl.path | shouldShowiOSBanner %}
 <!-- iOS banner -->
-{% if shouldShow and buildtype === 'vagovstaging' %}
+{% if shouldShow %}
   <meta name="apple-itunes-app" content="app-id=1559609596">
 {% endif %}
 


### PR DESCRIPTION
## Description
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14967

Previously, we added an iOS mobile app promo banner to a set of specific pages. It was controlled by a feature flag and by an environment check (to be viewed in staging only). We are removing the environment check so the feature can be viewed in production.

[See here](https://github.com/department-of-veterans-affairs/content-build/blob/8d975732f87abf1cb9113cd9513396e0e85e865b/src/site/filters/liquid.js#L1597) for the pages included in this feature. The feature flag remains.

## Testing done & Screenshots
Not able to test this locally or in the review instance.

## Acceptance Criteria
- [x] Staging environment check is removed