### PR TITLE
VACMS 15943: Move promo banner into header tag

### DIFF
--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -177,13 +177,13 @@
     {% unless noHeader %}
       {% include "src/site/includes/top-nav.html" %}
     {% endunless %}
+
+    <!-- Banners -->
+    {% include "src/site/components/banners.drupal.liquid" %}
   </header>
 
   <!-- Fullwidth banner alerts -->
   {% include "src/site/components/fullwidth_banner_alerts.drupal.liquid" %}
-
-  <!-- Banners -->
-  {% include "src/site/components/banners.drupal.liquid" %}
 
   <script nonce="**CSP_NONCE**" type="text/javascript">
     {% include "src/site/assets/js/skip-link-focus.js" %}


### PR DESCRIPTION
## Summary
Moves promo banner under the header. Checked and this will not impact injected header. 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15943

## Testing done
Tested the header markup to make sure the promo banner element is inside the header tag

## What areas of the site does it impact?
Header

## Acceptance criteria
- [x] The `<va-promo-banner>` is wrapped within the `<header>`
- [x] The injected header is not impacted
- [x] Requires design review
- [x] Requires accessibility review

