### PR TITLE
removes-burial-v6

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1312,16 +1312,6 @@
     }
   },
   {
-    "appName": "burial-poc-v6",
-    "entryName": "burial-poc-v6",
-    "rootUrl": "/burial-poc-v6",
-    "productId": "3f7db617-af4b-4d7f-b30f-f288d5756668",
-    "template": {
-      "vagovprod": false,
-      "layout": "page-react.html"
-    }
-  },
-  {
     "appName": "MHV Secure Messaging",
     "entryName": "secure-messaging",
     "rootUrl": "/my-health/secure-messages",


### PR DESCRIPTION
This PR removes ```burials_poc_v6``` from ```/registry.json```. The ask came from this [Zenhub Ticket](https://app.zenhub.com/workspaces/identity-5f5bab705a94c9001ba33734/issues/gh/department-of-veterans-affairs/va.gov-team/77051)
