### PR TITLE
VACMS-16517: Remove use of FEATURE_EVENT_OUTREACH_CHECKBOX.

### DIFF
--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -93,13 +93,9 @@ function createPastEventListPages(page, drupalPagePath, files) {
  *  @return nothing
  */
 function compileEventListingPage(page) {
-  const { cmsFeatureFlags } = global;
   // Combine events from reverse entity reference queries, if additional
   // listings data exists and feature flag is on.
-  if (
-    cmsFeatureFlags.FEATURE_EVENT_OUTREACH_CHECKBOX &&
-    page?.reverseFieldAdditionalListingsNode?.entities
-  ) {
+  if (page?.reverseFieldAdditionalListingsNode?.entities) {
     page.reverseFieldListingNode.entities.push(
       ...page.reverseFieldAdditionalListingsNode.entities,
     );


### PR DESCRIPTION
## Summary

Removes use of FEATURE_EVENT_OUTREACH_CHECKBOX.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16517

## Testing done
Verified content-build build succeeded.
Checked that content build succeeds. Also performed 

There are no behavior changes in this PR.

## What areas of the site does it impact?
Events

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria
Visit /outreach-and-events/outreach-materials/
- [ ] Verify publications are rendering/present

Visit /alaska-health-care/stories/learn-how-to-cook-with-healthy-teaching-kitchen
 Verify the 
- [ ] 'See all stories' link is present and points to the correct location.

Visit /lovell-federal-health-care-va/events/
- [ ] Verify events have correct and functioning URLs for both types of pages (tricare && beneficiary)

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
