### PR TITLE
[VA-15076] Remove limited width from basic landing page

### DIFF
--- a/src/site/layouts/basic_landing_page.drupal.liquid
+++ b/src/site/layouts/basic_landing_page.drupal.liquid
@@ -42,19 +42,17 @@
       </div>
 
       <!-- Content blocks -->
-      <article class="usa-width-three-fourths vads-u-padding-bottom--4">
-        <div class="usa-content">
-          {% for block in fieldContentBlock %}
-            {% if block.entity.entityBundle == 'lists_of_links' and block.entity.fieldSectionHeader == 'Browse by audience' %}
-              {% include 'src/site/components/browse-by-audience.drupal.liquid' %}
-            {% else %}
-                {% assign bundleComponent = "src/site/paragraphs/" | append: block.entity.entityBundle %}
-                {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
-                {% include {{ bundleComponentWithExtension }} with entity = block.entity %}
-            {% endif %}
+      <article class="vads-u-padding-bottom--4">
+        {% for block in fieldContentBlock %}
+          {% if block.entity.entityBundle == 'lists_of_links' and block.entity.fieldSectionHeader == 'Browse by audience' %}
+            {% include 'src/site/components/browse-by-audience.drupal.liquid' %}
+          {% else %}
+              {% assign bundleComponent = "src/site/paragraphs/" | append: block.entity.entityBundle %}
+              {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
+              {% include {{ bundleComponentWithExtension }} with entity = block.entity %}
+          {% endif %}
 
-          {% endfor %}
-        </div>
+        {% endfor %}
       </article>
 
       <div class="usa-width-three-fourths">


### PR DESCRIPTION
## Description

#15076 was a bug caused by [this pull request,](https://github.com/department-of-veterans-affairs/content-build/pull/1653) which fixed a bug that occurs when two alerts appear on a single page. However, the layout change negatively affected the width of other pages like a list of links.

As [Steve pointed out in a Slack discussion thread,](https://dsva.slack.com/archives/C0FQSS30V/p1693940186357309?thread_ts=1693601589.812439&cid=C0FQSS30V) the main layouts where the two alerts are likely to appear already have the needed layout classes that fixed the layout adjusted in the PR. This confirms that those layouts should avoid the same bug as the layout from the pull request.

Since the page using the layout from the pull request was a test page no longer being used, this pull request reverts the change.

relates to [#15076](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15076)

## Testing done & Screenshots

### Before

<img width="1141" alt="Screen Shot 2023-09-05 at 5 21 32 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10790736/dbaf4bf5-97a1-4a45-99e0-ab60b0594791">

### After

<img width="1146" alt="Screen Shot 2023-09-05 at 5 22 07 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10790736/b34b24d4-53ff-4631-86a3-02a9e24804c1">

## QA steps

**What needs to be checked to prove this works?** That the link list page renders with the expected full width (`/resources/`)  
**What needs to be checked to prove it didn't break any related things?** That other affected page layouts don't have incorrect widths. 

1. Check `/resources/`
   - [ ] Validate that the links go full width across the screen and not only partway across it
2. Then click other pages (likely need to confer with someone else on the front-end or CMS side for what other pages use the `basic_landing_page` layout template.
   - [ ] Validate that their layouts are still unaffected.

## Acceptance criteria

- [ ] All QA steps pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
