### PR TITLE
VACMS-15641: Adds 'add to National Outreach Calendar' checkbox

### DIFF
--- a/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
@@ -309,6 +309,32 @@ const nodeEventWithoutBreadcrumbs = `
         }
       }
     }
+    fieldAdditionalListings {
+      entity {
+        entityBundle
+        entityId
+        entityType
+        ... on NodeEventListing {
+          fieldDescription
+          fieldIntroText
+          fieldOffice {
+            entity {
+              entityType
+              entityBundle
+              entityId
+              ... on NodeOffice {
+                fieldBody {
+                  value
+                  format
+                  processed
+                }
+                fieldDescription
+              }
+            }
+          }
+        }
+      }
+    }
     fieldLocationHumanreadable
     fieldLocationType
     fieldMedia {

--- a/src/site/stages/build/drupal/graphql/nodeEventListing.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeEventListing.graphql.js
@@ -21,6 +21,11 @@ const nodeEventListing = `
         ... nodeEventWithoutBreadcrumbs
       }
     }
+    reverseFieldAdditionalListingsNode(limit: 5000, filter: { conditions: [{ field: "status", value: "1", operator: EQUAL, enabled: $onlyPublishedContent }, { field: "moderation_state", value: "archived", operator: NOT_EQUAL }, { field: "type", value: "event" }]}, sort: {field: "changed", direction: DESC}) {
+      entities {
+        ... nodeEventWithoutBreadcrumbs
+      }
+    }
     fieldOffice {
       entity {
         ...on NodeHealthCareRegionPage {

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -86,6 +86,25 @@ function createPastEventListPages(page, drupalPagePath, files) {
   );
 }
 
+/**
+ * Compiles fields for event listing pages.
+ *
+ *  @param {page} page The page object.
+ *  @return nothing
+ */
+function compileEventListingPage(page) {
+  // Combine events from reverse entity reference queries, if additional
+  // listings data exists.
+  if (page?.reverseFieldAdditionalListingsNode?.entities) {
+    page.reverseFieldListingNode.entities.push(
+      ...page.reverseFieldAdditionalListingsNode.entities,
+    );
+  }
+  // Compile final template variables.
+  page.pastEventTeasers = page.pastEvents;
+  page.allEventTeasers = page.reverseFieldListingNode;
+}
+
 // Creates the facility pages
 function createHealthCareRegionListPages(page, drupalPagePath, files) {
   const sidebar = page.facilitySidebar;
@@ -283,4 +302,5 @@ module.exports = {
   createPastEventListPages,
   addGetUpdatesFields,
   addPager,
+  compileEventListingPage,
 };

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -93,9 +93,13 @@ function createPastEventListPages(page, drupalPagePath, files) {
  *  @return nothing
  */
 function compileEventListingPage(page) {
+  const { cmsFeatureFlags } = global;
   // Combine events from reverse entity reference queries, if additional
-  // listings data exists.
-  if (page?.reverseFieldAdditionalListingsNode?.entities) {
+  // listings data exists and feature flag is on.
+  if (
+    cmsFeatureFlags.FEATURE_EVENT_OUTREACH_CHECKBOX &&
+    page?.reverseFieldAdditionalListingsNode?.entities
+  ) {
     page.reverseFieldListingNode.entities.push(
       ...page.reverseFieldAdditionalListingsNode.entities,
     );

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -16,6 +16,7 @@ const {
   createPastEventListPages,
   addGetUpdatesFields,
   addPager,
+  compileEventListingPage,
 } = require('./health-care-region');
 const createReactPages = require('../plugins/create-react-pages');
 
@@ -83,8 +84,7 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
         addGetUpdatesFields(pageCompiled, pages);
         break;
       case 'event_listing':
-        pageCompiled.pastEventTeasers = pageCompiled.pastEvents;
-        pageCompiled.allEventTeasers = pageCompiled.reverseFieldListingNode;
+        compileEventListingPage(pageCompiled);
         addPager(
           pageCompiled,
           files,


### PR DESCRIPTION
Relates to:
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15856
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15641

## Description
In https://github.com/department-of-veterans-affairs/va.gov-cms/pull/15761 we are adding a new field to the CMS to support adding an Event to multiple Event Listings, without changing the cardinality of field_listing to unlimited.

This PR adds the additional field query to the existing Event List GraphQl query, and assembles the data together before handing off to the event listing, providing the related feature toggle is enabled.

Relates to:
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15641

## Testing done & Screenshots
[Jill](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15641#issuecomment-1773419429) and Laura tested this end-to-end along with the CMS changes in Tugboat.

## QA steps
Use this Tugboat instance for QA testing: https://web-hslpokhhcwuf19pbvpxpq3ppmlpldumq.demo.cms.va.gov/

1. Visit /outreach-and-events/outreach-materials/
   - [ ] Verify publications are rendering/present
2. Visit /alaska-health-care/stories/learn-how-to-cook-with-healthy-teaching-kitchen
   - [ ] Verify the 'See all stories' link is present and points to the correct location.
3. Visit /lovell-federal-health-care-va/events/
   - [ ] Verify events have correct and functioning URLs for both types of pages (tricare && beneficiary)

## Acceptance criteria
- [ ] Tests are passing
- [ ] Outreach Materials page displays publications
- [ ] VAMC Stories ([example](https://web-hslpokhhcwuf19pbvpxpq3ppmlpldumq.demo.cms.va.gov/alaska-health-care/stories/learn-how-to-cook-with-healthy-teaching-kitchen/)) -- "See all stories" link is present at the foot of the page.
- [ ] Lovell events are not affected
