### PR TITLE
Reintroducing "Find a VA accredited representative or VSO" to app registry

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1661,5 +1661,15 @@
       "vagovprod": false,
       "layout": "page-react.html"
     }
+  },
+  {
+    "appName": "Find a VA accredited representative or VSO",
+    "entryName": "find-a-representative",
+    "rootUrl": "/get-help-from-accredited-representative/find-rep",
+    "productId": "decb6c85-abcd-44b5-b722-550905f48dd7",
+    "template": {
+      "vagovprod": true,
+      "layout": "page-react.html"
+    }
   }
 ]

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1663,6 +1663,16 @@
     }
   },
   {
+    "appName": "10-10d Application for CHAMPVA benefits",
+    "entryName": "10-10D",
+    "rootUrl": "/ivc-champva/10-10D",
+    "productId": "c485d6da-8094-433d-9cd3-3d31e7813650",
+    "template": {
+      "vagovprod": false,
+      "layout": "page-react.html"
+    }
+  },
+  {
     "appName": "Find a VA accredited representative or VSO",
     "entryName": "find-a-representative",
     "rootUrl": "/get-help-from-accredited-representative/find-rep",


### PR DESCRIPTION
## Summary

- The appName of **Find a Representative** is changing to **Find a VA accredited representative or VSO**
- Initially removed the entry from content-build entirely, but that resulted in failing e2e tests in vets-website
- The appName has **not** yet been updated in our manifest.json in vets-website ([PR link](https://github.com/department-of-veterans-affairs/vets-website/pull/27330))