### PR TITLE
VACMS-16039: Remove duplicate back to top buttons

### DIFF
--- a/src/site/layouts/faq_multiple_q_a.drupal.liquid
+++ b/src/site/layouts/faq_multiple_q_a.drupal.liquid
@@ -58,7 +58,6 @@
 
             <!-- TOC -->
             {% if fieldTableOfContentsBoolean %}
-              <button type="button" class="vads-u-visibility--screen-reader">Back to top</button>
               <va-on-this-page class="vads-u-margin-left--1 vads-u-margin-bottom--0 vads-u-padding-bottom--0"></va-on-this-page>
             {% endif %}
 
@@ -66,7 +65,6 @@
             {% for fieldQAGroup in fieldQAGroups %}
               <!-- Optional section header -->
               {% if fieldQAGroup.entity.fieldSectionHeader %}
-                <button type="button" class="vads-u-visibility--screen-reader">Back to top</button>
                 <h2>{{ fieldQAGroup.entity.fieldSectionHeader }}</h2>
               {% endif %}
 
@@ -100,7 +98,6 @@
                   {% endif %}
 
                   {% for fieldQA in fieldQAGroup.entity.fieldQAs %}
-                    <button type="button" class="vads-u-visibility--screen-reader">Back to top</button>
                     <{{ fieldSectionHeaderTag }}>{{ fieldQA.entity.title }}</{{ fieldSectionHeaderTag }}>
                     {% if fieldQA.entity %}
                       {% assign fieldAnswer = fieldQA.entity.fieldAnswer %}


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary
This PR removes duplicate back to top buttons that no longer are needed with the newer web components of the button.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16039

## Testing done
Tested that the buttons are no longer showing in the page markup

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?
Pages using the faq_mulitple_q_a drupal template.

## Acceptance criteria
