### PR TITLE
extended timeout period to 4200 seconds

### DIFF
--- a/.github/workflows/wait-for-cms-ready/action.yml
+++ b/.github/workflows/wait-for-cms-ready/action.yml
@@ -13,7 +13,7 @@ inputs:
   timeout:
     description: How long should we wait for the cms to be ready (in seconds)
     required: false
-    default: '1800'
+    default: '4200'
 
 runs:
   using: composite


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

- We extended the wait timeout period for CMS Ready portion of the CI Workflow to account for `staging.cms.va.gov` to be in the midst of deploying. 
- CMS Team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17610

