### PR TITLE
40-0247 - Fix app-registry breadcrumb-paths

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1618,15 +1618,15 @@
         },
         {
           "name": "Memorial items",
-          "path": "memorial-items"
+          "path": "burials-memorials/memorial-items"
         },
         {
           "name": "Presidential Memorial Certificates",
-          "path": "presidential-memorial-certificates"
+          "path": "burials-memorials/memorial-items/presidential-memorial-certificates"
         },
         {
           "name": "Request a Presidential Memorial Certificate",
-          "path": "request-certificate-form-40-0247"
+          "path": "burials-memorials/memorial-items/presidential-memorial-certificates/request-certificate-form-40-0247"
         }
       ]
     }


### PR DESCRIPTION
## Description

closes department-of-veterans-affairs/va.gov-team-forms#616  
relates to [previous PR](https://github.com/department-of-veterans-affairs/content-build/pull/1730) \[w/ incorrect breadcrumb-paths\] 

## Testing done & Screenshots

Local browser testing was successful

