### PR TITLE
test if JSON file exists before rmSync

### DIFF
--- a/src/site/stages/build/drupal/static-data-files/generate.js
+++ b/src/site/stages/build/drupal/static-data-files/generate.js
@@ -107,9 +107,11 @@ const writeProcessedDataFilesToCache = (
     },
   );
   for (const processedData of newSuccessful) {
-    fs.rmSync(`${fullCacheFilepath}/${processedData.filename}`, {
-      force: true,
-    });
+    if (fs.existsSync(`${fullCacheFilepath}/${processedData.filename}`)) {
+      fs.rmSync(`${fullCacheFilepath}/${processedData.filename}`, {
+        force: true,
+      });
+    }
   }
   newSuccessful.forEach(({ filename, data }) => {
     writeProcessedDataFileToCache(fullCacheFilepath, filename, data);


### PR DESCRIPTION
## Summary

- Tests if JSON file for output exists in cache before delete
- if cache file did not exist but was producing it anew, sys would crash according to: https://dsva.slack.com/archives/C03LFSPGV16/p1699983055858059
- Test with existsSync first
- Sitewide Facilities 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16124

## Testing done

- Tested with static files directory but no vamc_police.json
- Tested without static files directory
- Tested with static files directory but no supplemental status file to see if police file is regenerated.

## Screenshots

No visible changes

## What areas of the site does it impact?

Impacts KISS data generated

## Acceptance criteria

No crash when building without cache.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A)
- [x] Screenshot of the developed feature is added (N/A)
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed (N/A)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (not affected)

## Requested Feedback

Check if KISS JSON files get generated in static files cache path.