### PR TITLE
VACMS-17486 Featured content block link upgrade

### DIFF
--- a/src/site/blocks/promo.drupal.liquid
+++ b/src/site/blocks/promo.drupal.liquid
@@ -37,8 +37,9 @@
     {% assign link = entity.fieldPromoLink.entity.fieldLink %}
     <section class="hub-promo-text">
         <h2 class="vads-u-font-size--h4 vads-u-text-decoration--underline vads-u-margin-top--0">
-          <a onClick="recordEvent({ event: 'nav-hub-promo' });"
-            href="{{ link.url.path }}">{{ link.title }}</a>
+          <va-link disable-analytics onClick="recordEvent({ event: 'nav-hub-promo' });"
+            href="{{ link.url.path }}" text="{{ link.title }}"
+          />
         </h2>
         <p>{{ entity.fieldPromoLink.entity.fieldLinkSummary }}</p>
     </section>


### PR DESCRIPTION
## Summary
In support of the v1 -> v3 component upgrades, upgrade the link in Featured Content promo blocks to use `<va-link>`.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17486

## Testing done
Tested locally at `/service-member-benefits`.

## Screenshots
<img width="417" alt="Screenshot 2024-03-12 at 1 19 54 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/03e80806-8ef5-432e-ae4c-86b1d1728c85">
<img width="272" alt="Screenshot 2024-03-12 at 1 19 50 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/00f0bd50-476c-4e49-b181-a2e0cf843794">