### PR TITLE
adding parallel builds back in

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -43,7 +43,6 @@ jobs:
 
     strategy:
       fail-fast: true
-      max-parallel: 1
       matrix:
         buildtype: [vagovdev, vagovstaging, vagovprod]
         include:


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

- Adding parallel builds back into the CI workflow
- CMS Team

## Related issue(s)

