### PR TITLE
VACMS 17299 Lovell TRICARE MHS Genesis portal link and VA Make an appointment link testing

### DIFF
--- a/src/site/includes/lovell-switch-link.drupal.liquid
+++ b/src/site/includes/lovell-switch-link.drupal.liquid
@@ -17,6 +17,7 @@
       <div>
         <p className="vads-u-margin-y--0">
           <va-link
+            data-testid="lovell-switch-link"
             active
             href="{{ entityUrl.switchPath }}"
             text="View this page as a {{ switchPageVariation }} beneficiary"

--- a/src/site/tests/cypress/vamc-lovell.cypress.spec.js
+++ b/src/site/tests/cypress/vamc-lovell.cypress.spec.js
@@ -1,0 +1,96 @@
+import { expect } from 'chai';
+
+describe('VAMC Lovell - All TRICARE pages with expected MHS Genesis Patient Portal Top Task have it', () => {
+  it('TRICARE system has MHS Genesis Patient Portal link', () => {
+    cy.visit('/lovell-federal-health-care-tricare/');
+    cy.injectAxeThenAxeCheck();
+    cy.findByText('MHS Genesis Patient Portal').then(el => {
+      const attr = el.attr('href');
+      expect(attr).to.equal('https://my.mhsgenesis.health.mil/');
+    });
+    // https://www.va.gov/lovell-federal-health-care-tricare/
+  });
+
+  it('TRICARE Health services has MHS Genesis Patient Portal link', () => {
+    cy.visit('/lovell-federal-health-care-tricare/health-services');
+    cy.injectAxeThenAxeCheck();
+    cy.findByText('MHS Genesis Patient Portal').then(el => {
+      const attr = el.attr('href');
+      expect(attr).to.equal('https://my.mhsgenesis.health.mil/');
+    });
+    // https://www.va.gov/lovell-federal-health-care-tricare/health-services/
+  });
+
+  it('TRICARE Locations has MHS Genesis Patient Portal link', () => {
+    cy.visit('/lovell-federal-health-care-tricare/locations');
+    cy.injectAxeThenAxeCheck();
+    cy.findByText('MHS Genesis Patient Portal').then(el => {
+      const attr = el.attr('href');
+      expect(attr).to.equal('https://my.mhsgenesis.health.mil/');
+    });
+    // https://www.va.gov/lovell-federal-health-care-tricare/locations/
+  });
+
+  it('TRICARE Captain James A. Lovell Location has MHS Genesis Patient Portal link', () => {
+    cy.visit(
+      '/lovell-federal-health-care-tricare/locations/captain-james-a-lovell-federal-health-care-center/',
+    );
+    cy.injectAxeThenAxeCheck();
+    cy.findByText('MHS Genesis Patient Portal').then(el => {
+      const attr = el.attr('href');
+      expect(attr).to.equal('https://my.mhsgenesis.health.mil/');
+    });
+    // https://www.va.gov/lovell-federal-health-care-tricare/locations/captain-james-a-lovell-federal-health-care-center/
+  });
+});
+
+describe('VAMC Lovell - All VA pages with expected Make an appointment Top Task have it', () => {
+  it('VA system has Make an appointment link', () => {
+    cy.visit('/lovell-federal-health-care-va/');
+    cy.injectAxeThenAxeCheck();
+    cy.findByText('Make an appointment').then(el => {
+      const attr = el.attr('href');
+      expect(attr.endsWith('make-an-appointment')).to.be.true;
+    });
+    // https://www.va.gov/lovell-federal-health-care-va/
+  });
+
+  it('VA Health services has Make an appointment link', () => {
+    cy.visit('/lovell-federal-health-care-va/health-services/');
+    cy.injectAxeThenAxeCheck();
+    cy.findByText('Make an appointment').then(el => {
+      const attr = el.attr('href');
+      expect(attr.endsWith('make-an-appointment')).to.be.true;
+    });
+    // https://www.va.gov/lovell-federal-health-care-va/health-services/
+  });
+
+  it('VA Locations has Make an appointment link', () => {
+    cy.visit('/lovell-federal-health-care-va/locations/');
+    cy.injectAxeThenAxeCheck();
+    cy.findByText('Make an appointment').then(el => {
+      const attr = el.attr('href');
+      expect(attr.endsWith('make-an-appointment')).to.be.true;
+    });
+    // https://www.va.gov/lovell-federal-health-care-va/locations/
+  });
+  it('VA Captain James A. Lovell Location has Make an appointment link', () => {
+    cy.visit(
+      '/lovell-federal-health-care-va/locations/captain-james-a-lovell-federal-health-care-center/',
+    );
+    cy.injectAxeThenAxeCheck();
+    cy.findByText('Make an appointment').then(el => {
+      const attr = el.attr('href');
+      expect(attr.endsWith('make-an-appointment')).to.be.true;
+    });
+    // https://www.va.gov/lovell-federal-health-care-va/locations/captain-james-a-lovell-federal-health-care-center/
+  });
+});
+
+describe('VAMC Lovell - VA Make an appointment page does not have TRICARE experience switcher', () => {
+  it('VA Make an appointment page does not have TRICARE experience switcher', () => {
+    cy.visit('/lovell-federal-health-care-va/make-an-appointment/');
+    cy.injectAxeThenAxeCheck();
+    cy.findByTestId('lovell-switch-link').should('not.exist');
+  });
+});


### PR DESCRIPTION

## Summary

- Adds testing now that EHR system is cerner on all platforms. Tests that MHS Genesis link is present on all necessary pages and Make an appointment link on VA pages. Tests that a user shouldn't be able to travel from VA Make an appointment page to TRICARE counterpart.
- Sitewide Facilities

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17107

## Testing done

- Added cypress E2E testing for Lovell pages/links on TRICARE and VA

## Screenshots

No visual changes. Just testing.

## What areas of the site does it impact?

Does not impact the site.

## Acceptance criteria

- [x] Testing for Lovell TRICARE MHS Genesis links working for all Lovell TRICARE pages.
- [x] Testing for absence of Experience switcher on Lovell VA Make an appointment page

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (N/A)
- [x] Screenshot of the developed feature is added (N/A)
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed (N/A)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A)

## Requested Feedback

Check that tests pass in CI