### PR TITLE
VACMS-15318 Remove environment check for smart banners

### DIFF
--- a/src/site/includes/metatags.drupal.liquid
+++ b/src/site/includes/metatags.drupal.liquid
@@ -29,7 +29,7 @@
 {% endif %}
 
 {% assign shouldShowCustomBanner = entityUrl.path | shouldShowCustomMobilePromoBanner: false %}
-{% if shouldShowCustomBanner and buildtype === 'vagovstaging' %}
+{% if shouldShowCustomBanner %}
   <script nonce="**CSP_NONCE**" type="text/javascript" src="/js/smartbanner/smartbanner.js"></script>  
 
   <!-- Start SmartBanner configuration -->


### PR DESCRIPTION
## Summary
Smart banners are ready for release to production for testing. Removing the environment check so we are not isolated to staging.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15318

## Testing done
Staging tests in Android Chrome/Firefox and iOS Chrome (also tested iOS Safari for regressions)