### PR TITLE
Codeowner updates for Facilities/PW ownership in layouts/tests folders

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,6 +46,7 @@ src/site/layouts/story.drupal.liquid @department-of-veterans-affairs/vfs-facilit
 src/site/layouts/tests/vamc* @department-of-veterans-affairs/vfs-facilities-frontend
 src/site/layouts/vamc*.drupal.liquid @department-of-veterans-affairs/vfs-facilities-frontend
 src/site/stages/build/drupal/static-data-files/vaPoliceData @department-of-veterans-affairs/vfs-facilities-frontend
+src/site/tests/police @department-of-veterans-affairs/vfs-facilities-frontend
 
 ## VBA
 src/site/includes/vba_facilities @department-of-veterans-affairs/vfs-facilities-frontend
@@ -71,6 +72,7 @@ src/site/layouts/publication_listing.drupal.liquid @department-of-veterans-affai
 src/site/layouts/q_a.drupal.liquid @department-of-veterans-affairs/vfs-public-websites-frontend
 src/site/layouts/support*.drupal.liquid @department-of-veterans-affairs/vfs-public-websites-frontend
 src/site/layouts/va_form.drupal.liquid @department-of-veterans-affairs/vfs-public-websites-frontend
+src/site/tests/home @department-of-veterans-affairs/vfs-public-websites-frontend
 
 
 # GraphQL Queries

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,13 +25,53 @@ src/site/teasers @department-of-veterans-affairs/vfs-public-websites-frontend @d
 src/site/filters @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/vfs-facilities-frontend
 
 # Facility Locator and VAMC pages
+## Multiple Facility types
 src/site/facilities @department-of-veterans-affairs/vfs-facilities-frontend
-src/site/layouts/health*.drupal.liquid @department-of-veterans-affairs/vfs-facilities-frontend
+src/site/layouts/locations_listing.drupal.liquid @department-of-veterans-affairs/vfs-facilities-frontend
 src/site/navigation/facility_no_drupal_page_sidebar_nav.drupal.liquid @department-of-veterans-affairs/vfs-facilities-frontend
 src/site/navigation/facility_sidebar_nav.drupal.liquid @department-of-veterans-affairs/vfs-facilities-frontend
 src/site/paragraphs/facilities @department-of-veterans-affairs/vfs-facilities-frontend
+
+
+## Facility locator
+
+## VAMC
+src/site/includes/va_police @department-of-veterans-affairs/vfs-facilities-frontend
+src/site/layouts/health*.drupal.liquid @department-of-veterans-affairs/vfs-facilities-frontend
+src/site/layouts/leadership_listing*.drupal.liquid @department-of-veterans-affairs/vfs-facilities-frontend
+src/site/layouts/news_story.drupal.liquid @department-of-veterans-affairs/vfs-facilities-frontend
+src/site/layouts/person_profile.drupal.liquid @department-of-veterans-affairs/vfs-facilities-frontend
+src/site/layouts/press_release.drupal.liquid @department-of-veterans-affairs/vfs-facilities-frontend
+src/site/layouts/story.drupal.liquid @department-of-veterans-affairs/vfs-facilities-frontend
+src/site/layouts/tests/vamc* @department-of-veterans-affairs/vfs-facilities-frontend
+src/site/layouts/vamc*.drupal.liquid @department-of-veterans-affairs/vfs-facilities-frontend
 src/site/stages/build/drupal/static-data-files/vaPoliceData @department-of-veterans-affairs/vfs-facilities-frontend
+
+## VBA
+src/site/includes/vba_facilities @department-of-veterans-affairs/vfs-facilities-frontend
+src/site/layouts/vba*.drupal.liquid @department-of-veterans-affairs/vfs-facilities-frontend
+src/site/layouts/tests/vba* @department-of-veterans-affairs/vfs-facilities-frontend
+
+## Vet Center
 src/site/includes/vet_centers @department-of-veterans-affairs/vfs-facilities-frontend
+src/site/layouts/vet_center*.drupal.liquid @department-of-veterans-affairs/vfs-facilities-frontend
+src/site/layouts/tests/vet_center* @department-of-veterans-affairs/vfs-facilities-frontend
+
+# Public Websites
+src/site/layouts/campaign_landing_page.drupal.liquid @department-of-veterans-affairs/vfs-public-websites-frontend
+src/site/layouts/checklist.drupal.liquid @department-of-veterans-affairs/vfs-public-websites-frontend
+src/site/layouts/event* @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/ap-admins
+src/site/layouts/faq*.drupal.liquid @department-of-veterans-affairs/vfs-public-websites-frontend
+src/site/layouts/full_width_banner_alert.drupal.liquid @department-of-veterans-affairs/vfs-public-websites-frontend
+src/site/layouts/home* @department-of-veterans-affairs/vfs-public-websites-frontend
+src/site/layouts/media_list*.drupal.liquid @department-of-veterans-affairs/vfs-public-websites-frontend
+src/site/layouts/outreach_asset.drupal.liquid @department-of-veterans-affairs/vfs-public-websites-frontend
+src/site/layouts/page* @department-of-veterans-affairs/vfs-public-websites-frontend
+src/site/layouts/publication_listing.drupal.liquid @department-of-veterans-affairs/vfs-public-websites-frontend
+src/site/layouts/q_a.drupal.liquid @department-of-veterans-affairs/vfs-public-websites-frontend
+src/site/layouts/support*.drupal.liquid @department-of-veterans-affairs/vfs-public-websites-frontend
+src/site/layouts/va_form.drupal.liquid @department-of-veterans-affairs/vfs-public-websites-frontend
+
 
 # GraphQL Queries
 src/site/stages/build/drupal @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/vfs-facilities-frontend @department-of-veterans-affairs/cms-infrastructure


### PR DESCRIPTION
This started bc I realized that the va_police layout wasn't set for Facilities as codeowner. Give a mouse a cookie. 🐭 🍪 

Done: 
* Specified which layouts for which products belong to PW vs. Fac. That will be useful as AP team moves forward, for knowing who to coordinate with about what.
* Specified Test folders that are owned by Facilities.
* Grouped Facilities-owned items into product buckets (VAMC/VBA/Vet Centers)
* Added @department-of-veterans-affairs/ap-admins as codeowners of Events, so they'll get notified of any changes to the Events liquid template. Can remove this once PW owns the Next implementation and we have a path to Prod. 

Didn't do: Anything else, including but not limited to: 
* paragraphs
* navigation
* includes that aren't in a subfolder
* blocks

Looking at those helped me realize I was a mouse with a cookie. I'm interested in whether reviewers think the changes I _did_ make are at all useful / should merge, or create a burden and it's easier just to leave things co-owned and let everyone get the PR noise and decide where they want to / should weigh in. 

## Why do I care
1. PR noise. It's nice to get notified where you're needed, instead of everywhere every time.
2. Expedient reviews: less noise means the people who need to actually review will take the time to do so more readily.
3. Growing contributor base: for example, the IIR team will soon join in on the fun. We need to be able to spell out ownership in here, as easily as we do in vets-website.

And maybe a note to @timcosgrove that it would be so cool if it were easy to establish full codeownership of features / related files in Next. I don't know if that's real, but: consider it a request to consider.