### PR TITLE
VACMS-15318 Add nonce to smartbanner script

### DIFF
--- a/src/site/includes/metatags.drupal.liquid
+++ b/src/site/includes/metatags.drupal.liquid
@@ -30,7 +30,7 @@
 
 {% assign shouldShowCustomBanner = entityUrl.path | shouldShowCustomMobilePromoBanner: false %}
 {% if shouldShowCustomBanner and buildtype === 'vagovstaging' %}
-  <script type="text/javascript" src="/js/smartbanner/smartbanner.js"></script>  
+  <script nonce="**CSP_NONCE**" type="text/javascript" src="/js/smartbanner/smartbanner.js"></script>  
 
   <!-- Start SmartBanner configuration -->
   <meta name="smartbanner:exclude-user-agent-regex" content="^.*(Version).*Safari">


### PR DESCRIPTION
## Summary
Add `nonce` to smart banner script in hopes of getting through the content security policy errors in staging.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15318

## Testing done
Locally on iOS Chrome, Safari (regression check), Android Chrome and Android Firefox.