### PR TITLE
Added temporary CPAP form redirect to registry.json

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1531,6 +1531,16 @@
     }
   },
   {
+    "appName": "Temporary order hearing aid or CPAP supplies redirect",
+    "entryName": "health-care-supply-reordering-redirect",
+    "rootUrl": "/my-health/order-hearing-aid-or-CPAP-supplies-form",
+    "productId": "",
+    "template": {
+      "vagovprod": false,
+      "layout": "page-react.html"
+    }
+  },
+  {
     "appName": "Notification Center",
     "entryName": "notification-center",
     "rootUrl": "/notification-center",

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1536,7 +1536,7 @@
     "rootUrl": "/my-health/order-hearing-aid-or-cpap-supplies-form",
     "productId": "",
     "template": {
-      "vagovprod": false,
+      "vagovprod": true,
       "layout": "page-react.html"
     }
   },

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1533,7 +1533,7 @@
   {
     "appName": "Temporary order hearing aid or CPAP supplies redirect",
     "entryName": "health-care-supply-reordering-redirect",
-    "rootUrl": "/my-health/order-hearing-aid-or-CPAP-supplies-form",
+    "rootUrl": "/my-health/order-hearing-aid-or-cpap-supplies-form",
     "productId": "",
     "template": {
       "vagovprod": false,


### PR DESCRIPTION
## Summary
Added a temporary CPAP form redirect app to the registry. This app will facilitate the migration of the CPAP form from the old path of `/health-care/order-hearing-aid-or-CPAP-supplies-form.` to the new one of `/my-health/order-hearing-aid-or-CPAP-supplies-form`. This entry will be removed once the migration is complete.

## Related issue(s)
https://app.zenhub.com/workspaces/mhv-on-vagov-top-level-view-62619a987d74510018ecc546/issues/gh/department-of-veterans-affairs/va.gov-team/70757

## Testing done
N/A

## Screenshots
N/A

## What areas of the site does it impact?
None. This is a new app.

## Acceptance criteria
- `/my-health/order-hearing-aid-or-CPAP-supplies-form` gets redirected to `/health-care/order-hearing-aid-or-CPAP-supplies-form`

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

