### PR TITLE
VACMS-14307 Contain Veteran banner in main element

### DIFF
--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -204,9 +204,9 @@
         {% endif %}
       </div>
     </div>
+  {% include "src/site/includes/veteran-banner.html" %}
   </main>
 </div>
 
-{% include "src/site/includes/veteran-banner.html" %}
 {% include "src/site/includes/footer.html" %}
 {% include "src/site/includes/debug.drupal.liquid" %}


### PR DESCRIPTION
## Description
The `div` that contains the Veteran portraits on Benefits Hub landing pages (i.e. `/health-care`) is not contained by a landmark (the `<main>` element). This moves it into that element.

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14307

Tugboat to review: https://web-1wtvtqpercm3v5ybkwhzw7ai8277jd1u.demo.cms.va.gov/health-care/

## Testing done & Screenshots
<img width="500" alt="Screenshot 2023-10-16 at 12 23 09 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/ecfcbed7-30cd-4f20-a113-8a503a6c248f">
<br/>
<br/>
<img width="1068" alt="Screenshot 2023-10-16 at 12 23 00 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/bef15577-75dd-40a3-96a1-8d4fd0247666">
<br/>
<br/>
<img width="498" alt="Screenshot 2023-10-16 at 12 21 19 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/222f79e5-30c8-4a18-8349-c0ab66e3af27">
<br/>
<br/>
<img width="1819" alt="Screenshot 2023-10-16 at 12 21 06 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/76f68de4-1592-49f4-90ac-4f81c8a39775">

## QA steps
1. Navigate to `/health-care`
2. Inspect the Veteran banner at the bottom of the page
3. Confirm the `.veteran-banner` element is contained within `main`
4. Run the axe DevTools scan (Chrome plugin)
5. Validate that the `All page content should be contained by landmarks` category either doesn't exist or does not contain `veteran-banner` if it does exist

## Acceptance criteria

- [x] As a screen reader user, I want to navigate the content of the page by landmark regions.