### PR TITLE
Removing no longer needed entry for rated-disabilities

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -56,15 +56,6 @@
   },
   {
     "appName": "Rated Disabilities",
-    "entryName": "disability-my-rated-disabilities",
-    "rootUrl": "/disability/view-disability-rating/my-rating",
-    "template": {
-      "layout": "page-react.html",
-      "vagovprod": true
-    }
-  },
-  {
-    "appName": "Rated Disabilities",
     "entryName": "rated-disabilities",
     "rootUrl": "/disability/view-disability-rating/rating",
     "template": {


### PR DESCRIPTION
## Description
Removing a no longer needed entry for the rated-disabilities application. The new entry has `entryName: "rated-disabilities"` and the rootUrl for the entry being removed is not one used in VA.gov links

## Related Issue(s)
- department-of-veterans-affairs/va.gov-team/issues/66061

## QA steps

What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?  

1. Do this
   - [ ] Validate that
2. Then
   - [ ] Validate that
3. Then validate Acceptance Criteria from issue


## Acceptance criteria

- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
