### PR TITLE
Remove coronavirus-vaccination app

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -973,31 +973,6 @@
     }
   },
   {
-    "appName": "Coronavirus Vaccination",
-    "entryName": "coronavirus-vaccination",
-    "rootUrl": "/health-care/covid-19-vaccine/stay-informed",
-    "template": {
-      "title": "Sign up to get a COVID-19 vaccine at VA",
-      "layout": "page-react.html",
-      "includeBreadcrumbs": true,
-      "description": "We’re working to provide COVID-19 vaccines as quickly and safely as we can. We base our vaccine plans on CDC guidelines, federal law, and available supply. Sign up to tell us you’d like to get a COVID-19 vaccine at VA.",
-      "breadcrumbs_override": [
-        {
-          "path": "health-care/",
-          "name": "Health care"
-        },
-        {
-          "path": "health-care/covid-19-vaccine/",
-          "name": "COVID-19 vaccines"
-        },
-        {
-          "path": "health-care/covid-19-vaccine/stay-informed",
-          "name": "Sign up for vaccine updates"
-        }
-      ]
-    }
-  },
-  {
     "appName": "View your representative",
     "entryName": "view-representative",
     "rootUrl": "/view-change-representative/view",


### PR DESCRIPTION
## Description

The coronavirus vaccination app is no longer in use, having [been redirected](https://github.com/department-of-veterans-affairs/devops/blob/69e0a7da36a4f8004fae5ed5821b6fd2efe18c9d/ansible/deployment/config/revproxy-vagov/vars/redirects.yml#L4878).

I've also verified that no 200s have been served for [/health-care/covid-19-vaccine/stay-informed](https://www.va.gov/health-care/covid-19-vaccine/sign-up/introduction)* in [the past week](https://grafana.vfs.va.gov/explore?orgId=1&left=%5B%22now-7d%22,%22now%22,%22Loki%20(Prod)%22,%7B%22expr%22:%22%7Bapp%3D%5C%22revproxy%5C%22%7D%20%7C%3D%20%5C%22GET%20%2Fhealth-care%2Fcovid-19-vaccine%2Fstay-informed%5C%22%22%7D%5D) (but [plenty of 301s](https://grafana.vfs.va.gov/explore?orgId=1&left=%5B%22now-7d%22,%22now%22,%22Loki%20(Prod)%22,%7B%22expr%22:%22%7Bapp%3D%5C%22revproxy%5C%22%7D%20%7C~%20%5C%22GET%20%2Fhealth-care%2Fcovid-19-vaccine%2Fstay-informed.*%20301%20%5C%22%22%7D%5D) have)


## Acceptance criteria

- [ ] coronavirus vaccine app is no longer in the registry

