### PR TITLE
[VA-14940] Remove unavailable Spotlight CC fields

### DIFF
--- a/src/site/stages/build/drupal/graphql/vbaFacility.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vbaFacility.graphql.js
@@ -52,12 +52,6 @@ const vbaFacilityFragment = `
           fieldCcNationalSpotlight1 {
             fetched
           }
-          fieldCcNationalSpotlight2 {
-            fetched
-          }
-          fieldCcNationalSpotlight3 {
-            fetched
-          }
           fieldCcGetUpdatesFromVba {
             fetched
           }


### PR DESCRIPTION
## Summary

The VBA Regional Facility page has been merged to production. Two fields for the query on `vbaFacility.graphql.js` are referenced but do not yet exist on the Drupal side, which causes an error on [this staging page.](https://staging.cms.va.gov/get-help-from-a-va-accredited-representative-or-vso) Production is not broken (see [this Slack thread](https://dsva.slack.com/archives/CT4GZBM8F/p1701179249804799) for more details).

This pull request removes the two fields creating the error for the time being. The template will still render properly, just with a few missing elements, so that can be left alone for now to minimize the code being changed. Once this is merged, I'll open up a draft PR adding the fields back. It will be marked as "do not merge" and left alone until Drupal adds those two fields in.

## Related issue(s)

[Ticket 14940](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14940)

## Testing done

Confirmed this error was hitting the staging page, so removing these fields will remove them.

```
Pulling feature flags from Drupal...
Error: Drupal errors: [
  {
    "message": "Cannot query field \"fieldCcNationalSpotlight2\" on type \"NodeVbaFacility\". Did you mean \"fieldCcNationalSpotlight1\" or \"fieldLocalSpotlight\"?",
    "extensions": {
      "category": "graphql"
    },
    "locations": [
      {
        "line": 4580,
        "column": 11
      }
    ]
  },
  {
    "message": "Cannot query field \"fieldCcNationalSpotlight3\" on type \"NodeVbaFacility\". Did you mean \"fieldCcNationalSpotlight1\" or \"fieldLocalSpotlight\"?",
    "extensions": {
      "category": "graphql"
    },
    "locations": [
      {
        "line": 4583,
        "column": 11
      }
    ]
  }
]
    at /home/node/script/preview.js:274:13
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
```

## What areas of the site does it impact?

Page previews in prod, although `content-build` itself still runs properly.

## Acceptance criteria

This removes the above error.
