### PR TITLE
[VA-16311] Add analytics to Regional Facilities pages

### DIFF
--- a/src/site/includes/vba_facilities/service_location.liquid
+++ b/src/site/includes/vba_facilities/service_location.liquid
@@ -30,6 +30,14 @@
         contact="{{ serviceLocationMainPhone.phoneNumber }}"
         extension="{{ serviceLocationMainPhone.extension }}"
         message-aria-describedby="Main Phone"
+        onclick="recordEvent(
+          {
+            'event': 'vba-regional-facility-service-location-phone-number',
+            'vba-regional-facility-name': '{{ facilityName }}',
+            'accordion-parent-label': '{{ entityName }}',
+            'link-label': 'Main Phone'
+          }
+        )"
       />
     </div>
   {% elsif location.entity.fieldPhone %}
@@ -51,13 +59,33 @@
           {% endif %}
           contact="{{ phoneObj.entity.fieldPhoneNumber }}"
           extension="{{ phoneObj.entity.fieldPhoneExtension }}"
-          message-aria-describedby="{{ phoneObj.entity.fieldPhoneLabel }}" />
+          message-aria-describedby="{{ phoneObj.entity.fieldPhoneLabel }}"
+          onclick="recordEvent(
+            {
+              'event': 'vba-regional-facility-service-location-phone-number',
+              'vba-regional-facility-name': '{{ facilityName }}',
+              'accordion-parent-label': '{{ entityName }}',
+              'link-label': '{{ phoneObj.entity.fieldPhoneLabel }}'
+            }
+          )"
+        />
       </div>
     {% endfor %}
   {% endif %}
 
   <div class="vads-u-margin-bottom--3">
-    <a class="vads-c-action-link--blue" href="/health-care/schedule-view-va-appointments">
+    <a
+      class="vads-c-action-link--blue"
+      href="/health-care/schedule-view-va-appointments"
+      onclick="recordEvent(
+        {
+          'event': 'vba-regional-facility-service-location-schedule-appointment',
+          'vba-regional-facility-name': '{{ facilityName }}',
+          'accordion-parent-label': '{{ entityName }}',
+          'link-label': 'Schedule an appointment online'
+        }
+      )"
+    >
       Schedule an appointment online
     </a>
   </div>
@@ -112,7 +140,18 @@
                     vads-u-margin--0
                     vads-u-margin-bottom--0p5
                     vads-u-font-weight--regular">
-          <a target="_blank" href="mailto:{{ emailObj.entity.fieldEmailAddress }}">
+          <a
+            target="_blank"
+            href="mailto:{{ emailObj.entity.fieldEmailAddress }}"
+            onclick="recordEvent(
+              {
+                'event': 'vba-regional-facility-service-location-email-address',
+                'vba-regional-facility-name': '{{ facilityName }}',
+                'accordion-parent-label': '{{ entityName }}',
+                'link-label': '{{ emailObj.entity.fieldEmailAddress }}'
+              }
+            )"
+          >
             {{ emailObj.entity.fieldEmailAddress }}
           </a>
         </p>

--- a/src/site/includes/vba_facilities/services.liquid
+++ b/src/site/includes/vba_facilities/services.liquid
@@ -60,6 +60,8 @@
           class="va-accordion-item"
           id="vba-service-item-{{ entityId }}"
           header="{{ entityName }}"
+          data-label="{{ entityName }}"
+          data-template="vba_facilities/services"
           level="3">
           {% if vbaServiceDescription != empty %}
             <p>{{ vbaServiceDescription | drupalToVaPath | phoneLinks }}</p>
@@ -74,16 +76,33 @@
               <va-link
                 active
                 href="{{ onlineSelfService.url.path }}"
-                text="{{ onlineSelfService.title }}" />
+                text="{{ onlineSelfService.title }}" /
+                onclick="recordEvent(
+                  {
+                    'event': 'vba-regional-facility-services-manage-benefits-online',
+                    'vba-regional-facility-name': '{{ facilityName }}',
+                    'accordion-parent-label': '{{ entityName }}',
+                    'link-label': '{{ onlineSelfService.title }}'
+                  }
+                )"
+              >
             </p>
           {% endif %}
 
           {% for fServiceLocation in entity.facilityService.fieldServiceLocation %}
