### PR TITLE
[VA-15465] Add YouTube link to VAMC Facility social links

### DIFF
--- a/src/site/facilities/facility_social_links.drupal.liquid
+++ b/src/site/facilities/facility_social_links.drupal.liquid
@@ -72,6 +72,15 @@
                             </a>
                         </div>
                     {% endif %}
+
+                    {% if fieldYoutube != empty %}
+                        <div class="social-links social-links-youtube vads-u-margin-bottom--2">
+                            <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" rel="noreferrer" href="{{ fieldYoutube.uri }}">
+                                <i class="fab fa-youtube vads-u-text-decoration--none vads-u-margin-right--1"></i>
+                                <span class="vads-u-text-decoration--underline">{{ fieldYoutube.title }}</span>
+                            </a>
+                        </div>
+                    {% endif %}
                 </div>
             </div>
         {% endif %}

--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareSocialMedia.fields.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareSocialMedia.fields.graphql.js
@@ -5,17 +5,21 @@ module.exports = `
     fieldFacebook {
       title
       uri
-    }    
+    }
     fieldTwitter {
-      title    
+      title
       uri
     }
     fieldFlickr {
-      title    
+      title
       uri
     }
     fieldInstagram {
-      title    
+      title
+      uri
+    }
+    fieldYoutube {
+      title
       uri
     }
 `;


### PR DESCRIPTION
## Description

This adds the YouTube channel link to any facilities that include data for it.

relates to [#15465](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15465)

## Testing done & Screenshots

Local, see screenshot below.

<img width="1106" alt="Screen Shot 2023-10-20 at 11 21 33 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10790736/6343a583-759f-4a48-a8fc-c99f282cdace">

## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

1. Create a local build with this branch, and with the command `yarn build --pull-drupal --drupal-address=https://cms-ewako3qasxgcgkwsgdkkb3tlsr09jost.ci.cms.va.gov/ username=max.antonucci@agile6.com password=drupal8`
   - [ ] Validate that the build completes and does not error out
2. Confirm that the page where a YouTube link was added shows it on the front-end
   - [ ] Validate that the YouTube link is on http://localhost:3002/lebanon-health-care/

## Acceptance criteria

- [ ] All QA acceptance criteria pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
