### PR TITLE
VACMS-16578 Add registration required for events

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -277,14 +277,15 @@ module.exports = function registerFilters() {
   liquid.filters.phoneLinks = data => {
     // Change phone to tap to dial.
     const replacePattern = /\(?(\d{3})\)?[- ]?(\d{3}-\d{4})(?!([^<]*>)|(((?!<a).)*<\/a>))/g;
-    if (data) {
-      return data.replace(
-        replacePattern,
-        '<va-telephone target="_blank" href="tel:$1-$2" contact="$1-$2"></va-telephone>',
-      );
+
+    if (!data?.match(replacePattern)) {
+      return data;
     }
 
-    return data;
+    return data.replace(
+      replacePattern,
+      '<va-telephone target="_blank" href="tel:$1-$2" contact="$1-$2"></va-telephone>',
+    );
   };
 
   liquid.filters.separatePhoneNumberExtension = phoneNumber => {

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -1305,9 +1305,16 @@ describe('phoneLinks', () => {
       'Here is a <va-telephone href="test">phone number</va-telephone>: <va-telephone target="_blank" href="tel:123-456-7890" contact="123-456-7890"></va-telephone>. Pretty cool!';
     expect(liquid.filters.phoneLinks(html)).to.equal(html);
   });
+
   it('does not double-wrap phone numbers in va-telephone components', () => {
     const html =
       'Here is a <a href="test">phone number</a>: <va-telephone contact="123-456-7890"></va-telephone>. Pretty cool!';
+    expect(liquid.filters.phoneLinks(html)).to.equal(html);
+  });
+
+  it('properly returns the data when a phone number is not in it', () => {
+    const html =
+      'Here is some completely unrelated stuff <h4> with no phone numbers </h4> and just <p> some basic text</p> blah';
     expect(liquid.filters.phoneLinks(html)).to.equal(html);
   });
 });

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -156,7 +156,7 @@
 
           <!-- Cost -->
           {% if fieldEventCost %}
-            <div class="vads-u-display--flex vads-u-flex-direction--row vads-u-margin-bottom--2">
+            <div class="vads-u-display--flex vads-u-flex-direction--row vads-u-margin-bottom--1">
               <p class="vads-u-margin--0 vads-u-margin-right--0p5">
                 <strong>Cost:</strong>
               </p>
@@ -164,6 +164,28 @@
               <p class="vads-u-margin--0">
                 {{ fieldEventCost }}
               </p>
+            </div>
+          {% endif %}
+
+          <!-- Registration / Apply / RSVP required -->
+          {% if fieldEventRegistrationrequired %}
+            <div class="vads-u-display--flex vads-u-flex-direction--row vads-u-margin-bottom--3">
+              {% if fieldEventCta %}
+                <p class="vads-u-margin--0 vads-u-margin-right--0p5">
+                  {% if fieldEventCta == 'register' %}
+                    <strong>Registration:</strong>
+                  {% elsif fieldEventCta == 'apply' %}
+                    <strong>Application:</strong>
+                  {% elsif fieldEventCta == 'rsvp' %}
+                    <strong>RSVP:</strong>
+                  {% endif %}
+                </p>
+                {% if fieldEventCta != 'more_details' %}
+                  <p class="vads-u-margin--0">
+                    Required
+                  </p>
+                {% endif %}
+              {% endif %}
             </div>
           {% endif %}
 
@@ -184,28 +206,35 @@
                 <p class="vads-u-margin--0">
                   <a class="vads-c-action-link--green" href="{{ fieldLink.url.path }}">
                     {% if fieldEventCta %}
-                      {{ fieldEventCta | removeUnderscores | capitalize }}
+                      {% if fieldEventCta == 'rsvp' %}
+                        RSVP
+                      {% else %}
+                        {{ fieldEventCta | removeUnderscores | capitalize }}
+                      {% endif %}
                     {% else %}
                       More details
                     {% endif %}
                   </a>
                 </p>
               {% endif %}
-
               {% if fieldHowToSignUp == 'email' %}
                 {% assign now = '' | currentTime %}
                 {% assign mostRecentDate = fieldDatetimeRangeTimezone | deriveMostRecentDate: now %}   
                 <p class="vads-u-margin--0">
                   <a class="vads-c-action-link--green" href="mailto:{{ fieldCtaEmail }}?subject=RSVP for {{ title }} on {{ mostRecentDate | deriveFormattedTimestamp }}&body=I would like to register for {{title}} on {{ mostRecentDate | deriveFormattedTimestamp }}. (https://va.gov{{entityUrl.path}}) ">
                     {% if fieldEventCta %}
-                      {{ fieldEventCta | removeUnderscores | capitalize }}
+                      {% if fieldEventCta == 'rsvp' %}
+                        RSVP
+                      {% else %}
+                        {{ fieldEventCta | removeUnderscores | capitalize }}
+                      {% endif %}
                     {% endif %}
                   </a>
                 </p>
               {% endif %}
 
-              {% if fieldAdditionalInformationAbo %}
-                <p class="vads-u-margin--0">{{ fieldAdditionalInformationAbo.processed | phoneLinks }}</p>
+              {% if fieldAdditionalInformationAbo.processed %}
+                {{ fieldAdditionalInformationAbo.processed | phoneLinks }}
               {% endif %}
             {% endif %}
           </div>


### PR DESCRIPTION
## Summary
Use the field `fieldEventRegistrationrequired` coming from Drupal to add appropriate information to event templates:

- If registration is required, it should say `Registration: Required`
- If you must apply, it should say `Application: Required`
- If you need to RSVP, it should say `RSVP: Required`
- If none of these are true ("More details"), there should be no mention of anything required

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16578

## Tugboat to test
https://web-qyrx3kbwmz09ov7ewb8jhxyrcgjfgftb.demo.cms.va.gov/

## Testing done

Tested these URLs:
- `/outreach-and-events/events/66665/` (Apply)
- `/outreach-and-events/events/64652/` (Register)
- `/outreach-and-events/events/66435/` (More details)
- `/outreach-and-events/events/65961/` (RSVP)
- `/poplar-bluff-health-care/events/66486/` (None)
- `/chicago-health-care/events/66229/` (None)
- `/initiatives/sign-in-securely-with-logingov/` (To regression check the changes I had to make for the liquid filter; check last accordion for proper phone number rendering)

## Screenshots

### Desktop
<img width="800" alt="Screenshot 2024-04-02 at 1 38 58 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/8b0a0694-087d-4909-9d40-074b76ea2db1">
<img width="800" alt="Screenshot 2024-04-02 at 1 11 42 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/b9715b38-ac8d-47ad-8abc-8d8a65b013dc">
<img width="800" alt="Screenshot 2024-04-02 at 1 11 32 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/e0c0d4f6-654e-4005-9774-9dcd107a2b25">
<img width="800" alt="Screenshot 2024-04-02 at 1 11 26 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/4b04d1fe-c70d-4c5e-978f-d24ef0331133">


### Mobile


<img width="401" alt="Screenshot 2024-04-02 at 1 38 54 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/5710b9f7-a485-496e-af76-2a1f1954ec35">
<img width="399" alt="Screenshot 2024-04-02 at 1 12 14 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/acd70ce7-28f0-469f-8a58-ca3ef7bbfb20">
<img width="404" alt="Screenshot 2024-04-02 at 1 11 59 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/68c0fa44-d849-4d03-8a70-fc7771e27884">
<img width="403" alt="Screenshot 2024-04-02 at 1 11 52 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/4c43c366-7656-444c-afea-357f6fc4a428">