### PR TITLE
VACMS-10939 Add Reusable Q&As to Campaign Landing Pages

### DIFF
--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -458,7 +458,7 @@
             <p class="va-u-text-transform--uppercase vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">FAQ</p>
             <h2 class="vads-u-margin-top--0">Frequently asked questions</h2>
 
-            <!-- Questions/Answers -->
+            <!-- Page-specific Questions/Answers -->
             <va-accordion bordered>
               {% for faqParagraph in fieldClpFaqParagraphs %}
                 {% if faqParagraph.entity %}
@@ -477,6 +477,17 @@
                 {% endif %}
               {% endfor %}
             </va-accordion>
+
+            <!-- Reusable QAs -->
+            {% for reusableQA in fieldClpReusableQA %}
+              {% if reusableQA.entity.entityBundle == "q_a_group" %}
+                {% if reusableQA.entity.fieldAccordionDisplay %}
+                  {% include "src/site/paragraphs/q_a_group_collapsible_content.drupal.liquid" with entity = reusableQA.entity %}
+                {% else %}
+                  {% include "src/site/paragraphs/q_a_group_content.drupal.liquid" with entity = reusableQA.entity %}
+                {% endif %}  
+              {% endif %}
+            {% endfor %}
           </div>
         </div>
 

--- a/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
@@ -75,6 +75,40 @@ const nodeCampaignLandingPage = `
         }
       }
     }
+    fieldClpReusableQA {
+      entity {
+        entityType
+        entityBundle
+        entityId
+        ... on ParagraphQAGroup {
+          fieldSectionHeader
+          fieldRichWysiwyg {
+            processed
+          }
+          fieldAccordionDisplay
+          queryFieldQAs {
+            entities {
+              entityId
+              entityLabel
+              entityBundle
+              ... on NodeQA {
+                fieldAnswer {
+                  entity {
+                    entityBundle
+                    entityId
+                    ... on ParagraphRichTextCharLimit1000 {
+                      fieldWysiwyg {
+                        processed
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
     fieldClpResources {
       entity {
         entityType


### PR DESCRIPTION
## Description
Add Reusable Q&As to Campaign Landing Pages.

## Testing done & Screenshots
<img width="1188" alt="Screenshot 2023-10-17 at 12 44 23 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/0d0f782b-b71c-470a-8904-cb7d1df6e6ac">
<img width="1188" alt="Screenshot 2023-10-17 at 12 44 37 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/02be253f-bd41-45bc-84be-b1590b24f3ac">
<img width="1188" alt="Screenshot 2023-10-17 at 12 44 46 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/c99ea178-3ba3-403f-8671-e59807c5e7ff">
<img width="1188" alt="Screenshot 2023-10-17 at 12 44 56 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/51a6b5cb-dc20-4f11-9395-9a27d439bc70">

Tugboat for testing: https://web-vjbjvpfgrmddgcl975iwjghzeudgmgkq.demo.cms.va.gov/initiatives/clp-test-title/
CMS test CLP entry: https://cms-n5953dtomqw1xd0rkphemtf55dby0uer.demo.cms.va.gov/node/62291/edit

## QA steps
1. Go to the above Tugboat URL (with SOCKS on, and socks, if you prefer)
2. Under the FAQ section, verify that you see 3 Page-specific Q&As (verify questions and answers appear) in accordions
3. Scroll down to Reusable QA (Accordion) and verify that you see 3 sets of questions and answers in accordions
4. Scroll down to Reusable QA (normal display) and verify that you see 3 sets of questions and answers laid out on the page

## Acceptance criteria

- [x] Followed FE runbook created in https://github.com/department-of-veterans-affairs/va.gov-cms/issues/10937
- [x] Reusable Q&As entered into a new "Reusable Q&A Section" block in the CLP Drupal UI are displayed in the appropriate place on CLP pages on FE – which will always be below Q&As entered into the "Page-specific Q&As Section" in Drupal