### PR TITLE
Revert 20-10206 app-registry entryName change

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1641,7 +1641,7 @@
   },
   {
     "appName": "Request personal records",
-    "entryName": "10206-pa",
+    "entryName": "10206-foia",
     "rootUrl": "/request-personal-records",
     "productId": "560247e7-3a80-4fdd-ad00-8d0e14435d22",
     "template": {


### PR DESCRIPTION
## Summary

- Revert Personal Records Request (20-10206) app-registry entryName change
- Team: Veteran Facing Forms
- Flipper not implemented yet

## Related PR

[vets-website](https://github.com/department-of-veterans-affairs/vets-website/pull/26780)

## Related PR

[content-build](https://github.com/department-of-veterans-affairs/content-build/pull/1800)

## Related issue(s)

- _Link to ticket created in va.gov-team-forms repo_
department-of-veterans-affairs/va.gov-team-forms#807

## Testing done

- Local browser-testing was successful

## What areas of the site does it impact?

This form ONLY, but should also unblock any other PR-builds that were failing due to this form's broken stylesheet link.