### PR TITLE
increase heap for build command

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -18,7 +18,7 @@ env:
   DEPLOY_BUCKET: content.www.va.gov
   DRUPAL_ADDRESS: https://prod.cms.va.gov
   INSTANCE_TYPE: m6i.4xlarge
-  MAXIMUM_HEAP: 6000
+  MAXIMUM_HEAP: 8192
   # secrets.ACTIONS_RUNNER_DEBUG is set to 'true' when re-running a workflow with debug.
   ACTIONS_RUNNER_DEBUG: ${{ secrets.ACTIONS_RUNNER_DEBUG }}
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Content build for vets.gov website static assets.",
   "scripts": {
-    "build": "node --max-old-space-size=6000 --expose-gc script/build-content.js",
+    "build": "node --max-old-space-size=8192 --expose-gc script/build-content.js",
     "build:compare": "node script/content-build-compare.js",
     "build:validate": "node ./script/validate-content-builds.js",
     "build:webpack": "webpack --config config/webpack.config.js",


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

- The `build` command started running out of heap memory. 
- Run `yarn build` with `--max-old-space-size=6000`
- increase heap to `--max-old-space-size=8192`
- CMS Team


## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17760

## Testing done

- Tested locally; increase allowed build to run without errors. 

