### PR TITLE
VACMS-15883: Don't log every file download message.

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -106,7 +106,7 @@ jobs:
       ARCHIVE_END_TIME: ${{ steps.export-archive-end-time.outputs.ARCHIVE_END_TIME }}
     env:
       CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
-
+      DEBUG: ${{ secrets.ACTIONS_RUNNER_DEBUG }}
     steps:
       - name: Export build start time
         id: export-build-start-time

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -106,7 +106,6 @@ jobs:
       ARCHIVE_END_TIME: ${{ steps.export-archive-end-time.outputs.ARCHIVE_END_TIME }}
     env:
       CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
-      DEBUG: ${{ secrets.ACTIONS_RUNNER_DEBUG }}
     steps:
       - name: Export build start time
         id: export-build-start-time
@@ -209,6 +208,7 @@ jobs:
         timeout-minutes: 40
         env:
           NODE_ENV: production
+          DEBUG: ${{ secrets.ACTIONS_RUNNER_DEBUG }}
 
       - name: Export content build end time
         id: export-content-build-end
@@ -534,7 +534,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
         with:
@@ -594,7 +594,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -135,6 +135,7 @@ jobs:
         run: yarn build --buildtype=${{ matrix.buildtype }} --asset-source=local --drupal-address=${{ env.DRUPAL_ADDRESS }} --drupal-user=${{ env.DRUPAL_USERNAME }} --drupal-password="${{ env.DRUPAL_PASSWORD }}" --pull-drupal --drupal-max-parallel-requests=15 --no-drupal-proxy --verbose
         env:
           NODE_ENV: production
+          DEBUG: ${{ secrets.ACTIONS_RUNNER_DEBUG }}
 
       - name: Check broken links
         id: get-broken-link-info

--- a/src/site/stages/build/plugins/download-drupal-assets.js
+++ b/src/site/stages/build/plugins/download-drupal-assets.js
@@ -16,6 +16,7 @@ async function downloadFile(
   downloadResults,
   everythingDownloaded,
   downloaderIndex,
+  verbose = false,
 ) {
   const asset = assetsToDownload.shift();
   if (!asset) {
@@ -36,7 +37,7 @@ async function downloadFile(
   // eslint-disable-next-line no-plusplus
   while (retries--) {
     try {
-      if (global.verbose) {
+      if (verbose) {
         const startDate = new Date().toISOString();
         log(
           `${startDate}: index ${downloaderIndex}: Starting download ${asset.src}`,
@@ -82,7 +83,7 @@ async function downloadFile(
     // eslint-disable-next-line no-plusplus
     downloadResults.downloadCount++;
 
-    if (global.verbose) {
+    if (verbose) {
       const endDate = new Date().toISOString();
       log(
         `${endDate}: index ${downloaderIndex}: Finished downloading ${asset.src}`,
@@ -96,7 +97,7 @@ async function downloadFile(
     // Should get caught by the broken link checker, though
     // eslint-disable-next-line no-plusplus
     downloadResults.errorCount++;
-    if (global.verbose) {
+    if (verbose) {
       log(`File download failed: ${response.statusText}: ${asset.src}`);
     } else {
       process.stdout.write(chalk.red('.'));
@@ -120,6 +121,7 @@ async function downloadFile(
       downloadResults,
       everythingDownloaded,
       downloaderIndex,
+      verbose,
     );
   } else {
     // Some downloads must still be in progress, but there are no files left to begin downloading
@@ -151,6 +153,7 @@ function downloadDrupalAssets(options) {
       };
 
       const downloadersCount = 5;
+      const verbose = global.verbose && process.env.DEBUG === 'true';
 
       await new Promise(everythingDownloaded => {
         // eslint-disable-next-line no-plusplus
@@ -163,6 +166,7 @@ function downloadDrupalAssets(options) {
             downloadResults,
             everythingDownloaded,
             i,
+            verbose,
           );
         }
       });


### PR DESCRIPTION
Closes department-of-veterans-affairs/va.gov-cms#15883. Should make life easier for people trying to find reasons for failure in the action log.

Before:
![Screenshot 2023-10-27 at 12 03 38 PM](https://github.com/department-of-veterans-affairs/content-build/assets/1318579/9dfd691f-befc-4e83-b4d2-cce0a2484cab)

After:
![Screenshot 2023-10-27 at 12 02 54 PM](https://github.com/department-of-veterans-affairs/content-build/assets/1318579/30b20106-fb85-43de-8ba4-aee6f41412f3)

Verified we can still see full info with debug enabled:
![Screenshot 2023-10-30 at 1 22 00 PM](https://github.com/department-of-veterans-affairs/content-build/assets/1318579/3c02839e-a6ca-469e-902e-5e72d6b73539)


Saved almost 70K lines.
