### PR TITLE
removed mhv-inherited-proofing from registry

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1226,16 +1226,6 @@
     }
   },
   {
-    "appName": "Transfer Account",
-    "entryName": "mhv-inherited-proofing",
-    "rootUrl": "/transfer-account",
-    "template": {
-      "vagovprod": false,
-      "title": "Transfer Account",
-      "layout": "page-react.html"
-    }
-  },
-  {
     "appName": "Combined Debt Portal",
     "entryName": "combined-debt-portal",
     "rootUrl": "/manage-va-debt/summary",


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

- Removing app `mhv-inherited-proofing` form registry.json

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17580
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/74148

## Testing done

