### PR TITLE
Deprecate coronavirus vaccine expansion app

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1016,31 +1016,6 @@
     }
   },
   {
-    "appName": "covid-vaccine-expansion",
-    "entryName": "covid-vaccine",
-    "rootUrl": "/health-care/covid-19-vaccine/sign-up",
-    "template": {
-      "vagovprod": true,
-      "layout": "page-react.html",
-      "title": "Sign up to get a vaccine",
-      "description": "We’re working to provide COVID-19 vaccines as quickly and safely as we can. We base our vaccine plans on CDC guidelines, federal law, and available supply. Sign up to tell us you’d like to get a COVID-19 vaccine at VA.",
-      "breadcrumbs_override": [
-        {
-          "path": "health-care/",
-          "name": "Health care"
-        },
-        {
-          "path": "health-care/covid-19-vaccine/",
-          "name": "COVID-19 vaccines"
-        },
-        {
-          "path": "health-care/covid-19-vaccine/sign-up",
-          "name": "Sign up to get a vaccine"
-        }
-      ]
-    }
-  },
-  {
     "appName": "Veteran Rapid Retraining Assistance Program (VRRAP)",
     "entryName": "1990s-edu-benefits",
     "rootUrl": "/education/other-va-education-benefits/veteran-rapid-retraining-assistance/apply-for-vrrap-form-22-1990s",


### PR DESCRIPTION
## Description

The coronavirus vaccine expansion app is no longer in use, having [been redirected](https://github.com/department-of-veterans-affairs/devops/blob/69e0a7da36a4f8004fae5ed5821b6fd2efe18c9d/ansible/deployment/config/revproxy-vagov/vars/redirects.yml#L4881C12-L4881C48).

I've also verified that no 200s have been served for [/health-care/covid-19-vaccine/sign-up](https://www.va.gov/health-care/covid-19-vaccine/sign-up/introduction)* in [the past week](https://grafana.vfs.va.gov/explore?orgId=1&left=%5B%22now-7d%22,%22now%22,%22Loki%20(Prod)%22,%7B%22expr%22:%22%7Bapp%3D%5C%22revproxy%5C%22%7D%20%7C%3D%20%5C%22GET%20%2Fhealth-care%2Fcovid-19-vaccine%2Fsign-up%5C%22%22%7D%5D) (but [plenty of 301s](https://grafana.vfs.va.gov/explore?orgId=1&left=%5B%22now-7d%22,%22now%22,%22Loki%20(Prod)%22,%7B%22expr%22:%22%7Bapp%3D%5C%22revproxy%5C%22%7D%20%7C~%20%5C%22GET%20%2Fhealth-care%2Fcovid-19-vaccine%2Fsign-up.*%20301%20%5C%22%22%7D%5D) have)

## Testing done & Screenshots

Not sure how to test this, would welcome input from the CMS/FE reviewers on this 🙂 


## Acceptance criteria

- [ ] coronavirus vaccine expansion app is no longer in the registry