-            {% include "src/site/includes/vba_facilities/service_location.liquid" with location = fServiceLocation entityLabel = facilityLabel serviceHeader = facilityServiceHeader serviceDescription = facilityServiceDescription
+            {% include "src/site/includes/vba_facilities/service_location.liquid" with
+              location = fServiceLocation
+              entityLabel = facilityLabel
+              serviceHeader = facilityServiceHeader
+              serviceDescription = facilityServiceDescription
             %}
           {% endfor %}
           {% for rServiceLocation in entity.regionalService.fieldServiceLocation %}
-            {% include "src/site/includes/vba_facilities/service_location.liquid" with location = rServiceLocation entityLabel = regionalLabel serviceHeader = regionalServiceHeader serviceDescription = regionalServiceDescription
+            {% include "src/site/includes/vba_facilities/service_location.liquid" with
+              location = rServiceLocation
+              entityLabel = regionalLabel
+              serviceHeader = regionalServiceHeader
+              serviceDescription = regionalServiceDescription
             %}
           {% endfor %}
 

--- a/src/site/layouts/vba_facility.drupal.liquid
+++ b/src/site/layouts/vba_facility.drupal.liquid
@@ -120,6 +120,13 @@
                               contact="{{ vbaFacilityMainPhone.phoneNumber }}"
                               extension="{{ vbaFacilityMainPhone.extension }}"
                               message-aria-describedby="Main Phone"
+                              onclick="recordEvent(
+                                {
+                                  'event': 'vba-regional-facility-vba-facility-main-phone-number',
+                                  'vba-regional-facility-name': '{{ entityLabel }}',
+                                  'link-label': 'Main Phone'
+                                }
+                              )"
                             />
                           </p>
                         </div>
@@ -132,6 +139,13 @@
                             <va-telephone
                               contact="{{ benefitsHotline.fieldPhoneNumber }}"
                               extension="{{ benefitsHotline.fieldPhoneExtension }}"
+                              onclick="recordEvent(
+                                {
+                                  'event': 'vba-regional-facility-vba-facility-va-benefits-online',
+                                  'vba-regional-facility-name': '{{ entityLabel }}',
+                                  'link-label': 'VA benefits hotline'
+                                }
+                              )"
                             />
                           </p>
                         </div>
@@ -200,6 +214,7 @@
           {% include "src/site/includes/vba_facilities/services.liquid" with
             vbaTitle = "Veteran benefits"
             vbaServices = allVbaServices.veteranBenefits
+            facilityName = entityLabel
             facilityAddress = fieldAddress
             facilityPhone = fieldPhoneNumber
           %}
@@ -207,6 +222,7 @@
           {% include "src/site/includes/vba_facilities/services.liquid" with
             vbaTitle = "Family member and caregiver benefits"
             vbaServices = allVbaServices.familyMemberCaregiverBenefits
+            facilityName = entityLabel
             facilityAddress = fieldAddress
             facilityPhone = fieldPhoneNumber
           %}
@@ -214,6 +230,7 @@
           {% include "src/site/includes/vba_facilities/services.liquid" with
             vbaTitle = "Service member benefits"
             vbaServices = allVbaServices.serviceMemberBenefits
+            facilityName = entityLabel
             facilityAddress = fieldAddress
             facilityPhone = fieldPhoneNumber
           %}
@@ -221,6 +238,7 @@
           {% include "src/site/includes/vba_facilities/services.liquid" with
             vbaTitle = "Other services"
             vbaServices = allVbaServices.otherServices
+            facilityName = entityLabel
             facilityAddress = fieldAddress
             facilityPhone = fieldPhoneNumber
           %}
@@ -273,6 +291,13 @@
             <va-link
               href="/find-locations"
               text="Find a VA benefits location"
+              onclick="recordEvent(
+                {
+                  'event': 'vba-regional-facility-vba-facility-find-VA-benefits-location',
+                  'vba-regional-facility-name': '{{ entityLabel }}',
+                  'link-label': 'Find a VA benefits location'
+                }
+              )"
             >
           </p>
           <va-back-to-top></va-back-to-top>


### PR DESCRIPTION
## Summary

This adds event tracking to the VBA Regional Facilities pages, and any button and links used in that page's partials. The page views and scroll depth are automatically tracked by Google Analytics. This pull request adds specific event tracking for the links and buttons.

## Related issue(s)

- _Link to ticket created in va.gov-cms repo_
[department-of-veterans-affairs/va.gov-cms#16311](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16311)
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#0000

## Testing done

Visual, made sure the page built properly and there was no improper code in the affected elements.

## What areas of the site does it impact?

VBA Regional Facilities pages

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user