### PR TITLE
VACMS-16725: Fix captions for all table integrations

### DIFF
--- a/src/site/paragraphs/table.drupal.liquid
+++ b/src/site/paragraphs/table.drupal.liquid
@@ -26,7 +26,7 @@
         }
     }
 {% endcomment %}
-<va-table data-template="paragraphs/table" data-entity-id="{{ entity.entityId }}" role="table" tableTitle="{{ entity.fieldTable.caption }}">
+<va-table data-template="paragraphs/table" data-entity-id="{{ entity.entityId }}" role="table" table-title="{{ entity.fieldTable.caption }}">
     {% assign colLabels = entity.fieldTable.value.0  %}
     {% for value in entity.fieldTable.value %}
         {% if forloop.first == true %}

--- a/src/site/paragraphs/table.drupal.liquid
+++ b/src/site/paragraphs/table.drupal.liquid
@@ -26,7 +26,7 @@
         }
     }
 {% endcomment %}
-<va-table data-template="paragraphs/table" data-entity-id="{{ entity.entityId }}" role="table">
+<va-table data-template="paragraphs/table" data-entity-id="{{ entity.entityId }}" role="table" tableTitle="{{ entity.fieldTable.caption }}">
     {% assign colLabels = entity.fieldTable.value.0  %}
     {% for value in entity.fieldTable.value %}
         {% if forloop.first == true %}


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary
Recently we switched over to va-table for the content-build repo's reusable component. This PR adds back the captions for tables that was missing in the switch.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16725

## Testing done
Tested pages that have the table component. Now seeing the caption showing properly

## Screenshots

**Before**
![2024_VA_Health_Care_Copay_Rates___Veterans_Affairs](https://github.com/department-of-veterans-affairs/content-build/assets/42885441/0f643b68-4882-459d-8460-312ceca4ce4e)



**After**
![2024_VA_Health_Care_Copay_Rates___Veterans_Affairs](https://github.com/department-of-veterans-affairs/content-build/assets/42885441/22495398-f5ef-4a34-ab32-5d0c16adaefc)



## What areas of the site does it impact?
All pages with table components.

## Acceptance criteria
