### PR TITLE
MBMS-51911 Add preneed integration to registry

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1642,5 +1642,15 @@
       "vagovprod": false,
       "layout": "page-react.html"
     }
+  },
+  {
+    "appName": "40-10007 Burial pre-need eligibility determination",
+    "entryName": "pre-need-integration",
+    "rootUrl": "/burials-and-memorials/pre-need-integration",
+    "productId": "e5593a96-1ba0-476c-9033-31ab963436c6",
+    "template": {
+      "vagovprod": false,
+      "layout": "page-react.html"
+    }
   }
 ]


### PR DESCRIPTION
## Description

Adding the new 40-10007 preneed integration form. Form will be set to vagovprod:false for upcoming work to the registry

vets-website - https://github.com/department-of-veterans-affairs/vets-website/pull/26374
Devops PR - https://github.com/department-of-veterans-affairs/devops/pull/13635

## Testing done & Screenshots



## QA steps

run a `yarn build` and navigate to `http://localhost:3001/burials-and-memorials/pre-need-integration/introduction`

## Acceptance criteria

- [x] Preneed integration form added

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
