### PR TITLE
Replace deprecated .va-button-primary class

### DIFF
--- a/src/site/paragraphs/react_widget.drupal.liquid
+++ b/src/site/paragraphs/react_widget.drupal.liquid
@@ -59,7 +59,7 @@
       <span class="static-widget-content vads-u-display--none" aria-hidden="true">
         {% if entity.fieldDefaultLink != empty %}
           {% if entity.fieldButtonFormat %}
-            {% assign classes = 'class="usa-button-primary va-button-primary"' %}
+            {% assign classes = 'class="vads-c-action-link--green"' %}
           {% else %}
             {% assign classes = '' %}
           {% endif %}

--- a/src/site/tests/static-pages/static-page-widgets.unit.spec.js
+++ b/src/site/tests/static-pages/static-page-widgets.unit.spec.js
@@ -14,7 +14,7 @@ const widgetContent = `
       </span>
     </div>
     <span class="static-widget-content vads-u-display--none" aria-hidden="true">
-     <a class="usa-button-primary va-button-primary" href="/pension/application/527EZ">Apply for Veterans Pension Benefits</a>
+     <a class="vads-c-action-link--green" href="/pension/application/527EZ">Apply for Veterans Pension Benefits</a>
     </span>
     <div class="usa-alert usa-alert-error sip-application-error vads-u-display--none" aria-hidden="true">
      <div class="usa-alert-body">


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

The design system team has deprecated the Formation style for `.va-button-primary` in favor of the va-button web component or other alternative like the action link depending on the scenario.

In this case, the usage of `.va-button-primary` was being used with a link. When clicked, the behavior of this link changes the URL. 

This means that it should not be presented as a button so I have removed that style and add the [action link](https://design.va.gov/storybook/?path=/docs/components-action-link--primary) class instead.

Reference [Links vs Buttons](https://design.va.gov/components/button/#links-vs-buttons):

> A good rule is if the action changes the URL, it should not be a button.

> Button and link confusion can be very frustrating for assistive technology users. A user with a screen reader may pull up a list of links and may not find a specific link because it turns out that it’s been designated as a button in the markup.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2312

## Testing done

local testing

## Screenshots

I'm not sure if I am previewing it in the right place locally but this update should change the "button" from this:

![Screenshot 2024-01-10 at 10 39 22 AM](https://github.com/department-of-veterans-affairs/content-build/assets/872479/f6b14c89-7b8d-4296-a37d-e480767a1655)


... to this:

![Screenshot 2024-01-10 at 10 39 35 AM](https://github.com/department-of-veterans-affairs/content-build/assets/872479/591f8ea2-a555-4df7-8ddf-320953a9bde6)


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
