### PR TITLE
update vaos root url in prod

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -48,18 +48,9 @@
   {
     "appName": "VA Online Scheduling",
     "entryName": "vaos",
-    "rootUrl": "/health-care/schedule-view-va-appointments/appointments",
-    "template": {
-      "vagovprod": true,
-      "layout": "page-react.html"
-    }
-  },
-  {
-    "appName": "VA Online Scheduling NEW",
-    "entryName": "vaos",
     "rootUrl": "/my-health/appointments",
     "template": {
-      "vagovprod": false,
+      "vagovprod": true,
       "layout": "page-react.html"
     }
   },


### PR DESCRIPTION
VAOS is going LIVE with our url changes tomorrow at 10am ET. This PR updates the root url to our new root url and removes the workaround we had in place for testing the new url in staging.