### PR TITLE
fix(): Increase the role-duration-seconds for AWS cred step in deploy

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -648,7 +648,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-gov-west-1
           role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
-          role-duration-seconds: 900
+          role-duration-seconds: 1800
           role-session-name: vsp-frontendteam-githubaction
 
       - name: Deploy


### PR DESCRIPTION
## Overview
Encountered the following error during a run of `continuous-integration` workflow
`An error occurred (ExpiredToken) when calling the PutObject operation: The provided token has expired.`

Adjusting the role session duration to verify if that is the cause for the token expiration mid-deploy

### Notes
- https://dsva.slack.com/archives/CT4GZBM8F/p1710255732049039