### PR TITLE
VA-15567: Remove Top Task Links for Programs pages

### DIFF
--- a/src/site/facilities/health_care_region_detail_content.drupal.liquid
+++ b/src/site/facilities/health_care_region_detail_content.drupal.liquid
@@ -9,8 +9,7 @@
   </div>
 
   {% assign isContactPage = entityUrl.path | isPage: "contact-us" %}
-  {% assign isProgramsChildPage = entityUrl | isChildPageOf: "Programs" %}
-  {% if isContactPage || isProgramsChildPage %}
+  {% if isContactPage %}
     <div class="usa-grid usa-grid-full vads-u-margin-y--1p5">{% assign basePath = entityUrl.path | regionBasePath %}
       {% include "src/site/facilities/main_buttons.drupal.liquid" with path = basePath %}</div>
   {% endif %}


### PR DESCRIPTION
## Summary

This removes top task links from the Programs pages.

Facilities team.

## Related issue(s)

- _Link to ticket created in va.gov-cms repo_
department-of-veterans-affairs/va.gov-cms#15567

## Testing done

Locally, visual testing.

- https://web-txcrk8bym4a0ivw3xfr8xvdhezmls36f.demo.cms.va.gov/chicago-health-care/programs/covid-19-vaccines/jesse-brown-va-post-acute-sequelae-of-covid-19-long-covid-program/
- https://web-txcrk8bym4a0ivw3xfr8xvdhezmls36f.demo.cms.va.gov/lovell-federal-health-care-tricare/programs/immunizations/

## Screenshots

<img width="1031" alt="Screen Shot 2024-03-22 at 10 34 02 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10790736/9c4c0302-c569-4bb3-ac8e-e2caf36cea2c">
<img width="1052" alt="Screen Shot 2024-03-22 at 10 33 43 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10790736/537cd687-63a1-4338-992e-c677af8780f1">

## What areas of the site does it impact?

All Programs pages, including Lovell.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
