### PR TITLE
cypress image moved to private repo

### DIFF
--- a/.github/workflows/ecr-password-update.yml
+++ b/.github/workflows/ecr-password-update.yml
@@ -1,0 +1,30 @@
+name: Update ECR PW
+
+on:
+  schedule:
+    # CodeArtifact token expires in 12 hours, update token every 11 hours
+    - cron: 02 */11 * * *
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  update-ecr-pw:
+    runs-on: ubuntu-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      # need an Github Access token with Admin access to update secret
+      GH_TOKEN: ${{ secrets.GH_CLI }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: us-gov-west-1
+          # should be the arn to your role created for oidc
+          role-to-assume: arn:aws-us-gov:iam::008577686731:role/gha-frontend-prod-role
+      - name: Get pw and update secret
+        run: |
+          export ECR_PW=`aws ecr get-login-password --region us-gov-west-1 --output text`
+          gh secret set AWS_ECR_PW --org department-of-veterans-affairs --visibility all --body "$ECR_PW"

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1747,16 +1747,6 @@
   },
   {
     "appName": "Accredited Representative Portal",
-    "entryName": "representatives",
-    "rootUrl": "/representatives",
-    "productId": "89100c00-5b5f-46fd-bd98-d3b35f220958",
-    "template": {
-      "vagovprod": false,
-      "layout": "page-react.html"
-    }
-  },
-  {
-    "appName": "Accredited Representative Portal",
     "entryName": "representative",
     "rootUrl": "/representative",
     "productId": "89100c00-5b5f-46fd-bd98-d3b35f220958",


### PR DESCRIPTION
…ntative replacement (#1983)

**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

- We were hitting rate limits for the docker image used for cypress testing. We moved the image into the proved ECR repo under `/cypress-io`. This adds a new workflow to update the ECR password. A second PR will implement the change in the CI workflow. 
- CMS Team


## Related issue(s)
https://dsva.slack.com/archives/C04CYC4LMU6/p1711382453727949


