### PR TITLE
Update registry.json to correct appName for form 4142

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1339,7 +1339,7 @@
     }
   },
   {
-    "appName": "Authorize the release of medical information to the VA",
+    "appName": "Authorize the release of non-VA medical information to VA",
     "entryName": "21-4142-medical-release",
     "rootUrl": "/supporting-forms-for-claims/release-information-to-va-form-21-4142",
     "productId": "56438c7b-e586-490d-a7f6-7e3c92136564",


### PR DESCRIPTION
## Summary
The `appName` for form 4142 was incorrect in `registry.json` which was causing some titles to display incorrectly. This fixes that error.

## Related issue(s)
department-of-veterans-affairs/va.gov-team-forms#959