### PR TITLE
21-0845 -Enable in Prod

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1446,7 +1446,7 @@
     "rootUrl": "/supporting-forms-for-claims/third-party-authorization-form-21-0845",
     "productId": "08a7da80-f48a-4677-9b74-0dcb642b97a1",
     "template": {
-      "vagovprod": false,
+      "vagovprod": true,
       "layout": "page-react.html",
       "includeBreadcrumbs": true,
       "breadcrumbs_override": [


### PR DESCRIPTION
## Description

Update app-registry to enable Third-Party Authorization (21-0845) form-app in Production

part of the form's Slow-Rollout [#555](https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/555)

Flipper `form210845` ON in Staging only; OFF in [Prod](https://api.va.gov/flipper/features).  End-date TBD.

## Testing done & Screenshots

N/A; this is just an app-registry prop-change.  The form still won't load in Prod just yet &mdash; we have a Flipper feature-flag that hasn't been turned on in Prod.

