### PR TITLE
Fixes Newsletter and the intro text which is not introtext in VBA it is Centralized Content

### DIFF
--- a/src/site/facilities/vba_social_links.drupal.liquid
+++ b/src/site/facilities/vba_social_links.drupal.liquid
@@ -7,7 +7,7 @@
                         <div class="social-links-email vads-u-margin-bottom--2">
                             <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" rel="noreferrer"
                              href="{{fieldNews.uri}}">
-                                <i class="fas fa-envelope vads-u-margin-right--1"></i>
+                                <i class="fas fa-envelope vads-u-margin-right--1" aria-hidden="true"></i>
                                 <span class="vads-u-text-decoration--underline">{{ fieldNews.title }}</span>
                             </a>
                         </div>
@@ -15,7 +15,7 @@
                 {% if fieldFacebook != empty %}
                     <div class="social-links social-links-facebook vads-u-margin-bottom--2">
                         <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" rel="noreferrer" href="{{ fieldFacebook.uri }}">
-                            <i class="fab fa-facebook-square vads-u-margin-right--1"></i>
+                            <i class="fab fa-facebook-square vads-u-margin-right--1" aria-hidden="true"></i>
                             <span class="vads-u-text-decoration--underline">{{ fieldFacebook.title }}</span>
                         </a>
                     </div>
@@ -27,7 +27,7 @@
                     {% if fieldTwitter != empty %}
                         <div class="social-links social-links-twitter vads-u-margin-bottom--2">
                             <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" rel="noreferrer" href="{{ fieldTwitter.uri }}">
-                                <i class="fab fa-twitter vads-u-text-decoration--none vads-u-margin-right--1"></i>
+                                <i class="fab fa-twitter vads-u-text-decoration--none vads-u-margin-right--1" aria-hidden="true"></i>
                                 <span class="vads-u-text-decoration--underline">{{ fieldTwitter.title }}</span>
                             </a>
                         </div>
@@ -35,7 +35,7 @@
                     {% if fieldFlickr != empty %}
                         <div class="social-links social-links-flickr vads-u-margin-bottom--2">
                             <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" rel="noreferrer" href="{{ fieldFlickr.uri }}">
-                                <i class="fab fa-flickr vads-u-text-decoration--none vads-u-margin-right--1"></i>
+                                <i class="fab fa-flickr vads-u-text-decoration--none vads-u-margin-right--1" aria-hidden="true"></i>
                                 <span class="vads-u-text-decoration--underline">{{ fieldFlickr.title }}</span>
                             </a>
                         </div>
@@ -44,7 +44,7 @@
                     {% if fieldInstagram != empty %}
                         <div class="social-links social-links-instagram vads-u-margin-bottom--2">
                             <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" rel="noreferrer" href="{{ fieldInstagram.uri }}">
-                                <i class="fab fa-instagram vads-u-text-decoration--none vads-u-margin-right--1"></i>
+                                <i class="fab fa-instagram vads-u-text-decoration--none vads-u-margin-right--1" aria-hidden="true"></i>
                                 <span class="vads-u-text-decoration--underline">{{ fieldInstagram.title }}</span>
                             </a>
                         </div>
@@ -53,7 +53,7 @@
                     {% if fieldYoutube != empty %}
                         <div class="social-links social-links-youtube vads-u-margin-bottom--2">
                             <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" rel="noreferrer" href="{{ fieldYoutube.uri }}">
-                                <i class="fab fa-youtube vads-u-text-decoration--none vads-u-margin-right--1"></i>
+                                <i class="fab fa-youtube vads-u-text-decoration--none vads-u-margin-right--1" aria-hidden="true"></i>
                                 <span class="vads-u-text-decoration--underline">{{ fieldYoutube.title }}</span>
                             </a>
                         </div>

--- a/src/site/facilities/vba_social_links.drupal.liquid
+++ b/src/site/facilities/vba_social_links.drupal.liquid
@@ -10,7 +10,7 @@
               class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none"
               rel="noreferrer"
               href="{{ fieldNews.uri }}">
