### PR TITLE
VACMS-15717: Change reusable Q&As header structure  

### DIFF
--- a/src/site/layouts/faq_multiple_q_a.drupal.liquid
+++ b/src/site/layouts/faq_multiple_q_a.drupal.liquid
@@ -64,69 +64,11 @@
 
             <!-- QAs -->
             {% for fieldQAGroup in fieldQAGroups %}
-                {% if fieldQAGroup.entity.fieldAccordionDisplay %}
-                  {% include "src/site/paragraphs/q_a_group_collapsible_content.drupal.liquid" with entity = fieldQAGroup.entity %}
-                {% else %}
-                  {% include "src/site/paragraphs/q_a_group_content.drupal.liquid" with entity = fieldQAGroup.entity %}
-              {% endif %}
-            {% endfor %}
-
-
-
-            {% for fieldQAGroup in fieldQAGroups %}
-              <!-- Optional section header -->
-              {% if fieldQAGroup.entity.fieldSectionHeader %}
-                <button type="button" class="vads-u-visibility--screen-reader">Back to top</button>
-                <h2>{{ fieldQAGroup.entity.fieldSectionHeader }}</h2>
-              {% endif %}
-
               {% if fieldQAGroup.entity.fieldAccordionDisplay %}
-                <va-accordion>
-                {% assign groupId = fieldQAGroup.entity.entityId %}
-                  {% for fieldQA in fieldQAGroup.entity.fieldQAs %}
-                    {% if fieldQA.entity %}
-                      <va-accordion-item
-                        class="va-accordion-item"
-                        data-faq-entity-id="{{ fieldQA.entity.entityId }}"
-                        id="{{ fieldQA.entity.title | hashReference: 60 }}"
-                      >
-                      {% if fieldQAGroup.entity.fieldSectionHeader %}
-                        <h3 slot="headline">
-                          {{ fieldQA.entity.title }}
-                        </h3>
-                      {% else %}
-                        <h2 slot="headline">
-                          {{ fieldQA.entity.title }}
-                        </h2>
-                      {% endif %}
-                        <div id="{{ fieldQA.entity.entityBundle }}-{{ fieldQA.entity.entityId }}-{{ groupId }}">
-                          {% assign fieldAnswer = fieldQA.entity.fieldAnswer %}
-                          {% assign bundleComponent = "src/site/paragraphs/" | append: fieldAnswer.entity.entityBundle %}
-                          {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
-                          {% include {{ bundleComponentWithExtension }} with entity = fieldAnswer.entity %}
-                        </div>
-                      </va-accordion-item>
-                    {% endif %}
-                  {% endfor %}
-                </va-accordion>
+                {% include "src/site/paragraphs/q_a_group_collapsible_content.drupal.liquid" with entity = fieldQAGroup.entity %}
               {% else %}
-                  {% assign fieldSectionHeaderTag = 'h2' %}
-                  {% if fieldQAGroup.entity.fieldSectionHeader %}
-                    {% assign fieldSectionHeaderTag = 'h3' %}
-                  {% endif %}
-
-                  {% for fieldQA in fieldQAGroup.entity.fieldQAs %}
-                    <button type="button" class="vads-u-visibility--screen-reader">Back to top</button>
-                    <{{ fieldSectionHeaderTag }}>{{ fieldQA.entity.title }}</{{ fieldSectionHeaderTag }}>
-                    {% if fieldQA.entity %}
-                      {% assign fieldAnswer = fieldQA.entity.fieldAnswer %}
-                      {% assign bundleComponent = "src/site/paragraphs/" | append: fieldAnswer.entity.entityBundle %}
-                      {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
-                      {% include {{ bundleComponentWithExtension }} with entity = fieldAnswer.entity %}
-                    {% endif %}
-                  {% endfor %}
-                </ul>
-              {% endif %}
+                {% include "src/site/paragraphs/q_a_group_content.drupal.liquid" with entity = fieldQAGroup.entity %}
+              {% endif %}  
             {% endfor %}
 
             <!-- Repeated buttons -->

--- a/src/site/layouts/faq_multiple_q_a.drupal.liquid
+++ b/src/site/layouts/faq_multiple_q_a.drupal.liquid
@@ -76,6 +76,7 @@
                 <button type="button" class="vads-u-visibility--screen-reader">Back to top</button>
                 <h2>{{ fieldQAGroup.entity.fieldSectionHeader }}</h2>
               {% endif %}
+            {% if fieldQAGroup.entity.fieldAccordionDisplay %}
               {% assign headerLevel = '2' %}
               {% if fieldQAGroup.entity.fieldSectionHeader %}
                 {% assign headerLevel = '3' %}

--- a/src/site/layouts/faq_multiple_q_a.drupal.liquid
+++ b/src/site/layouts/faq_multiple_q_a.drupal.liquid
@@ -64,11 +64,61 @@
 
             <!-- QAs -->
             {% for fieldQAGroup in fieldQAGroups %}
-              {% if fieldQAGroup.entity.fieldAccordionDisplay %}
+              {% if fieldQA.entity.fieldAccordionDisplay %}
                 {% include "src/site/paragraphs/q_a_group_collapsible_content.drupal.liquid" with entity = fieldQAGroup.entity %}
               {% else %}
                 {% include "src/site/paragraphs/q_a_group_content.drupal.liquid" with entity = fieldQAGroup.entity %}
               {% endif %}  
+          {% endfor %}
+            {% for fieldQAGroup in fieldQAGroups %}
+              <!-- Optional section header -->
+              {% if fieldQAGroup.entity.fieldSectionHeader %}
+                <button type="button" class="vads-u-visibility--screen-reader">Back to top</button>
+                <h2>{{ fieldQAGroup.entity.fieldSectionHeader }}</h2>
+              {% endif %}
+              {% assign headerLevel = '2' %}
+              {% if fieldQAGroup.entity.fieldSectionHeader %}
+                {% assign headerLevel = '3' %}
+              {% endif %}
+              <va-accordion>
+                {% assign groupId = fieldQAGroup.entity.entityId %}
+                  {% for fieldQA in fieldQAGroup.entity.fieldQAs %}
+                    {% if fieldQA.entity %}
+                      <va-accordion-item
+                        class="va-accordion-item"
+                        level="{{ headerLevel }}"
+                        header="{{fieldQA.entity.title}}"
+                        data-faq-entity-id="{{ fieldQA.entity.entityId }}"
+                        id="{{ fieldQA.entity.title | hashReference: 60 }}"
+                      >
+                        <div id="{{ fieldQA.entity.entityBundle }}-{{ fieldQA.entity.entityId }}-{{ groupId }}">
+                          {% assign fieldAnswer = fieldQA.entity.fieldAnswer %}
+                          {% assign bundleComponent = "src/site/paragraphs/" | append: fieldAnswer.entity.entityBundle %}
+                          {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
+                          {% include {{ bundleComponentWithExtension }} with entity = fieldAnswer.entity %}
+                        </div>
+                      </va-accordion-item>
+                    {% endif %}
+                  {% endfor %}
+                </va-accordion>
+              {% else %}
+                  {% assign fieldSectionHeaderTag = 'h2' %}
+                  {% if fieldQAGroup.entity.fieldSectionHeader %}
+                    {% assign fieldSectionHeaderTag = 'h3' %}
+                  {% endif %}
+
+                  {% for fieldQA in fieldQAGroup.entity.fieldQAs %}
+                    <button type="button" class="vads-u-visibility--screen-reader">Back to top</button>
+                    <{{ fieldSectionHeaderTag }}>{{ fieldQA.entity.title }}</{{ fieldSectionHeaderTag }}>
+                    {% if fieldQA.entity %}
+                      {% assign fieldAnswer = fieldQA.entity.fieldAnswer %}
+                      {% assign bundleComponent = "src/site/paragraphs/" | append: fieldAnswer.entity.entityBundle %}
+                      {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
+                      {% include {{ bundleComponentWithExtension }} with entity = fieldAnswer.entity %}
+                    {% endif %}
+                  {% endfor %}
+                </ul>
+              {% endif %}
             {% endfor %}
 
             <!-- Repeated buttons -->

--- a/src/site/layouts/faq_multiple_q_a.drupal.liquid
+++ b/src/site/layouts/faq_multiple_q_a.drupal.liquid
@@ -64,6 +64,18 @@
 
             <!-- QAs -->
             {% for fieldQAGroup in fieldQAGroups %}
+              {% if fieldQAGroup.entity.entityBundle == "q_a_group" %}
+                {% if fieldQAGroup.entity.fieldAccordionDisplay %}
+                  {% include "src/site/paragraphs/q_a_group_collapsible_content.drupal.liquid" with entity = fieldQAGroup.entity %}
+                {% else %}
+                  {% include "src/site/paragraphs/q_a_group_content.drupal.liquid" with entity = fieldQAGroup.entity %}
+                {% endif %}  
+              {% endif %}
+            {% endfor %}
+
+
+
+            {% for fieldQAGroup in fieldQAGroups %}
               <!-- Optional section header -->
               {% if fieldQAGroup.entity.fieldSectionHeader %}
                 <button type="button" class="vads-u-visibility--screen-reader">Back to top</button>
@@ -80,9 +92,15 @@
                         data-faq-entity-id="{{ fieldQA.entity.entityId }}"
                         id="{{ fieldQA.entity.title | hashReference: 60 }}"
                       >
+                      {% if fieldQAGroup.entity.fieldSectionHeader %}
                         <h3 slot="headline">
                           {{ fieldQA.entity.title }}
                         </h3>
+                      {% else %}
+                        <h2 slot="headline">
+                          {{ fieldQA.entity.title }}
+                        </h2>
+                      {% endif %}
                         <div id="{{ fieldQA.entity.entityBundle }}-{{ fieldQA.entity.entityId }}-{{ groupId }}">
                           {% assign fieldAnswer = fieldQA.entity.fieldAnswer %}
                           {% assign bundleComponent = "src/site/paragraphs/" | append: fieldAnswer.entity.entityBundle %}

--- a/src/site/layouts/faq_multiple_q_a.drupal.liquid
+++ b/src/site/layouts/faq_multiple_q_a.drupal.liquid
@@ -64,13 +64,6 @@
 
             <!-- QAs -->
             {% for fieldQAGroup in fieldQAGroups %}
-              {% if fieldQA.entity.fieldAccordionDisplay %}
-                {% include "src/site/paragraphs/q_a_group_collapsible_content.drupal.liquid" with entity = fieldQAGroup.entity %}
-              {% else %}
-                {% include "src/site/paragraphs/q_a_group_content.drupal.liquid" with entity = fieldQAGroup.entity %}
-              {% endif %}  
-          {% endfor %}
-            {% for fieldQAGroup in fieldQAGroups %}
               <!-- Optional section header -->
               {% if fieldQAGroup.entity.fieldSectionHeader %}
                 <button type="button" class="vads-u-visibility--screen-reader">Back to top</button>

--- a/src/site/layouts/faq_multiple_q_a.drupal.liquid
+++ b/src/site/layouts/faq_multiple_q_a.drupal.liquid
@@ -64,12 +64,10 @@
 
             <!-- QAs -->
             {% for fieldQAGroup in fieldQAGroups %}
-              {% if fieldQAGroup.entity.entityBundle == "q_a_group" %}
                 {% if fieldQAGroup.entity.fieldAccordionDisplay %}
                   {% include "src/site/paragraphs/q_a_group_collapsible_content.drupal.liquid" with entity = fieldQAGroup.entity %}
                 {% else %}
                   {% include "src/site/paragraphs/q_a_group_content.drupal.liquid" with entity = fieldQAGroup.entity %}
-                {% endif %}  
               {% endif %}
             {% endfor %}
 

--- a/src/site/paragraphs/q_a.drupal.liquid
+++ b/src/site/paragraphs/q_a.drupal.liquid
@@ -1,9 +1,9 @@
 <div data-template="paragraphs/q_a" data-entity-id="{{ entity.entityId }}" data-analytics-faq-section="{{ sectionHeader | escape }}" data-analytics-faq-text="{{ entity.fieldQuestion | escape }}">
   <div id="{{ entity.entityId }}">
     <div class="vads-u-display--flex">
-      <h3>
+      <h2>
         {{ entity.fieldQuestion }}
-      </h3>
+      </h2>
     </div>
 
     <div data-entity-id="{{ entity.entityId }}">

--- a/src/site/paragraphs/q_a.drupal.liquid
+++ b/src/site/paragraphs/q_a.drupal.liquid
@@ -1,9 +1,9 @@
 <div data-template="paragraphs/q_a" data-entity-id="{{ entity.entityId }}" data-analytics-faq-section="{{ sectionHeader | escape }}" data-analytics-faq-text="{{ entity.fieldQuestion | escape }}">
   <div id="{{ entity.entityId }}">
     <div class="vads-u-display--flex">
-      <h2>
+      <h3>
         {{ entity.fieldQuestion }}
-      </h2>
+      </h3>
     </div>
 
     <div data-entity-id="{{ entity.entityId }}">

--- a/src/site/paragraphs/q_a_group_collapsible_content.drupal.liquid
+++ b/src/site/paragraphs/q_a_group_collapsible_content.drupal.liquid
@@ -12,8 +12,6 @@
   {{ entity.fieldRichWysiwyg.processed }}
 {% endif %}
 
-
-
 <va-accordion>
   {% for item in fieldQAs %}
     {% assign id = item.entityId %}

--- a/src/site/paragraphs/q_a_group_collapsible_content.drupal.liquid
+++ b/src/site/paragraphs/q_a_group_collapsible_content.drupal.liquid
@@ -4,7 +4,7 @@
 {% assign headerLevel = "2" %}
 {% if entity.fieldSectionHeader %}
   <h2>{{ entity.fieldSectionHeader }}</h2>
-  {% headerLevel = "3" %}
+  {% assign  headerLevel = "3" %}
 {% endif %}
 
 <!-- Optional QA Group Introduction -->
@@ -17,7 +17,7 @@
 <va-accordion>
   {% for item in fieldQAs %}
     {% assign id = item.entityId %}
-    <va-accordion-item header="{{ item.entityLabel }}" level="{ headerLevel }" id="{{ item.entityLabel | hashReference: 60 }}">
+    <va-accordion-item header="{{ item.entityLabel }}" level="{{ headerLevel }}" id="{{ item.entityLabel | hashReference: 60 }}">
       <div id={{ id }} data-entity-id="{{ id }}">
         <div id="{{ item.fieldAnswer.entity.entityBundle }}-{{ item.fieldAnswer.entity.entityId }}">
           {% if item.fieldAnswer %}

--- a/src/site/paragraphs/q_a_group_collapsible_content.drupal.liquid
+++ b/src/site/paragraphs/q_a_group_collapsible_content.drupal.liquid
@@ -1,8 +1,10 @@
 {% assign fieldQAs = entity.queryFieldQAs.entities %}
 
 <!-- Optional section header -->
+{% assign headerLevel = "2" %}
 {% if entity.fieldSectionHeader %}
   <h2>{{ entity.fieldSectionHeader }}</h2>
+  {% headerLevel = "3" %}
 {% endif %}
 
 <!-- Optional QA Group Introduction -->
@@ -10,10 +12,12 @@
   {{ entity.fieldRichWysiwyg.processed }}
 {% endif %}
 
+
+
 <va-accordion>
   {% for item in fieldQAs %}
     {% assign id = item.entityId %}
-    <va-accordion-item header="{{ item.entityLabel }}" id="{{ item.entityLabel | hashReference: 60 }}">
+    <va-accordion-item header="{{ item.entityLabel }}" level="{ headerLevel }" id="{{ item.entityLabel | hashReference: 60 }}">
       <div id={{ id }} data-entity-id="{{ id }}">
         <div id="{{ item.fieldAnswer.entity.entityBundle }}-{{ item.fieldAnswer.entity.entityId }}">
           {% if item.fieldAnswer %}


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary
For this ticket we addressed header tags for accordions based on if we have a header title or not. There were multiple implementations of these reusable Q&As so we created tugboat content for each. 

```
 FAQs
 Resources & Support
 Benefit Detail Pages
 CLPs
```

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15717

## Testing done
Tugboat Env: main-dyel3cg3kniaoc6nrizjhqazkfgueref.demo.cms.va.gov/

CLP: https://web-dyel3cg3kniaoc6nrizjhqazkfgueref.demo.cms.va.gov/initiatives/this-is-my-clp
FAQs: https://web-dyel3cg3kniaoc6nrizjhqazkfgueref.demo.cms.va.gov/resources/test-faq-page
Resources & Support: https://web-dyel3cg3kniaoc6nrizjhqazkfgueref.demo.cms.va.gov/resources/r-s-detail-page
Benefit Detail Pages:  https://web-dyel3cg3kniaoc6nrizjhqazkfgueref.demo.cms.va.gov/benefits-detail


## Screenshots


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria
- [ ] Test Reusable Q&As across multiple content types.
- [ ] A11y review

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
