### PR TITLE
VACMS-17252 Discharge Upgrade Wizard breadcrumbs update

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -446,8 +446,7 @@
       "keywords": "upgrade discharge, military discharge upgrade, discharge upgrade",
       "order": 6,
       "spoke": "Get records",
-      "collection": "records",
-      "includeBreadcrumbs": true
+      "collection": "records"
     }
   },
   {


### PR DESCRIPTION
## Summary
Remove breadcrumbs prop from Discharge Upgrade Wizard application registry so we can use the web component for breadcrumbs in vets-website.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17252

## Testing done
Testing done locally from vets-website.

## Screenshots
<img width="446" alt="Screenshot 2024-03-05 at 10 40 25 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/5ec7128f-91db-43cb-a5d6-72de9c252021">
<img width="594" alt="Screenshot 2024-03-05 at 10 40 31 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/91267558-8ea5-44f8-9013-08bb732b3cf8">