### PR TITLE
(my-health) Update registry.json to remove medications from the sitemap

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1515,7 +1515,7 @@
     "template": {
       "vagovprod": true,
       "layout": "page-react.html",
-      "private":true
+      "private": true
     }
   },
   {

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1514,7 +1514,8 @@
     "productId": "0203ca08-b7a2-4cd6-abb5-56d38c239cd3",
     "template": {
       "vagovprod": true,
-      "layout": "page-react.html"
+      "layout": "page-react.html",
+      "private":true
     }
   },
   {


### PR DESCRIPTION
## Summary

We are looking to remove the my-health section from the site map while we are in the early stages of the rollout. We believe that setting a project to `private:false` should remove it form the site. 

This PR removes on the my-health tools to test the theory that its removed form the site map


## Related issue(s)

No issue, but this was covered in a private slack channel

## Testing done

Not sure how to test the site map locally 

## Screenshots
No UI changes

## What areas of the site does it impact?

/my-health/medications

## Acceptance criteria

### Quality Assurance & Testing

Tests in CI

### Error Handling

N/A

### Authentication

N/A

## Requested Feedback
N/A