### PR TITLE
VACMS-15411: Event CTA addition of Email Register button functionality

### DIFF
--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -192,6 +192,17 @@
                   </a>
                 </p>
               {% endif %}
+              {% if fieldHowToSignUp == 'email' %}
+                <p class="vads-u-margin--0">
+                  <a class="vads-c-action-link--green" href="mailto:{{ fieldCtaEmail.url.path }}">
+                    {% if fieldEventCta %}
+                      {{ fieldEventCta | removeUnderscores | capitalize }}
+                    {% else %}
+                      More details
+                    {% endif %}
+                  </a>
+                </p>
+              {% endif %}
 
               {% if fieldAdditionalInformationAbo %}
                 <p class="vads-u-margin--0">{{ fieldAdditionalInformationAbo.processed | phoneLinks }}</p>

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -193,9 +193,11 @@
                 </p>
               {% endif %}
 
-              {% if fieldHowToSignUp == 'email' %}
+            {% if fieldHowToSignUp == 'email' %}
+              {% assign now = '' | currentTime %}
+              {% assign mostRecentDate = fieldDatetimeRangeTimezone | deriveMostRecentDate: now %}   
                 <p class="vads-u-margin--0">
-                  <a class="vads-c-action-link--green" href="mailto:{{ fieldCtaEmail }}">
+                  <a class="vads-c-action-link--green" href="mailto:{{ fieldCtaEmail }}?subject={{ title }}?body=I would like to register for {{title}} on {{ mostRecentDate | deriveFormattedTimestamp }}. ({{entityUrl.path}}) ">
                     {% if fieldEventCta %}
                       {{ fieldEventCta | removeUnderscores | capitalize }}
                     {% endif %}

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -197,7 +197,7 @@
               {% assign now = '' | currentTime %}
               {% assign mostRecentDate = fieldDatetimeRangeTimezone | deriveMostRecentDate: now %}   
                 <p class="vads-u-margin--0">
-                  <a class="vads-c-action-link--green" href="mailto:{{ fieldCtaEmail }}?subject={{ title }}?body=I would like to register for {{title}} on {{ mostRecentDate | deriveFormattedTimestamp }}. ({{entityUrl.path}}) ">
+                  <a class="vads-c-action-link--green" href="mailto:{{ fieldCtaEmail }}?subject=RSVP for {{ title }} on {{ mostRecentDate | deriveFormattedTimestamp }}&body=I would like to register for {{title}} on {{ mostRecentDate | deriveFormattedTimestamp }}. (VA.gov{{entityUrl.path}}) ">
                     {% if fieldEventCta %}
                       {{ fieldEventCta | removeUnderscores | capitalize }}
                     {% endif %}

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -192,6 +192,7 @@
                   </a>
                 </p>
               {% endif %}
+              
               {% if fieldHowToSignUp == 'email' %}
                 <p class="vads-u-margin--0">
                   <a class="vads-c-action-link--green" href="mailto:{{ fieldCtaEmail }}">

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -192,14 +192,12 @@
                   </a>
                 </p>
               {% endif %}
-              
+
               {% if fieldHowToSignUp == 'email' %}
                 <p class="vads-u-margin--0">
                   <a class="vads-c-action-link--green" href="mailto:{{ fieldCtaEmail }}">
                     {% if fieldEventCta %}
                       {{ fieldEventCta | removeUnderscores | capitalize }}
-                    {% else %}
-                      More details
                     {% endif %}
                   </a>
                 </p>

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -196,9 +196,6 @@
               {% if fieldHowToSignUp == 'email' %}
                 {% assign now = '' | currentTime %}
                 {% assign mostRecentDate = fieldDatetimeRangeTimezone | deriveMostRecentDate: now %}   
-                <p class="vads-u-margin-bottom--2">
-                  Registration is required for this event.
-                </p>
                 <p class="vads-u-margin--0">
                   <a class="vads-c-action-link--green" href="mailto:{{ fieldCtaEmail }}?subject=RSVP for {{ title }} on {{ mostRecentDate | deriveFormattedTimestamp }}&body=I would like to register for {{title}} on {{ mostRecentDate | deriveFormattedTimestamp }}. (https://va.gov{{entityUrl.path}}) ">
                     {% if fieldEventCta %}

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -194,7 +194,7 @@
               {% endif %}
               {% if fieldHowToSignUp == 'email' %}
                 <p class="vads-u-margin--0">