-              <i class="fas fa-envelope vads-u-margin-right--1"></i>
+              <i class="fas fa-envelope vads-u-margin-right--1" aria-hidden="true"></i>
               <span class="vads-u-text-decoration--underline">{{ fieldNews.title }}</span>
             </a>
           </div>
@@ -22,7 +22,7 @@
               class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none"
               rel="noreferrer"
               href="https://public.govdelivery.com/accounts/USVHA/subscriber/new?topic_id={{ fieldGovdeliveryIdEmerg }}">
-              <i class="fas fa-envelope vads-u-margin-right--1"></i>
+              <i class="fas fa-envelope vads-u-margin-right--1" aria-hidden="true"></i>
               <span class="vads-u-text-decoration--underline">Subscribe to {{ regionNickname }} emergency notifications</span>
             </a>
           </div>
@@ -33,7 +33,7 @@
               class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none"
               rel="noreferrer"
               href="{{ fieldFacebook.uri }}">
-              <i class="fab fa-facebook-square vads-u-margin-right--1"></i>
+              <i class="fab fa-facebook-square vads-u-margin-right--1" aria-hidden="true"></i>
               <span class="vads-u-text-decoration--underline">{{ fieldFacebook.title }}</span>
             </a>
           </div>
@@ -52,7 +52,7 @@
                 class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none"
                 rel="noreferrer"
                 href="{{ fieldTwitter.uri }}">
-                <i class="fab fa-twitter vads-u-text-decoration--none vads-u-margin-right--1"></i>
+                <i class="fab fa-twitter vads-u-text-decoration--none vads-u-margin-right--1" aria-hidden="true"></i>
                 <span class="vads-u-text-decoration--underline">{{ fieldTwitter.title }}</span>
               </a>
             </div>
@@ -63,7 +63,7 @@
                 class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none"
                 rel="noreferrer"
                 href="{{ fieldFlickr.uri }}">
-                <i class="fab fa-flickr vads-u-text-decoration--none vads-u-margin-right--1"></i>
+                <i class="fab fa-flickr vads-u-text-decoration--none vads-u-margin-right--1" aria-hidden="true"></i>
                 <span class="vads-u-text-decoration--underline">{{ fieldFlickr.title }}</span>
               </a>
             </div>
@@ -75,7 +75,7 @@
                 class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none"
                 rel="noreferrer"
                 href="{{ fieldInstagram.uri }}">
-                <i class="fab fa-instagram vads-u-text-decoration--none vads-u-margin-right--1"></i>
+                <i class="fab fa-instagram vads-u-text-decoration--none vads-u-margin-right--1" aria-hidden="true"></i>
                 <span class="vads-u-text-decoration--underline">{{ fieldInstagram.title }}</span>
               </a>
             </div>
@@ -87,7 +87,7 @@
                 class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none"
                 rel="noreferrer"
                 href="{{ fieldYoutube.uri }}">
-                <i class="fab fa-youtube vads-u-text-decoration--none vads-u-margin-right--1"></i>
+                <i class="fab fa-youtube vads-u-text-decoration--none vads-u-margin-right--1" aria-hidden="true"></i>
                 <span class="vads-u-text-decoration--underline">{{ fieldYoutube.title }}</span>
               </a>
             </div>

--- a/src/site/facilities/vba_social_links.drupal.liquid
+++ b/src/site/facilities/vba_social_links.drupal.liquid
@@ -1,65 +1,99 @@
 <section data-template="facilities/facility_social_links" class="feature vads-u-background-color--gray-lightest vads-u-margin-top--4 small-screen:vads-u-margin-top--6 vads-u-padding-x--3 vads-u-padding-y--2p5">
-    <h2 class="vads-u-margin-bottom--2">Get updates from {{ regionNickname }}</h2>
-    <div class="va-c-list-link-teasers usa-grid usa-grid-full">
+  <h2 class="vads-u-margin-bottom--2">Get updates from {{ regionNickname }}</h2>
+  <div class="va-c-list-link-teasers usa-grid usa-grid-full">
 
