### PR TITLE
VACMS-14870: Add aria-label "Secondary" to sidenav

### DIFF
--- a/src/site/navigation/sidebar_nav.drupal.liquid
+++ b/src/site/navigation/sidebar_nav.drupal.liquid
@@ -1,4 +1,4 @@
-<nav data-template="navigation/sidebar_nav" id="va-detailpage-sidebar" data-drupal-sidebar="true" class="va-drupal-sidebarnav usa-width-one-fourth va-sidebarnav">
+<nav data-template="navigation/sidebar_nav" aria-label="Secondary" id="va-detailpage-sidebar" data-drupal-sidebar="true" class="va-drupal-sidebarnav usa-width-one-fourth va-sidebarnav">
     <div>
 
         <button class="va-btn-close-icon va-sidebarnav-close" type="button" aria-label="Close this menu"></button>


### PR DESCRIPTION
## Description
Added a aria-label secondary to sidenav for accessibility concerns about not having a unique label. 

## Testing done & Screenshots

![About_VA_Health_Benefits___Veterans_Affairs](https://github.com/department-of-veterans-affairs/content-build/assets/42885441/da6aacbc-2d03-4b54-ab06-6b5f7e2aaddb)


## Acceptance criteria

- [ ] The sidenav menu should have aria-label="Secondary" to distinguish it from other navigation menus on the same page
- [ ] A11y Review
