### PR TITLE
VACMS-15758: Remove feature toggle for single value link

### DIFF
--- a/src/site/blocks/promo.drupal.liquid
+++ b/src/site/blocks/promo.drupal.liquid
@@ -34,7 +34,7 @@
 <div data-template="blocks/promo" data-entity-id="{{ entity.entityId }}" class="merger-r-rail hub-promo" id="promo">
     <img src="{{ image.derivative.url }}" alt="{{ image.alt }}" title="{{ image.title }}" width="{{ image.derivative.width }}" height="{{ image.derivative.height }}">
   {% if entity.fieldPromoLink != empty %}
-    {% assign link = entity.fieldPromoLink.entity.fieldLink | featureSingleValueFieldLink %}
+    {% assign link = entity.fieldPromoLink.entity.fieldLink %}
     <section class="hub-promo-text">
         <h2 class="vads-u-font-size--h4 vads-u-text-decoration--underline vads-u-margin-top--0">
           <a onClick="recordEvent({ event: 'nav-hub-promo' });"

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -583,14 +583,6 @@ module.exports = function registerFilters() {
     ];
   };
 
-  liquid.filters.featureSingleValueFieldLink = fieldLink => {
-    if (fieldLink && cmsFeatureFlags.FEATURE_SINGLE_VALUE_FIELD_LINK) {
-      return fieldLink[0];
-    }
-
-    return fieldLink;
-  };
-
   liquid.filters.accessibleNumber = data => {
     if (data) {
       return data

--- a/src/site/paragraphs/linkTeaser.drupal.liquid
+++ b/src/site/paragraphs/linkTeaser.drupal.liquid
@@ -25,7 +25,7 @@
     {% endif %}
 {% endif %}
 
-{% assign link = linkTeaser.fieldLink | featureSingleValueFieldLink %}
+{% assign link = linkTeaser.fieldLink %}
 
 <li
   data-template="paragraphs/linkTeaser"

--- a/src/site/paragraphs/link_teaser_featured_content.drupal.liquid
+++ b/src/site/paragraphs/link_teaser_featured_content.drupal.liquid
@@ -1,6 +1,6 @@
 <li data-template="paragraphs/link_teaser_featured_content" data-entity-id="{{ linkTeaser.entityId }}"
   class="featured-content-list-item vads-u-background-color--primary-alt-lightest  vads-u-padding-y--1p5 vads-u-padding-x--1p5 vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0 vads-u-display--flex vads-u-flex-direction--column">
-  {% assign link = linkTeaser.fieldLink | featureSingleValueFieldLink %}
+  {% assign link = linkTeaser.fieldLink %}
     {% if link.title != empty %}
         <b>{{ link.title }}</b>
         <hr class="featured-content-hr vads-u-margin-y--1p5 vads-u-border-color--primary">


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary
Remove code associated with feature_single_value_field_link feature flag that is no longer in use.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15758

