### PR TITLE
DNM: Corrections to allow broken link checks to work locally.

### DIFF
--- a/script/preview.js
+++ b/script/preview.js
@@ -353,7 +353,9 @@ if (process.env.SENTRY_DSN) {
   app.use(Raven.errorHandler());
 }
 
-app.use((err, _req, res) => {
+// `next` commented out for time being.
+app.use((err, req, res) => {
+  // , next) => {
   console.error(err);
   res.send(`
     <p>We're sorry, something went wrong when trying to preview that page.</p>

--- a/src/site/stages/build/plugins/modify-dom/check-broken-links/helpers/getBrokenLinks.js
+++ b/src/site/stages/build/plugins/modify-dom/check-broken-links/helpers/getBrokenLinks.js
@@ -8,7 +8,12 @@ const isCMSUrl = require('./isCMSUrl');
  * @param {*} file The HTML file from the Metalsmith pipeline
  * @param {Set<string>} allPaths The paths of all files in the website. Used to confirm the existence of a file.
  */
-function getBrokenLinks(file, allPaths, isBrokenLink = _isBrokenLink) {
+function getBrokenLinks(
+  file,
+  allPaths,
+  isBrokenLink = _isBrokenLink,
+  buildType,
+) {
   const $ = file.dom;
   const elements = $('a, img, script');
   const currentPath = file.path;
@@ -34,6 +39,15 @@ function getBrokenLinks(file, allPaths, isBrokenLink = _isBrokenLink) {
       const isInlineScript = target === undefined && !!$node.html().trim();
       if (isInlineScript) {
         return;
+      }
+      // On local builds, vets-website files are not downloaded and do not
+      // become part of the build, but instead are accessed by symlink. This
+      // means that broken link checking fails if it looks for those files.
+      if (buildType === 'localhost') {
+        const generatedTest = /^\/generated\/.*?\.js/;
+        if (target && generatedTest.test(target)) {
+          return;
+        }
       }
     }
 

--- a/src/site/stages/build/plugins/modify-dom/check-broken-links/index.js
+++ b/src/site/stages/build/plugins/modify-dom/check-broken-links/index.js
@@ -42,8 +42,15 @@ module.exports = {
 
     const isHtml = path.extname(fileName) === '.html';
     if (!isHtml) return;
-
-    const linkErrors = getBrokenLinks(file, this.allPaths);
+    // The use of `undefined` here allows the function getBrokenLinks() to use
+    // its default parameter even in cases where there are further arguments
+    // to the 'right'.
+    const linkErrors = getBrokenLinks(
+      file,
+      this.allPaths,
+      undefined,
+      this.buildOptions.buildtype,
+    );
 
     if (linkErrors.length > 0) {
       // next-build generated files return file.path as undefined, this slices off /index.html to match live link


### PR DESCRIPTION
## Description

relates to #15564

## Testing done & Screenshots



## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue


## Acceptance criteria

- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
