### PR TITLE
40-0247 - Enable form in app-registry

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1566,7 +1566,7 @@
     "rootUrl": "/burials-memorials/memorial-items/presidential-memorial-certificates/request-certificate-form-40-0247",
     "productId": "5af7a83b-c1a0-4a0a-b0e9-88baf150e6a9",
     "template": {
-      "vagovprod": false,
+      "vagovprod": true,
       "layout": "page-react.html",
       "includeBreadcrumbs": true,
       "breadcrumbs_override": [


### PR DESCRIPTION
## Summary

- Enable Presidential Memorial Certificate (40-0247) form-app in application registry
- Team: Veteran Facing Forms
- Flipper ON in Staging, OFF in Prod.  End-date TBD.

## Related issue(s)

- _Link to ticket created in va.gov-team-forms repo_
department-of-veterans-affairs/va.gov-team-forms#484

## Testing done

- N/A &mdash; just a Cypress config-enhancement to enable reporting locally.
## What areas of the site does it impact?

This form ONLY