### PR TITLE
[VA-14948] Add VBA Facility GraphQL Query

### DIFF
--- a/src/site/layouts/vba_facility.drupal.liquid
+++ b/src/site/layouts/vba_facility.drupal.liquid
@@ -1,0 +1,3 @@
+{% comment %}
+  This is a placeholder layout for now, since not including it breaks the main build.
+{% endcomment %}

--- a/src/site/stages/build/drupal/graphql/CountEntityTypes.graphql.js
+++ b/src/site/stages/build/drupal/graphql/CountEntityTypes.graphql.js
@@ -31,6 +31,16 @@ const CountEntityTypes = `
     count
   }
 
+  vbaFacilities: nodeQuery(
+    filter: {
+      conditions: [
+        {field: "status", value: ["1"]},
+        {field: "type", value: ["vba_facility"]}
+      ]}
+  	) {
+    count
+  }
+
   newsStories: nodeQuery(
     filter: {
       conditions: [

--- a/src/site/stages/build/drupal/graphql/GetLatestPageById.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetLatestPageById.graphql.js
@@ -31,13 +31,14 @@ const vamcPolicyPages = require('./vamcPoliciesPage.graphql');
 const vamcRegisterForCarePages = require('./vamcRegisterForCarePage.graphql');
 const vetCenterLocations = require('./vetCenterLocations.graphql');
 const vetCenters = require('./vetCenter.graphql');
+const vbaFacilities = require('./vbaFacility.graphql');
 const { ALL_FRAGMENTS } = require('./fragments.graphql');
 
 // String Helpers
 const {
   updateQueryString,
   queryParamToBeChanged,
-} = require('./../../../../utilities/stringHelpers');
+} = require('../../../../utilities/stringHelpers');
 
 /**
  * Queries for a page by the node id, getting the latest revision
@@ -72,6 +73,7 @@ module.exports = `
   ${nodeBasicLandingPage.fragment}
   ${nodeCampaignLandingPage.fragment}
   ${vetCenters.fragment}
+  ${vbaFacilities.fragment}
   ${vetCenterLocations.fragment}
   ${vamcPolicyPages.fragment}
   ${vamcRegisterForCarePages.fragment}
