### PR TITLE
Enable form 21-0966

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1426,7 +1426,7 @@
     "rootUrl": "/supporting-forms-for-claims/intent-to-file-form-21-0966",
     "productId": "8233bd78-20c6-4498-b36f-55ec0028b1e5",
     "template": {
-      "vagovprod": false,
+      "vagovprod": true,
       "layout": "page-react.html",
       "includeBreadcrumbs": true,
       "breadcrumbs_override": [


### PR DESCRIPTION
## Summary

Enable production route for simple forms 21-0966, Intent to File.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/403

[vets-website PR](https://github.com/department-of-veterans-affairs/vets-website/pull/26602)
[vets-api PR](https://github.com/department-of-veterans-affairs/vets-api/pull/14442)
