### PR TITLE
[VA-15424] Add common and official names to Vet Center locations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,6 +31,7 @@ src/site/navigation/facility_no_drupal_page_sidebar_nav.drupal.liquid @departmen
 src/site/navigation/facility_sidebar_nav.drupal.liquid @department-of-veterans-affairs/vfs-facilities-frontend
 src/site/paragraphs/facilities @department-of-veterans-affairs/vfs-facilities-frontend
 src/site/stages/build/drupal/static-data-files/vaPoliceData @department-of-veterans-affairs/vfs-facilities-frontend
+src/site/includes/vet_centers @department-of-veterans-affairs/vfs-facilities-frontend
 
 # GraphQL Queries
 src/site/stages/build/drupal @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/vfs-facilities-frontend @department-of-veterans-affairs/cms-infrastructure

--- a/src/site/includes/vet_centers/address_phone_image.liquid
+++ b/src/site/includes/vet_centers/address_phone_image.liquid
@@ -2,15 +2,21 @@
      class="region-list usa-width-one-whole vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row facility vads-u-margin-bottom--4 medium-screen:vads-u-margin-bottom--1">
   <section class="region-grid vads-u-margin-right--2">
     {% if vetCenter.title %}
-      <h3 class="vads-u-margin-bottom--1 vads-u-margin-top--0 vads-u-font-size--md vads-u-font-size--lg">
+      {% if vetCenter.fieldOfficialName and vetCenter.title != vetCenter.fieldOfficialName %}
+        {% assign vetCenterId = vetCenter.title | downcase | replace: " ", "-" %}
+      {% else %}
+        {% assign vetCenterId = false %}
+      {% endif %}
+
+      <h3 class="vads-u-margin-bottom--1 vads-u-margin-top--0 vads-u-font-size--md vads-u-font-size--lg" {% if vetCenterId %}aria-describedby={{ vetCenterId }}{% endif %}>
         {% if vetCenter.entityBundle == "vet_center_cap" or vetCenter.entityBundle == "vet_center" or vetCenter.entityBundle == "vet_center_outstation" or vetCenter.entityBundle == "vet_center_mobile_vet_center" %}
           <vctitle>{{ vetCenter.title }}</vctitle>
         {% else %}
           <a href="{{ vetCenterUrl }}"><vctitle>{{ vetCenter.title }}</vctitle></a>
         {% endif %}
       </h3>
-      {% if vetCenter.fieldOfficialName and vetCenter.title != vetCenter.fieldOfficialName %}
-        <p class="field-official-name vads-u-line-height--4 vads-u-font-family--sans vads-u-font-size--md
+      {% if vetCenterId %}
+        <p id="{{ vetCenterId }}" class="field-official-name vads-u-line-height--4 vads-u-font-family--sans vads-u-font-size--md
         vads-u-font-weight--bold vads-u-padding-bottom--0p5">
           Also called the {{ vetCenter.fieldOfficialName }}
         </p>

--- a/src/site/includes/vet_centers/address_phone_image.liquid
+++ b/src/site/includes/vet_centers/address_phone_image.liquid
@@ -9,6 +9,12 @@
           <a href="{{ vetCenterUrl }}"><vctitle>{{ vetCenter.title }}</vctitle></a>
         {% endif %}
       </h3>
+      {% if vetCenter.fieldOfficialName and vetCenter.title != vetCenter.fieldOfficialName %}
+        <p class="field-official-name vads-u-line-height--4 vads-u-font-family--sans vads-u-font-size--md
+        vads-u-font-weight--bold vads-u-padding-bottom--0p5">
+          Also called the {{ vetCenter.fieldOfficialName }}
+        </p>
+      {% endif %}
     {% endif %}
     <div data-widget-type="expandable-operating-status-{{ vetCenter.fieldFacilityLocatorApiId }}"
          facilityId="{{ vetCenter.fieldFacilityLocatorApiId }}"

--- a/src/site/layouts/vet_center.drupal.liquid
+++ b/src/site/layouts/vet_center.drupal.liquid
@@ -9,12 +9,15 @@
       <div class="usa-width-three-fourths">
         <article class="usa-content va-l-facility-detail vads-u-padding-bottom--0">
           {% if title != empty %}
-            <h1 aria-describedby="vet-center-title">{{ title }}</h1>
             {% if fieldOfficialName and title != fieldOfficialName %}
+              <h1 aria-describedby="vet-center-title">{{ title }}</h1>
+
               <p id="vet-center-title" class="field-official-name vads-u-line-height--4 vads-u-font-family--sans vads-u-font-size--lg
               vads-u-font-weight--bold vads-u-padding-bottom--0p5">
                 Also called the {{fieldOfficialName}}
               </p>
+            {% else %}
+            <h1>{{ title }}</h1>
             {% endif %}
           {% elsif fieldOfficialName != empty %}
             <h1>{{ fieldOfficialName}}</h1>

--- a/src/site/layouts/vet_center.drupal.liquid
+++ b/src/site/layouts/vet_center.drupal.liquid
@@ -12,8 +12,7 @@
             {% if fieldOfficialName and title != fieldOfficialName %}
               <h1 aria-describedby="vet-center-title">{{ title }}</h1>
 
