### PR TITLE
removing concurrency

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,8 +16,9 @@ env:
   INSTANCE_TYPE: m5.4xlarge
 
 concurrency:
-  group: ${{ github.ref != 'refs/heads/main' && github.ref || github.sha }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  # If this is no a prod push it sets the concurrency group to the workflow name. Otherwise, it sets to the branch name.
+  group: ${{ github.ref != 'refs/heads/main' && github.workflow || github.ref }}
+  cancel-in-progress: false
 
 jobs:
   build:
@@ -42,13 +43,14 @@ jobs:
 
     strategy:
       fail-fast: true
+      max-parallel: 1
       matrix:
         buildtype: [vagovdev, vagovstaging, vagovprod]
         include:
           - buildtype: vagovdev
             drupal-address: https://main-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov
           - buildtype: vagovstaging
-            drupal-address: https://main-bwj6qn18llmdla8pffimuqxckl0nsehj.ci.cms.va.gov
+            drupal-address: https://main-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov
           - buildtype: vagovprod
             drupal-address: https://prod.cms.va.gov
 


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

- We are temporarily removing concurrency from the builds for content-build CI workflow. This is a short-term fix while we work on the longer-term fix. A single PR build and a single prod push will be allowed at one time. 
- This workflow has been overwhelming the content-build prod mirror tugboat, causing 504 and 502 errors. 
- This solution will reduce the load on the tugboat prod mirror while we work on a more permanent fix. 
- CMS Team

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17538

