### PR TITLE
15632 CLP Aspect Ratio update

### DIFF
--- a/src/site/assets/sass/style.scss
+++ b/src/site/assets/sass/style.scss
@@ -18,3 +18,7 @@
   margin-top: 0;
   padding-top: 1.25rem;
 }
+
+#clp-header-image img {
+  width: 468px;
+}

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -6,12 +6,11 @@
 <div id="content" class="interior" data-template="node-campaign_landing_page">
   <main>
     <!-- Hero-->
-    <div class="va-u-background--image" style="background-image: url('{{ fieldHeroImage.entity.image.derivative.url }}">
-      <!-- Hero Content -->
-      <div class="vads-l-grid-container vads-u-padding-x--0">
-        <div class="vads-l-row">
-          <div class="vads-l-col--12 medium-screen:vads-l-col--6">
-            <div class="va-u-background--gradiant-blue vads-u-padding-x--4 vads-u-padding-bottom--6 vads-u-padding-top--4 medium-screen:vads-u-margin-right--4">
+    <div class="va-u-background--gradiant-blue">
+      <div class="vads-l-grid-container vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
+        <div class="vads-l-col--12 small-screen:vads-l-col--10 medium-screen:vads-l-col--8 small-desktop-screen:vads-l-col--12">
+          <div class="vads-u-display--flex small-desktop-screen:vads-l-row">
+            <div class="vads-l-col--12 small-desktop-screen:vads-l-col--6 vads-u-padding-top--4 vads-u-padding-bottom--6 small-desktop-screen:vads-u-padding-right--4">
               <h1 class="vads-u-color--white">{{ title }}</h1>
               <hr class="va-c-blue-line--large vads-u-border-color--primary-alt vads-u-border--2px vads-u-margin-y--2" />
               <p class="va-introtext vads-u-color--white">{{ fieldHeroBlurb }}</p>
@@ -25,6 +24,9 @@
                   {{ fieldPrimaryCallToAction.entity.fieldButtonLabel }}
                 </a>
               {% endif %}
+            </div>
+            <div class="vads-u-display--none small-desktop-screen:vads-u-display--block" id="clp-header-image">
+              <img class="vads-u-height--full" style="object-fit:cover" alt="" src="{{ fieldHeroImage.entity.image.derivative.url }}">
             </div>
           </div>
         </div>

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -26,7 +26,7 @@
               {% endif %}
             </div>
             <div class="vads-u-display--none small-desktop-screen:vads-u-display--block" id="clp-header-image">
-              <img class="vads-u-height--full" style="object-fit:cover" alt="" src="{{ fieldHeroImage.entity.image.derivative.url }}">
+              <img alt="" src="{{ fieldHeroImage.entity.image.derivative.url }}">
             </div>
           </div>
         </div>

--- a/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
@@ -274,7 +274,7 @@ const nodeCampaignLandingPage = `
         entityId
         ... on MediaImage {
           image {
-            derivative(style: VIEWPORTWIDTH) {
+            derivative(style: CROPSQUARE) {
               height
               url
               width


### PR DESCRIPTION
## Summary

Campaign Landing Pages currently use a 7:2 aspect ratio that causes problems for rendering the image at various breakpoints.

Current design:

<img width="1190" alt="Screenshot 2023-11-13 at 4 13 23 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/65aa38c4-dad6-4e19-a512-b4d76d8927e5">

Design put together a new 1:1 design for Campaign Landing Pages so the text and the image would be side by side.

New design:

<img width="1528" alt="Screenshot 2023-11-13 at 4 12 36 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/b3e64cb9-0bed-4ebc-814e-e6c330ba4e52">

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15632

## Testing done

Tested local build on:
- /initiatives/protecting-veterans-from-fraud
- /initiatives/veterans-experience-action-centers
- /initiatives/national-buddy-check-week-talk-to-10-veterans
- /initiatives/sign-in-securely-with-logingov
- /initiatives/covid-flu
- /initiatives/veteran-trust-in-va
- /initiatives/end-of-life-benefits/
- /initiatives/emergency-room-911-or-urgent-care
- /initiatives/network-of-support
- /initiatives/vote
- /initiatives/recognizing-lgbtq-veterans-during-pride-month

## Screenshots
<img width="500" alt="Screenshot 2023-11-27 at 11 07 02 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/a04d6b37-3fd0-4439-93b5-8efa322cc1e2">
<img width="500" alt="Screenshot 2023-11-27 at 11 06 45 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/d31f2bf0-032d-43ae-a423-a7269171ad63">
<img width="500" alt="Screenshot 2023-11-27 at 11 06 32 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/490b535e-c484-4f54-939c-9f6c1efe6853">
<img width="500" alt="Screenshot 2023-11-27 at 11 06 18 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/20cdc9b5-3601-4a4c-9267-3ff5527b04b0">
<img width="500" alt="Screenshot 2023-11-27 at 11 06 03 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/8831d6f1-6294-438b-91f7-da3f65463187">
<img width="500" alt="Screenshot 2023-11-27 at 11 05 49 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/8c6fcdbf-dfb8-4985-ab24-8e55de0c819f">
<img width="500" alt="Screenshot 2023-11-27 at 11 05 36 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/6fd24b4e-1db1-430e-a809-f919709cb66e">
<img width="500" alt="Screenshot 2023-11-27 at 11 05 23 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/7caacda1-52f9-4c36-96da-bf0263a7225e">
<img width="500" alt="Screenshot 2023-11-27 at 11 05 09 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/c83fff3a-d15f-402b-afda-214b6747a19c">
<img width="500" alt="Screenshot 2023-11-27 at 11 04 30 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/a263ac96-a31f-4a75-b335-ed61daa6cdc7">

## Acceptance criteria

- [x] CLP template(s) use the design-recommended image aspect ratio & updated gradient across all breakpoints where the image should appear
- [ ] Design review is required, including verifying existing published CLPs in a Tugboat
- [x] Include alt text tag but ensure value is NULL ("") - verify with Laura in Tugboat
- [x] Mark PR DO NOT MERGE