### PR TITLE
Resources for Schools - Fix issue where links open in new tab

### DIFF
--- a/src/site/components/merger-social-sco.html
+++ b/src/site/components/merger-social-sco.html
@@ -46,6 +46,8 @@ See https://help.shopify.com/themes/liquid/tags/theme-tags#include
                       onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': '{{ navPath }}' });"
                       {% if link.external == true %}
                         target="_blank" rel="noopener noreferrer"
+                      {% else %}
+                        target="_self"
                       {% endif %}
                       >
                       {% if link.icon != empty %}


### PR DESCRIPTION
## Summary

Fixes a bug where links in the Resources for Schools sidebar always opened in a new browsing context, despite specifying otherwise.

**To reproduce the bug, please follow these steps:**
1. Do not pull the changes in this PR.
2. Open `pages/school-administrators.md`.
3. Give some `links` in the metadata `external: true`, some `external: false`.  Set the key but not the value (`external:`) for some, and omit the attribute from other links.
4. Build the project and view the page.
5. Observe that all of the links you changed unexpectedly open in a new tab.

The solution is to provide an else statement that explicitly sets the link to open in the same tab. The current Liquid conditional appears to be sound, but links end up with `target="_blank"` anyway, suggesting that some other process is adding this attribute. Nevertheless, this added conditional resolves the issue.

I work for [IIR](https://github.com/department-of-veterans-affairs/va-iir). My team owns Resources for Schools.


## Related issue(s)

- Closes [IIR Issue #331](https://app.zenhub.com/workspaces/va-iir-6508c0bd79e64e0fb5855caf/issues/gh/department-of-veterans-affairs/va-iir/331)

## Testing done

Prior to this change, all links received `target="_blank"`. Whether the `external` attribute was set to `true`, `false`, or whether it was omitted, links opened in a new tab which is not desirable.

**To verify that the changes fix this bug:**
1. Pull the changes in this PR.
2. Open `pages/school-administrators.md`.
3. Give some `links` in the metadata `external: true`, some `external: false`.  Set the key but not the value (`external:`) for some, and omit the attribute from other links.
4. Build the project and view the page.
5. Observe `true` yields a link that opens in a new window, `false` or omitted leads to a link that opens in the same tab.

Tests completed: N/a

## Screenshots

These changes do not affect the UI.

## What areas of the site does it impact?

This change only affects [Resources for Schools](https://www.va.gov/school-administrators/). The affected file, `src/site/components/merger-social-sco.html` is exclusively utilized for that site.

## Acceptance criteria
- [ ] Setting `external: true` yields a link that opens in a new tab
- [ ] Setting `external: false` yields a link that opens in the **same** tab
- [ ] Giving the key but no value (`external:`) yields a link that opens in the **same** tab
- [ ] Omitting the `external` attribute  yields a link that opens in the **same** tab

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

This is my first contribution to this repository. Please let me know how I can improve my write-up and/or my code contribution.
