### PR TITLE
VACMS-17187 Benefits Detail pages web component upgrades

### DIFF
--- a/src/site/layouts/page.drupal.liquid
+++ b/src/site/layouts/page.drupal.liquid
@@ -40,13 +40,16 @@
 
           {% assign featureCount = fieldFeaturedContent | size  %}
           {% if featureCount > 0 %}
-            <div class="feature">
+            <va-summary-box>
               {% for block in fieldFeaturedContent %}
                 {% assign bundleComponent = "src/site/paragraphs/" | append: block.entity.entityBundle %}
                 {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
-                {% include {{ bundleComponentWithExtension }} with entity = block.entity %}
+                {% include {{ bundleComponentWithExtension }} with
+                  entity = block.entity
+                  inSummaryBox = true
+                %}
               {% endfor %}
-            </div>
+            </va-summary-box>
           {% endif %}
 
           {% for block in fieldContentBlock %}

--- a/src/site/paragraphs/q_a.drupal.liquid
+++ b/src/site/paragraphs/q_a.drupal.liquid
@@ -1,7 +1,11 @@
 <div data-template="paragraphs/q_a" data-entity-id="{{ entity.entityId }}" data-analytics-faq-section="{{ sectionHeader | escape }}" data-analytics-faq-text="{{ entity.fieldQuestion | escape }}">
   <div id="{{ entity.entityId }}">
     <div class="vads-u-display--flex">
-      <h2>
+      {% if inSummaryBox %}
+        <h2 class="vads-u-margin-top--0">
+      {% else %}
+        <h2>
+      {% endif %}
         {{ entity.fieldQuestion }}
       </h2>
     </div>


### PR DESCRIPTION
## Summary
Convert summary box in Benefit Detail pages to the web component.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17187

## Testing done
Tested `/health-care/about-va-health-benefits/` locally.

## Screenshots
<img width="500" alt="Screenshot 2024-03-19 at 11 04 27 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/55f98b58-d19d-44a5-8e6d-25754f1ffe64">

## Acceptance criteria
- [x] Featured content section is now using V3 Summary box component
- [x] other features display correctly
- [x] verify/review the E2E tests
- [x] check desktop and mobile
- [ ] a11y review