### PR TITLE
update formatting issue for event detail page

### DIFF
--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -12,7 +12,7 @@
         {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
       {% endunless %}
 
-      <div class="usa-width-three-fourths vads-u-display--flex vads-u-flex-direction--column vads-u-padding-x--1p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--2">
+      <div class="vads-u-display--flex vads-u-flex-direction--column vads-u-padding-x--1p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--2">
         {% include "src/site/includes/lovell-switch-link.drupal.liquid" with
          entityUrl = entityUrl %}
 
@@ -281,62 +281,62 @@
 
   function onExpandRecurringEventsClick() {
   var expandRecurringEventsButton = document.getElementById('expand-recurring-events');
-            var expandRecurringEventsIcon = document.getElementById('expand-recurring-events-icon');
-            var recurringEvents = document.getElementById('recurring-events');
-          
-            // Escape early if we are not able to find the elements.
-            if (!expandRecurringEventsButton || !expandRecurringEventsIcon || !recurringEvents) {
-              return;
-            }
-          
-            // Toggle the bottom borders of the button.
-            if (expandRecurringEventsButton.style.borderBottomLeftRadius === '0px') {
-              expandRecurringEventsButton.style.borderBottomLeftRadius = '5px';
-              expandRecurringEventsButton.style.borderBottomRightRadius = '5px';
-            } else {
-              expandRecurringEventsButton.style.borderBottomLeftRadius = '0px';
-              expandRecurringEventsButton.style.borderBottomRightRadius = '0px';
-            }
-          
-            // Toggle the visibility of the recurring events.
-            recurringEvents.classList.toggle('vads-u-display--none');
-            recurringEvents.classList.toggle('vads-u-display--flex');
-          
-            // Toggle the icon.
-            expandRecurringEventsIcon.classList.toggle('fa-plus');
-            expandRecurringEventsIcon.classList.toggle('fa-minus');
-          }
-          
-          function onShowAllRecurringEventsClick() {
-            // Derive recurring event items.
-            var recurringEventItems = document.querySelectorAll('.recurring-event');
-          
-            // Show all recurring events.
-            for (var index = 0; index < recurringEventItems.length; index++) {
-              if (recurringEventItems[index]) {
-                recurringEventItems[index].classList.remove('vads-u-display--none');
+                var expandRecurringEventsIcon = document.getElementById('expand-recurring-events-icon');
+                var recurringEvents = document.getElementById('recurring-events');
+              
+                // Escape early if we are not able to find the elements.
+                if (!expandRecurringEventsButton || !expandRecurringEventsIcon || !recurringEvents) {
+                  return;
+                }
+              
+                // Toggle the bottom borders of the button.
+                if (expandRecurringEventsButton.style.borderBottomLeftRadius === '0px') {
+                  expandRecurringEventsButton.style.borderBottomLeftRadius = '5px';
+                  expandRecurringEventsButton.style.borderBottomRightRadius = '5px';
+                } else {
+                  expandRecurringEventsButton.style.borderBottomLeftRadius = '0px';
+                  expandRecurringEventsButton.style.borderBottomRightRadius = '0px';
+                }
+              
+                // Toggle the visibility of the recurring events.
+                recurringEvents.classList.toggle('vads-u-display--none');
+                recurringEvents.classList.toggle('vads-u-display--flex');
+              
+                // Toggle the icon.
+                expandRecurringEventsIcon.classList.toggle('fa-plus');
+                expandRecurringEventsIcon.classList.toggle('fa-minus');
               }
-            }
-          
-            // Hide the show all recurring events button.
-            var showAllRecurringEventsButton = document.getElementById('show-all-recurring-events');
-          
-            // Hide the button if we find it.
-            if (showAllRecurringEventsButton) {
-              showAllRecurringEventsButton.classList.add('vads-u-display--none');
-            }
-          }
-          
-          
-          var expandRecurringEventsButton = document.getElementById('expand-recurring-events');
-          if (expandRecurringEventsButton) {
-            expandRecurringEventsButton.addEventListener('click', onExpandRecurringEventsClick);
-          }
-          
-          var showAllRecurringEventsButton = document.getElementById('show-all-recurring-events');
-          if (showAllRecurringEventsButton) {
-            showAllRecurringEventsButton.addEventListener('click', onShowAllRecurringEventsClick);
-          }</script>
+              
+              function onShowAllRecurringEventsClick() {
+                // Derive recurring event items.
+                var recurringEventItems = document.querySelectorAll('.recurring-event');
+              
+                // Show all recurring events.
+                for (var index = 0; index < recurringEventItems.length; index++) {
+                  if (recurringEventItems[index]) {
+                    recurringEventItems[index].classList.remove('vads-u-display--none');
+                  }
+                }
+              
+                // Hide the show all recurring events button.
+                var showAllRecurringEventsButton = document.getElementById('show-all-recurring-events');
+              
+                // Hide the button if we find it.
+                if (showAllRecurringEventsButton) {
+                  showAllRecurringEventsButton.classList.add('vads-u-display--none');
+                }
+              }
+              
+              
+              var expandRecurringEventsButton = document.getElementById('expand-recurring-events');
+              if (expandRecurringEventsButton) {
+                expandRecurringEventsButton.addEventListener('click', onExpandRecurringEventsClick);
+              }
+              
+              var showAllRecurringEventsButton = document.getElementById('show-all-recurring-events');
+              if (showAllRecurringEventsButton) {
+                showAllRecurringEventsButton.addEventListener('click', onShowAllRecurringEventsClick);
+              }</script>
 
 {% include "src/site/includes/footer.html" %}
 {% include "src/site/includes/debug.drupal.liquid" %}


### PR DESCRIPTION
## Description
There was a defect filed that the format for description of the event is not showing up in the proper place for non-VA location events. This change to the styles will take care of that. 

## Testing done & Screenshots
Validated that non-VA locations have the correct layout for description. Also verified that other events are not affected by this change. 
![VA_Boston_Health_Care___Veterans_Stand_Down___Veterans_Affairs](https://github.com/department-of-veterans-affairs/content-build/assets/42885441/0382b600-eec2-4353-9dea-3bdabf65e346)

![Outreach_And_Events___PACT_Act_Registration_Day_For_Gulf_War_Veterans_-_Philadelphia__Pa____Veterans_Affairs](https://github.com/department-of-veterans-affairs/content-build/assets/42885441/6e9db715-2e82-49d0-80d5-d894ea837131)


