### PR TITLE
VACMS-14910: Add unique identifier to va-accordion-item id for healh services

### DIFF
--- a/src/site/facilities/health_service.drupal.liquid
+++ b/src/site/facilities/health_service.drupal.liquid
@@ -7,7 +7,7 @@
             class="va-accordion-item"
             data-label="{{ serviceTaxonomy.name }}"
             data-template="facilities/health_service"
-            id="{{serviceTaxonomy.name | hashReference: 60 }}"
+            id="item-{{ serviceTaxonomy.name | hashReference: 60 }}"
         >
             <h3 slot="headline">
                 {{ serviceTaxonomy.name }}


### PR DESCRIPTION
## Description
On the health services page we have `h2` headings with the same id as the accordion id's. This change will add a prefix of `item-` to the va-accordion items. Allowing for deep linking to these accordions and not breaking the header `On this Page `functionality.  

## Testing done & Screenshots

`/boston-health-care/health-services/#item-primary-care`

![Health_Services___VA_Boston_Health_Care___Veterans_Affairs_and_baby_moon_in_oahu_-_Google_Search](https://github.com/department-of-veterans-affairs/content-build/assets/42885441/af685584-9576-4c38-99c3-b992d043e8fc)


## QA steps
Verify that deep-linking works and that there are no identical ids on the page specifically the headers and va-accordion-items. 

## Acceptance criteria

- [x] Elements on the same page should not have the same ID, each ID should be unique
- [x] Accessibility Review

