### PR TITLE
VACMS-13555: Remove hidden attribute for skip to content

### DIFF
--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -105,7 +105,6 @@
   <script nonce="**CSP_NONCE**" type="text/javascript">
     function focusContent(e) {
       e.preventDefault();
-      e.target.hidden = true;
       const contentElement = document.querySelector('#content h1') || document.querySelector('#content');
       contentElement.setAttribute('tabindex', '-1');
       contentElement.addEventListener('blur', function(event) {


### PR DESCRIPTION
## Description

Remove the hidden attribute when clicking the skip to content button

## Testing done & Screenshots
Verified that the hidden attribute is not being added to the skip to content link. Tabbing back through the content shows the skip to content link again.

Old Behavior:

https://github.com/department-of-veterans-affairs/content-build/assets/42885441/4c05f381-8938-4ea7-a9be-a3862dec9567

New Behavior:

https://github.com/department-of-veterans-affairs/content-build/assets/42885441/9817c778-7c57-4d1c-b9fd-e34dfe6a60da

## QA Steps

1. Go to any page on VA.gov, for example: https://www.va.gov/health-care/about-va-health-benefits/
2. Start tabbing through the page immediately
3. You will see the Skip to content link appear once you focus on it
4. Hit enter to activate the link and jump down to the main content portion of the page
5. Now tab backwards through the page (SHIFT + Tab) to try and get back to the Skip to Content link.

## Acceptance criteria

- [ ] a11y review
- [ ]  The Skip to content link should always be available, even after it has been activated.