-              <p id="vet-center-title" class="field-official-name vads-u-line-height--4 vads-u-font-family--sans vads-u-font-size--lg
-              vads-u-font-weight--bold vads-u-padding-bottom--0p5">
+              <p id="vet-center-title" class="field-official-name vads-u-line-height--4 vads-u-font-family--serif vads-u-font-size--lg vads-u-font-weight--bold vads-u-padding-bottom--0p5">
                 Also called the {{fieldOfficialName}}
               </p>
             {% else %}

--- a/src/site/stages/build/drupal/graphql/vetCenterLocations.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vetCenterLocations.graphql.js
@@ -25,6 +25,7 @@ fragment vetCenterLocationsFragment on NodeVetCenterLocationsList {
       ... on NodeVetCenter {
         title
         entityBundle
+        fieldOfficialName
         fieldOperatingStatusFacility
         fieldOperatingStatusMoreInfo
         fieldAddress {
@@ -40,6 +41,7 @@ fragment vetCenterLocationsFragment on NodeVetCenterLocationsList {
       ... on NodeVetCenterOutstation {
         title
         entityBundle
+        fieldOfficialName
         fieldOperatingStatusFacility
         fieldOperatingStatusMoreInfo
         fieldAddress {
@@ -123,6 +125,7 @@ fragment vetCenterLocationsFragment on NodeVetCenterLocationsList {
               title
               entityBundle
               fieldFacilityLocatorApiId
+              fieldOfficialName
               fieldOperatingStatusFacility
               fieldOperatingStatusMoreInfo
               ${derivativeImage('_32MEDIUMTHUMBNAIL')}
@@ -165,6 +168,7 @@ fragment vetCenterLocationsFragment on NodeVetCenterLocationsList {
         }
         fieldFacilityLocatorApiId
         fieldPhoneNumber
+        fieldOfficialName
         fieldOperatingStatusFacility
         fieldOperatingStatusMoreInfo
         ${derivativeImage('_32MEDIUMTHUMBNAIL')}


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

Veterans may know and search for their closest Vet Center by a common name, rather than an official name. This shows the common names alongside the official names when available on location listings and location details pages.

**Note:** The ticket covers three examples of current name behavior that needs to change. Examples 1 and 3 are covered by these changes. Example 2 needs changes made to `vets-website` and `vets-api` due to the data being pulled in differently.

## Related issue(s)

- _Link to ticket created in va.gov-cms repo_
[department-of-veterans-affairs/va.gov-cms#15424](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15424)

## Testing done

Visually and on local build.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | <img width="784" alt="Screen Shot 2023-12-04 at 12 55 38 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10790736/d4bbaf6e-732a-4557-b771-910309d3e607"> | <img width="704" alt="Screen Shot 2023-12-04 at 12 55 12 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10790736/dff150bf-8127-4c28-9730-de56d3cbdfcb"> |

The above screenshots are for example 1 in the ticket. The below screenshot shows that example 3 is also addressed with these changes. Both official and common names are pulled into the updated template, but since both of them are the same, the additional line of text isn't added.

<img width="1557" alt="Screen Shot 2023-12-04 at 12 57 26 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10790736/ccabc353-d334-48a3-b946-ea623ab1ae22">

## What areas of the site does it impact?

Location listing pages

## Acceptance criteria

### QA

- [x]  Go to [Prescott Vet Center main page](https://web-txcrk8bym4a0ivw3xfr8xvdhezmls36f.demo.cms.va.gov/prescott-vet-center/) and confirm:
  - [x] Common name is displaying as `<h1>`
  - [x] Official name is displaying a `<p>`
  - [x] Both names are tied together using `id/aria-describedby` pattern
- [x]  Go to [Prescott Vet Center Locations page](https://web-txcrk8bym4a0ivw3xfr8xvdhezmls36f.demo.cms.va.gov/prescott-vet-center/locations/) and confirm that in the main location section:
  - [x] Common name is displaying as a linked `<h3>`
  - [x] Official name is displaying a `<p>`
  - [x] Both names are tied together using `id/aria-describedby` pattern
- [x] Go to [Boston vet Center main page](https://web-txcrk8bym4a0ivw3xfr8xvdhezmls36f.demo.cms.va.gov/boston-vet-center/) and confirm
  - [x] Common name is displaying as `<h1>`
  - [x] Official name is not displaying
  - [x] Common name does not have an `aria-describedby` attribute
- [x] Go to [Boston vet Center Locations page](https://web-txcrk8bym4a0ivw3xfr8xvdhezmls36f.demo.cms.va.gov/boston-vet-center/locations/) and confirm
  - [x] Common name is displaying as a linked `<h3>`
  - [x] Official name is not displaying
  - [x] Common name does not have an `aria-describedby` attribute
- [x]  Go to [Salt Lake City Vet Center locations page](https://web-txcrk8bym4a0ivw3xfr8xvdhezmls36f.demo.cms.va.gov/salt-lake-city-vet-center/locations/) and confirm that in the Satellite locations section:
  - [x] Each location has a common name displaying as `<h3>`
  - [x] If there is an official name, it is displaying a `<p>` (Major Brent Taylor should)
  - [x] When an official name is present, both names are tied together using `id/aria-describedby` pattern
  - [x] When an official name is not present, the common name does not have an `aria-describedby` attribute

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed


### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
