### PR TITLE
VACMS 17511 fix use main facility phone 3rd time is the charm

### DIFF
--- a/src/site/paragraphs/service_location.drupal.liquid
+++ b/src/site/paragraphs/service_location.drupal.liquid
@@ -112,7 +112,8 @@
             phoneHeaderLevel = serviceLocationH
           %}
     </div>
-  {% elsif single.fieldOtherPhoneNumbers.length > 0 %}
+  {% endif %}
+  {% if single.fieldOtherPhoneNumbers.length > 0 %}
     {% comment %} other phone numbers {% endcomment %}
     <div class="vads-u-display--flex vads-u-flex-direction--column" data-template="facilities/health_care_local_health_service" data-testid="service-location-show-other-phone-numbers" >
       {% for number in single.fieldOtherPhoneNumbers %}
@@ -160,7 +161,8 @@
         phoneHeaderLevel = serviceLocationH
       %}
     </div>
-  {% elsif single.fieldPhone.length > 0 %}
+  {% endif %}
+  {% if single.fieldPhone.length > 0 %}
     {% comment %}
       Display each additional contact phone number provided
     {% endcomment %}


### PR DESCRIPTION
THIS IS BRANCHED OFF Service Location Paragraph integration branch so tests will not pass

## Summary

- Makes main number conditional for appointments and contact info in Service Location Paragraphs and always shows optional numbers if they exist for both appointments and contact.
- Sitewide Facilities

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17511

## Testing done

- tested locally and on Service Location integration site

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

<details>
<summary>Billing Service Location (new) with multiple contact numbers and Main Number checked</summary>
<img width="716" alt="Screenshot 2024-04-04 at 3 30 13 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/134605f9-5e9a-40f2-99a6-3df5254382bd">
</details>

<details>
<summary>Clinical Service Location with appointment number and main number Off</summary>

<img width="720" alt="Screenshot 2024-04-04 at 3 32 22 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/6593a8b4-1b9e-46ac-82b4-af8288e22024">

<img width="1145" alt="Screenshot 2024-04-04 at 3 35 36 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/0c56edba-d031-46bd-a07e-631cda3209dd">

</details>

## What areas of the site does it impact?

Updated Service Location Paragraph type only.

## Acceptance criteria

- [ ] Displays main number in appointments when "Use the facility phone number" is On.
- [ ] Displays alternate numbers in appointments when provided
- [ ] Displays main number in contact info when Use the general facility phone number is "Yes, display the general facility phone number"
- [ ] Displays alternate contact numbers

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Check various clinical and non-clinical Service Locations on 
https://web-xptmfsnjoodldn85nzgkrgljqtfbz24b.ci.cms.va.gov/washington-dc-health-care/locations/washington-va-medical-center/
or 
https://web-xptmfsnjoodldn85nzgkrgljqtfbz24b.ci.cms.va.gov/washington-dc-health-care/billing-and-insurance/
or
https://web-xptmfsnjoodldn85nzgkrgljqtfbz24b.ci.cms.va.gov/northeast-ohio-health-care/billing-and-insurance/