### PR TITLE
VACMS-16969: Mobile banner fix for touchscreen laptops

### DIFF
--- a/src/site/assets/js/smartbanner/smartbanner.js
+++ b/src/site/assets/js/smartbanner/smartbanner.js
@@ -45,6 +45,7 @@ class Detector {
     const { maxTouchPoints } = window.navigator;
     const { userAgent } = window.navigator;
 
+    console.log(userAgent)
     if (/Android/i.test(userAgent)) {
       return 'android';
     }
@@ -58,9 +59,8 @@ class Detector {
     ) {
       return 'ios';
     }
-
-    return null;
-  }
+    return null;  
+}
 
   static userAgentMatchesRegex(regexString) {
     return new RegExp(regexString).test(window.navigator.userAgent);
@@ -198,10 +198,10 @@ class SmartBanner {
 
   get icon() {
     if (this.platform === 'android') {
-      return '/img/Android_app_icon.webp';
+      return this.options.iconGoogle;
     }
 
-    return '/img/iOS_app_icon.webp';
+    return this.options.iconApple;
   }
 
   get buttonUrl() {

--- a/src/site/assets/js/smartbanner/smartbanner.js
+++ b/src/site/assets/js/smartbanner/smartbanner.js
@@ -209,11 +209,11 @@ class SmartBanner {
 
   get buttonUrl() {
     if (this.platform === 'android') {
-      return this.options.buttonUrlGoogle;
+      return '/img/Android_app_icon.webp';
     }
 
     if (this.platform === 'ios') {
-      return this.options.buttonUrlApple;
+      return '/img/iOS_app_icon.webp';
     }
     return '#';
   }

--- a/src/site/assets/js/smartbanner/smartbanner.js
+++ b/src/site/assets/js/smartbanner/smartbanner.js
@@ -201,19 +201,19 @@ class SmartBanner {
 
   get icon() {
     if (this.platform === 'android') {
-      return this.options.iconGoogle;
+      return '/img/Android_app_icon.webp';
     }
 
-    return this.options.iconApple;
+    return '/img/iOS_app_icon.webp';
   }
 
   get buttonUrl() {
     if (this.platform === 'android') {
-      return '/img/Android_app_icon.webp';
+      return this.options.buttonUrlGoogle;
     }
 
     if (this.platform === 'ios') {
-      return '/img/iOS_app_icon.webp';
+      return this.options.buttonUrlApple;
     }
     return '#';
   }

--- a/src/site/assets/js/smartbanner/smartbanner.js
+++ b/src/site/assets/js/smartbanner/smartbanner.js
@@ -45,7 +45,7 @@ class Detector {
     const { maxTouchPoints } = window.navigator;
     const { userAgent } = window.navigator;
 
-  if(userAgent.match((/(iPhone|iPod|iPad|Android|BlackBerry|IEMobile)/))) {
+  if(userAgent.match((/(iPhone|iPad|Android)/))) {
     if (/Android/i.test(userAgent)) {
       return 'android';
     }

--- a/src/site/assets/js/smartbanner/smartbanner.js
+++ b/src/site/assets/js/smartbanner/smartbanner.js
@@ -45,7 +45,7 @@ class Detector {
     const { maxTouchPoints } = window.navigator;
     const { userAgent } = window.navigator;
 
-    console.log(userAgent)
+  if(userAgent.match((/(iPhone|iPod|iPad|Android|BlackBerry|IEMobile)/))) {
     if (/Android/i.test(userAgent)) {
       return 'android';
     }
@@ -59,7 +59,10 @@ class Detector {
     ) {
       return 'ios';
     }
-    return null;  
+  } else {
+    return null;
+  }    
+
 }
 
   static userAgentMatchesRegex(regexString) {

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1901,10 +1901,6 @@ module.exports = function registerFilters() {
   };
 
   liquid.filters.shouldShowCustomMobilePromoBanner = currentPath => {
-    const isCorrectPath = liquid.filters.shouldShowMobileAppPromoBanner(
-      currentPath,
-    );
-
-    return cmsFeatureFlags?.FEATURE_MOBILE_APP_PROMO && isCorrectPath;
+    return liquid.filters.shouldShowMobileAppPromoBanner(currentPath);
   };
 };


### PR DESCRIPTION
## Summary

Our mobile app promotional banners for Android Chrome & Firefox and iOS Chrome were released to production last week successfully. But the banners were also showing on Windows desktop (for any machine that was also touchscreen). We added a fix to check specifically for iPhone, iPad and Android platforms to avoid Veteran confusion.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16969

## Testing done

Testing conducted via ngrok with the team on [this thread](https://dsva.slack.com/archives/C52CL1PKQ/p1706119034838499).