### PR TITLE
[VA-16921] Add Prepare for Visit to VBA Facility Page

### DIFF
--- a/src/site/layouts/vba_facility.drupal.liquid
+++ b/src/site/layouts/vba_facility.drupal.liquid
@@ -147,9 +147,29 @@
             %}
           </div>
 
-          <h2 class="vads-u-line-height--1 vads-u-margin-bottom--3">
-            Prepare for your visit
-          </h2>
+          {% if fieldPrepareForVisit %}
+            <h2 class="vads-u-line-height--1 vads-u-margin-bottom--3">
+              Prepare for your visit
+            </h2>
+
+            <p>
+              Select a topic to learn more.
+            </p>
+
+            <div class="vads-u-margin-bottom--3">
+              <va-accordion uswds bordered id="vba-regional-facilities-accordion-prepare-for-visit">
+                {% for prepareObj in fieldPrepareForVisit %}
+                  <va-accordion-item uswds
+                    class="va-accordion-item"
+                    id="vba-service-item-{{ prepareObj.entity.id }}"
+                    header="{{ prepareObj.entity.fieldHeader }}"
+                    level="3">
+                    {{ prepareObj.entity.fieldRichWysiwyg.processed | drupalToVaPath | phoneLinks }}
+                  </va-accordion-item>
+                {% endfor %}
+              </va-accordion>
+            </div>
+          {% endif %}
 
           <h2 class="vads-u-line-height--2 vads-u-margin-bottom--3">
             In the spotlight at {{ entityLabel }}

--- a/src/site/stages/build/drupal/graphql/vbaFacility.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vbaFacility.graphql.js
@@ -107,6 +107,19 @@ const vbaFacilityFragment = `
               }
             }
           }
+          fieldPrepareForVisit {
+            entity {
+              id
+              entityBundle
+              ... on ParagraphBasicAccordion {
+                id
+                fieldHeader
+                fieldRichWysiwyg {
+                  processed
+                }
+              }
+            }
+          }
           reverseFieldOfficeNode(
             filter: {conditions: [{field: "type", value: ["vba_facility_service"]}]}
           ) {


### PR DESCRIPTION
## Summary

The VBA Regional Facilities pages have a "Prepare for your Visit" section but no content. This pull request shows that information on the page. If there's no information for this section, it and its header aren't added to the page.

## Related issue(s)

- _Link to ticket created in va.gov-cms repo_
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16921

## Testing done

Visual. See [this regional facility page on my tugboat](https://web-txcrk8bym4a0ivw3xfr8xvdhezmls36f.demo.cms.va.gov/cleveland-va-regional-benefit-office/locations/cleveland-va-regional-benefit-office/#prepare-for-your-visit) that, as of this writing, has an example of the displayed data.

## Screenshots

<img width="728" alt="Screen Shot 2024-02-07 at 3 14 09 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10790736/7df0747d-ff0b-470c-9d52-af11d9879658">

## What areas of the site does it impact?

All regional facilities pages (not currently published)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] A Screenshot of the developed feature is added
- [ ] Design review has been performed
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed