### PR TITLE
VA-16652: separate phone extension for mental health numbers

### DIFF
--- a/src/site/components/phone-number.drupal.liquid
+++ b/src/site/components/phone-number.drupal.liquid
@@ -1,8 +1,19 @@
-<h{{ phoneHeaderLevel }}>{{ phoneLabel | default: 'Phone' }}</h{{ phoneHeaderLevel }}>
-<div>
-  <va-telephone
-    contact="{{ phoneNumber | removeDashes }}"
-    extension="{{ phoneExtension | default: '' }}"
-    message-aria-describedby="{{ phoneLabel | default: 'Phone' }}"
-  />
-</div>
+{% if phoneNumber %}
+  {% if phoneExtension %}
+    {% assign partialPhoneNumber = phoneNumber %}
+    {% assign partialPhoneExtension = phoneExtension %}
+  {% else %}
+    {% assign separatedPhoneNumber = phoneNumber | separatePhoneNumberExtension %}
+    {% assign partialPhoneNumber = separatedPhoneNumber.phoneNumber %}
+    {% assign partialPhoneExtension = separatedPhoneNumber.extension %}
+  {% endif %}
+
+  <h{{ phoneHeaderLevel }}>{{ phoneLabel | default: 'Phone' }}</h{{ phoneHeaderLevel }}>
+  <div>
+    <va-telephone
+      contact="{{ partialPhoneNumber | removeDashes }}"
+      extension="{{ partialPhoneExtension | default: '' }}"
+      message-aria-describedby="{{ phoneLabel | default: 'Phone' }}"
+    />
+  </div>
+{% endif %}

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -289,6 +289,26 @@ module.exports = function registerFilters() {
     return data;
   };
 
+  liquid.filters.separatePhoneNumberExtension = phoneNumber => {
+    if (!phoneNumber) {
+      return null;
+    }
+
+    if (!phoneNumber.includes(', ext. ')) {
+      return {
+        phoneNumber,
+        extension: null,
+      };
+    }
+
+    const splitNumber = phoneNumber.split(', ext. ');
+
+    return {
+      phoneNumber: splitNumber[0],
+      extension: splitNumber[1],
+    };
+  };
+
   liquid.filters.trackLinks = (html, eventDataString) => {
     // Add calls to "recordEvent" to all links found in html
     const eventData = JSON.parse(eventDataString);
@@ -867,7 +887,7 @@ module.exports = function registerFilters() {
 
   /**
     * Converts a string to camel case and removes a prefix
-    @param {string} prefix - prefix to be removed - make empty string not to change string 
+    @param {string} prefix - prefix to be removed - make empty string not to change string
     @param {string} string - string to be converted
   */
   liquid.filters.trimAndCamelCase = (toRemove, string) => {

--- a/src/site/includes/vba_facilities/service_location.liquid
+++ b/src/site/includes/vba_facilities/service_location.liquid
@@ -25,7 +25,12 @@
         Main Phone
       </h5>
 
-      <va-telephone contact="{{ facilityPhone }}" message-aria-describedby="Main Phone" />
+      {% assign serviceLocationMainPhone = facilityPhone | separatePhoneNumberExtension %}
+      <va-telephone
+        contact="{{ serviceLocationMainPhone.phoneNumber }}"
+        extension="{{ serviceLocationMainPhone.extension }}"
+        message-aria-describedby="Main Phone"
+      />
     </div>
   {% elsif location.entity.fieldPhone %}
     {% for phoneObj in location.entity.fieldPhone %}

--- a/src/site/layouts/vba_facility.drupal.liquid
+++ b/src/site/layouts/vba_facility.drupal.liquid
@@ -114,7 +114,13 @@
                         <div class="vads-u-margin-bottom--1">
                           <p class="vads-u-margin-top--0">
                             <strong>Main phone:</strong>
-                            <va-telephone contact="{{fieldPhoneNumber}}" />
+
+                            {% assign vbaFacilityMainPhone = fieldPhoneNumber | separatePhoneNumberExtension %}
+                            <va-telephone
+                              contact="{{ vbaFacilityMainPhone.phoneNumber }}"
+                              extension="{{ vbaFacilityMainPhone.extension }}"
+                              message-aria-describedby="Main Phone"
+                            />
                           </p>
                         </div>
                       {% endif %}
@@ -249,7 +255,7 @@
                     fieldTwitter = fieldUpdatesVba.links.twitter
                     fieldInstagram = fieldUpdatesVba.links.instagram
                     fieldFlickr = fieldUpdatesVba.links.flickr
-                    
+
             %}
           {% endif %}
           <h2 class="vads-u-line-height--1 vads-u-margin-bottom--3">


### PR DESCRIPTION
## Summary

[A pull request for using VBA facility mental health numbers in the mental health service accordions](https://github.com/department-of-veterans-affairs/content-build/pull/1907) was recently merged. However, the phone number component needs to have the phone number's extension separated from the number for it to display correctly.

## Related issue(s)

- _Link to ticket created in va.gov-cms repo_
    https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16652

## Testing done

Locally, on tugboat build.

See the services at the [Hot Springs VA Medical Center](https://web-txcrk8bym4a0ivw3xfr8xvdhezmls36f.demo.cms.va.gov/black-hills-health-care/locations/hot-springs-va-medical-center/#health-care-offered-here) (no mental health phone number extension) and the [Fayetteville VA Medical Center](https://web-txcrk8bym4a0ivw3xfr8xvdhezmls36f.demo.cms.va.gov/fayetteville-arkansas-health-care/locations/fayetteville-va-medical-center/) (has mental health phone number extension)

## Screenshots

Data from the filter that confirms the extension is separated from the phone number as expected:

<img width="288" alt="Screen Shot 2024-02-27 at 12 25 31 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10790736/1a73a20b-a7e6-4adf-86a4-1bf0a6ce2ba9">

The mental health phone number showing properly in the accordion.

<img width="697" alt="Screen Shot 2024-02-27 at 12 25 48 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10790736/a7b9b143-569d-4763-8812-25b9a92faaa9">

## What areas of the site does it impact?

VBA Regional Facility pages, specifically only the main numbers for each service.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