-            <div class="usa-width-one-half social-links">
-                {% if fieldNews != empty %}
-                        <div class="social-links-email vads-u-margin-bottom--2">
-                            <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" rel="noreferrer"
-                             href="{{fieldNews.uri}}">
-                                <i class="fas fa-envelope vads-u-margin-right--1" aria-hidden="true"></i>
-                                <span class="vads-u-text-decoration--underline">{{ fieldNews.title }}</span>
-                            </a>
-                        </div>
-                {% endif %}
-                {% if fieldFacebook != empty %}
-                    <div class="social-links social-links-facebook vads-u-margin-bottom--2">
-                        <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" rel="noreferrer" href="{{ fieldFacebook.uri }}">
-                            <i class="fab fa-facebook-square vads-u-margin-right--1" aria-hidden="true"></i>
-                            <span class="vads-u-text-decoration--underline">{{ fieldFacebook.title }}</span>
-                        </a>
-                    </div>
-                {% endif %}
-            </div>
-            {% if fieldTwitter != empty || fieldFlickr != empty || fieldInstagram != empty %}
-            <div class="usa-width-one-half social-links">
-                <div class="">
-                    {% if fieldTwitter != empty %}
-                        <div class="social-links social-links-twitter vads-u-margin-bottom--2">
-                            <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" rel="noreferrer" href="{{ fieldTwitter.uri }}">
-                                <i class="fab fa-twitter vads-u-text-decoration--none vads-u-margin-right--1" aria-hidden="true"></i>
-                                <span class="vads-u-text-decoration--underline">{{ fieldTwitter.title }}</span>
-                            </a>
-                        </div>
-                    {% endif %}
-                    {% if fieldFlickr != empty %}
-                        <div class="social-links social-links-flickr vads-u-margin-bottom--2">
-                            <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" rel="noreferrer" href="{{ fieldFlickr.uri }}">
-                                <i class="fab fa-flickr vads-u-text-decoration--none vads-u-margin-right--1" aria-hidden="true"></i>
-                                <span class="vads-u-text-decoration--underline">{{ fieldFlickr.title }}</span>
-                            </a>
-                        </div>
-                    {% endif %}
-
-                    {% if fieldInstagram != empty %}
-                        <div class="social-links social-links-instagram vads-u-margin-bottom--2">
-                            <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" rel="noreferrer" href="{{ fieldInstagram.uri }}">
-                                <i class="fab fa-instagram vads-u-text-decoration--none vads-u-margin-right--1" aria-hidden="true"></i>
-                                <span class="vads-u-text-decoration--underline">{{ fieldInstagram.title }}</span>
-                            </a>
-                        </div>
-                    {% endif %}
-
-                    {% if fieldYoutube != empty %}
-                        <div class="social-links social-links-youtube vads-u-margin-bottom--2">
-                            <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none" rel="noreferrer" href="{{ fieldYoutube.uri }}">
-                                <i class="fab fa-youtube vads-u-text-decoration--none vads-u-margin-right--1" aria-hidden="true"></i>
-                                <span class="vads-u-text-decoration--underline">{{ fieldYoutube.title }}</span>
-                            </a>
-                        </div>
-                    {% endif %}
-                </div>
-            </div>
+    {% if fieldGovdeliveryIdEmerg != empty or fieldNews != empty %}
+      <div class="usa-width-one-half social-links">
+        {% if fieldNews != empty %}
+          <div class="social-links-email vads-u-margin-bottom--2">
+            <a
+              class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none"
+              rel="noreferrer"
+              href="{{ fieldNews.uri }}">
+              <i class="fas fa-envelope vads-u-margin-right--1"></i>
+              <span class="vads-u-text-decoration--underline">{{ fieldNews.title }}</span>
+            </a>
+          </div>
         {% endif %}
-    </div>
+
+        {% if fieldGovdeliveryIdEmerg != empty %}
+          <div class="social-links-email vads-u-margin-bottom--2">
+            <a
+              class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none"
+              rel="noreferrer"
+              href="https://public.govdelivery.com/accounts/USVHA/subscriber/new?topic_id={{ fieldGovdeliveryIdEmerg }}">
+              <i class="fas fa-envelope vads-u-margin-right--1"></i>
+              <span class="vads-u-text-decoration--underline">Subscribe to {{ regionNickname }} emergency notifications</span>
+            </a>
+          </div>
+        {% endif %}
+        {% if fieldFacebook != empty %}
+          <div class="social-links social-links-facebook vads-u-padding-bottom--2">
+            <a
+              class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none"
+              rel="noreferrer"
+              href="{{ fieldFacebook.uri }}">
+              <i class="fab fa-facebook-square vads-u-margin-right--1"></i>
+              <span class="vads-u-text-decoration--underline">{{ fieldFacebook.title }}</span>
+            </a>
+          </div>
+        {% endif %}
+      </div>
+    {% endif %}
+
+    {% if fieldFacebook != empty | | fieldTwitter != empty | | fieldFlickr != empty | | fieldInstagram != empty %}
+      <div class="usa-width-one-half social-links">
+        <div class="">
+
+
+          {% if fieldTwitter != empty %}
+            <div class="social-links social-links-twitter vads-u-margin-bottom--2">
+              <a
+                class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none"
+                rel="noreferrer"
+                href="{{ fieldTwitter.uri }}">
+                <i class="fab fa-twitter vads-u-text-decoration--none vads-u-margin-right--1"></i>
+                <span class="vads-u-text-decoration--underline">{{ fieldTwitter.title }}</span>
+              </a>
+            </div>
+          {% endif %}
+          {% if fieldFlickr != empty %}
+            <div class="social-links social-links-flickr vads-u-margin-bottom--2">
+              <a
+                class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none"
+                rel="noreferrer"
+                href="{{ fieldFlickr.uri }}">
+                <i class="fab fa-flickr vads-u-text-decoration--none vads-u-margin-right--1"></i>
+                <span class="vads-u-text-decoration--underline">{{ fieldFlickr.title }}</span>
+              </a>
+            </div>
+          {% endif %}
+
+          {% if fieldInstagram != empty %}
+            <div class="social-links social-links-instagram vads-u-margin-bottom--2">
+              <a
+                class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none"
+                rel="noreferrer"
+                href="{{ fieldInstagram.uri }}">
+                <i class="fab fa-instagram vads-u-text-decoration--none vads-u-margin-right--1"></i>
+                <span class="vads-u-text-decoration--underline">{{ fieldInstagram.title }}</span>
+              </a>
+            </div>
+          {% endif %}
+
+          {% if fieldYoutube != empty %}
+            <div class="social-links social-links-youtube vads-u-margin-bottom--2">
+              <a
+                class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none"
+                rel="noreferrer"
+                href="{{ fieldYoutube.uri }}">
+                <i class="fab fa-youtube vads-u-text-decoration--none vads-u-margin-right--1"></i>
+                <span class="vads-u-text-decoration--underline">{{ fieldYoutube.title }}</span>
+              </a>
+            </div>
+          {% endif %}
+        </div>
+      </div>
+    {% endif %}
+  </div>
 </section>

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -823,6 +823,7 @@ module.exports = function registerFilters() {
   };
 
   liquid.filters.replace = (string, oldVal, newVal) => {
+    if (!string) return null;
     const regex = new RegExp(oldVal, 'g');
     return string.replace(regex, newVal);
   };

--- a/src/site/layouts/vba_facility.drupal.liquid
+++ b/src/site/layouts/vba_facility.drupal.liquid
@@ -22,9 +22,9 @@
 
           <h1>{{ title }}</h1>
 
-          {% if fieldIntroText %}
+          {% if fieldCcVbaFacilityOverview %}
             <div class="va-introtext">
-              {{ fieldCcVbaFacilityOverview.fetched.fieldWysiwyg.0.value }}
+              {{ fieldCcVbaFacilityOverview | processWysiwygSimple }}
             </div>
           {% endif %}
 

