### PR TITLE
Fix typo in breadcrumb link for 10-10EZR application

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -228,7 +228,7 @@
       "includeBreadcrumbs": true,
       "breadcrumbs_override": [
         {
-          "path": "my-heath/",
+          "path": "my-health/",
           "name": "My Health"
         },
         {

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -232,7 +232,7 @@
           "name": "My Health"
         },
         {
-          "path": "update-benefits-information-form-10-10ezr",
+          "path": "my-health/update-benefits-information-form-10-10ezr",
           "name": "Update your VA health benefits information"
         }
       ]


### PR DESCRIPTION
## Summary
This PR fixes a minor typo in a breadcrumb override for the 10-10EZR application.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#70193

## Acceptance criteria
- Breadcrumbs contain no typos that would cause a broken link

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution