### PR TITLE
Lovell TRICARE pages now present MHS site when cerner/cerner_staged

### DIFF
--- a/src/site/facilities/facilities_health_services_buttons.drupal.liquid
+++ b/src/site/facilities/facilities_health_services_buttons.drupal.liquid
@@ -3,7 +3,13 @@
 {% endcomment %}
 <div data-template="facilities/facilities_health_services_buttons">
     <div>
-        <a class="vads-c-action-link--blue" href="/{{ path }}/make-an-appointment">Make an appointment</a>
+        {% if fieldAdministration.entity.entityId == '1039' %}
+            {% assign ehrSystem = fieldVamcEhrSystem | findEhr: fieldRegionPage, fieldOffice %}
+            {% assign topTaskLovell = ehrSystem | topTaskLovell: path, "make-an-appointment", buildtype %}
+            <a class="vads-c-action-link--blue" href="{{topTaskLovell.url}}">{{topTaskLovell.text}}</a>
+        {% else %}
+            <a class="vads-c-action-link--blue" href="/{{ path }}/make-an-appointment">Make an appointment</a>
+        {% endif %}
     </div>
     <div class="vads-u-margin-y--2">
         <a class="vads-c-action-link--blue" href="/{{ path }}/register-for-care">Register for care</a>

--- a/src/site/facilities/facilities_health_services_buttons.drupal.liquid
+++ b/src/site/facilities/facilities_health_services_buttons.drupal.liquid
@@ -3,13 +3,8 @@
 {% endcomment %}
 <div data-template="facilities/facilities_health_services_buttons">
     <div>
-        {% if fieldAdministration.entity.entityId == '1039' %}
-            {% assign ehrSystem = fieldVamcEhrSystem | findEhr: fieldRegionPage, fieldOffice %}
-            {% assign topTaskLovell = ehrSystem | topTaskLovell: path, "make-an-appointment", buildtype %}
-            <a class="vads-c-action-link--blue" href="{{topTaskLovell.url}}">{{topTaskLovell.text}}</a>
-        {% else %}
-            <a class="vads-c-action-link--blue" href="/{{ path }}/make-an-appointment">Make an appointment</a>
-        {% endif %}
+        {% assign topTask = "make-an-appointment" | topTaskLovellComp: path, buildtype, fieldAdministration, fieldVamcEhrSystem, fieldRegionPage, fieldOffice %}
+        <a class="vads-c-action-link--blue" href="{{topTask.url}}">{{topTask.text}}</a>
     </div>
     <div class="vads-u-margin-y--2">
         <a class="vads-c-action-link--blue" href="/{{ path }}/register-for-care">Register for care</a>

--- a/src/site/facilities/main_buttons.drupal.liquid
+++ b/src/site/facilities/main_buttons.drupal.liquid
@@ -3,31 +3,29 @@
     Also used for VBA with parameter
 {% endcomment %}
 <div data-template="facilities/main_buttons">
-    {% if buttonType == 'vba'  %}
-        <div>
+    <div>
+        {% assign ehrSystem = fieldVamcEhrSystem | findEhr: fieldRegionPage, fieldOffice %}
+        {% if buttonType == 'vba' %}
             <a class="vads-c-action-link--blue" href="https://va.my.site.com/VAVERA/s/">Make an appointment</a>
-        </div>
-    {% else %}
-        <div>
+        {% elsif fieldAdministration.entity.entityId == '1039' %}
+            {% assign topTaskLovell = ehrSystem | topTaskLovell: path, "make-an-appointment", buildtype %}
+            <a class="vads-c-action-link--blue" href="{{topTaskLovell.url}}">{{topTaskLovell.text}}</a>
+        {% else %}
             <a class="vads-c-action-link--blue" href="/{{ path }}/make-an-appointment">Make an appointment</a>
-        </div>
-    {% endif %}
-    {% if buttonType == 'vba'  %}
-        <div class="vads-u-margin-y--2">
+        {% endif %}
+    </div>
+    <div class="vads-u-margin-y--2">
+        {% if buttonType == 'vba'  %}
             <a class="vads-c-action-link--blue" href="https://ask.va.gov">Ask a benefit question</a>
