### PR TITLE
Updated Pension & Burial Breadcrumbs

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -40,7 +40,7 @@
         },
         {
           "path": "pension/application/527EZ",
-          "name": "Apply for Veterans Pension"
+          "name": "Review pension benefits application"
         }
       ]
     }
@@ -178,7 +178,7 @@
         },
         {
           "path": "burials-and-memorials/application/530",
-          "name": "Apply for burial benefits"
+          "name": "Review burial benefits application"
         }
       ]
     }


### PR DESCRIPTION
## Description

This PR updates the Burial and Pension bread crumbs from `"Apply for burial benefits"` and `"Apply for pension benefits"` to say `"Review burial benefits application"` and `"Review pension benefits application"` to accommodate the temporary Review pages while the forms are deactivated. This was done as overrides.

## Testing done & Screenshots

- Manual / Accessibility

## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked? 


## Acceptance criteria

- [x] Updated breadcrumb verbiage

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