--- a/src/site/layouts/vba_facility.drupal.liquid
+++ b/src/site/layouts/vba_facility.drupal.liquid
@@ -24,9 +24,7 @@
 
           {% if fieldIntroText %}
             <div class="va-introtext">
-              <p>
-                {{ fieldIntroText }}
-              </p>
+              {{ fieldCcVbaFacilityOverview.fetched.fieldWysiwyg.0.value }}
             </div>
           {% endif %}
 
@@ -245,11 +243,12 @@
             {%  assign fieldUpdatesVba = fieldCcGetUpdatesFromVba | processCentralizedUpdatesVBA: fieldCcGetUpdatesFromVba %}
             {% include "src/site/facilities/vba_social_links.drupal.liquid"
               with  regionNickname = "the Veteran Benefits Administration"
-                    fieldNews = fieldUpdatesVba.links.news
+                    fieldNews = fieldUpdatesVba.links.govdelivery
                     fieldFacebook = fieldUpdatesVba.links.facebook
                     fieldTwitter = fieldUpdatesVba.links.twitter
                     fieldInstagram = fieldUpdatesVba.links.instagram
                     fieldFlickr = fieldUpdatesVba.links.flickr
+                    
             %}
           {% endif %}
           <h2 class="vads-u-line-height--1 vads-u-margin-bottom--3">

--- a/src/site/stages/build/drupal/graphql/vbaFacility.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vbaFacility.graphql.js
@@ -21,6 +21,9 @@ const vbaFacilityFragment = `
               }
             }
           }
+          fieldCcVbaFacilityOverview {
+            fetched
+          }
           fieldShowBanner
           fieldAlertType
           fieldDismissibleOption


### PR DESCRIPTION
## Summary

- Updates graphql query. Uses correct source for intro text and updates newsletter content.
- Processes centralized content for intro text.
- Sitewide Facilities

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14933

## Testing done

- Checked content on tugboat. Checked at multiple viewport sizes.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Benefits mobile  |   <img width="393" alt="Screenshot 2024-02-20 at 9 17 16 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/c2ded707-42f9-4c92-8e3a-193e1c4ff76c">    |   <img width="393" alt="Screenshot 2024-02-23 at 1 14 34 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/815ec617-2155-405a-88e6-15fd5173f2ab">   |
| Benefits desktop |   <img width="1479" alt="Screenshot 2024-02-20 at 9 17 50 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/e2bb3298-0f06-4ed0-8447-d92c9d287b56">     |   <img width="713" alt="Screenshot 2024-02-23 at 12 40 35 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/00725340-bb0b-49e0-b843-46faf975f28e">   |
| Intro text mobile |  <img width="393" alt="Screenshot 2024-02-20 at 9 17 08 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/8adabc7e-8958-4073-b940-3c76044fa375"> | <img width="340" alt="Screenshot 2024-02-20 at 9 06 26 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/3c4d81b8-ec4e-4cc9-937b-4662eeef9a23"> |
| Intro text desktop | <img width="742" alt="Screenshot 2024-02-20 at 9 17 40 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/5c63b7f4-2c17-4a25-a0bf-5a5cfa51a224"> | <img width="1480" alt="Screenshot 2024-02-20 at 9 05 47 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/1d37d127-e772-4be3-b09b-a7e12b5d6d35"> |

## What areas of the site does it impact?

Only VBA pages

## Acceptance criteria

- [x] Centralized content listed displays on a VBA regional office page
  - [x] Benefit office overview
  - [x] [Subscribe to our newsletter about VA benefits](https://public.govdelivery.com/accounts/USVAVBA/subscribers/new) in the social media area
- [x] Requires design review (added to PR)
- [x] Requires accessibility review (added to PR)


### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

View Cleveland Regional Benefit Office on tugboat: https://web-ihqrv6rby5lxlkn8zqdxf9u7lk1aplcp.demo.cms.va.gov/cleveland-va-regional-benefit-office/locations/cleveland-va-regional-benefit-office/