### PR TITLE
VACMS 14937 Add Banner to vba template

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -963,31 +963,6 @@
     }
   },
   {
-    "appName": "Coronavirus Vaccination",
-    "entryName": "coronavirus-vaccination",
-    "rootUrl": "/health-care/covid-19-vaccine/stay-informed",
-    "template": {
-      "title": "Sign up to get a COVID-19 vaccine at VA",
-      "layout": "page-react.html",
-      "includeBreadcrumbs": true,
-      "description": "We’re working to provide COVID-19 vaccines as quickly and safely as we can. We base our vaccine plans on CDC guidelines, federal law, and available supply. Sign up to tell us you’d like to get a COVID-19 vaccine at VA.",
-      "breadcrumbs_override": [
-        {
-          "path": "health-care/",
-          "name": "Health care"
-        },
-        {
-          "path": "health-care/covid-19-vaccine/",
-          "name": "COVID-19 vaccines"
-        },
-        {
-          "path": "health-care/covid-19-vaccine/stay-informed",
-          "name": "Sign up for vaccine updates"
-        }
-      ]
-    }
-  },
-  {
     "appName": "View your representative",
     "entryName": "view-representative",
     "rootUrl": "/view-change-representative/view",

--- a/src/site/includes/vba_facilities/banner.liquid
+++ b/src/site/includes/vba_facilities/banner.liquid
@@ -1,10 +1,11 @@
 {% comment %} 
-              Creates a full width va-alert banner
-              expcts the following variables to be passed in
-              alertType: "information" or "warning"; string
-              alertTitle: "title of the alert"; string
-              alertContent: "content of the alert"; string
-              dismissible: "dismiss" or something else; string
+    Creates a full width va-banner (banner alert)
+    expcts the following variables to be passed in
+    alertType: "information" or "warning"; string
+    alertTitle: "title of the alert"; string
+    alertContent: "content of the alert"; string
+    dismissible: "dismiss" or something else; string
+    shouldDisplayBanner: true or false; boolean
 {% endcomment %}
 {% if shouldDisplayBanner and alertType and alertTitle and alertContent %}
   {% if alertType == "information" %}

--- a/src/site/includes/vba_facilities/banner.liquid
+++ b/src/site/includes/vba_facilities/banner.liquid
@@ -7,7 +7,6 @@
     <va-alert
       uswds
       status="{{ status }}"
-      fullWidth
       {% if  dismissible == "dismiss" %}closeable{% endif %}
     >
       <h3 slot="headline">{{ alertTitle }}</h3>

--- a/src/site/includes/vba_facilities/banner.liquid
+++ b/src/site/includes/vba_facilities/banner.liquid
@@ -1,10 +1,10 @@
 {% comment %} 
-          Creates a full width va-alert banner
-          expcts the following variables to be passed in
-          alertType: "information" or "warning"; string
-          alertTitle: "title of the alert"; string
-          alertContent: "content of the alert"; string
-          dismissible: "dismiss" or something else; string
+              Creates a full width va-alert banner
+              expcts the following variables to be passed in
+              alertType: "information" or "warning"; string
+              alertTitle: "title of the alert"; string
+              alertContent: "content of the alert"; string
+              dismissible: "dismiss" or something else; string
 {% endcomment %}
 {% if shouldDisplayBanner and alertType and alertTitle and alertContent %}
   {% if alertType == "information" %}
@@ -14,6 +14,7 @@
   {% endif %}
   <va-banner
     id="vba-banner"
+    data-testid="vba-banner"
     type="{{ status }}"
     {% if dismissible == "dismiss" %}
     show-close

--- a/src/site/includes/vba_facilities/banner.liquid
+++ b/src/site/includes/vba_facilities/banner.liquid
@@ -1,0 +1,27 @@
+{% if shouldDisplayBanner %}
+    {% if alertType ==  "information" %}
+      {% assign status = "info" %}
+    {% elsif alertType ==  "warning" %}
+      {% assign status = "warning" %}
+    {% endif %}
+    <va-alert
+      uswds
+      status="{{ status }}"
+      fullWidth
+      {% if  dismissible == "dismiss" %}closeable{% endif %}
+    >
+      <h3 slot="headline">{{ alertTitle }}</h3>
+      <div>
+        <p className="vads-u-margin-y--0">
+          {{ alertContent }}
+        </p>
+      </div>
+    </va-alert> 
+    <script>
+      // This removes the va-alert when the close button is clicked
+      const element = document.querySelector('va-alert');
+      const exampleCallback = event => { element.remove() }
+      element.addEventListener('closeEvent', exampleCallback)
+    </script>
+{% endif %}
+   

--- a/src/site/includes/vba_facilities/banner.liquid
+++ b/src/site/includes/vba_facilities/banner.liquid
@@ -1,26 +1,26 @@
-{% if shouldDisplayBanner %}
-    {% if alertType ==  "information" %}
-      {% assign status = "info" %}
-    {% elsif alertType ==  "warning" %}
-      {% assign status = "warning" %}
+{% comment %} 
+          Creates a full width va-alert banner
+          expcts the following variables to be passed in
+          alertType: "information" or "warning"; string
+          alertTitle: "title of the alert"; string
+          alertContent: "content of the alert"; string
+          dismissible: "dismiss" or something else; string
+{% endcomment %}
+{% if shouldDisplayBanner and alertType and alertTitle and alertContent %}
+  {% if alertType == "information" %}
+    {% assign status = "info" %}
+  {% elsif alertType == "warning" %}
+    {% assign status = "warning" %}
+  {% endif %}
+  <va-banner
+    id="vba-banner"
+    type="{{ status }}"
+    {% if dismissible == "dismiss" %}
+    show-close
     {% endif %}
-    <va-alert
-      uswds
-      status="{{ status }}"
-      {% if  dismissible == "dismiss" %}closeable{% endif %}
-    >
-      <h3 slot="headline">{{ alertTitle }}</h3>
-      <div>
-        <p className="vads-u-margin-y--0">
-          {{ alertContent }}
-        </p>
-      </div>
-    </va-alert> 
-    <script>
-      // This removes the va-alert when the close button is clicked
-      const element = document.querySelector('va-alert');
-      const exampleCallback = event => { element.remove() }
-      element.addEventListener('closeEvent', exampleCallback)
-    </script>
+    headline="{{ alertTitle }}">
+    <p className="vads-u-margin-y--0">
+      {{ alertContent }}
+    </p>
+  </va-banner>
 {% endif %}
-   

--- a/src/site/includes/vba_facilities/spotlight_content.liquid
+++ b/src/site/includes/vba_facilities/spotlight_content.liquid
@@ -1,6 +1,4 @@
 <div class="feature featured-content-list-item vads-u-flex--fill vads-u-padding-y--1p5 vads-u-padding-x--1p5 vads-u-margin-bottom--0 medium-screen:vads-u-margin-bottom--2">
-    <script>console.log({{entity.fieldCta|json}})</script>
-
     {% if entity.fieldSectionHeader != empty %}
         <h3 class="force-small-header vads-u-margin-bottom--2">{{ entity.fieldSectionHeader }}</h3>
         <hr class="featured-content-hr vads-u-margin-y--1p5 vads-u-border-color--primary">

--- a/src/site/layouts/tests/vba/template/fixtures/vba_banner_informational_dismissible.json
+++ b/src/site/layouts/tests/vba/template/fixtures/vba_banner_informational_dismissible.json
@@ -1,0 +1,373 @@
+{
+  "entityBundle": "vba_facility",
+  "entityId": "4105",
+  "entityPublished": true,
+  "title": "Cleveland VA Regional Benefit Office",
+  "vid": 830427,
+  "entityUrl": {
+    "breadcrumb": [
+      {
+        "url": {
+          "path": "/",
+          "routed": true
+        },
+        "text": "Home"
+      },
+      {
+        "url": {
+          "path": "/cleveland-va-regional-benefit-office/locations/cleveland-va-regional-benefit-office",
+          "routed": true
+        },
+        "text": "Cleveland VA Regional Benefit Office"
+      }
+    ],
+    "path": "/cleveland-va-regional-benefit-office/locations/cleveland-va-regional-benefit-office"
+  },
+  "entityMetatags": [
+    {
+      "__typename": "MetaValue",
+      "key": "title",
+      "value": "Cleveland VA Regional Benefit Office | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "description",
+      "value": "Placeholder text: Veterans benefits offices provide services to Veterans ... "
+    },
+    {
+      "__typename": "MetaLink",
+      "key": "image_src",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:site_name",
+      "value": "Veterans Affairs"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:title",
+      "value": "Cleveland VA Regional Benefit Office | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:description",
+      "value": "Placeholder text: Veterans benefits offices provide services to Veterans ... "
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:image",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:image:alt",
+      "value": "U.S. Department of Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:card",
+      "value": "summary_large_image"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:site",
+      "value": "@DeptVetAffairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:title",
+      "value": "Cleveland VA Regional Benefit Office | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:image",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:image:alt",
+      "value": "U.S. Department of Veterans Affairs"
+    }
+  ],
+  "entityLabel": "Cleveland VA Regional Benefit Office",
+  "changed": 1703889361,
+  "fieldShowBanner": true,
+  "fieldAlertType": "information",
+  "fieldDismissibleOption": "dismiss",
+  "fieldBannerTitle": "Dismissible Informational banner",
+  "fieldBannerContent": {
+    "value": "<p>This is the informational banner. Lorem ipsum does have a place here, but more so the repetition of phrases. Lorem ipsum does have a place here, but more so the repetition of phrases. Lorem ipsum does have a place here, but more so the repetition of phrases. Lorem ipsum does have a place here.</p>",
+    "format": "rich_text_limited",
+    "processed": "<p>This is the informational banner. Lorem ipsum does have a place here, but more so the repetition of phrases. Lorem ipsum does have a place here, but more so the repetition of phrases. Lorem ipsum does have a place here, but more so the repetition of phrases. Lorem ipsum does have a place here.</p>\n"
+  },
+  "fieldIntroText": null,
+  "fieldFacilityLocatorApiId": "vba_325",
+  "fieldOperatingStatusFacility": "limited",
+  "fieldPhoneNumber": "800-827-1000",
+  "fieldCcBenefitsHotline": {
+    "fetched": {
+      "fieldPhoneExtension": [
+        {
+          "value": "4023022840"
+        }
+      ],
+      "fieldPhoneLabel": [
+        {
+          "value": "VA benefits hotline"
+        }
+      ],
+      "fieldPhoneNumber": [
+        {
+          "value": "800-827-1000"
+        }
+      ],
+      "fieldPhoneNumberType": [
+        {
+          "value": "tel"
+        }
+      ]
+    }
+  },
+  "fieldCcCantFindBenefits": {
+    "fetched": {
+      "fieldCta": [
+        {
+          "entity": {
+            "targetId": "139797",
+            "targetRevisionId": "1146331",
+            "entityType": "paragraph",
+            "entityBundle": "button",
+            "pid": "139797",
+            "label": "VBA -- benefit office content > Content > Call to Action",
+            "status": true,
+            "langcode": "en",
+            "fieldButtonLabel": [
+              {
+                "value": "Find a VA benefits location"
+              }
+            ],
+            "fieldButtonLink": [
+              {
+                "uri": "https://www.va.gov/find-locations/?facilityType=benefits",
+                "title": "",
+                "options": {
+                  "href": "https://www.va.gov/find-locations/?facilityType=benefits",
+                  "dataEntityType": "",
+                  "dataEntityUuid": "",
+                  "dataEntitySubstitution": ""
+                },
+                "url": {
+                  "path": "https://www.va.gov/find-locations/?facilityType=benefits"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "fieldDescription": [
+        {
+          "value": "<p>Call our VA benefits hotline at <a href=\"tel:+18008271000\" aria-label=\"8 0 0. 8 2 7. 1 0 0 0.\">800-827-1000</a> (<a href=\"tel:711\" aria-label=\"TTY. 7 1 1.\">TTY: 711</a>). We’re here 8:00 a.m. to 9:00 p.m. ET, Monday through Friday.</p>",
+          "format": "rich_text_limited",
+          "processed": "<p>Call our VA benefits hotline at <a href=\"tel:+18008271000\" aria-label=\"8 0 0. 8 2 7. 1 0 0 0.\">800-827-1000</a> (<a href=\"tel:711\" aria-label=\"TTY. 7 1 1.\">TTY: 711</a>). We’re here 8:00 a.m. to 9:00 p.m. ET, Monday through Friday.</p>\n"
+        }
+      ],
+      "fieldSectionHeader": [
+        {
+          "value": "Can't find the service you're looking for?"
+        }
+      ]
+    }
+  },
+  "fieldAddress": {
+    "addressLine1": "1240 E. 9th Street, A.J. Celebrezze Federal Building",
+    "addressLine2": null,
+    "countryCode": "US",
+    "locality": "Cleveland",
+    "postalCode": "44199",
+    "administrativeArea": "OH"
+  },
+  "fieldGeolocation": {
+    "lat": 41.50535984,
+    "lon": -81.69134442
+  },
+  "fieldOfficeHours": [
+    {
+      "day": 0,
+      "starthours": null,
+      "endhours": null,
+      "comment": "Closed"
+    },
+    {
+      "day": 1,
+      "starthours": 800,
+      "endhours": 1630,
+      "comment": ""
+    },
+    {
+      "day": 2,
+      "starthours": 800,
+      "endhours": 1630,
+      "comment": ""
+    },
+    {
+      "day": 3,
+      "starthours": 800,
+      "endhours": 1630,
+      "comment": ""
+    },
+    {
+      "day": 4,
+      "starthours": 800,
+      "endhours": 1630,
+      "comment": ""
+    },
+    {
+      "day": 5,
+      "starthours": 800,
+      "endhours": 1630,
+      "comment": ""
+    },
+    {
+      "day": 6,
+      "starthours": null,
+      "endhours": null,
+      "comment": "Closed"
+    }
+  ],
+  "fieldCcNationalSpotlight1": {
+    "fetched": {
+      "fieldCta": [
+        {
+          "entity": {
+            "targetId": "139794",
+            "targetRevisionId": "1146324",
+            "entityType": "paragraph",
+            "entityBundle": "button",
+            "pid": "139794",
+            "label": "VBA -- benefit office content > Content > Call to Action",
+            "status": true,
+            "langcode": "en",
+            "fieldButtonLabel": [
+              {
+                "value": "Learn about your life insurance options"
+              }
+            ],
+            "fieldButtonLink": [
+              {
+                "uri": "entity:node/906",
+                "title": "",
+                "options": {
+                  "href": "entity:node/906",
+                  "dataEntityType": "node",
+                  "dataEntityUuid": "84e469a4-6465-4ec7-a055-1e44c535a809",
+                  "dataEntitySubstitution": "canonical"
+                },
+                "url": {
+                  "path": "/disability/how-to-file-claim/additional-forms"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "fieldDescription": [
+        {
+          "value": "<p>Need a new VA form? Always download the latest version from our VA Forms website.</p>",
+          "format": "rich_text_limited",
+          "processed": "<p>Need a new VA form? Always download the latest version from our VA Forms website.</p>\n"
+        }
+      ],
+      "fieldSectionHeader": [
+        {
+          "value": "April is financial literacy awareness month"
+        }
+      ]
+    }
+  },
+  "fieldCcGetUpdatesFromVba": {
+    "fetched": {
+      "fieldLink": [],
+      "fieldLinks": [
+        {
+          "uri": "https://public.govdelivery.com/accounts/USVAVBA/subscribers/new",
+          "title": "Subscribe to our newsletter about VA benefits",
+          "options": {
+            "href": "https://public.govdelivery.com/accounts/USVAVBA/subscribers/new",
+            "dataEntityType": "",
+            "dataEntityUuid": "",
+            "dataEntitySubstitution": ""
+          },
+          "url": {
+            "path": "https://public.govdelivery.com/accounts/USVAVBA/subscribers/new"
+          }
+        },
+        {
+          "uri": "https://www.facebook.com/VeteransBenefits",
+          "title": "Get updates about VA benefits on Facebook",
+          "options": {
+            "href": "https://www.facebook.com/VeteransBenefits",
+            "dataEntityType": "",
+            "dataEntityUuid": "",
+            "dataEntitySubstitution": ""
+          },
+          "url": {
+            "path": "https://www.facebook.com/VeteransBenefits"
+          }
+        },
+        {
+          "uri": "https://twitter.com/VAVetBenefits",
+          "title": "Get updates about VA benefits on X",
+          "options": {
+            "href": "https://twitter.com/VAVetBenefits",
+            "dataEntityType": "",
+            "dataEntityUuid": "",
+            "dataEntitySubstitution": ""
+          },
+          "url": {
+            "path": "https://twitter.com/VAVetBenefits"
+          }
+        },
+        {
+          "uri": "https://www.instagram.com/vabenefits/",
+          "title": "Get updates about VA benefits on Instagram",
+          "options": {
+            "href": "https://www.instagram.com/vabenefits/",
+            "dataEntityType": "",
+            "dataEntityUuid": "",
+            "dataEntitySubstitution": ""
+          },
+          "url": {
+            "path": "https://www.instagram.com/vabenefits/"
+          }
+        }
+      ],
+      "fieldSectionHeader": [
+        {
+          "value": "Get updates from the Veterans Benefits Administration"
+        }
+      ]
+    }
+  },
+  "fieldMedia": null,
+  "reverseFieldVbaRegionFacilityListNode": {
+    "count": 1,
+    "entities": [
+      {
+        "entityId": "61786",
+        "entityLabel": "Regional Loan Center in Cleveland",
+        "reverseFieldVbaServiceRegionsTaxonomyTerm": {
+          "count": 1,
+          "entities": [
+            {
+              "entityId": "1131",
+              "entityLabel": "Home loans",
+              "fieldRegionalServiceHeader": "Get help checking the status of your COE",
+              "fieldRegionalServiceDescripti": "Check the status of your COE by calling a VA home loan representative at a Regional Loan Center."
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/src/site/layouts/tests/vba/template/fixtures/vba_banner_warning.json
+++ b/src/site/layouts/tests/vba/template/fixtures/vba_banner_warning.json
@@ -1,0 +1,357 @@
+{
+  "entityBundle": "vba_facility",
+  "entityId": "4224",
+  "entityPublished": true,
+  "title": "Seattle VA Regional Benefit Office",
+  "vid": 830424,
+  "entityUrl": {
+    "breadcrumb": [
+      {
+        "url": {
+          "path": "/",
+          "routed": true
+        },
+        "text": "Home"
+      },
+      {
+        "url": {
+          "path": "/vba-facilities/locations/seattle-regional-office",
+          "routed": true
+        },
+        "text": "Seattle VA Regional Benefit Office"
+      }
+    ],
+    "path": "/vba-facilities/locations/seattle-regional-office"
+  },
+  "entityMetatags": [
+    {
+      "__typename": "MetaValue",
+      "key": "title",
+      "value": "Seattle VA Regional Benefit Office | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "description",
+      "value": "Placeholder text: Veterans benefits offices provide services to Veterans ... "
+    },
+    {
+      "__typename": "MetaLink",
+      "key": "image_src",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:site_name",
+      "value": "Veterans Affairs"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:title",
+      "value": "Seattle VA Regional Benefit Office | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:description",
+      "value": "Placeholder text: Veterans benefits offices provide services to Veterans ... "
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:image",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:image:alt",
+      "value": "U.S. Department of Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:card",
+      "value": "summary_large_image"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:site",
+      "value": "@DeptVetAffairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:title",
+      "value": "Seattle VA Regional Benefit Office | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:image",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:image:alt",
+      "value": "U.S. Department of Veterans Affairs"
+    }
+  ],
+  "entityLabel": "Seattle VA Regional Benefit Office",
+  "changed": 1703886934,
+  "fieldShowBanner": true,
+  "fieldAlertType": "warning",
+  "fieldDismissibleOption": "perm",
+  "fieldBannerTitle": "Warning Banner",
+  "fieldBannerContent": {
+    "value": "<p>This is the warning banner. Lorem ipsum does have a place here, but more so the repetition of phrases. Lorem ipsum does have a place here, but more so the repetition of phrases. Lorem ipsum does have a place here, but more so the repetition of phrases. Lorem ipsum does have a place here.</p>",
+    "format": "rich_text_limited",
+    "processed": "<p>This is the warning banner. Lorem ipsum does have a place here, but more so the repetition of phrases. Lorem ipsum does have a place here, but more so the repetition of phrases. Lorem ipsum does have a place here, but more so the repetition of phrases. Lorem ipsum does have a place here.</p>\n"
+  },
+  "fieldIntroText": null,
+  "fieldFacilityLocatorApiId": "vba_346",
+  "fieldOperatingStatusFacility": "normal",
+  "fieldPhoneNumber": "800-827-1000",
+  "fieldCcBenefitsHotline": {
+    "fetched": {
+      "fieldPhoneExtension": [
+        {
+          "value": "4023022840"
+        }
+      ],
+      "fieldPhoneLabel": [
+        {
+          "value": "VA benefits hotline"
+        }
+      ],
+      "fieldPhoneNumber": [
+        {
+          "value": "800-827-1000"
+        }
+      ],
+      "fieldPhoneNumberType": [
+        {
+          "value": "tel"
+        }
+      ]
+    }
+  },
+  "fieldCcCantFindBenefits": {
+    "fetched": {
+      "fieldCta": [
+        {
+          "entity": {
+            "targetId": "139797",
+            "targetRevisionId": "1146331",
+            "entityType": "paragraph",
+            "entityBundle": "button",
+            "pid": "139797",
+            "label": "VBA -- benefit office content > Content > Call to Action",
+            "status": true,
+            "langcode": "en",
+            "fieldButtonLabel": [
+              {
+                "value": "Find a VA benefits location"
+              }
+            ],
+            "fieldButtonLink": [
+              {
+                "uri": "https://www.va.gov/find-locations/?facilityType=benefits",
+                "title": "",
+                "options": {
+                  "href": "https://www.va.gov/find-locations/?facilityType=benefits",
+                  "dataEntityType": "",
+                  "dataEntityUuid": "",
+                  "dataEntitySubstitution": ""
+                },
+                "url": {
+                  "path": "https://www.va.gov/find-locations/?facilityType=benefits"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "fieldDescription": [
+        {
+          "value": "<p>Call our VA benefits hotline at <a href=\"tel:+18008271000\" aria-label=\"8 0 0. 8 2 7. 1 0 0 0.\">800-827-1000</a> (<a href=\"tel:711\" aria-label=\"TTY. 7 1 1.\">TTY: 711</a>). We’re here 8:00 a.m. to 9:00 p.m. ET, Monday through Friday.</p>",
+          "format": "rich_text_limited",
+          "processed": "<p>Call our VA benefits hotline at <a href=\"tel:+18008271000\" aria-label=\"8 0 0. 8 2 7. 1 0 0 0.\">800-827-1000</a> (<a href=\"tel:711\" aria-label=\"TTY. 7 1 1.\">TTY: 711</a>). We’re here 8:00 a.m. to 9:00 p.m. ET, Monday through Friday.</p>\n"
+        }
+      ],
+      "fieldSectionHeader": [
+        {
+          "value": "Can't find the service you're looking for?"
+        }
+      ]
+    }
+  },
+  "fieldAddress": {
+    "addressLine1": "915 Second Avenue",
+    "addressLine2": null,
+    "countryCode": "US",
+    "locality": "Seattle",
+    "postalCode": "98174",
+    "administrativeArea": "WA"
+  },
+  "fieldGeolocation": {
+    "lat": 47.60485762,
+    "lon": -122.3349132
+  },
+  "fieldOfficeHours": [
+    {
+      "day": 0,
+      "starthours": null,
+      "endhours": null,
+      "comment": "Closed"
+    },
+    {
+      "day": 1,
+      "starthours": 800,
+      "endhours": 1600,
+      "comment": ""
+    },
+    {
+      "day": 2,
+      "starthours": 800,
+      "endhours": 1600,
+      "comment": ""
+    },
+    {
+      "day": 3,
+      "starthours": 800,
+      "endhours": 1600,
+      "comment": ""
+    },
+    {
+      "day": 4,
+      "starthours": 800,
+      "endhours": 1600,
+      "comment": ""
+    },
+    {
+      "day": 5,
+      "starthours": 800,
+      "endhours": 1600,
+      "comment": ""
+    },
+    {
+      "day": 6,
+      "starthours": null,
+      "endhours": null,
+      "comment": "Closed"
+    }
+  ],
+  "fieldCcNationalSpotlight1": {
+    "fetched": {
+      "fieldCta": [
+        {
+          "entity": {
+            "targetId": "139794",
+            "targetRevisionId": "1146324",
+            "entityType": "paragraph",
+            "entityBundle": "button",
+            "pid": "139794",
+            "label": "VBA -- benefit office content > Content > Call to Action",
+            "status": true,
+            "langcode": "en",
+            "fieldButtonLabel": [
+              {
+                "value": "Learn about your life insurance options"
+              }
+            ],
+            "fieldButtonLink": [
+              {
+                "uri": "entity:node/906",
+                "title": "",
+                "options": {
+                  "href": "entity:node/906",
+                  "dataEntityType": "node",
+                  "dataEntityUuid": "84e469a4-6465-4ec7-a055-1e44c535a809",
+                  "dataEntitySubstitution": "canonical"
+                },
+                "url": {
+                  "path": "/disability/how-to-file-claim/additional-forms"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "fieldDescription": [
+        {
+          "value": "<p>Need a new VA form? Always download the latest version from our VA Forms website.</p>",
+          "format": "rich_text_limited",
+          "processed": "<p>Need a new VA form? Always download the latest version from our VA Forms website.</p>\n"
+        }
+      ],
+      "fieldSectionHeader": [
+        {
+          "value": "April is financial literacy awareness month"
+        }
+      ]
+    }
+  },
+  "fieldCcGetUpdatesFromVba": {
+    "fetched": {
+      "fieldLink": [],
+      "fieldLinks": [
+        {
+          "uri": "https://public.govdelivery.com/accounts/USVAVBA/subscribers/new",
+          "title": "Subscribe to our newsletter about VA benefits",
+          "options": {
+            "href": "https://public.govdelivery.com/accounts/USVAVBA/subscribers/new",
+            "dataEntityType": "",
+            "dataEntityUuid": "",
+            "dataEntitySubstitution": ""
+          },
+          "url": {
+            "path": "https://public.govdelivery.com/accounts/USVAVBA/subscribers/new"
+          }
+        },
+        {
+          "uri": "https://www.facebook.com/VeteransBenefits",
+          "title": "Get updates about VA benefits on Facebook",
+          "options": {
+            "href": "https://www.facebook.com/VeteransBenefits",
+            "dataEntityType": "",
+            "dataEntityUuid": "",
+            "dataEntitySubstitution": ""
+          },
+          "url": {
+            "path": "https://www.facebook.com/VeteransBenefits"
+          }
+        },
+        {
+          "uri": "https://twitter.com/VAVetBenefits",
+          "title": "Get updates about VA benefits on X",
+          "options": {
+            "href": "https://twitter.com/VAVetBenefits",
+            "dataEntityType": "",
+            "dataEntityUuid": "",
+            "dataEntitySubstitution": ""
+          },
+          "url": {
+            "path": "https://twitter.com/VAVetBenefits"
+          }
+        },
+        {
+          "uri": "https://www.instagram.com/vabenefits/",
+          "title": "Get updates about VA benefits on Instagram",
+          "options": {
+            "href": "https://www.instagram.com/vabenefits/",
+            "dataEntityType": "",
+            "dataEntityUuid": "",
+            "dataEntitySubstitution": ""
+          },
+          "url": {
+            "path": "https://www.instagram.com/vabenefits/"
+          }
+        }
+      ],
+      "fieldSectionHeader": [
+        {
+          "value": "Get updates from the Veterans Benefits Administration"
+        }
+      ]
+    }
+  },
+  "fieldMedia": null,
+  "reverseFieldVbaRegionFacilityListNode": {
+    "count": 0,
+    "entities": []
+  }
+}

--- a/src/site/layouts/tests/vba/template/fixtures/vba_banner_warning_dismissible.json
+++ b/src/site/layouts/tests/vba/template/fixtures/vba_banner_warning_dismissible.json
@@ -1,0 +1,357 @@
+{
+  "entityBundle": "vba_facility",
+  "entityId": "4350",
+  "entityPublished": true,
+  "title": "Wilmington VA Regional Benefit Office",
+  "vid": 830426,
+  "entityUrl": {
+    "breadcrumb": [
+      {
+        "url": {
+          "path": "/",
+          "routed": true
+        },
+        "text": "Home"
+      },
+      {
+        "url": {
+          "path": "/wilmington-va-regional-benefit-office/locations/wilmington-va-regional-benefit-office",
+          "routed": true
+        },
+        "text": "Wilmington VA Regional Benefit Office"
+      }
+    ],
+    "path": "/wilmington-va-regional-benefit-office/locations/wilmington-va-regional-benefit-office"
+  },
+  "entityMetatags": [
+    {
+      "__typename": "MetaValue",
+      "key": "title",
+      "value": "Wilmington VA Regional Benefit Office | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "description",
+      "value": "Placeholder text: Veterans benefits offices provide services to Veterans ... "
+    },
+    {
+      "__typename": "MetaLink",
+      "key": "image_src",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:site_name",
+      "value": "Veterans Affairs"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:title",
+      "value": "Wilmington VA Regional Benefit Office | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:description",
+      "value": "Placeholder text: Veterans benefits offices provide services to Veterans ... "
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:image",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    },
+    {
+      "__typename": "MetaProperty",
+      "key": "og:image:alt",
+      "value": "U.S. Department of Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:card",
+      "value": "summary_large_image"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:site",
+      "value": "@DeptVetAffairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:title",
+      "value": "Wilmington VA Regional Benefit Office | Veterans Affairs"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:image",
+      "value": "https://www.va.gov/img/design/logo/va-og-image.png"
+    },
+    {
+      "__typename": "MetaValue",
+      "key": "twitter:image:alt",
+      "value": "U.S. Department of Veterans Affairs"
+    }
+  ],
+  "entityLabel": "Wilmington VA Regional Benefit Office",
+  "changed": 1703889275,
+  "fieldShowBanner": true,
+  "fieldAlertType": "warning",
+  "fieldDismissibleOption": "dismiss",
+  "fieldBannerTitle": "Warning dismissible",
+  "fieldBannerContent": {
+    "value": "<p>Warning dismissible. Warning dismissible. Warning dismissible. Warning dismissible. Warning dismissible. Warning dismissible. Warning dismissible. Warning dismissible. Warning dismissible.&nbsp;</p>",
+    "format": "rich_text_limited",
+    "processed": "<p>Warning dismissible. Warning dismissible. Warning dismissible. Warning dismissible. Warning dismissible. Warning dismissible. Warning dismissible. Warning dismissible. Warning dismissible. </p>\n"
+  },
+  "fieldIntroText": null,
+  "fieldFacilityLocatorApiId": "vba_460",
+  "fieldOperatingStatusFacility": "normal",
+  "fieldPhoneNumber": "800-827-1000",
+  "fieldCcBenefitsHotline": {
+    "fetched": {
+      "fieldPhoneExtension": [
+        {
+          "value": "4023022840"
+        }
+      ],
+      "fieldPhoneLabel": [
+        {
+          "value": "VA benefits hotline"
+        }
+      ],
+      "fieldPhoneNumber": [
+        {
+          "value": "800-827-1000"
+        }
+      ],
+      "fieldPhoneNumberType": [
+        {
+          "value": "tel"
+        }
+      ]
+    }
+  },
+  "fieldCcCantFindBenefits": {
+    "fetched": {
+      "fieldCta": [
+        {
+          "entity": {
+            "targetId": "139797",
+            "targetRevisionId": "1146331",
+            "entityType": "paragraph",
+            "entityBundle": "button",
+            "pid": "139797",
+            "label": "VBA -- benefit office content > Content > Call to Action",
+            "status": true,
+            "langcode": "en",
+            "fieldButtonLabel": [
+              {
+                "value": "Find a VA benefits location"
+              }
+            ],
+            "fieldButtonLink": [
+              {
+                "uri": "https://www.va.gov/find-locations/?facilityType=benefits",
+                "title": "",
+                "options": {
+                  "href": "https://www.va.gov/find-locations/?facilityType=benefits",
+                  "dataEntityType": "",
+                  "dataEntityUuid": "",
+                  "dataEntitySubstitution": ""
+                },
+                "url": {
+                  "path": "https://www.va.gov/find-locations/?facilityType=benefits"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "fieldDescription": [
+        {
+          "value": "<p>Call our VA benefits hotline at <a href=\"tel:+18008271000\" aria-label=\"8 0 0. 8 2 7. 1 0 0 0.\">800-827-1000</a> (<a href=\"tel:711\" aria-label=\"TTY. 7 1 1.\">TTY: 711</a>). We’re here 8:00 a.m. to 9:00 p.m. ET, Monday through Friday.</p>",
+          "format": "rich_text_limited",
+          "processed": "<p>Call our VA benefits hotline at <a href=\"tel:+18008271000\" aria-label=\"8 0 0. 8 2 7. 1 0 0 0.\">800-827-1000</a> (<a href=\"tel:711\" aria-label=\"TTY. 7 1 1.\">TTY: 711</a>). We’re here 8:00 a.m. to 9:00 p.m. ET, Monday through Friday.</p>\n"
+        }
+      ],
+      "fieldSectionHeader": [
+        {
+          "value": "Can't find the service you're looking for?"
+        }
+      ]
+    }
+  },
+  "fieldAddress": {
+    "addressLine1": "1601 Kirkwood Hwy",
+    "addressLine2": null,
+    "countryCode": "US",
+    "locality": "Wilmington",
+    "postalCode": "19805",
+    "administrativeArea": "DE"
+  },
+  "fieldGeolocation": {
+    "lat": 39.738793,
+    "lon": -75.605755
+  },
+  "fieldOfficeHours": [
+    {
+      "day": 0,
+      "starthours": null,
+      "endhours": null,
+      "comment": "Closed"
+    },
+    {
+      "day": 1,
+      "starthours": 830,
+      "endhours": 1600,
+      "comment": ""
+    },
+    {
+      "day": 2,
+      "starthours": 830,
+      "endhours": 1600,
+      "comment": ""
+    },
+    {
+      "day": 3,
+      "starthours": 830,
+      "endhours": 1600,
+      "comment": ""
+    },
+    {
+      "day": 4,
+      "starthours": 830,
+      "endhours": 1600,
+      "comment": ""
+    },
+    {
+      "day": 5,
+      "starthours": 830,
+      "endhours": 1600,
+      "comment": ""
+    },
+    {
+      "day": 6,
+      "starthours": null,
+      "endhours": null,
+      "comment": "Closed"
+    }
+  ],
+  "fieldCcNationalSpotlight1": {
+    "fetched": {
+      "fieldCta": [
+        {
+          "entity": {
+            "targetId": "139794",
+            "targetRevisionId": "1146324",
+            "entityType": "paragraph",
+            "entityBundle": "button",
+            "pid": "139794",
+            "label": "VBA -- benefit office content > Content > Call to Action",
+            "status": true,
+            "langcode": "en",
+            "fieldButtonLabel": [
+              {
+                "value": "Learn about your life insurance options"
+              }
+            ],
+            "fieldButtonLink": [
+              {
+                "uri": "entity:node/906",
+                "title": "",
+                "options": {
+                  "href": "entity:node/906",
+                  "dataEntityType": "node",
+                  "dataEntityUuid": "84e469a4-6465-4ec7-a055-1e44c535a809",
+                  "dataEntitySubstitution": "canonical"
+                },
+                "url": {
+                  "path": "/disability/how-to-file-claim/additional-forms"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "fieldDescription": [
+        {
+          "value": "<p>Need a new VA form? Always download the latest version from our VA Forms website.</p>",
+          "format": "rich_text_limited",
+          "processed": "<p>Need a new VA form? Always download the latest version from our VA Forms website.</p>\n"
+        }
+      ],
+      "fieldSectionHeader": [
+        {
+          "value": "April is financial literacy awareness month"
+        }
+      ]
+    }
+  },
+  "fieldCcGetUpdatesFromVba": {
+    "fetched": {
+      "fieldLink": [],
+      "fieldLinks": [
+        {
+          "uri": "https://public.govdelivery.com/accounts/USVAVBA/subscribers/new",
+          "title": "Subscribe to our newsletter about VA benefits",
+          "options": {
+            "href": "https://public.govdelivery.com/accounts/USVAVBA/subscribers/new",
+            "dataEntityType": "",
+            "dataEntityUuid": "",
+            "dataEntitySubstitution": ""
+          },
+          "url": {
+            "path": "https://public.govdelivery.com/accounts/USVAVBA/subscribers/new"
+          }
+        },
+        {
+          "uri": "https://www.facebook.com/VeteransBenefits",
+          "title": "Get updates about VA benefits on Facebook",
+          "options": {
+            "href": "https://www.facebook.com/VeteransBenefits",
+            "dataEntityType": "",
+            "dataEntityUuid": "",
+            "dataEntitySubstitution": ""
+          },
+          "url": {
+            "path": "https://www.facebook.com/VeteransBenefits"
+          }
+        },
+        {
+          "uri": "https://twitter.com/VAVetBenefits",
+          "title": "Get updates about VA benefits on X",
+          "options": {
+            "href": "https://twitter.com/VAVetBenefits",
+            "dataEntityType": "",
+            "dataEntityUuid": "",
+            "dataEntitySubstitution": ""
+          },
+          "url": {
+            "path": "https://twitter.com/VAVetBenefits"
+          }
+        },
+        {
+          "uri": "https://www.instagram.com/vabenefits/",
+          "title": "Get updates about VA benefits on Instagram",
+          "options": {
+            "href": "https://www.instagram.com/vabenefits/",
+            "dataEntityType": "",
+            "dataEntityUuid": "",
+            "dataEntitySubstitution": ""
+          },
+          "url": {
+            "path": "https://www.instagram.com/vabenefits/"
+          }
+        }
+      ],
+      "fieldSectionHeader": [
+        {
+          "value": "Get updates from the Veterans Benefits Administration"
+        }
+      ]
+    }
+  },
+  "fieldMedia": null,
+  "reverseFieldVbaRegionFacilityListNode": {
+    "count": 0,
+    "entities": []
+  }
+}

--- a/src/site/layouts/tests/vba/template/vba_banner_test.unit.spec.js
+++ b/src/site/layouts/tests/vba/template/vba_banner_test.unit.spec.js
@@ -1,0 +1,49 @@
+/* eslint-disable @department-of-veterans-affairs/axe-check-required */
+import { expect } from 'chai';
+import { getByTestId } from '@testing-library/dom';
+import { parseFixture, renderHTML } from '../../../../tests/support';
+
+describe('include: VBA banner tests', () => {
+  it('should correctly render dismissible info banner', async () => {
+    const fixtureForVBAInfo = parseFixture(
+      'src/site/layouts/tests/vba/template/fixtures/vba_banner_informational_dismissible.json',
+    );
+
+    const vbaHTML = await renderHTML(
+      'src/site/layouts/vba_facility.drupal.liquid',
+      fixtureForVBAInfo,
+    );
+    const foundBanner = getByTestId(vbaHTML, 'vba-banner');
+    expect(foundBanner).to.exist;
+    expect(foundBanner).to.have.attribute('type', 'info');
+    expect(foundBanner).to.have.attribute('show-close');
+  });
+  it('should correctly render dismissible warning banner', async () => {
+    const fixtureForVBAWarning = parseFixture(
+      'src/site/layouts/tests/vba/template/fixtures/vba_banner_warning_dismissible.json',
+    );
+
+    const vbaHTML = await renderHTML(
+      'src/site/layouts/vba_facility.drupal.liquid',
+      fixtureForVBAWarning,
+    );
+    const foundBanner = getByTestId(vbaHTML, 'vba-banner');
+    expect(foundBanner).to.exist;
+    expect(foundBanner).to.have.attribute('type', 'warning');
+    expect(foundBanner).to.have.attribute('show-close');
+  });
+  it('should correctly render non-dismissible warning banner', async () => {
+    const fixtureForVBAWarning = parseFixture(
+      'src/site/layouts/tests/vba/template/fixtures/vba_banner_warning.json',
+    );
+
+    const vbaHTML = await renderHTML(
+      'src/site/layouts/vba_facility.drupal.liquid',
+      fixtureForVBAWarning,
+    );
+    const foundBanner = getByTestId(vbaHTML, 'vba-banner');
+    expect(foundBanner).to.exist;
+    expect(foundBanner).to.have.attribute('type', 'warning');
+    expect(foundBanner).not.to.have.attribute('show-close');
+  });
+});

--- a/src/site/layouts/vba_facility.drupal.liquid
+++ b/src/site/layouts/vba_facility.drupal.liquid
@@ -1,12 +1,13 @@
 {% include "src/site/includes/header.html" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/vba_facilities/banner.liquid" with
-      shouldDisplayBanner = fieldShowBanner
+      shouldDisplayBanner = fieldShowBanner 
       alertType = fieldAlertType
       alertTitle = fieldBannerTitle
       alertContent = fieldBannerContent.processed
       dismissible = fieldDismissibleOption
 %}
+
 {% include "src/site/includes/breadcrumbs.drupal.liquid" %}
 
 <div id="content" class="interior">

--- a/src/site/layouts/vba_facility.drupal.liquid
+++ b/src/site/layouts/vba_facility.drupal.liquid
@@ -1,6 +1,12 @@
 {% include "src/site/includes/header.html" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/components/banners.drupal.liquid" %}
+{% include "src/site/includes/vba_facilities/banner.liquid" with
+      shouldDisplayBanner = fieldShowBanner
+      alertType = fieldAlertType
+      alertTitle = fieldBannerTitle
+      alertContent = fieldBannerContent.processed
+      dismissible = fieldDismissibleOption
+%}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" %}
 
 <div id="content" class="interior">

--- a/src/site/layouts/vba_facility.drupal.liquid
+++ b/src/site/layouts/vba_facility.drupal.liquid
@@ -1,5 +1,6 @@
 {% include "src/site/includes/header.html" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
+{% include "src/site/components/banners.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" %}
 
 <div id="content" class="interior">

--- a/src/site/stages/build/drupal/graphql/vbaFacility.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vbaFacility.graphql.js
@@ -21,6 +21,14 @@ const vbaFacilityFragment = `
               }
             }
           }
+          fieldShowBanner
+          fieldDismissibleOption
+          fieldBannerTitle
+          fieldBannerContent {
+            value
+            format
+            processed
+          }
           fieldIntroText
           fieldFacilityLocatorApiId
           fieldOperatingStatusFacility

--- a/src/site/stages/build/drupal/graphql/vbaFacility.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vbaFacility.graphql.js
@@ -22,6 +22,7 @@ const vbaFacilityFragment = `
             }
           }
           fieldShowBanner
+          fieldAlertType
           fieldDismissibleOption
           fieldBannerTitle
           fieldBannerContent {


### PR DESCRIPTION
## Summary

- Adds banner dependent on CMS banner completion for a VBA Facility. Only shows the banner when form is complete on CMS (even though CMS doesn't let you save an incomplete form -- cannot test this edge case).  
- Sitewide Facilities
- No flippers

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14937

## Testing done

- Tested banner is created for informational type (unit)
- Tested banner is created for warning type (unit)
- Tested banner can be made dismissible (unit)
- e2e tests will have to be made after VBA facilities are published on prod

## Screenshots
<img width="1673" alt="Screenshot 2023-12-29 at 5 50 07 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/c9f86848-5ea0-4f22-89e9-ed835d8910b9">
<img width="1671" alt="Screenshot 2023-12-29 at 5 49 50 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/09bffb3e-739f-4f59-8d36-ebe08e4e1cb8">
<img width="1667" alt="Screenshot 2023-12-29 at 5 49 41 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/df8da14c-cecb-4f02-b364-f3c3ff676b49">

Mobile:
<img width="398" alt="Screenshot 2023-12-29 at 9 11 57 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/1140a3f5-a678-4427-8e2a-c5953fcdacbb">
<img width="419" alt="Screenshot 2023-12-29 at 9 11 06 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/de2ccd9b-89b2-4bc8-8186-6686723f5dbc">
<img width="399" alt="Screenshot 2023-12-29 at 9 10 55 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/7b6ce685-e1a1-41fb-817b-b37b87da7cda">


## What areas of the site does it impact?

Just the VBA Regional Office pages

## Acceptance criteria



### Quality Assurance & Testing

- [x] I added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (not applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

View: 
- [ ] [Dismissible Info](https://web-ihqrv6rby5lxlkn8zqdxf9u7lk1aplcp.demo.cms.va.gov/cleveland-va-regional-benefit-office/locations/cleveland-va-regional-benefit-office/)
- [ ] [Dismissible Warning](https://web-ihqrv6rby5lxlkn8zqdxf9u7lk1aplcp.demo.cms.va.gov/wilmington-va-regional-benefit-office/locations/wilmington-va-regional-benefit-office/)
- [ ] [Seattle non-dismissible banner](https://web-ihqrv6rby5lxlkn8zqdxf9u7lk1aplcp.demo.cms.va.gov/vba-facilities/locations/seattle-regional-office/)