### PR TITLE
Shifts daily deployment time two hours earlier.

### DIFF
--- a/.github/workflows/daily-production-release.yml
+++ b/.github/workflows/daily-production-release.yml
@@ -3,7 +3,7 @@ name: Daily Production Release
 on:
   workflow_dispatch:
   schedule:
-    - cron: 0 20 * * 1-5
+    - cron: 0 18 * * 1-5
 
 concurrency:
   group: daily-prod-release

--- a/.github/workflows/daily-release-warning.yml
+++ b/.github/workflows/daily-release-warning.yml
@@ -2,7 +2,7 @@ name: Daily Release Warning
 
 on:
   schedule:
-    - cron: 0 19 * * 1-5
+    - cron: 0 17 * * 1-5
 
 concurrency:
   group: daily-release-warning


### PR DESCRIPTION
# Description

Closes department-of-veterans-affairs/va.gov-cms#17117.

February 21, `vets-website` will begin deploying two hours earlier in the day. This significantly impacts how `content-build` must be developed, reviewed, and merged. 

The transition between current and new CMS teams in mid-February means that the team responsible for support requests and problems that might arise in content releases will likely be still onboarding and without benefit of the current CMS team's accrued experience.

This PR preëmptively shifts `content-build` daily deploys earlier in the day so that this change is less likely to cause problems.
