### PR TITLE
MHV-50152 Allow MHV MR to be visible in production

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1329,7 +1329,7 @@
     "rootUrl": "/my-health/medical-records",
     "productId": "c054e1e8-7be2-11ed-a1eb-0242ac120002",
     "template": {
-      "vagovprod": false,
+      "vagovprod": true,
       "layout": "page-react.html"
     }
   },


### PR DESCRIPTION
## Description

Enabling the MHV Medical Records application to support UAT testing and eventual release to Phase 0. The application will be hidden behind the `mhv_medical_records_to_va_gov_release` flag. The path /my-health/medical-records will be controlled by that flag. Disallowed users will be redirected to the MHV homepage.

There are two related PRs to create a Flipper toggle for the MHV MR application:
- https://github.com/department-of-veterans-affairs/vets-website/pull/26106
- https://github.com/department-of-veterans-affairs/vets-api/pull/14084

### [MHV-50152](https://jira.devops.va.gov/browse/MHV-50152) - Change production flag to true for MR for UAT ###
> In order for UAT to take place in a production environment, MR must be visible in production.
> 
> It is not linked from any other part of the VA.gov website, so will be "dark deployed." Only those participating in UAT will know to browse there.

## Testing done & Screenshots

Testing has been done to ensure that the `mhv_medical_records_to_va_gov_release` feature toggle works appropriately. For the details of that testing, please see: https://github.com/department-of-veterans-affairs/vets-website/pull/26106

## QA steps

Once MHV MR is active in production, we are planning to turn on the feature toggle and open up the MR app in a "dark deployed" state, since the path is not internally linked from anywhere in VA.gov. This will be used to conduct UAT.

We are not currently planning on enabling this flag on a per-user basis, although that can be easily implemented.

## Acceptance criteria

- [x] Production flag for MHV MR application has been set to "true"

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