-        </div>
-    {% else %}
-        <div class="vads-u-margin-y--2">
+        {% else %}
             <a class="vads-c-action-link--blue" href="/{{ path }}/health-services">View all health services</a>
-        </div>
-    {% endif %}
-    {% if buttonType == 'vba' %}
-        <div>
+        {% endif %}
+    </div>
+    <div>
+        {% if buttonType == 'vba' %}
             <a class="vads-c-action-link--blue" href="/claim-or-appeal-status">Check a claim status</a>
-        </div>
-    {% else %}
-        <div>
+        {% else %}
             <a class="vads-c-action-link--blue" href="/{{ path }}/register-for-care">Register for care</a>
-        </div>
-    {% endif %}
+        {% endif %}
+    </div>
 </div>

--- a/src/site/facilities/main_buttons.drupal.liquid
+++ b/src/site/facilities/main_buttons.drupal.liquid
@@ -4,14 +4,11 @@
 {% endcomment %}
 <div data-template="facilities/main_buttons">
     <div>
-        {% assign ehrSystem = fieldVamcEhrSystem | findEhr: fieldRegionPage, fieldOffice %}
         {% if buttonType == 'vba' %}
             <a class="vads-c-action-link--blue" href="https://va.my.site.com/VAVERA/s/">Make an appointment</a>
-        {% elsif fieldAdministration.entity.entityId == '1039' %}
-            {% assign topTaskLovell = ehrSystem | topTaskLovell: path, "make-an-appointment", buildtype %}
-            <a class="vads-c-action-link--blue" href="{{topTaskLovell.url}}">{{topTaskLovell.text}}</a>
         {% else %}
-            <a class="vads-c-action-link--blue" href="/{{ path }}/make-an-appointment">Make an appointment</a>
+            {% assign topTask = "make-an-appointment" | topTaskLovellComp: path, buildtype, fieldAdministration, fieldVamcEhrSystem, fieldRegionPage, fieldOffice %}
+            <a class="vads-c-action-link--blue" href="{{topTask.url}}">{{topTask.text}}</a>
         {% endif %}
     </div>
     <div class="vads-u-margin-y--2">

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1663,30 +1663,41 @@ module.exports = function registerFilters() {
     };
   };
 
-  liquid.filters.findEhr = (value, fieldRegionPage, fieldOffice) => {
-    return (
-      value ||
+  liquid.filters.topTaskLovellComp = (
+    linkType,
+    basePath,
+    buildtype,
+    fieldAdministration,
+    fieldVamcEhrSystem,
+    fieldRegionPage,
+    fieldOffice,
+  ) => {
+    const isNotProd = buildtype !== 'vagovprod';
+    const flag =
+      fieldVamcEhrSystem ||
       fieldOffice?.entity?.fieldVamcEhrSystem ||
       fieldRegionPage?.entity?.fieldVamcEhrSystem ||
-      ''
-    );
-  };
+      '';
+    const isPageLovell = fieldAdministration?.entity.entityId === '1039';
 
-  liquid.filters.topTaskLovell = (flag, basePath, linkType, buildtype) => {
-    const isNotProd = buildtype !== 'vagovprod';
     if (flag === 'cerner' || (flag === 'cerner_staged' && isNotProd)) {
-      if (linkType === 'make-an-appointment')
+      if (linkType === 'make-an-appointment' && isPageLovell) {
         return {
           text: 'MHS Genesis Patient Portal',
           url: 'https://my.mhsgenesis.health.mil/',
         };
+      }
     } else if (linkType === 'make-an-appointment') {
       return {
         text: 'Make an appointment',
         url: `/${basePath}/make-an-appointment`,
       };
     }
-    return {};
+    // fallback
+    return {
+      text: 'Make an appointment',
+      url: `/${basePath}/make-an-appointment`,
+    };
   };
 
   liquid.filters.topTaskUrl = (flag, path, buildtype) => {

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1688,12 +1688,14 @@ module.exports = function registerFilters() {
         };
       }
     } else if (linkType === 'make-an-appointment') {
+      // If we remove this eslint complains of the nested if, so
+      // keeping this as a placeholder for future other linktypes for the MHS Genesis site (e.g. Pharmacy)
       return {
         text: 'Make an appointment',
         url: `/${basePath}/make-an-appointment`,
       };
     }
-    // fallback
+    // fallback as default
     return {
       text: 'Make an appointment',
       url: `/${basePath}/make-an-appointment`,

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1663,6 +1663,32 @@ module.exports = function registerFilters() {
     };
   };
 
+  liquid.filters.findEhr = (value, fieldRegionPage, fieldOffice) => {
+    return (
+      value ||
+      fieldOffice?.entity?.fieldVamcEhrSystem ||
+      fieldRegionPage?.entity?.fieldVamcEhrSystem ||
+      ''
+    );
+  };
+
+  liquid.filters.topTaskLovell = (flag, basePath, linkType, buildtype) => {
+    const isNotProd = buildtype !== 'vagovprod';
+    if (flag === 'cerner' || (flag === 'cerner_staged' && isNotProd)) {
+      if (linkType === 'make-an-appointment')
+        return {
+          text: 'MHS Genesis Patient Portal',
+          url: 'https://my.mhsgenesis.health.mil/',
+        };
+    } else if (linkType === 'make-an-appointment') {
+      return {
+        text: 'Make an appointment',
+        url: `/${basePath}/make-an-appointment`,
+      };
+    }
+    return {};
+  };
+
   liquid.filters.topTaskUrl = (flag, path, buildtype) => {
     const isNotProd = buildtype !== 'vagovprod';
 

--- a/src/site/stages/build/drupal/graphql/bannerAlerts.graphql.js
+++ b/src/site/stages/build/drupal/graphql/bannerAlerts.graphql.js
@@ -40,6 +40,7 @@ const bannerAlerts = `
               fieldOffice {
                 entity {
                   ... on NodeHealthCareRegionPage {
+                    fieldVamcEhrSystem
                     title
                     entityUrl {
                       path

--- a/src/site/stages/build/drupal/graphql/bioPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/bioPage.graphql.js
@@ -21,6 +21,7 @@ const personProfileFragment = `
           entityLabel
           entityType
           ...on NodeHealthCareRegionPage {
+            fieldVamcEhrSystem
             ${entityElementsFromPages}
             title
           }

--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareLocalFacility.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareLocalFacility.node.graphql.js
@@ -10,7 +10,6 @@ const FACILITIES_RESULTS = `
         path
       }
     }
-      entityBundle
       title
       entityId
       entityBundle

--- a/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
@@ -83,6 +83,7 @@ const healthCareLocalFacilityPageFragment = `
     fieldRegionPage {
       entity {
         ... on NodeHealthCareRegionPage {
+          fieldVamcEhrSystem
           entityBundle
           entityId
           entityPublished

--- a/src/site/stages/build/drupal/graphql/healthCareRegionDetailPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionDetailPage.graphql.js
@@ -69,6 +69,7 @@ const healthCareRegionDetailPage = `
     fieldOffice {
       entity {
         ...on NodeHealthCareRegionPage {
+          fieldVamcEhrSystem
           entityLabel
           title
         }

--- a/src/site/stages/build/drupal/graphql/healthServicesListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthServicesListingPage.graphql.js
@@ -103,8 +103,10 @@ const healthServicesListingPage = `
       targetId
       entity {
         ... on NodeHealthCareRegionPage {
+          entityId
           entityLabel
           title
+          fieldVamcEhrSystem
         }
       }
     }

--- a/src/site/stages/build/drupal/graphql/leadershipListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/leadershipListingPage.graphql.js
@@ -108,8 +108,10 @@ const leadershipListingPage = `
       targetId
       entity {
         ... on NodeHealthCareRegionPage {
+          entityId
           entityLabel
           title
+          fieldVamcEhrSystem
         }
       }
     }

--- a/src/site/stages/build/drupal/graphql/locationsListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/locationsListingPage.graphql.js
@@ -43,6 +43,7 @@ const locationListingPage = `
               }
             }
           }
+          fieldVamcEhrSystem
           fieldVaHealthConnectPhone
           ${healthCareLocalFacilities}
           fieldOtherVaLocations

