### PR TITLE
[VA-16652] Align Main mental health phone number with service contact info

### DIFF
--- a/src/site/components/phone-number.drupal.liquid
+++ b/src/site/components/phone-number.drupal.liquid
@@ -3,5 +3,6 @@
   <va-telephone
     contact="{{ phoneNumber | removeDashes }}"
     extension="{{ phoneExtension | default: '' }}"
+    message-aria-describedby="{{ phoneLabel | default: 'Phone' }}"
   />
 </div>

--- a/src/site/facilities/facility_health_service.drupal.liquid
+++ b/src/site/facilities/facility_health_service.drupal.liquid
@@ -1,4 +1,6 @@
     {% assign serviceTaxonomy = healthService.fieldServiceNameAndDescripti.entity %}
+    {% assign isMentalHealthService = serviceTaxonomy.name | localHealthCareServiceIsMentalHealth %}
+
     <va-accordion-item
       {% if serviceTaxonomy.fieldAlsoKnownAs %}
         subheader="{{ serviceTaxonomy.fieldAlsoKnownAs }}"

--- a/src/site/facilities/health_care_local_health_service.drupal.liquid
+++ b/src/site/facilities/health_care_local_health_service.drupal.liquid
@@ -3,6 +3,7 @@
 {% for location in locations %}
   {% include "src/site/paragraphs/service_location.drupal.liquid" with
     single = location.entity
+    isMentalHealth = isMentalHealthService
     serviceLocationSubHeaderLevel = 5
   %}
 {% endfor %}
@@ -47,9 +48,15 @@
       {% endfor %}
     </div>
   {% else %}
+    {% if isMentalHealthService and fieldMentalHealthPhone %}
+      {% assign localHealthServiceMainNumber = fieldMentalHealthPhone %}
+    {% else %}
+      {% assign localHealthServiceMainNumber = fieldPhoneNumber %}
+    {% endif %}
+
     <div class="vads-u-display--flex vads-u-flex-direction--column vads-u-margin-bottom--1" data-template="facilities/health_care_local_health_service">
       {% include "src/site/components/phone-number.drupal.liquid" with
-        phoneNumber = fieldPhoneNumber
+        phoneNumber = localHealthServiceMainNumber
         phoneLabel = 'Main Phone'
         phoneHeaderLevel = 5
       %}

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -583,6 +583,10 @@ module.exports = function registerFilters() {
     ];
   };
 
+  liquid.filters.localHealthCareServiceIsMentalHealth = healthServiceName => {
+    return healthServiceName.toLowerCase().includes('mental health');
+  };
+
   liquid.filters.accessibleNumber = data => {
     if (data) {
       return data

--- a/src/site/paragraphs/service_location.drupal.liquid
+++ b/src/site/paragraphs/service_location.drupal.liquid
@@ -32,9 +32,16 @@
 {% comment %}
   Conditionally display facility phone number
 {% endcomment %}
-{% if fieldPhoneNumber and single.fieldUseMainFacilityPhone %}
+
+{% if isMentalHealthService and fieldMentalHealthPhone %}
+  {% assign serviceLocationMainNumber = fieldMentalHealthPhone %}
+{% else %}
+  {% assign serviceLocationMainNumber = fieldPhoneNumber %}
+{% endif %}
+
+{% if serviceLocationMainNumber and single.fieldUseMainFacilityPhone %}
   {% include "src/site/components/phone-number.drupal.liquid" with
-    phoneNumber = fieldPhoneNumber
+    phoneNumber = serviceLocationMainNumber
     phoneLabel = 'Main Phone'
     phoneHeaderLevel = serviceLocationSubHeaderLevel
   %}


### PR DESCRIPTION
## Summary

If the facility's mental health care chooses "Use the general facility phone number," it will show the facility's mental health care number, not their main phone number. It also updates the phone number partial being used so it includes `aria-describedby` with the label.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-cms#16652

## Testing done

Visual. Checked all available services on [Hot Springs VA Medical Center](http://deb34fb5e1a35391d2628af88f742060.review.vetsgov-internal/black-hills-health-care/locations/hot-springs-va-medical-center/#health-care-offered-here) and [Cheyenne VA Medical Center](http://deb34fb5e1a35391d2628af88f742060.review.vetsgov-internal/cheyenne-health-care/locations/cheyenne-va-medical-center/#health-care-offered-here) in my tugboat instance.

## Screenshots

_Note:_ this screenshots include changes that are no longer included in this pull request. The only ones relevant to this pull request are the main phone numbers.

### Before

<img width="719" alt="Screen Shot 2024-02-12 at 1 16 10 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10790736/9e9c519f-2306-4506-b8b0-b4fbc33395a8">
<img width="722" alt="Screen Shot 2024-02-12 at 1 16 43 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10790736/f27844c8-1631-400c-ade2-3768dff2fe63">

### After

<img width="732" alt="Screen Shot 2024-02-12 at 1 17 59 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10790736/f8c65239-0353-4c2e-84b8-78ae5ac2976d">
<img width="728" alt="Screen Shot 2024-02-12 at 1 18 12 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10790736/407fcb95-bb78-46c2-a33e-81830f9de821">

## What areas of the site does it impact?

VA Health Care Facilities

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
