### PR TITLE
increase timeout for continuous integration workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     name: Build
     runs-on: [self-hosted, asg]
-    timeout-minutes: 60
+    timeout-minutes: 120
 
     defaults:
       run:


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

- Change the timeout length to give development environment long enough to complete the build.