### PR TITLE
Fix breadcrumb name in form 21-0972

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1464,7 +1464,7 @@
     }
   },
   {
-    "appName": "Sign for benefits on behalf of another person",
+    "appName": "Sign VA claim forms as an alternate signer",
     "entryName": "21-0972-alternate-signer",
     "rootUrl": "/supporting-forms-for-claims/alternate-signer-form-21-0972",
     "productId": "38f07696-546f-4c9a-a6f0-16348bde4d33",
@@ -1478,7 +1478,7 @@
           "path": "supporting-forms-for-claims"
         },
         {
-          "name": "Sign for benefits on behalf of another person",
+          "name": "Sign VA claim forms as an alternate signer",
           "path": "supporting-forms-for-claims/alternate-signer-form-21-0972"
         }
       ]


### PR DESCRIPTION
## Description

This PR fixes a breadcrumb name for 21-0972, per feedback from the collaboration cycle.

I've also updated the `appName` to be consistent. Is there any risk to doing this? I've checked and, with this update, it is consistent with the `appName` in the `vets-website` repo.

closes https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/64660