### PR TITLE
Added entry for new URL

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -22,6 +22,32 @@
   {
     "appName": "21-527EZ pension benefits form",
     "entryName": "pensions",
+    "rootUrl": "/pension/apply-for-veteran-pension-form-21p-527ez",
+    "template": {
+      "title": "Apply For Pension Benefits",
+      "heading": "Apply for pension benefits",
+      "display_title": "Apply now",
+      "description": "Submit your VA pension application (VA Form 21P-527EZ) online now. Get step-by-step instructions, and consider signing in to save your in-progress application if you need to come back later to finish filling it out.",
+      "layout": "page-react.html",
+      "spoke": "Get benefits",
+      "collection": "pension",
+      "order": 3,
+      "includeBreadcrumbs": true,
+      "breadcrumbs_override": [
+        {
+          "path": "pension/",
+          "name": "Pension benefits"
+        },
+        {
+          "path": "pension/apply-for-veteran-pension-form-21p-527ez",
+          "name": "Apply for Veterans Pension benefits"
+        }
+      ]
+    }
+  },
+  {
+    "appName": "21-527EZ pension benefits form",
+    "entryName": "pensions",
     "rootUrl": "/pension/application/527EZ",
     "template": {
       "title": "Apply For Pension Benefits",


### PR DESCRIPTION
Pensions team has been asked to change the root url of the site from:
pension/application/527EZ

to:
pension/apply-for-veteran-pension-form-21p-527ez

Testing done
Made the changes, tested locally.