### PR TITLE
Turn off Medallia rating scale A/B test

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1496,20 +1496,16 @@ module.exports = function registerFilters() {
   };
 
   liquid.filters.getSurvey = (buildtype, url) => {
-    const abTestSurvey = (surveyA, surveyB) => {
-      return Math.random() < 0.5 ? surveyA : surveyB;
-    };
-
     if (
       buildtype === 'localhost' ||
       buildtype === 'vagovstaging' ||
       buildtype === 'vagovdev'
     ) {
-      return stagingSurveys[url] ? stagingSurveys[url] : abTestSurvey(11, 37);
+      return stagingSurveys[url] ? stagingSurveys[url] : 11;
     }
 
     if (buildtype === 'vagovprod') {
-      return prodSurveys[url] ? prodSurveys[url] : abTestSurvey(17, 39);
+      return prodSurveys[url] ? prodSurveys[url] : 17;
     }
     return null;
   };

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -2560,47 +2560,33 @@ describe('deriveFormattedTimestamp', () => {
 });
 
 describe('getSurvey', () => {
+  const testBuildTypes = ['vagovprod', 'vagovstaging', 'localhost'];
+  const testUrls = [
+    '/resources',
+    '/find-locations',
+    '/search',
+    '/contact-us/virtual-agent',
+  ];
+
   it('returns the survey number if url is listed in the survey object', () => {
-    const testUrls = [
-      '/resources',
-      '/find-locations',
-      '/search',
-      '/contact-us/virtual-agent',
-    ];
-    const testBuildTypes = ['vagovprod', 'vagovstaging', 'localhost'];
-    const stagingAbTest = [11, 37];
-    const prodAbTest = [17, 39];
-
     // Staging survey tests
-    const stagingDefault = liquid.filters.getSurvey(
-      testBuildTypes[1],
-      testUrls[1],
-      stagingSurveys,
-    );
-
-    expect(stagingAbTest.includes(stagingDefault)).to.be.true;
-
-    expect(prodAbTest.includes(stagingDefault)).to.be.false;
-
     expect(
       liquid.filters.getSurvey(testBuildTypes[1], testUrls[2], stagingSurveys),
+    ).to.equal(20);
+
+    expect(
+      liquid.filters.getSurvey(testBuildTypes[2], testUrls[2], stagingSurveys),
     ).to.equal(20);
 
     expect(
       liquid.filters.getSurvey(testBuildTypes[1], testUrls[3], stagingSurveys),
     ).to.equal(26);
 
+    expect(
+      liquid.filters.getSurvey(testBuildTypes[1], testUrls[3], stagingSurveys),
+    ).to.equal(26);
+
     // Prod survey tests
-    const prodDefault = liquid.filters.getSurvey(
-      testBuildTypes[0],
-      testUrls[1],
-      prodSurveys,
-    );
-
-    expect(prodAbTest.includes(prodDefault)).to.be.true;
-
-    expect(stagingAbTest.includes(prodDefault)).to.be.false;
-
     expect(
       liquid.filters.getSurvey(testBuildTypes[0], testUrls[2], prodSurveys),
     ).to.equal(21);
@@ -2608,6 +2594,18 @@ describe('getSurvey', () => {
     expect(
       liquid.filters.getSurvey(testBuildTypes[0], testUrls[3], prodSurveys),
     ).to.equal(25);
+  });
+
+  it('returns null for a build type not present in the staging survey object', () => {
+    expect(
+      liquid.filters.getSurvey('invalidbuildtype', testUrls[2], stagingSurveys),
+    ).to.be.null;
+  });
+
+  it('returns null for a build type not present in the production survey object', () => {
+    expect(
+      liquid.filters.getSurvey('invalidbuildtype', testUrls[2], prodSurveys),
+    ).to.be.null;
   });
 });
 


### PR DESCRIPTION
## Description

This PR turns off the A/B test for the Medallia survey rating scale
closes [#64865  ](https://github.com/department-of-veterans-affairs/va.gov-team/issues/64865)
relates to #1648  

## Testing done & Screenshots


## QA steps

What needs to be checked to prove this works? 
When you click the FEEDBACK button at the bottom of main content on every page, the same rating scale appears 

## Acceptance criteria

- [x] The same rating scale appears on in Medallia survey modal on different pages

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
