### PR TITLE
Adding new entry for rated disabilities application

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -64,6 +64,15 @@
     }
   },
   {
+    "appName": "Rated Disabilities",
+    "entryName": "rated-disabilities",
+    "rootUrl": "/disability/view-disability-rating/my-rating",
+    "template": {
+      "layout": "page-react.html",
+      "vagovprod": true
+    }
+  },
+  {
     "appName": "Dashboard",
     "entryName": "dashboard",
     "rootUrl": "/my-va",

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -69,7 +69,22 @@
     "rootUrl": "/disability/view-disability-rating/my-rating",
     "template": {
       "layout": "page-react.html",
-      "vagovprod": true
+      "vagovprod": true,
+      "includeBreadcrumbs": true,
+      "breadcrumbs_override": [
+        {
+          "path": "disability",
+          "name": "Disability benefits"
+        },
+        {
+          "path": "disability/view-disability-rating",
+          "name": "View your VA disability rating"
+        },
+        {
+          "path": "disability/view-disability-rating/my-rating",
+          "name": "Your VA disability rating"
+        }
+      ]
     }
   },
   {


### PR DESCRIPTION
## Description
Adding a new entry for the rated-disabilities application. The goal is to move the application folder in `vets-website` and update the `entryName` at the same time. Once this PR is merged and I've confirmed that both routes are working in production, I will swap the routes on the entries and test again. If that is successful, then I will remove the unneeded entry.

## Related PR(s)
- https://github.com/department-of-veterans-affairs/vets-website/pull/26240

## QA steps
- What needs to be checked to prove this works? 
Visiting both of these routes (`/disability/view-disability-rating/my-rating` and `/disability/view-disability-rating/rating`) while authenticated should result in the rated disabilities react app rendering

1. Do this
   - [ ] Validate that you can navigate to `/disability/view-disability-rating/my-rating` while authenticated
2. Then
   - [ ] Validate that you can also navigate to `/disability/view-disability-rating/rating` while authenticated and see the same webpage