### PR TITLE
VACMS-15565 breadcrumb data changes

### DIFF
--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -259,10 +259,9 @@
         {% endif %}
 
         <!-- See more events. -->
-        {% assign index = entityUrl.breadcrumb.length | minus: 2 %}
         <a
           class="vads-u-padding-bottom--3 vads-u-margin-top--1 vads-u-font-weight--bold"
-          href="{{ entityUrl.breadcrumb | getValueFromArrayObjPath: index, 'url.path' }}"
+          href="{{ fieldListing.entity.entityUrl.path }}"
           onclick="recordEvent({ event: 'nav-secondary-button-click' });">
           See more events
           <i
@@ -283,12 +282,12 @@
   var expandRecurringEventsButton = document.getElementById('expand-recurring-events');
                 var expandRecurringEventsIcon = document.getElementById('expand-recurring-events-icon');
                 var recurringEvents = document.getElementById('recurring-events');
-              
+
                 // Escape early if we are not able to find the elements.
                 if (!expandRecurringEventsButton || !expandRecurringEventsIcon || !recurringEvents) {
                   return;
                 }
-              
+
                 // Toggle the bottom borders of the button.
                 if (expandRecurringEventsButton.style.borderBottomLeftRadius === '0px') {
                   expandRecurringEventsButton.style.borderBottomLeftRadius = '5px';
@@ -297,42 +296,42 @@
                   expandRecurringEventsButton.style.borderBottomLeftRadius = '0px';
                   expandRecurringEventsButton.style.borderBottomRightRadius = '0px';
                 }
-              
+
                 // Toggle the visibility of the recurring events.
                 recurringEvents.classList.toggle('vads-u-display--none');
                 recurringEvents.classList.toggle('vads-u-display--flex');
-              
+
                 // Toggle the icon.
                 expandRecurringEventsIcon.classList.toggle('fa-plus');
                 expandRecurringEventsIcon.classList.toggle('fa-minus');
               }
-              
+
               function onShowAllRecurringEventsClick() {
                 // Derive recurring event items.
                 var recurringEventItems = document.querySelectorAll('.recurring-event');
-              
+
                 // Show all recurring events.
                 for (var index = 0; index < recurringEventItems.length; index++) {
                   if (recurringEventItems[index]) {
                     recurringEventItems[index].classList.remove('vads-u-display--none');
                   }
                 }
-              
+
                 // Hide the show all recurring events button.
                 var showAllRecurringEventsButton = document.getElementById('show-all-recurring-events');
-              
+
                 // Hide the button if we find it.
                 if (showAllRecurringEventsButton) {
                   showAllRecurringEventsButton.classList.add('vads-u-display--none');
                 }
               }
-              
-              
+
+
               var expandRecurringEventsButton = document.getElementById('expand-recurring-events');
               if (expandRecurringEventsButton) {
                 expandRecurringEventsButton.addEventListener('click', onExpandRecurringEventsClick);
               }
