### PR TITLE
Codeowners: Sitewide team name changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,21 +18,21 @@
 script @department-of-veterans-affairs/cms-infrastructure @department-of-veterans-affairs/va-platform-cop-frontend
 
 # Shared templates
-src/site/includes @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend @department-of-veterans-affairs/1010-health-apps-frontend
-src/site/components @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend @department-of-veterans-affairs/1010-health-apps-frontend
-src/site/layouts @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend
-src/site/teasers @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend
-src/site/filters @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend
+src/site/includes @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/vfs-facilities-frontend @department-of-veterans-affairs/1010-health-apps-frontend
+src/site/components @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/vfs-facilities-frontend @department-of-veterans-affairs/1010-health-apps-frontend
+src/site/layouts @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/vfs-facilities-frontend
+src/site/teasers @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/vfs-facilities-frontend
+src/site/filters @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/vfs-facilities-frontend
 
 # Facility Locator and VAMC pages
-src/site/facilities @department-of-veterans-affairs/vsa-facilities-frontend
-src/site/layouts/health*.drupal.liquid @department-of-veterans-affairs/vsa-facilities-frontend
-src/site/navigation/facility_no_drupal_page_sidebar_nav.drupal.liquid @department-of-veterans-affairs/vsa-facilities-frontend
-src/site/navigation/facility_sidebar_nav.drupal.liquid @department-of-veterans-affairs/vsa-facilities-frontend
-src/site/paragraphs/facilities @department-of-veterans-affairs/vsa-facilities-frontend
+src/site/facilities @department-of-veterans-affairs/vfs-facilities-frontend
+src/site/layouts/health*.drupal.liquid @department-of-veterans-affairs/vfs-facilities-frontend
+src/site/navigation/facility_no_drupal_page_sidebar_nav.drupal.liquid @department-of-veterans-affairs/vfs-facilities-frontend
+src/site/navigation/facility_sidebar_nav.drupal.liquid @department-of-veterans-affairs/vfs-facilities-frontend
+src/site/paragraphs/facilities @department-of-veterans-affairs/vfs-facilities-frontend
 
 # GraphQL Queries
-src/site/stages/build/drupal @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend @department-of-veterans-affairs/cms-infrastructure
+src/site/stages/build/drupal @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/vfs-facilities-frontend @department-of-veterans-affairs/cms-infrastructure
 
 # Site Assets
 src/site/assets/robots.txt @department-of-veterans-affairs/vfs-public-websites-frontend

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,11 +18,11 @@
 script @department-of-veterans-affairs/cms-infrastructure @department-of-veterans-affairs/va-platform-cop-frontend
 
 # Shared templates
-src/site/includes @department-of-veterans-affairs/vsa-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend @department-of-veterans-affairs/1010-health-apps-frontend
-src/site/components @department-of-veterans-affairs/vsa-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend @department-of-veterans-affairs/1010-health-apps-frontend
-src/site/layouts @department-of-veterans-affairs/vsa-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend
-src/site/teasers @department-of-veterans-affairs/vsa-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend
-src/site/filters @department-of-veterans-affairs/vsa-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend
+src/site/includes @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend @department-of-veterans-affairs/1010-health-apps-frontend
+src/site/components @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend @department-of-veterans-affairs/1010-health-apps-frontend
+src/site/layouts @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend
+src/site/teasers @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend
+src/site/filters @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend
 
 # Facility Locator and VAMC pages
 src/site/facilities @department-of-veterans-affairs/vsa-facilities-frontend
@@ -32,7 +32,7 @@ src/site/navigation/facility_sidebar_nav.drupal.liquid @department-of-veterans-a
 src/site/paragraphs/facilities @department-of-veterans-affairs/vsa-facilities-frontend
 
 # GraphQL Queries
-src/site/stages/build/drupal @department-of-veterans-affairs/vsa-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend @department-of-veterans-affairs/cms-infrastructure
+src/site/stages/build/drupal @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend @department-of-veterans-affairs/cms-infrastructure
 
 # Site Assets
-src/site/assets/robots.txt @department-of-veterans-affairs/vsa-public-websites-frontend
+src/site/assets/robots.txt @department-of-veterans-affairs/vfs-public-websites-frontend


### PR DESCRIPTION
## Summary

Platform support request Slack: https://dsva.slack.com/archives/CBU0KDSB1/p1698336681097449

 I have 2 teams, Sitewide Public Websites & Facilities. We have a variety of Github teams and I'd like help understanding how they are managed / if we can make some changes.
* https://github.com/orgs/department-of-veterans-affairs/teams/vfs-facilities/members - what is this team used for? (Lindsey Hattamer is maintainer.)  I see this Team listed as codeowners in vets-api, and it includes researchers.
* https://github.com/orgs/department-of-veterans-affairs/teams/vsa-facilities-frontend/members -- this is the correct group of people for vets-api / vets-website / content build code reviewers. Is it possible to EOL the @vfs-facilities team and rename this team to be @vfs-facilities?
* https://github.com/orgs/department-of-veterans-affairs/teams/vsa-public-websites-frontend -- this team should really be named @vfs-public-websites-frontend, but we don't have the power to change it. Could someone do that? We need to add this team as codeowners to a few things in vets-api but would like to rename it before we do that.

We'll need to make codeowners changes at the same time.
- vets-website PR: https://github.com/department-of-veterans-affairs/vets-website/pull/26402
- content-build PR: https://github.com/department-of-veterans-affairs/content-build/pull/1764