@@ -112,6 +114,7 @@ module.exports = `
         ... nodeBasicLandingPage
         ... nodeCampaignLandingPage
         ... vetCenterFragment
+        ... vbaFacilityFragment
         ... vetCenterLocationsFragment
         ... policiesPageFragment
         ... registerForCareFragment

--- a/src/site/stages/build/drupal/graphql/vbaFacility.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vbaFacility.graphql.js
@@ -1,0 +1,88 @@
+const { generatePaginatedQueries } = require('../individual-queries-helpers');
+
+const draftContentOverride = process.env.UNPUBLISHED_CONTENT === 'true';
+
+const vbaFacilityFragment = `
+      fragment vbaFacilityFragment on NodeVbaFacility {
+        entityId
+        entityUrl {
+          path
+          routed
+        }
+        entityMetatags {
+          __typename
+          key
+          value
+        }
+        entityBundle
+        entityLabel
+        ... on NodeVbaFacility {
+          title
+          changed
+          fieldIntroText
+          fieldFacilityLocatorApiId
+          fieldOperatingStatusFacility
+          fieldOperatingStatusMoreInfo
+          fieldPhoneNumber
+          fieldAddress {
+            addressLine1
+            addressLine2
+            countryCode
+            locality
+            postalCode
+            administrativeArea
+          }
+          fieldGeolocation {
+            lat
+            lon
+          }
+          fieldOfficeHours {
+            day
+            starthours
+            endhours
+            comment
+          }
+        }
+      }`;
+
+const getVbaFacilitySlice = (operationName, offset, limit) => {
+  return `
+    ${vbaFacilityFragment}
+
+    query GetVbaFacilitys${
+      !draftContentOverride ? '($onlyPublishedContent: Boolean!)' : ''
+    } {
+      nodeQuery(
+        limit: ${limit}
+        offset: ${offset}
+        filter: {
+          conditions: [
+            ${
+              !draftContentOverride
+                ? '{ field: "status", value: ["1"], enabled: $onlyPublishedContent },'
+                : ''
+            }
+            { field: "type", value: ["vba_facility"] }
+          ]
+        }) {
+        entities {
+          ... vbaFacilityFragment
+        }
+      }
+    }
+`;
+};
+
+const getVbaFacilityQueries = entityCounts => {
+  return generatePaginatedQueries({
+    operationNamePrefix: 'GetVbaFacility',
+    entitiesPerSlice: 25,
+    totalEntities: entityCounts.data.vbaFacilities.count,
+    getSlice: getVbaFacilitySlice,
+  });
+};
+
+module.exports = {
+  fragment: vbaFacilityFragment,
+  getVbaFacilityQueries,
+};

--- a/src/site/stages/build/drupal/individual-queries.js
+++ b/src/site/stages/build/drupal/individual-queries.js
@@ -97,6 +97,7 @@ const {
 } = require('./graphql/vamcBillingAndInsurancePage.graphql');
 
 const { getVetCenterQueries } = require('./graphql/vetCenter.graphql');
+const { getVbaFacilityQueries } = require('./graphql/vbaFacility.graphql');
 
 const {
   GetVetCenterLocations,
@@ -137,6 +138,7 @@ function getNodeQueries(entityCounts) {
     GetNodeBasicLandingPage,
     GetCampaignLandingPages,
     ...getVetCenterQueries(entityCounts),
+    ...getVbaFacilityQueries(entityCounts),
     GetVetCenterLocations,
     GetPolicyPages,
     GetBillingAndInsurancePages,


### PR DESCRIPTION
## Description

This pull request should add a working query that pulls data about the VBA Facility pages. This query should pull in available data from those pages without breaking the build.

relates to [#14948](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14948)

## Testing done & Screenshots

When pulling from a tugboat instance with published Facility pages, I confirmed that a local build pulls the data in without breaking the build.

<img width="863" alt="Screen Shot 2023-09-21 at 4 42 37 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10790736/99028fef-ce26-4aaa-bb14-98324f57d99c">

<img width="887" alt="Screen Shot 2023-09-22 at 5 42 04 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10790736/924e2350-7e2e-488c-b4d4-b38ef804e103">

I also confirmed that the page data is present in `.cache/localhost/drupal/pages.json`, which proves the query was successful.

<img width="724" alt="Screen Shot 2023-09-22 at 5 43 40 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10790736/d655711e-0b01-41ea-893f-c26159486adc">

## QA steps

What needs to be checked to prove this works? **That the query pulls in the needed data without breaking the build.** 
What needs to be checked to prove it didn't break any related things? **The local build process and local `pages.json` file.**
What variations of circumstances (users, actions, values) need to be checked? **A CMS variation where at least one VBA Facility is published.**

1. Run a local build with a tugboat environment that has VBA Facilities published
   - [ ] Delete the `.cache/localhost/drupal/pages.json` file in your `content-build` repo.
   - [ ] Run `yarn build --pull-drupal --drupal-address=https://cms-txcrk8bym4a0ivw3xfr8xvdhezmls36f.demo.cms.va.gov/ username=max.antonucci@agile6.com password=drupal8` for a local build.
   - [ ] Confirm that the metalsmith build runs successfully
2. Confirm that the queried data is present and correct
   - [ ] Go to `.cache/localhost/drupal/pages.json` and confirm that there are three pages with `"entityBundle": "vba_facility"`.
   - [ ] Confirm that the above three pages have the following titles:
       - [ ] "VA Regional Benefit Satellite Office at The Net Center"
       - [ ] "Baltimore VA Regional Benefit Office"
       - [ ] "Seattle VA Regional Benefit Office"
   - [ ] Confirm that each page object has properties that match what's listed in `src/site/stages/build/drupal/graphql/vbaFacility.graphql.js`, such as `entityId`, `title`, `fieldIntroText`, `fieldAddress`, etc. Their values can be empty as long as the keys are there.


## Acceptance criteria

- [ ] Query is aligned with all the sections in the VBA Facility Content Specs XLS in the Google Doc listed in #13096 
- [ ] Tests are identified for the page that is built around this query and added to the subsequent ticket #14941.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