-              
+
               var showAllRecurringEventsButton = document.getElementById('show-all-recurring-events');
               if (showAllRecurringEventsButton) {
                 showAllRecurringEventsButton.addEventListener('click', onShowAllRecurringEventsClick);

--- a/src/site/layouts/faq_multiple_q_a.drupal.liquid
+++ b/src/site/layouts/faq_multiple_q_a.drupal.liquid
@@ -20,7 +20,7 @@
 
 {% include "src/site/includes/header.html" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" with constructLcBreadcrumbs = true titleInclude = true %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with titleInclude = true %}
 
 <div id="content" class="interior" data-template="node-faq_multiple_q_a">
   <main class="va-l-detail-page">

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -1,6 +1,6 @@
 {% include "src/site/includes/header.html" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true deriveBreadcrumbsFromUrl = true %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
 
 <div class="interior" id="content">
   <main class="va-l-detail-page va-facility-page">

--- a/src/site/layouts/news_story.drupal.liquid
+++ b/src/site/layouts/news_story.drupal.liquid
@@ -3,7 +3,7 @@
 {% endif %}
 {% include "src/site/includes/header.html" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true deriveBreadcrumbsFromUrl = true %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
 
 <div id="content" class="interior">
     <main class="va-l-detail-page va-facility-page">

--- a/src/site/layouts/person_profile.drupal.liquid
+++ b/src/site/layouts/person_profile.drupal.liquid
@@ -1,6 +1,6 @@
 {% include "src/site/includes/header.html" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true deriveBreadcrumbsFromUrl = true %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
 
 <div id="content" class="interior">
     <main class="va-l-detail-page va-facility-page">

--- a/src/site/layouts/press_release.drupal.liquid
+++ b/src/site/layouts/press_release.drupal.liquid
@@ -1,6 +1,6 @@
 {% include "src/site/includes/header.html" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true deriveBreadcrumbsFromUrl = true %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
 
 <div id="content" class="interior">
     <main class="va-l-detail-page va-facility-page">
@@ -82,7 +82,6 @@
                     <section class="vads-u-margin-bottom--3">
                         {{ fieldOffice.entity.fieldPressReleaseBlurb.processed }}
                     </section>
-                    {% assign index = entityUrl.breadcrumb.length | minus: 2 %}
                     <a onClick="recordEvent({ event: 'nav-secondary-button-click' });"
                        href="{{ fieldListing.entity.entityUrl.path }}">See all news releases</a>
                 </article>

--- a/src/site/layouts/press_release.drupal.liquid
+++ b/src/site/layouts/press_release.drupal.liquid
@@ -84,7 +84,7 @@
                     </section>
                     {% assign index = entityUrl.breadcrumb.length | minus: 2 %}
                     <a onClick="recordEvent({ event: 'nav-secondary-button-click' });"
-                       href="{{ entityUrl.breadcrumb | getValueFromArrayObjPath: index, 'url.path' }}">See all news releases</a>
+                       href="{{ fieldListing.entity.entityUrl.path }}">See all news releases</a>
                 </article>
                 <!-- Last updated & feedback button-->
                   {% include "src/site/includes/above-footer-elements.drupal.liquid" %}

--- a/src/site/layouts/q_a.drupal.liquid
+++ b/src/site/layouts/q_a.drupal.liquid
@@ -1,6 +1,6 @@
 {% include "src/site/includes/header.html" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" with constructLcBreadcrumbs = true titleInclude = true %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with titleInclude = true %}
 
 <div id="content" class="interior" data-template="node-q_a">
   <main class="va-l-detail-page">

--- a/src/site/layouts/step_by_step.drupal.liquid
+++ b/src/site/layouts/step_by_step.drupal.liquid
@@ -1,6 +1,6 @@
 {% include "src/site/includes/header.html" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" with constructLcBreadcrumbs = true titleInclude = true %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with titleInclude = true %}
 
 <div id="content" class="interior" data-template="node-step_by_step">
   <main class="va-l-detail-page">
@@ -121,7 +121,7 @@
       <div class="usa-content">
         <va-back-to-top></va-back-to-top>
     <!-- Last updated & feedback button-->
-        {% include "src/site/includes/above-footer-elements.drupal.liquid" %}        
+        {% include "src/site/includes/above-footer-elements.drupal.liquid" %}
       </div>
     </div>
   </div>

--- a/src/site/layouts/support_resources_detail_page.drupal.liquid
+++ b/src/site/layouts/support_resources_detail_page.drupal.liquid
@@ -1,6 +1,6 @@
 {% include "src/site/includes/header.html" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" with constructLcBreadcrumbs = true titleInclude = true %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with titleInclude = true %}
 
 <div
   id="content"

--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -1,6 +1,6 @@
 {% include "src/site/includes/header.html" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" with deriveBreadcrumbsFromUrl = true %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
 
 <div id="content" class="interior">
   <main class="va-l-detail-page">
@@ -115,9 +115,9 @@
         {% if fieldVaFormToolUrl %}
           <h3 data-testid="va_form--online-tool">Online tool</h3>
           <p>{{ fieldVaFormToolIntro }}</p>
-          <a 
-            class="vads-c-action-link--blue" 
-            href="{{ fieldVaFormToolUrl.uri }}" 
+          <a
+            class="vads-c-action-link--blue"
+            href="{{ fieldVaFormToolUrl.uri }}"
             onclick="recordEvent({ event: 'cta-primary-button-click' });"
           >
             Go to the online tool

--- a/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
@@ -118,6 +118,9 @@ const nodeEvent = `
         entityBundle
         entityId
         entityType
+        entityUrl {
+          path
+        }
         ... on NodeEventListing {
           fieldDescription
           fieldIntroText

--- a/src/site/stages/build/drupal/graphql/pressReleasePage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/pressReleasePage.graphql.js
@@ -69,6 +69,13 @@ const pressReleaseFragment = `
 
       }
     }
+    fieldListing {
+      entity {
+        entityUrl {
+          path
+        }
+      }
+    }
     fieldAdministration {
       entity{
         ... on TaxonomyTermAdministration {
@@ -83,7 +90,7 @@ const getPressReleaseSlice = (operationName, offset, limit) => {
   return `
 
     ${pressReleaseFragment}
-  
+
     query GetNodePressRelease($onlyPublishedContent: Boolean!) {
       nodeQuery(
         limit: ${limit}


### PR DESCRIPTION
## Description

Related to #15565

The changes to breadcrumb data that are implemented in https://github.com/department-of-veterans-affairs/va.gov-cms/pull/15572 require some changes to Content Build to conform to the new data model. 

## Testing done & Screenshots

* Checked broken links and other tests, made sure that build succeeded
* Checked examples of every content type against their production equivalents to make sure they remained consistent
* Some links that were unnecessarily dependent on the breadcrumbs data shifted to a more stable mechanism

## QA steps
Links to example pages from each affected content type. Unless noted, what should be checked is the breadcrumb.

**Events**

Specifically check that the 'See more events' link works

* https://www.va.gov/lovell-federal-health-care-tricare/events/55993/
* https://web-7m0jwgfd3t0pt3txlgzvixowibrfagsq.ci.cms.va.gov/lovell-federal-health-care-tricare/events/55993/

**FAQ**

* https://www.va.gov/resources/ask-va-replaces-iris-and-the-gi-bill-help-portal/
* https://web-7m0jwgfd3t0pt3txlgzvixowibrfagsq.ci.cms.va.gov/resources/ask-va-replaces-iris-and-the-gi-bill-help-portal/

**VAMC Facility**

* https://www.va.gov/chicago-health-care/locations/lakeside-va-clinic/
* https://web-7m0jwgfd3t0pt3txlgzvixowibrfagsq.ci.cms.va.gov/chicago-health-care/locations/lakeside-va-clinic/

**Story**

* https://www.va.gov/chicago-health-care/stories/jesse-brown-will-be-hosting-a-food-drive-313-317-during-national-nutrition-month/
* https://web-7m0jwgfd3t0pt3txlgzvixowibrfagsq.ci.cms.va.gov/chicago-health-care/stories/jesse-brown-will-be-hosting-a-food-drive-313-317-during-national-nutrition-month/

**Staff Profile**

* https://www.va.gov/chicago-health-care/staff-profiles/jacqueline-neal/
* https://web-7m0jwgfd3t0pt3txlgzvixowibrfagsq.ci.cms.va.gov/chicago-health-care/staff-profiles/jacqueline-neal/

**Press Release**

Check both breadcrumb and 'See all press releases' link.

* https://www.va.gov/providence-health-care/news-releases/expanded-mental-health-benefits-aim-to-lower-veteran-suicide-rates/
* https://web-7m0jwgfd3t0pt3txlgzvixowibrfagsq.ci.cms.va.gov/providence-health-care/news-releases/expanded-mental-health-benefits-aim-to-lower-veteran-suicide-rates/

**Q & A**

* https://www.va.gov/resources/what-if-i-cant-sign-in-to-vagov-because-my-password-doesnt-work/
* https://web-7m0jwgfd3t0pt3txlgzvixowibrfagsq.ci.cms.va.gov/resources/what-if-i-cant-sign-in-to-vagov-because-my-password-doesnt-work/

**Step by Step**

* https://www.va.gov/resources/how-to-file-a-va-travel-reimbursement-claim-online/
* https://web-7m0jwgfd3t0pt3txlgzvixowibrfagsq.ci.cms.va.gov/resources/how-to-file-a-va-travel-reimbursement-claim-online/

**Resources and Support Detail Page**

* https://www.va.gov/resources/about-our-va-community-care-network-and-covered-services/
* https://web-7m0jwgfd3t0pt3txlgzvixowibrfagsq.ci.cms.va.gov/resources/about-our-va-community-care-network-and-covered-services/

**VA Form**

* https://www.va.gov/find-forms/about-form-21p-534/
* https://web-7m0jwgfd3t0pt3txlgzvixowibrfagsq.ci.cms.va.gov/find-forms/about-form-21p-534/


## Acceptance criteria

- [ ] All pages listed have identical breadcrumbs and if indicated other links

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
