### PR TITLE
VACMS-16852: Update margin for tables

### DIFF
--- a/src/site/assets/sass/style.scss
+++ b/src/site/assets/sass/style.scss
@@ -19,6 +19,10 @@
   padding-top: 1.25rem;
 }
 
+.va-table-margin {
+  margin: 2em auto;
+}
+
 // START: Styles for mobile app promo banner
 .smartbanner {
   position: absolute;

--- a/src/site/paragraphs/table.drupal.liquid
+++ b/src/site/paragraphs/table.drupal.liquid
@@ -26,20 +26,21 @@
         }
     }
 {% endcomment %}
-<va-table data-template="paragraphs/table" data-entity-id="{{ entity.entityId }}" role="table" table-title="{{ entity.fieldTable.caption }}">
-    {% assign colLabels = entity.fieldTable.value.0  %}
-    {% for value in entity.fieldTable.value %}
-        {% if forloop.first == true %}
-            <va-table-row slot="headers" key="header">
-                {% for column in value %}
-                    {% if column == "" or column == nil %}
-                    <span role="columnheader"> </span>
+<div class="va-table-margin">
+    <va-table data-template="paragraphs/table" data-entity-id="{{ entity.entityId }}" role="table" table-title="{{ entity.fieldTable.caption }}">
+        {% assign colLabels = entity.fieldTable.value.0  %}
+        {% for value in entity.fieldTable.value %}
+            {% if forloop.first == true %}
+                <va-table-row slot="headers" key="header">
+                    {% for column in value %}
+                        {% if column == "" or column == nil %}
+                        <span role="columnheader"> </span>
                     {% else %}
-                    <span role="columnheader" scope="col">{{ column }}</span>
+                        <span role="columnheader" scope="col">{{ column }}</span>
                     {% endif %}
-                {% endfor %}
-            </va-table-row>
-        {% else %}
+                    {% endfor %}
+                </va-table-row>
+            {% else %}
                 <va-table-row>
                     {% for column in value %}
                         <span>
@@ -47,6 +48,7 @@
                         </span>
                     {% endfor %}
                 </va-table-row>
-        {% endif %}
-    {% endfor %}
-</va-table>
+            {% endif %}
+        {% endfor %}    
+    </va-table>
+</div>


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary
Margin was removed from the design system component of the va-table. This adds back the 2em top and bottom margin for the va-table usage in content-build.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16852

## Testing done
Tested instances of the table to check the margin.

## Screenshots

Before
<img width="1059" alt="2024_Veterans_Disability_Compensation_Rates___Veterans_Affairs" src="https://github.com/department-of-veterans-affairs/content-build/assets/42885441/dfe0d0be-54cb-4acd-92fa-58afca9d2faf">


After
<img width="1483" alt="2024_Veterans_Disability_Compensation_Rates___Veterans_Affairs" src="https://github.com/department-of-veterans-affairs/content-build/assets/42885441/9755378d-5fa8-4848-84e2-38f43b781a9f">


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria
