### PR TITLE
Temporarily removing Find a Representative from app registry (while updating its name in vets-website)

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1637,16 +1637,6 @@
     }
   },
   {
-    "appName": "Find a VA accredited representative or VSO",
-    "entryName": "find-a-representative",
-    "rootUrl": "/get-help-from-accredited-representative/find-rep",
-    "productId": "decb6c85-abcd-44b5-b722-550905f48dd7",
-    "template": {
-      "vagovprod": true,
-      "layout": "page-react.html"
-    }
-  },
-  {
     "appName": "Verify Your Enrollment",
     "entryName": "verify-your-enrollment",
     "rootUrl": "/education/verify-your-enrollment",

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1637,7 +1637,7 @@
     }
   },
   {
-    "appName": "Find a Representative",
+    "appName": "Find a VA accredited representative or VSO",
     "entryName": "find-a-representative",
     "rootUrl": "/get-help-from-accredited-representative/find-rep",
     "productId": "decb6c85-abcd-44b5-b722-550905f48dd7",


### PR DESCRIPTION
## Summary

In the Find a Representative staging review, it was recommended that we update our app title to "Find a VA accredited representative or VSO".

To make this change without breaking any releases, this PR tentatively removes the application from the registry. Once the name has been updated in our manifest.json (and merged to the vets-website), we will reintroduce the app to the content-build registry with its updated name.

Find a Representative was enabled in production, but it currently lives behind a feature flag and has not gone live. Removing it from the registry should not impact any user experience.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/72527
