### PR TITLE
Migrate CPAP ordering app to new URL

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1531,8 +1531,8 @@
     }
   },
   {
-    "appName": "Temporary order hearing aid or CPAP supplies redirect",
-    "entryName": "health-care-supply-reordering-redirect",
+    "appName": "Order hearing aid or CPAP supplies",
+    "entryName": "health-care-supply-reordering",
     "rootUrl": "/my-health/order-hearing-aid-or-cpap-supplies-form",
     "productId": "",
     "template": {
@@ -1640,7 +1640,7 @@
   {
     "appName": "Order hearing aid or CPAP supplies",
     "entryName": "health-care-supply-reordering",
-    "rootUrl": "/health-care/order-hearing-aid-or-CPAP-supplies-form"
+    "rootUrl": "/my-health/order-hearing-aid-or-cpap-supplies-form"
   },
   {
     "appName": "Request personal records",

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1640,7 +1640,7 @@
   {
     "appName": "Order hearing aid or CPAP supplies",
     "entryName": "health-care-supply-reordering",
-    "rootUrl": "/my-health/order-hearing-aid-or-cpap-supplies-form"
+    "rootUrl": "/health-care/order-hearing-aid-or-CPAP-supplies-form"
   },
   {
     "appName": "Request personal records",


### PR DESCRIPTION
## Summary
Continue the migration of the CPAP React app from `/health-care/order-hearing-aid-or-CPAP-supplies-form` to `/my-health/order-hearing-aid-or-cpap-supplies-form`.
This change makes it so the registry has two entries for the CPAP app pointing to the new and old URLs. The result of this is that the app can be accessed by using either URL, but the URL in the browser will change to the URL specified in the manifest.json of the app. This essentially acts as a redirect from one URL to the other. The next step after this is to change the URL in the manifest.json to the new URL to continue the migration.

## Related issue(s)
https://app.zenhub.com/workspaces/mhv-on-vagov-top-level-view-62619a987d74510018ecc546/issues/gh/department-of-veterans-affairs/va.gov-team/70757

## Testing done
- Manual testing: Verify the CPAP ordering app can be accessed at both `/health-care/order-hearing-aid-or-CPAP-supplies-form` and `/my-health/order-hearing-aid-or-cpap-supplies-form` URLs

## Screenshots
N/A

## What areas of the site does it impact?
- CPAP ordering page

## Acceptance criteria
- Migrate the CPAP app from `/health-care/order-hearing-aid-or-CPAP-supplies-form` to `/my-health/order-hearing-aid-or-cpap-supplies-form`

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