-                  <a class="vads-c-action-link--green" href="mailto:{{ fieldCtaEmail.url.path }}">
+                  <a class="vads-c-action-link--green" href="mailto:{{ fieldCtaEmail }}">
                     {% if fieldEventCta %}
                       {{ fieldEventCta | removeUnderscores | capitalize }}
                     {% else %}

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -200,7 +200,7 @@
                   Registration is required for this event.
                 </p>
                 <p class="vads-u-margin--0">
-                  <a class="vads-c-action-link--green" href="mailto:{{ fieldCtaEmail }}?subject=RSVP for {{ title }} on {{ mostRecentDate | deriveFormattedTimestamp }}&body=I would like to register for {{title}} on {{ mostRecentDate | deriveFormattedTimestamp }}. (VA.gov{{entityUrl.path}}) ">
+                  <a class="vads-c-action-link--green" href="mailto:{{ fieldCtaEmail }}?subject=RSVP for {{ title }} on {{ mostRecentDate | deriveFormattedTimestamp }}&body=I would like to register for {{title}} on {{ mostRecentDate | deriveFormattedTimestamp }}. (https://va.gov{{entityUrl.path}}) ">
                     {% if fieldEventCta %}
                       {{ fieldEventCta | removeUnderscores | capitalize }}
                     {% endif %}

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -193,9 +193,12 @@
                 </p>
               {% endif %}
 
-            {% if fieldHowToSignUp == 'email' %}
-              {% assign now = '' | currentTime %}
-              {% assign mostRecentDate = fieldDatetimeRangeTimezone | deriveMostRecentDate: now %}   
+              {% if fieldHowToSignUp == 'email' %}
+                {% assign now = '' | currentTime %}
+                {% assign mostRecentDate = fieldDatetimeRangeTimezone | deriveMostRecentDate: now %}   
+                <p class="vads-u-margin-bottom--2">
+                  Registration is required for this event.
+                </p>
                 <p class="vads-u-margin--0">
                   <a class="vads-c-action-link--green" href="mailto:{{ fieldCtaEmail }}?subject=RSVP for {{ title }} on {{ mostRecentDate | deriveFormattedTimestamp }}&body=I would like to register for {{title}} on {{ mostRecentDate | deriveFormattedTimestamp }}. (VA.gov{{entityUrl.path}}) ">
                     {% if fieldEventCta %}

--- a/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
@@ -74,6 +74,8 @@ const nodeEvent = `
     fieldDescription
     fieldEventCost
     fieldEventCta
+    fieldCtaEmail
+    fieldHowToSignUp
     fieldEventRegistrationrequired
     fieldFacilityLocation {
       entity {
@@ -248,6 +250,8 @@ const nodeEventWithoutBreadcrumbs = `
     fieldDescription
     fieldEventCost
     fieldEventCta
+    fieldCtaEmail
+    fieldHowToSignUp
     fieldEventRegistrationrequired
     fieldFacilityLocation {
       entity {


### PR DESCRIPTION
## Summary
This ticket is in support of this [CMS change](https://github.com/department-of-veterans-affairs/va.gov-cms/pull/16173/) We are adding a new register CTA that can add a mailto: option to open a user's local email application when a email register for event option is selected in the CMS.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15411

## Testing done
Tested changes in tugboat env for registration required events with new CTA of email.
https://web-fwlvssypud9glye0p1gfv4hmamkufgpi.ci.cms.va.gov/puget-sound-health-care/events/63747

(Tugboat: https://tugboat.vfs.va.gov/655bd8ab1df1f2e9e200a940
CMS: https://cms-fwlvssypud9glye0p1gfv4hmamkufgpi.ci.cms.va.gov/)

Also verified that other register CTAs are not affected by this change.

## Screenshots

## What areas of the site does it impact?

Events

## Acceptance criteria
- [x] a11y review
- [x] design review

