### PR TITLE
Fixes to have VA Make appointment page not able to change to TRICARE

### DIFF
--- a/src/site/includes/lovell-switch-link.drupal.liquid
+++ b/src/site/includes/lovell-switch-link.drupal.liquid
@@ -1,22 +1,28 @@
 {% if entityUrl.switchPath %}
-  {% if entityUrl.switchPath contains "tricare" %}
-    {% assign currentPageVariation = "VA" %}
-    {% assign switchPageVariation = "TRICARE" %}
+    {% if entityUrl.switchPath contains "tricare" %}
+      {% assign currentPageVariation = "VA" %}
+      {% assign switchPageVariation = "TRICARE" %}
+    {% else %}
+      {% assign currentPageVariation = "TRICARE" %}
+      {% assign switchPageVariation = "VA" %}
+    {% endif %}
+  {% if currentPageVariation == "VA" and entityUrl.switchPath contains "make-an-appointment" %}
+    {% comment %} 
+      Cannot negate group of conditions, so negation of conditions handled in else.
+      Could instead do != "VA" and not contains but that would be more complex logic.
+    {% endcomment %}
   {% else %}
-    {% assign currentPageVariation = "TRICARE" %}
-    {% assign switchPageVariation = "VA" %}
+    <va-alert status="warning" class="vads-u-margin-bottom--2" id="va-info-alert" uswds="false">
+      <h2 slot="headline">You are viewing this page as a {{ currentPageVariation }} beneficiary.</h2>
+      <div>
+        <p className="vads-u-margin-y--0">
+          <va-link
+            active
+            href="{{ entityUrl.switchPath }}"
+            text="View this page as a {{ switchPageVariation }} beneficiary"
+          />
+        </p>
+      </div>
+    </va-alert>
   {% endif %}
-
-  <va-alert status="warning" class="vads-u-margin-bottom--2" id="va-info-alert" uswds="false">
-    <h2 slot="headline">You are viewing this page as a {{ currentPageVariation }} beneficiary.</h2>
-    <div>
-      <p className="vads-u-margin-y--0">
-        <va-link
-          active
-          href="{{ entityUrl.switchPath }}"
-          text="View this page as a {{ switchPageVariation }} beneficiary"
-        />
-      </p>
-    </div>
-  </va-alert>
 {% endif %}


### PR DESCRIPTION
## Summary

- Since TRICARE /make-an-appointment page was decided to be excluded in favor of direct links to the TRICARE MHS Genesis page, we should prevent people from accessing the existing page because it is only valid for VA consumers.
- Prevents creation of TRICARE experience switcher on VA make-an-apppointment page
- Sitewide Facilities

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17469

## Testing done

- Checked that switcher is removed only from Lovell VA `/make-an-appointment` page.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |    <img width="390" alt="Screenshot 2024-03-08 at 4 30 10 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/4a0317d8-2f55-4832-8b18-c245e120172e">    |    <img width="389" alt="Screenshot 2024-03-08 at 4 30 32 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/dd876174-3071-42ce-8394-c188d090f5f2">   |
| Desktop |   <img width="1653" alt="Screenshot 2024-03-08 at 4 29 33 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/fab6bfd6-b455-4007-8c55-30a88f812ab6">     |   <img width="1662" alt="Screenshot 2024-03-08 at 4 29 55 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/c738c375-9df3-4fb2-8fd7-fe4d1acc5686">    |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [-] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

View images and see that switcher is removed. Or build locally and navigate to:http://localhost:3002/lovell-federal-health-care-va/make-an-appointment/

Check that switcher still exists at other VA/TRICARE pages:
i.e. `/lovell-federal-health-care-va/register-for-care/`