--- a/src/site/stages/build/drupal/graphql/pressReleasesListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/pressReleasesListingPage.graphql.js
@@ -38,8 +38,10 @@ const pressReleasesListingPage = `
       targetId
       entity {
         ... on NodeHealthCareRegionPage {
+          entityId
           entityLabel
           title
+          fieldVamcEhrSystem
         }
       }
     }

--- a/src/site/stages/build/drupal/graphql/storyListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/storyListingPage.graphql.js
@@ -64,8 +64,10 @@ const storyListingPage = `
       entity {
         title
         ... on NodeHealthCareRegionPage {
+          entityId
           entityLabel
           title
+          fieldVamcEhrSystem
         }
       }
     }

--- a/src/site/stages/build/drupal/graphql/vaPolice.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vaPolice.graphql.js
@@ -10,8 +10,10 @@ const vaPoliceFragment = `
           fieldOffice {
             entity {
               ... on NodeHealthCareRegionPage {
+                entityId
                 entityLabel
                 title
+                fieldVamcEhrSystem
               }
             }
           }

--- a/src/site/stages/build/drupal/graphql/vamcPoliciesPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vamcPoliciesPage.graphql.js
@@ -32,6 +32,7 @@ const policiesPageFragment = `
     fieldOffice {
       entity {
         ...on NodeHealthCareRegionPage {
+          fieldVamcEhrSystem
           entityLabel
           title
         }

--- a/src/site/stages/build/drupal/static-data-files/vamcEhrSystem/index.js
+++ b/src/site/stages/build/drupal/static-data-files/vamcEhrSystem/index.js
@@ -17,6 +17,7 @@ const query = `
           fieldFacilityLocatorApiId,
           fieldRegionPage {
             entity {
+              entityId,
               title,
               ... on NodeHealthCareRegionPage {
                 fieldVamcEhrSystem


### PR DESCRIPTION
## Summary

- Pages with fieldAdministration of Lovell TRICARE now show MHS Genesis Patient Portal link instead of link to Make an appointment page. Things remain the same for Lovell VA and Lovell Federal pages (Program pages except ones that have Lovell TRICARE as fieldAdministration)
- Sitewide Facilities

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17299
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17416

## Testing done

- Top task link to Make an appointment was visible on all Lovell TRICARE pages
- Checked all pages as Lovell TRICARE user in staging/localhost build and vagovprod build

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |     ![Screenshot 2024-03-05 at 4 14 01 PM](https://github.com/department-of-veterans-affairs/content-build/assets/5606931/9e1e4ed5-b6ca-497f-9337-ae47f7917135)   |     ![Screenshot 2024-03-05 at 4 13 41 PM](https://github.com/department-of-veterans-affairs/content-build/assets/5606931/afe41ec7-cf79-463d-84ec-8f35b730f721)  |
| Desktop |    ![Screenshot 2024-03-05 at 4 14 59 PM](https://github.com/department-of-veterans-affairs/content-build/assets/5606931/7abb3412-5545-4773-9d3c-508f6f074098)    |    ![Screenshot 2024-03-05 at 4 13 31 PM](https://github.com/department-of-veterans-affairs/content-build/assets/5606931/cce7e6ac-31f6-4931-8002-5ae2d2d9dbc3)   |


## What areas of the site does it impact?

Affects all pages where fieldAdministration is Lovell TRICARE entity Id 1039. Changes the top task link from Make an appointment to MHS Genesis Patient Portal

## Acceptance criteria

- [x] On the Lovell Tricare page, the "Make an appointment" top task link on the following pages links to the [MHS GENESIS Patient Portal](https://my.mhsgenesis.health.mil).
  - [x] [TRICARE Main system page](https://www.va.gov/lovell-federal-health-care-tricare/)
  - [x] [Locations page](https://www.va.gov/lovell-federal-health-care-tricare/locations)
  - [x] [Health services page](https://www.va.gov/lovell-federal-health-care-tricare/health-services/)
  - [x] [Contact us page](https://www.va.gov/lovell-federal-health-care-tricare/contact-us/)
  - [-] [Programs](https://www.va.gov/lovell-federal-health-care-tricare/programs/)
- [x] For the Lovell Tricare page, the transitioning to Cerner EHR toggle being present in staging is confirmed.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

View Lovell TRICARE pages at
https://web-5zcelrjqvagaeosvzzyp1izj6ef2njrx.demo.cms.va.gov/lovell-federal-health-care-tricare/
and dependent pages (except Programs - not all are TRICARE, some are Federal)