### PR TITLE
[VA-15057] VAMC System Banner Alert inline editor FE Review

### DIFF
--- a/src/site/components/situation_updates.drupal.liquid
+++ b/src/site/components/situation_updates.drupal.liquid
@@ -3,9 +3,9 @@
   <h2>Situation updates and information</h2>
 
   <!-- Banner alerts -->
-  {% for situation in fieldBannerAlert %}
-    {% if situation.entity.status == true %}
-      {% assign sortedUpdates = situation.entity.fieldSituationUpdates | sort: mostRecentDate.value | reverse %}
+  {% for situation in fieldBannerAlertData %}
+    {% if situation.status == true %}
+      {% assign sortedUpdates = situation.fieldSituationUpdates | sort: mostRecentDate.value | reverse %}
       {% for update in sortedUpdates %}
         <div data-entity-id="{{ update.entity.entityId }}" class="usa-alert background-color-only vads-u-padding-y--1p5">
           <h3 class="vads-u-margin-top--0">
@@ -34,9 +34,9 @@
         </div>
       {% endfor %}
 
-      {% if situation.entity.fieldBannerAlertSituationinfo.processed %}
+      {% if situation.fieldBannerAlertSituationinfo.processed %}
         <h3 class="vads-u-margin-top--3">Situation info</h3>
-        {{ situation.entity.fieldBannerAlertSituationinfo.processed }}
+        {{ situation.fieldBannerAlertSituationinfo.processed }}
       {% endif %}
     {% endif %}
   {% endfor %}

--- a/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
+++ b/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
@@ -32,11 +32,12 @@
               </div>
             </div>
           {% endif %}
+          {% assign fieldBannerAlertData = reverseFieldBannerAlertVamcsNode.entities %}
           <section class="table-of-contents" class="vads-u-margin-bottom--5">
 	          <va-on-this-page class="vads-u-margin-left--1 vads-u-margin-bottom--0 vads-u-padding-bottom--0"/>
             <ul class="usa-unstyled-list" role="list">
 
-              {% if fieldBannerAlert.0.entity.status != false and fieldBannerAlert.0.entity.fieldSituationUpdates.0.entity %}
+              {% if fieldBannerAlertData.0.status != false and fieldBannerAlertData.0.fieldSituationUpdates.0.entity %}
                 <li class="vads-u-margin-bottom--2">
                   <a class="vads-u-display--flex vads-u-text-decoration--none" href="#situation-updates"
                      onclick="recordEvent({ event: 'nav-jumplink-click' });">
@@ -68,9 +69,9 @@
             </ul>
           </section>
 
-          {% assign situationUpdates = fieldBannerAlert | hasContentAtPath: 'entity.fieldSituationUpdates' %}
-          {% if fieldBannerAlert and situationUpdates %}
-            {% include "src/site/components/situation_updates.drupal.liquid" with fieldBannerAlert %}
+          {% assign situationUpdates = fieldBannerAlertData | hasContentAtPath: 'entity.fieldSituationUpdates' %}
+          {% if fieldBannerAlertData and situationUpdates %}
+            {% include "src/site/components/situation_updates.drupal.liquid" with fieldBannerAlertData %}
           {% endif %}
 
           {% if fieldFacilityOperatingStatus.0.entity %}

--- a/src/site/stages/build/drupal/graphql/vamcOperatingStatusAndAlerts.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vamcOperatingStatusAndAlerts.graphql.js
@@ -47,8 +47,8 @@ const vamcOperatingStatusAndAlerts = `
     fieldOperatingStatusEmergInf {
       processed
     }
-    fieldBannerAlert {
-      entity {
+    reverseFieldBannerAlertVamcsNode {
+      entities {
         ... on NodeFullWidthBannerAlert {
           status
           title


### PR DESCRIPTION
# DO NOT MERGE until PM review is done & work authorized to move forward, and CMS work is complete. 

## Description

This pull request changes the VAMC System Banner alert to make way for changes in the CMS, as per [Swirt's recommendations in this comment.](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15057#issuecomment-1736631747)

relates to [#15057](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15057)

## Testing done & Screenshots

Local tests pass and build is successful

**Confirmation that the update query returns the same data.** The front-end template was updated to reflect the new data structure.

<img width="1512" alt="Screen Shot 2023-10-10 at 10 44 18 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10790736/5ee563a9-3b15-407f-bc6c-961be3bb4261">

## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

1. Confirm that the build is still successful with the changes
   - [ ] Validate that the `src/site/stages/build/drupal/graphql/vamcOperatingStatusAndAlerts.graphql.js` query still builds properly
   - [ ] Check that the two affected front-end template files are updated with the new `entity` data structure.\

## Acceptance criteria

- [ ] QA criteria has passed.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
