### PR TITLE
74399 Delete /representatives app in registry

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1747,16 +1747,6 @@
   },
   {
     "appName": "Accredited Representative Portal",
-    "entryName": "representatives",
-    "rootUrl": "/representatives",
-    "productId": "89100c00-5b5f-46fd-bd98-d3b35f220958",
-    "template": {
-      "vagovprod": false,
-      "layout": "page-react.html"
-    }
-  },
-  {
-    "appName": "Accredited Representative Portal",
     "entryName": "representative",
     "rootUrl": "/representative",
     "productId": "89100c00-5b5f-46fd-bd98-d3b35f220958",


### PR DESCRIPTION
## Summary

- Purpose
  - There are a number of places we are using `reps` or `representatives` across the code bases
  - As a team we decided the subdomain should be representative.va.gov and as such uses of `reps` or `representatives` (plural) should be renamed to `rep` or `representative` (singular)
  - In addition, the portal within this subdomain now has a name - Accredited Representative Portal. As such, there are cases where `representatives` should actually be changed to `accredited-representative-portal` 
- This is step 5 of a platform recommended way to update an entryFile/entryName of an application ([source](https://dsva.slack.com/archives/C04868KS69L/p1710526246855809?thread_ts=1710526225.599819&cid=C04868KS69L)):
    1.  Keep the existing application in vets-website the way it is (so that content-build will continue working) - [PR](https://github.com/department-of-veterans-affairs/vets-website/pull/28477)
    2. Create a copy of the application with the desired entryName in the manifest and a new rootUrl (this is temporary) and get that merged - [PR](https://github.com/department-of-veterans-affairs/vets-website/pull/28672)
    3. In content-build, add a new entry to registry.json for the app copy
    4. Once you have confirmed that this is all working in prod / staging, you can update the entries in content-build to swap the urls (so new entry in content-build has the permanent URL, old entry has the temporary one) - [PR](https://github.com/department-of-veterans-affairs/content-build/pull/1957/files)
    5. Once the swap has happened and been confirmed to be working, you can remove the old entry from content-build and the old app from vets-website
- The corresponding vets-website application will be removed in a follow-up vets-website PR after this PR is merged - [74399 arf finish rename of app to arp](https://github.com/department-of-veterans-affairs/vets-website/pull/28698). Moving forward the ARF team will use the `accredited-representative-portal` application.
- Team: Benefits Accredited Representative Facing Team

## Related issue

[#74399 Rename to representative / accredited-representative-portal](https://app.zenhub.com/workspaces/accredited-representative-facing-team-65453a97a9cc36069a2ad1d6/issues/gh/department-of-veterans-affairs/va.gov-team/74399)

## Related PRs:
#### content-build
- [74399 rename to arp and representative](https://github.com/department-of-veterans-affairs/content-build/pull/1957)


#### vets-website
- [74399 ARF - Rename to arp and representative](https://github.com/department-of-veterans-affairs/vets-website/pull/28477)
- [74399 ARF - Create app copy named arp](https://github.com/department-of-veterans-affairs/vets-website/pull/28672)
- [74399 arf finish rename of app to arp](https://github.com/department-of-veterans-affairs/vets-website/pull/28698)

#### vagov-content
- [Revert "72956 add accredited representative page (#903)"](https://github.com/department-of-veterans-affairs/vagov-content/pull/915)