### PR TITLE
CH36 Forn Name Change Cleanup

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -774,31 +774,6 @@
     }
   },
   {
-    "appName": "Apply for Personalized Career Planning and Guidance with VA Form 28-8832",
-    "entryName": "28-8832-planning-and-career-guidance",
-    "rootUrl": "/careers-employment/education-and-career-counseling/apply-career-guidance-form-28-8832",
-    "template": {
-      "title": "Personalized Career Planning and Guidance Chapter 36 Form 28-8832",
-      "vagovprod": true,
-      "layout": "page-react.html",
-      "includeBreadcrumbs": true,
-      "breadcrumbs_override": [
-        {
-          "path": "careers-employment",
-          "name": "Careers and employment"
-        },
-        {
-          "path": "careers-employment/education-and-career-counseling/",
-          "name": "Career planning and guidance"
-        },
-        {
-          "path": "careers-employment/education-and-career-counseling/apply-career-guidance-form-28-8832/introduction",
-          "name": "Apply for Personalized Career Planning and Guidance Form 28‑8832"
-        }
-      ]
-    }
-  },
-  {
     "appName": "Apply for Personalized Career Planning and Guidance with VA Form 25-8832",
     "entryName": "25-8832-planning-and-career-guidance",
     "rootUrl": "/careers-employment/education-and-career-counseling/apply-career-guidance-form-25-8832",


### PR DESCRIPTION
## Description

relates to: https://github.com/department-of-veterans-affairs/vets-website/pull/25875

## Testing done & Screenshots
Tested local environment and confirmed app 28-8832 is removed and 25-8832 continues to stay live with the proper content.

## QA steps
Test w/ https://github.com/department-of-veterans-affairs/vets-website/pull/25875

What needs to be checked to prove this works? 
- Ensure careers-employment/education-and-career-counseling/apply-career-guidance-form-28-8832 does not load 
- Ensure careers-employment/education-and-career-counseling/apply-career-guidance-form-25-8832 still loads correctly
What needs to be checked to prove it didn't break any related things?  
See above
What variations of circumstances (users, actions, values) need to be checked?  


## Acceptance criteria

- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
