### PR TITLE
Add entry for Health Care Application URL update

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -273,6 +273,32 @@
     }
   },
   {
+    "appName": "1010ez Health Care Application form",
+    "entryName": "hca",
+    "rootUrl": "/health-care/apply-for-health-care-form-10-10ez",
+    "template": {
+      "title": "Apply for Health Care",
+      "display_title": "Apply Now",
+      "description": "Apply for VA health care benefits. Find out which documents you’ll need, and start your online application today.",
+      "body_class": "page-healthcare",
+      "layout": "page-react.html",
+      "collection": "healthCare",
+      "spoke": "Get benefits",
+      "order": 4,
+      "includeBreadcrumbs": true,
+      "breadcrumbs_override": [
+        {
+          "path": "health-care/",
+          "name": "Health care"
+        },
+        {
+          "path": "health-care/apply-for-health-care-form-10-10ez",
+          "name": "Apply for VA health care"
+        }
+      ]
+    }
+  },
+  {
     "appName": "10-10EZR Update health benefits info form",
     "entryName": "ezr",
     "rootUrl": "/my-health/update-benefits-information-form-10-10ezr",


### PR DESCRIPTION
## Summary
The Health Enrollment (1010) team has been asked to update the root URL of the Health Care Application to meet [VA.gov URL standards](https://design.va.gov/content-style-guide/url-standards). This PR adds a duplicate entry to the registry with the updated root URL to begin the process of migrating the app to the new URL.

**NOTE:** Once the URL update process is complete, the original entry will be removed.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#31768

## Testing done

- The current URL is `/health-care/apply/application`
- The new URL is `/health-care/apply-for-health-care-form-10-10ez`
- Tested locally to verify the app was successfully rendering with the updated URL (see screenshot)

## Screenshot(s)

With current URL: 

<img width="1904" alt="Screenshot 2024-04-08 at 12 50 11" src="https://github.com/department-of-veterans-affairs/content-build/assets/6738544/cc9cc19e-3c1d-4a5f-87a9-02ec5805216e">

With new URL:

<img width="1904" alt="Screenshot 2024-04-08 at 10 45 59" src="https://github.com/department-of-veterans-affairs/content-build/assets/6738544/912ce03b-0995-4f0b-af89-936284e686a8">

## Acceptance criteria

-  Health care application successfully renders with updated root URL.

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution