### PR TITLE
Swapping rootUrls for the old entry and new Rated Disability application entries

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -57,7 +57,7 @@
   {
     "appName": "Rated Disabilities",
     "entryName": "disability-my-rated-disabilities",
-    "rootUrl": "/disability/view-disability-rating/rating",
+    "rootUrl": "/disability/view-disability-rating/my-rating",
     "template": {
       "layout": "page-react.html",
       "vagovprod": true
@@ -66,7 +66,7 @@
   {
     "appName": "Rated Disabilities",
     "entryName": "rated-disabilities",
-    "rootUrl": "/disability/view-disability-rating/my-rating",
+    "rootUrl": "/disability/view-disability-rating/rating",
     "template": {
       "layout": "page-react.html",
       "vagovprod": true,


### PR DESCRIPTION
## Description
Swapping the `rootUrls` for the two Rated Disabilities application entries. Once I have verified that the swap worked correctly, I will make a follow-up PR to remove the old entry

relates to:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/66061

## Acceptance criteria

- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
