### PR TITLE
VACMS-15345: Remove feature flag code for mobile app promo banner

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1891,8 +1891,4 @@ module.exports = function registerFilters() {
 
     return urlsForBanner.includes(currentPath);
   };
-
-  liquid.filters.shouldShowCustomMobilePromoBanner = currentPath => {
-    return liquid.filters.shouldShowMobileAppPromoBanner(currentPath);
-  };
 };

--- a/src/site/includes/metatags.drupal.liquid
+++ b/src/site/includes/metatags.drupal.liquid
@@ -26,13 +26,10 @@
 <!-- iOS banner -->
 {% if shouldShowiOSBanner %}
   <meta name="apple-itunes-app" content="app-id=1559609596">
-{% endif %}
-
-{% assign shouldShowCustomBanner = entityUrl.path | shouldShowCustomMobilePromoBanner: false %}
-{% if shouldShowCustomBanner %}
+  
+  <!-- Start SmartBanner configuration -->
   <script nonce="**CSP_NONCE**" type="text/javascript" src="/js/smartbanner/smartbanner.js"></script>  
 
-  <!-- Start SmartBanner configuration -->
   <meta name="smartbanner:exclude-user-agent-regex" content="^.*(Version).*Safari">
   <meta name="smartbanner:title" content="VA: Health and Benefits">
   <meta name="smartbanner:author" content="US Dept. of Veteran Affairs">

--- a/src/site/includes/metatags.drupal.liquid
+++ b/src/site/includes/metatags.drupal.liquid
@@ -22,11 +22,11 @@
   <meta name="DC.Date" content="{{ lastupdate| date: '%Y-%m-%d' }}" property="http://purl.org/dc/terms/date">
 {% endif %}
 
-{% assign shouldShowiOSBanner = entityUrl.path | shouldShowMobileAppPromoBanner: false %}
+{% assign shouldShowMobileBanners = entityUrl.path | shouldShowMobileAppPromoBanner: false %}
 <!-- iOS banner -->
-{% if shouldShowiOSBanner %}
+{% if shouldShowMobileBanners %}
   <meta name="apple-itunes-app" content="app-id=1559609596">
-  
+
   <!-- Start SmartBanner configuration -->
   <script nonce="**CSP_NONCE**" type="text/javascript" src="/js/smartbanner/smartbanner.js"></script>  
 

--- a/src/site/includes/metatags.drupal.liquid
+++ b/src/site/includes/metatags.drupal.liquid
@@ -22,12 +22,14 @@
   <meta name="DC.Date" content="{{ lastupdate| date: '%Y-%m-%d' }}" property="http://purl.org/dc/terms/date">
 {% endif %}
 
+<!-- Mobile App Promo Banners config -->
 {% assign shouldShowMobileBanners = entityUrl.path | shouldShowMobileAppPromoBanner: false %}
-<!-- iOS banner -->
+
 {% if shouldShowMobileBanners %}
+  <!-- iOS Safari banner -->
   <meta name="apple-itunes-app" content="app-id=1559609596">
 
-  <!-- Start SmartBanner configuration -->
+  <!-- iOS Chrome / Android Chrome & Firefox banners -->
   <script nonce="**CSP_NONCE**" type="text/javascript" src="/js/smartbanner/smartbanner.js"></script>  
 
   <meta name="smartbanner:exclude-user-agent-regex" content="^.*(Version).*Safari">
@@ -41,8 +43,8 @@
   <meta name="smartbanner:button-url-google" content="https://play.google.com/store/apps/details?id=gov.va.mobileapp&hl=en_US&gl=US&pli=1">
   <meta name="smartbanner:enabled-platforms" content="android,ios">
   <meta name="smartbanner:close-label" content="Close">
-  <!-- End SmartBanner configuration -->
 {% endif %}
+<!-- End Mobile App Promo Banners config -->
 
 <!-- og:url -->
 {% if entityUrl.path %}


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary
 With the launch of the smartbanner mobile promo banner we no longer need the feature flag to be used in the code base.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15345

## Testing done




