### PR TITLE
MHV-55413: Removed mhv mr test app config

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1340,17 +1340,6 @@
     }
   },
   {
-    "appName": "MHV Medical Records isolated app test",
-    "entryName": "medical-records-test",
-    "rootUrl": "/my-health/medical-records-test",
-    "productId": "33f531eb-ed52-4e7f-a6ae-f9ff78de939f",
-    "template": {
-      "vagovprod": false,
-      "layout": "page-react.html",
-      "private": true
-    }
-  },
-  {
     "appName": "26-4555 Application in Acquiring Specially Adapted Housing or Special Home Adaptation Grant",
     "entryName": "4555-adapted-housing",
     "rootUrl": "/housing-assistance/disability-housing-grants/apply-for-grant-form-26-4555",


### PR DESCRIPTION
## Summary
I removed the mhv medical records test app config from the registry. 

This config was for a test app that was the same as the app that exists in the vets-website repo at src/applications/mhv/medical-records. It was copied to src/applications/mhv-medical-records to test isolated app deployments. It is no longer needed. 

## Related issue(s)
https://jira.devops.va.gov/browse/MHV-55413
> ### Isolated Apps - MR - Re-point the application to the new location
> Description
> Isolated Apps - MR - Re-point the application to the new location

## Testing done
The new medical records test app was successfully tested on staging and can now be replaced with the real app. 

## Screenshots
No UI changes.

## What areas of the site does it impact?
MHV Medical records new test app

## Acceptance criteria
MHV Medical records new test app has been removed from registry.json now that testing is complete. 

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
