### PR TITLE
VACMS-15694: Remove mobile promo banner flag in FE

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1660,9 +1660,6 @@ module.exports = function registerFilters() {
       '/change-direct-deposit',
     ];
 
-    return (
-      cmsFeatureFlags.FEATURE_MOBILE_APP_PROMO &&
-      urlsForBanner.includes(currentPath)
-    );
+    return urlsForBanner.includes(currentPath);
   };
 };


### PR DESCRIPTION
## Description
Removed the FE banner flag so that it unblocks CMS removal. 


## Acceptance criteria

- [ ] Remove code no longer needed so we can remove it from the CMS.
