### PR TITLE
Update to MHV on VA.gov title

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1328,7 +1328,7 @@
     }
   },
   {
-    "appName": "MyHealtheVet on VA.gov",
+    "appName": "My HealtheVet",
     "entryName": "mhv-landing-page",
     "rootUrl": "/my-health",
     "productId": "4d8b0801-dd86-4728-9609-9d794c923e03",


### PR DESCRIPTION
## Summary
Updated the title of the MHV on VA.gov landing page to "My HealtheVet" - this adds a space after `My` and removed the `on VA.gov`. Removed the `on VA.gov` per direction that the title should be the App name.

## Related issue(s)
https://app.zenhub.com/workspaces/mhv-on-vagov-top-level-view-62619a987d74510018ecc546/issues/gh/department-of-veterans-affairs/va.gov-team/73155

## Testing done
Manual testing to check the title.

## Screenshots
There are no updates to the UI, but to the title:
Before: 
![image](https://github.com/department-of-veterans-affairs/content-build/assets/63804190/b17e87de-da06-4d07-a84a-3b905b496831)

After:
![image](https://github.com/department-of-veterans-affairs/content-build/assets/63804190/79c5d9b5-6962-40eb-bf2d-b78935494fbe)

## What areas of the site does it impact?
- /my-health landing page only

## Acceptance criteria
- <title> tag in the html header has a space between "My" and "HealtheVet"

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

