### PR TITLE
16361 clp derivative

### DIFF
--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -26,7 +26,7 @@
               {% endif %}
             </div>
             <div class="vads-u-display--none small-desktop-screen:vads-u-display--block">
-              <img alt="" src="{{ fieldHeroImage.entity.image.derivative.url }}" style="width:468px">
+              <img alt="" src="{{ fieldHeroImage.entity.image.derivative.url }}">
             </div>
           </div>
         </div>

--- a/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
@@ -274,7 +274,7 @@ const nodeCampaignLandingPage = `
         entityId
         ... on MediaImage {
           image {
-            derivative(style: CROPSQUARE) {
+            derivative(style: _11SQUARELARGE) {
               height
               url
               width


### PR DESCRIPTION
## Summary
In a [previous ticket](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15632) ([PR here](https://github.com/department-of-veterans-affairs/content-build/pull/1810/), we updated the CLP landing page hero images to use a square crop rather than be a full-width banner. This included adding a hard-coded size to the image because the `CROPSQUARE` derivative from Drupal was sending images through at <400px, and the design was closer to 500px. We got a new derivative created that sends the images back at 500px, so we can remove the hard-coded size and update the GraphQL query.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16361

## Testing done
Tested and in Tugboat.

Full list of prod Campaign Landing Pages to verify in Tugboat:
- [/initiatives/veterans-experience-action-centers/](https://web-ih1d8gn3w4wnffyzhurocrlz2dfr2hso.demo.cms.va.gov/initiatives/veterans-experience-action-centers/)
- [/initiatives/protecting-veterans-from-fraud/](https://web-ih1d8gn3w4wnffyzhurocrlz2dfr2hso.demo.cms.va.gov/initiatives/protecting-veterans-from-fraud/)
- [/initiatives/covid-flu/](https://web-ih1d8gn3w4wnffyzhurocrlz2dfr2hso.demo.cms.va.gov/initiatives/covid-flu/)
- [/initiatives/end-of-life-benefits/](https://web-ih1d8gn3w4wnffyzhurocrlz2dfr2hso.demo.cms.va.gov/initiatives/end-of-life-benefits/)
- [/initiatives/vote](https://web-ih1d8gn3w4wnffyzhurocrlz2dfr2hso.demo.cms.va.gov/initiatives/vote/)
- [/initiatives/sign-in-securely-with-logingov](https://web-ih1d8gn3w4wnffyzhurocrlz2dfr2hso.demo.cms.va.gov/initiatives/sign-in-securely-with-logingov/)
- [/initiatives/veteran-trust-in-va](https://web-ih1d8gn3w4wnffyzhurocrlz2dfr2hso.demo.cms.va.gov/initiatives/veteran-trust-in-va/)
- [/initiatives/emergency-room-911-or-urgent-care](https://web-ih1d8gn3w4wnffyzhurocrlz2dfr2hso.demo.cms.va.gov/initiatives/emergency-room-911-or-urgent-care/)

## Screenshots
This banner image does not appear on mobile/tablet sizes, so there are no screenshots of that here.

### Before 
Hard-coded image size
<img width="374" alt="Screenshot 2024-01-09 at 2 02 30 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/90efbbdf-ab27-4978-b69e-3777c43adbc0">
<img width="1098" alt="Screenshot 2024-01-09 at 2 02 21 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/1aaee315-ab57-4ec4-80d2-34bbcd5dcd77">

### After
Image size coming from Drupal
<img width="376" alt="Screenshot 2024-01-09 at 2 02 54 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/a4a1f296-9075-4981-95d5-3b8b3d57475a">
<img width="1137" alt="Screenshot 2024-01-09 at 2 02 51 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/1a146a1b-a5c2-4829-8ab3-0c24d094a92b">