### PR TITLE
VACMS-76306 Adjust feedback button positioning on landing pages

### DIFF
--- a/src/site/includes/above-footer-elements.drupal.liquid
+++ b/src/site/includes/above-footer-elements.drupal.liquid
@@ -1,4 +1,23 @@
-<div class="last-updated usa-content vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
+{% comment %}
+  The landing_page.drupal.liquid template has a right column on the desktop layout. The feedback button on desktop is
+  included under the contents on the left column (spanning the normal page content). On mobile, this means the feedback
+  button ends up between the left column content and the right column content because the columns stack.
+
+  In landing_page.drupal.liquid, this template (above-footer-elements) appears twice. The desktop version is at the end of the left column content and
+  the mobile version is at the end of the page content.
+
+  The classes below control visibility of each of the templates in landing_page.drupal.liquid only. This should not affect any other templates where the right column is not present.
+{% endcomment %}
+
+{% assign classes = 'last-updated usa-content vads-u-padding-x--1 large-screen:vads-u-padding-x--0' %}
+
+{% if responsiveLayout == 'desktop' %}
+  {% assign classes = 'last-updated usa-content vads-u-padding-x--1 large-screen:vads-u-padding-x--0 vads-u-display--none medium-screen:vads-u-display--block' %}
+{% elsif responsiveLayout == 'mobile' %}
+  {% assign classes = 'last-updated usa-content vads-u-padding-x--1 large-screen:vads-u-padding-x--0 medium-screen:vads-u-display--none' %}
+{% endif %}
+
+<div class="{{ classes }}">
   <div class="small-screen:vads-u-display--flex above-footer-elements-container">
     <div class="vads-u-flex--auto">
       <span class="vads-u-text-align--justify">

--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -52,8 +52,10 @@
             {% include 'src/site/paragraphs/list_of_link_teasers.drupal.liquid' entity = fieldRelatedLinks.entity boldTitle = true %}
           </section>
         {% endif %}
-    <!-- Last updated & feedback button -->
-          {% include "src/site/includes/above-footer-elements.drupal.liquid" %}
+        <!-- Last updated & feedback button -->
+          {% include "src/site/includes/above-footer-elements.drupal.liquid" with
+            responsiveLayout = 'desktop'
+          %}
       </article>
 
       <div class="usa-width-one-third" id="hub-rail">
@@ -241,6 +243,10 @@
         {% endif %}
       </div>
     </div>
+    <!-- Last updated & feedback button -->
+      {% include "src/site/includes/above-footer-elements.drupal.liquid" with
+        responsiveLayout = 'mobile'
+      %}
   {% include "src/site/includes/veteran-banner.html" %}
   </main>
 </div>


### PR DESCRIPTION
## Summary
Pages that use the `landing_page.drupal.liquid` template have a right sidebar:
<br/><br/>
<img width="1200" alt="Screenshot 2024-04-08 at 10 14 37 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/71e6140d-bff7-4a94-bf40-6ef7c53d4d03">
<br/>
<br/>
The feedback button is at the end of the page content on the left side:
<br/>
<br/>
<img width="1200" alt="Screenshot 2024-04-08 at 10 14 30 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/ee49e07e-9ca4-425b-95d6-95da74f54947">
<br/>
This results in a strange experience on mobile where the feedback button appears between the content for the left side and the right:
<br/>
<img width="533" alt="Screenshot 2024-04-08 at 10 14 47 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/60ed7d4f-41dc-4fb0-966a-2462502ece89">

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/76306

## Testing done
Tested **many** templates (all for regression except `landing_page.drupal.liquid`:

<details>
<summary>Templates</summary>

- (health_care_local_facility) /south-texas-health-care/locations/audie-l-murphy-memorial-veterans-hospital/
- (health_care_region_detail_page) /loma-linda-health-care/work-with-us/internships-and-fellowships/pharmacy-residency/
- (health_care_region_page) /south-texas-health-care/
- (health_services_listing) /south-texas-health-care/health-services/
- (basic_landing_page) /resources
- (campaign_landing_page) /initiatives/vote
- (event_listing) /hampton-health-care/events
- (event) /columbia-south-carolina-health-care/events/66939/
- (faq_multiple_q_a) /resources/claim-status-tool-faqs/
- (home) /
- (landing_page) /service-member-benefits
- (leadership_listing) /southeast-louisiana-health-care/about-us/leadership/
- (locations_listing) /west-palm-beach-health-care/locations/
- (news_story) /west-palm-beach-health-care/stories/the-standard-for-247365-virtual-urgent-care/
- (office) /outreach-and-events/
- (page) /find-forms/
- (page_react) /health-care/income-limits
- (person_profile) /southeast-louisiana-health-care/staff-profiles/mark-morgan/
- (press_release) /kansas-city-health-care/news-releases/pact-act-awareness-event-at-honor-va-clinic-for-all-veterans-on-march-6/
- (press_releases_listing) /kansas-city-health-care/news-releases/
- (publication_listing) /outreach-and-events/outreach-materials/
- (q_a) /resources/what-if-i-dont-have-a-bank-account-but-i-want-to-use-direct-deposit/
- (step_by_step) /resources/how-to-get-community-care-referrals-and-schedule-appointments/
- (story_listing) /alexandria-health-care/stories/
- (support_resources_article_listing) /resources/decision-reviews-and-appeals/
- (support_resources_detail_page) /resources/reimbursed-va-travel-expenses-and-mileage-rate/
- (va_form) /find-forms/about-form-10-6001a/
- (vamc_operating_status_and_alerts) /tuscaloosa-health-care/operating-status/
- (vamc_system_billing_insurance) /loma-linda-health-care/billing-and-insurance
- (vamc_system_medical_records_offi) /west-palm-beach-health-care/medical-records-office
- (vamc_system_policies_page) /puget-sound-health-care/policies
- (vamc_system_register_for_care) /west-palm-beach-health-care/register-for-care
- (vamc_system_va_police) /west-palm-beach-health-care/va-police
- (vba_facility - no Published pages in prod?) /st-petersburg-va-regional-benefit-office/locations/veteran-readiness-and-employment-office-at-malcolm-randall-department-of-veterans-affairs-medical (draft)
- (vet_center) /mesa-vet-center
- (vet_center_locations_list) /fort-myers-vet-center/locations

</details>

## Screenshots

Desktop (`/service-member-benefits`)
<br/>
<img width="1566" alt="Screenshot 2024-04-08 at 12 20 39 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/959848ad-f0f3-466b-9fe0-707de4ca9436">
<br/>
Mobile (`/service-member-benefits`)
<br/>
<img width="551" alt="Screenshot 2024-04-08 at 12 20 30 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/f0dbeb7a-d424-45b4-b112-a0a3aa63b937">



## What areas of the site does it impact?

All Drupal templates