### PR TITLE
Opt Out of V3 Component Updates

### DIFF
--- a/src/site/components/informational_alert.drupal.liquid
+++ b/src/site/components/informational_alert.drupal.liquid
@@ -1,5 +1,5 @@
 <div class="vads-u-margin-bottom--2" id="field-cc-vet-call-center">
-  <va-alert status="info" id="va-info-alert">
+  <va-alert status="info" id="va-info-alert" uswds="false">
     <h3 slot="headline">
       Need help after hours?
     </h3>

--- a/src/site/components/merger-social-sco.html
+++ b/src/site/components/merger-social-sco.html
@@ -6,7 +6,7 @@ Social Media - R. Rail
 See https://help.shopify.com/themes/liquid/tags/theme-tags#include
 {% endcomment %}
 
-  <va-accordion bordered multi class="social">
+  <va-accordion bordered multi class="social" uswds="false">
   {% for group in social %}
     <va-accordion-item level="3" open="true" header="{{ group.heading }}">
       {% if group.url != empty %}

--- a/src/site/includes/health_services_listing_services.liquid
+++ b/src/site/includes/health_services_listing_services.liquid
@@ -5,7 +5,7 @@
   <section data-label="{{typeOfCare}}">
     <h2>{{typeOfCare}}</h2>
     <div class="service-accordion-output">
-      <va-accordion bordered>
+      <va-accordion bordered uswds="false">
       {% for service in servicesListOrderedByName %}
         {% include "src/site/facilities/health_service.drupal.liquid" with
           section

--- a/src/site/includes/lovell-switch-link.drupal.liquid
+++ b/src/site/includes/lovell-switch-link.drupal.liquid
@@ -7,7 +7,7 @@
     {% assign switchPageVariation = "VA" %}
   {% endif %}
 
-  <va-alert status="warning" class="vads-u-margin-bottom--2" id="va-info-alert">
+  <va-alert status="warning" class="vads-u-margin-bottom--2" id="va-info-alert" uswds="false">
     <h2 slot="headline">You are viewing this page as a {{ currentPageVariation }} beneficiary.</h2>
     <div>
       <p className="vads-u-margin-y--0">
@@ -17,6 +17,6 @@
           text="View this page as a {{ switchPageVariation }} beneficiary"
         />
       </p>
-    </div> 
+    </div>
   </va-alert>
 {% endif %}

--- a/src/site/includes/vet_centers/services.liquid
+++ b/src/site/includes/vet_centers/services.liquid
@@ -1,5 +1,5 @@
 <div class="vads-u-margin-bottom--3">
-    <va-accordion bordered id="{{ idService }}-accordion-{{ entity.entity.fieldServiceNameAndDescripti.entity.name }}">
+    <va-accordion bordered id="{{ idService }}-accordion-{{ entity.entity.fieldServiceNameAndDescripti.entity.name }}" uswds="false">
       {% for entity in services %}
         {% assign idService = entity.entity.fieldServiceNameAndDescripti.entity.fieldVetCenterTypeOfCare %}
             <va-accordion-item

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -150,7 +150,7 @@
                   class="vads-u-margin-top--0 vads-u-font-size--lg small-screen:vads-u-font-size--xl vads-u-margin-bottom--2">
                 Prepare for your visit</h2>
               <p>Click on a topic for more details.</p>
-              <va-accordion section-heading="Prepare for your visit" bordered>
+              <va-accordion section-heading="Prepare for your visit" bordered uswds="false">
                 {% for accordionItem in fieldLocationServices %}
                   {% assign item = accordionItem.entity %}
                   {% comment %}
@@ -190,7 +190,7 @@
 
               {% assign localHealthServices = fieldLocalHealthCareService | sortObjectsBy: 'entity.fieldRegionalHealthService.entity.fieldServiceNameAndDescripti.entity.name' %}
 
-              <va-accordion bordered>
+              <va-accordion bordered uswds="false">
               {% for localService in localHealthServices %}
                 {% assign serviceSection = localService.entity.fieldAdministration.entity %}
                 {% assign localHealthService = localService.entity | featureFieldRegionalHealthService %}

--- a/src/site/layouts/vet_center.drupal.liquid
+++ b/src/site/layouts/vet_center.drupal.liquid
@@ -153,7 +153,8 @@
             <p> Click on a topic for more details. </p>
             <div class="vads-u-margin-bottom--3">
               <va-accordion bordered
-                id="prepare-for-your-visit-accordion-{{ entity.entity.fieldHeader }}">
+                id="prepare-for-your-visit-accordion-{{ entity.entity.fieldHeader }}"
+                uswds="false">
                 {% for entity in fieldPrepareForVisit %}
                   <va-accordion-item
                     class="va-accordion-item"


### PR DESCRIPTION
## Summary

This adds an opt-out property to all the `content-build` components that we want to avoid automatically going from `v1` to `v3`. These are accordions and alerts (buttons and modals were also mentioned but aren't in this repo). This locks them into version 1.

## Related issue(s)

N/A. This is a collective effort to address all the front-end USWDS tickets in Sprint 103 that need work on the `content-build`.

## Testing done

Visual, local. Go to [this Lovell TriCare Health Services page](http://localhost:3002/lovell-federal-health-care-tricare/health-services/) to see V1 alerts and accordions in action and confirm they still function.

## What areas of the site does it impact?

All areas of `content-build` that use accordions and alerts.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
