### PR TITLE
VACMS-16981 v3 upgrade for Benefit Hub Landing Page

### DIFF
--- a/src/site/blocks/alert.drupal.liquid
+++ b/src/site/blocks/alert.drupal.liquid
@@ -10,8 +10,7 @@
     data-entity-id="{{ alert.entityId }}"
     status="{{ alertType }}"
     class="vads-u-margin-top--3"
-    role="alert"
-    uswds="false"
+    uswds
   >
     <h2 slot="headline" class="vads-u-font-size--h3">
       {{ alert.fieldAlertTitle }}

--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -61,13 +61,15 @@
           {% include "src/site/blocks/promo.drupal.liquid" with entity = fieldPromo.entity %}
         {% endif %}
 
-        <va-accordion bordered uswds="false">
+        <va-accordion bordered uswds>
           <va-accordion-item 
             class="va-accordion-item"
             level="2"
             open="true"
             header="Ask questions"
             id="{{ 'Message us' | hashReference: 60 }}"
+            bordered
+            uswds
           >
             <section>
               <h3 class="vads-u-font-size--h4">Message us</h3>
@@ -120,6 +122,8 @@
               open="true"
               header="Not a Veteran?"
               id="{{ 'Get information for' | hashReference: 60 }}"
+              bordered
+              uswds
             >
               <section>
                 <h3 class="vads-u-font-size--h4">Get information for:</h3>
@@ -142,6 +146,8 @@
               class="va-accordion-item"
               level="2"
               header="Connect with us"
+              bordered
+              uswds
               open="true"
               id="{{ fieldRelatedOffice.entity.fieldExternalLink.title | hashReference: 60 }}">
               {% if fieldRelatedOffice.entity.fieldExternalLink.url.path != empty %}


### PR DESCRIPTION
## Summary
Upgrade the `va-accordion` and `va-alert` component for the Benefit Hub landing pages.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16981

## Testing done
Tested locally at `/health-care` and `careers-employment`.

## Screenshots
<img width="1199" alt="Screenshot 2024-02-16 at 2 31 42 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/3bc4cdd2-5fa8-413f-811a-41d442d3a5d4">
<img width="451" alt="Screenshot 2024-02-16 at 2 31 48 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/4a68a9eb-ae7b-4c30-a326-1455241fcdcb">
<img width="452" alt="Screenshot 2024-02-16 at 2 31 55 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/c5e1fcf1-be4b-4e77-9fb0-02ed0cd0e23f">


## Acceptance criteria

 - [x] V3 components are now used for the accordion and alert
 - [x] V3 component features display correctly
 - [x] check desktop and mobile
 - [x] a11y review