### PR TITLE
VACMS-10176: Fix Featured events when no featured event is live on Health Care Region Pages

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1109,6 +1109,32 @@ module.exports = function registerFilters() {
     });
   };
 
+  //* Filters and Sorts event dates (fieldDatetimeRangeTimezone) starting with the most upcoming event.
+  //* Also sorts press releases (fieldReleaseDate) from newest to oldest.
+  liquid.filters.filterAndSortEvents = data => {
+    if (!data) return null;
+    const currentTimestamp = moment().unix();
+
+    const filteredEvents = data.filter(event => {
+      const occurrenceArray = event.fieldDatetimeRangeTimezone.map(
+        occurrence => {
+          return occurrence.value;
+        },
+      );
+      const futureOccurrences = occurrenceArray.filter(
+        occurrence => occurrence >= currentTimestamp,
+      );
+
+      return futureOccurrences.length > 0;
+    });
+
+    return liquid.filters.sortByDateKey(
+      filteredEvents,
+      'fieldDatetimeRangeTimezone',
+      false,
+    );
+  };
+
   //* paginatePages has limitations, it is not yet fully operational.
   liquid.filters.paginatePages = (page, items, aria) => {
     const perPage = 10;

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1110,7 +1110,6 @@ module.exports = function registerFilters() {
   };
 
   //* Filters and Sorts event dates (fieldDatetimeRangeTimezone) starting with the most upcoming event.
-  //* Also sorts press releases (fieldReleaseDate) from newest to oldest.
   liquid.filters.filterAndSortEvents = data => {
     if (!data) return null;
     const currentTimestamp = moment().unix();

--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -186,8 +186,7 @@
           </section>
           {% elsif eventTeasersAll.entities.0.reverseFieldListingNode.entities.length %}
           {% assign upcomingEvents = eventTeasersAll.entities.0.reverseFieldListingNode.entities %}
-          {% assign filteredEvents = upcomingEvents | filterPastEvents %}
-          {% assign sortedEvents = filteredEvents | sortByDateKey: 'fieldDatetimeRangeTimezone', false %}
+          {% assign sortedEvents = upcomingEvents | sortByDateKey: 'fieldDatetimeRangeTimezone', false %}
           
           <section>
             <h2

--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -186,11 +186,7 @@
           </section>
           {% elsif eventTeasersAll.entities.0.reverseFieldListingNode.entities.length %}
           {% assign upcomingEvents = eventTeasersAll.entities.0.reverseFieldListingNode.entities %}
-        {% comment %} {% assign filteredEvents = upcomingEvents | filterPastEvents %}
-          {% assign sortedEvents = filteredEvents | sortByDateKey: 'fieldDatetimeRangeTimezone', false %}  {% endcomment %}
-
-          {% assign sortedEvents = upcomingEvents | filterAndSortEvents %}
-          
+          {% assign sortedEvents = upcomingEvents | filterAndSortEvents %}         
           <section>
             <h2
               class="vads-u-margin-top--4 vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--2p5">

--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -186,13 +186,14 @@
           </section>
           {% elsif eventTeasersAll.entities.0.reverseFieldListingNode.entities.length %}
           {% assign upcomingEvents = eventTeasersAll.entities.0.reverseFieldListingNode.entities %}
-          {% assign sortedEvents = upcomingEvents | sortByDateKey: 'fieldDatetimeRangeTimezone', false %}
-          {% assign filteredEvents = sortedEvents | filterPastEvents %}
+          {% assign filteredEvents = upcomingEvents | filterPastEvents %}
+          {% assign sortedEvents = filteredEvents | sortByDateKey: 'fieldDatetimeRangeTimezone', false %}
+          
           <section>
             <h2
               class="vads-u-margin-top--4 vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--2p5">
               Events</h2>
-            {% for event in filteredEvents limit:1 %}
+            {% for event in sortedEvents limit:1 %}
               {% assign node = event %}
               {% include "src/site/teasers/event.drupal.liquid" %}
             {% endfor %}

--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -186,13 +186,13 @@
           </section>
           {% elsif eventTeasersAll.entities.0.reverseFieldListingNode.entities.length %}
           {% assign upcomingEvents = eventTeasersAll.entities.0.reverseFieldListingNode.entities %}
-          {% assign filtedEvents = upcomingEvents | filterPastEvents  %}
-          {% assign sortedEvents = filteredEvents | sortByDateKey: 'fieldDatetimeRangeTimezone', false %}
+          {% assign sortedEvents = upcomingEvents | sortByDateKey: 'fieldDatetimeRangeTimezone', false %}
+          {% assign filteredEvents = sortedEvents | filterPastEvents %}
           <section>
             <h2
               class="vads-u-margin-top--4 vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--2p5">
               Events</h2>
-            {% for event in sortedEvents limit:1 %}
+            {% for event in filteredEvents limit:1 %}
               {% assign node = event %}
               {% include "src/site/teasers/event.drupal.liquid" %}
             {% endfor %}

--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -186,7 +186,10 @@
           </section>
           {% elsif eventTeasersAll.entities.0.reverseFieldListingNode.entities.length %}
           {% assign upcomingEvents = eventTeasersAll.entities.0.reverseFieldListingNode.entities %}
-          {% assign sortedEvents = upcomingEvents | sortByDateKey: 'fieldDatetimeRangeTimezone', false %}
+        {% comment %} {% assign filteredEvents = upcomingEvents | filterPastEvents %}
+          {% assign sortedEvents = filteredEvents | sortByDateKey: 'fieldDatetimeRangeTimezone', false %}  {% endcomment %}
+
+          {% assign sortedEvents = upcomingEvents | filterAndSortEvents %}
           
           <section>
             <h2

--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -186,7 +186,8 @@
           </section>
           {% elsif eventTeasersAll.entities.0.reverseFieldListingNode.entities.length %}
           {% assign upcomingEvents = eventTeasersAll.entities.0.reverseFieldListingNode.entities %}
-          {% assign sortedEvents = upcomingEvents | sortByDateKey: 'fieldDatetimeRangeTimezone', false %}
+          {% assign filtedEvents = upcomingEvents | filterPastEvents  %}
+          {% assign sortedEvents = filteredEvents | sortByDateKey: 'fieldDatetimeRangeTimezone', false %}
           <section>
             <h2
               class="vads-u-margin-top--4 vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--2p5">

--- a/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
@@ -116,7 +116,7 @@ const nodeHealthCareRegionPage = `
     eventTeasersFeatured: reverseFieldOfficeNode(limit: 1000, filter: {conditions: [{field: "type", value: "event_listing"}]}) {
       entities {
         ... on NodeEventListing {
-          reverseFieldListingNode(limit: 5000, filter: {conditions: [{field: "type", value: "event"}, {field: "status", value: "1"}, {field: "field_featured", value: "1"}, { field: "field_datetime_range_timezone", value: [$today], operator: GREATER_THAN}]}) {
+          reverseFieldListingNode(limit: 5000, filter: {conditions: [{field: "type", value: "event"}, {field: "status", value: "1"}, {field: "field_featured", value: "1"}]}) {
             entities {
               ... nodeEventWithoutBreadcrumbs
             }

--- a/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
@@ -105,7 +105,7 @@ const nodeHealthCareRegionPage = `
     eventTeasersAll: reverseFieldOfficeNode(limit: 1, filter: {conditions: [{field: "type", value: "event_listing"}]}) {
       entities {
         ... on NodeEventListing {
-          reverseFieldListingNode(sort: {field: "field_datetime_range_timezone", direction: ASC }, limit: 10, filter: {conditions: [{field: "type", value: "event"}, {field: "status", value: "1"}, { field: "field_datetime_range_timezone", value: [$today], operator: GREATER_THAN}]}) {
+          reverseFieldListingNode(sort: {field: "field_datetime_range_timezone", direction: ASC }, limit: 1000, filter: {conditions: [{field: "type", value: "event"}, {field: "status", value: "1"}]}) {
             entities {
               ... nodeEventWithoutBreadcrumbs
             }


### PR DESCRIPTION
## Summary
Pulled filter logic from graphQL to the browser in drupal liquid filters. Now there is a `filterAndSortEvents` that we will use to take in all events for a health care region(up to 1000 events) and filter then sort the events based on most upcoming event. 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/10716

## Testing done
Tested in tugboat env to check for event staleness. Was able to see all events are being passed through to the FE, not just 10 and most upcoming event is being shown. 

