### PR TITLE
Turn on medications for prod

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1487,7 +1487,7 @@
     "rootUrl": "/my-health/medications",
     "productId": "0203ca08-b7a2-4cd6-abb5-56d38c239cd3",
     "template": {
-      "vagovprod": false,
+      "vagovprod": true,
       "layout": "page-react.html"
     }
   },


### PR DESCRIPTION
## Description

Enabling the MHV Medications application to support UAT testing and eventual release to Phase 0. The application will be hidden behind the `mhv_medications_to_va_gov_release` flag. The path /my-health/medications will be controlled by that flag. Disallowed users will be redirected to the MHV homepage.

There are two related PRs to create a Flipper toggle for the MHV MR application:
- https://github.com/department-of-veterans-affairs/vets-website/pull/26362
- https://github.com/department-of-veterans-affairs/content-build/pull/1584

### Change production flag to true for Mx for UAT ###
> In order for UAT to take place in a production environment, Mx must be visible in production.
> 
> It is not linked from any other part of the VA.gov website, so will be "dark deployed." Only those participating in UAT will know to browse there.

## Testing done & Screenshots

Testing has been done to ensure that the `mhv_medications_to_va_gov_release` feature toggle works appropriately.

## QA steps

Once MHV Mx is active in production, we are planning to turn on the feature toggle and open up the Mx app in a "dark deployed" state, since the path is not internally linked from anywhere in VA.gov. This will be used to conduct UAT.

We are not currently planning on enabling this flag on a per-user basis, although that can be easily implemented.

## Acceptance criteria

- [x] Production flag for MHV Mx application has been set to "true"

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
