### PR TITLE
[VA-17108] Update Lovell components to V3

### DIFF
--- a/src/site/includes/lovell-switch-link.drupal.liquid
+++ b/src/site/includes/lovell-switch-link.drupal.liquid
@@ -7,15 +7,15 @@
       {% assign switchPageVariation = "VA" %}
     {% endif %}
   {% if currentPageVariation == "VA" and entityUrl.switchPath contains "make-an-appointment" %}
-    {% comment %} 
+    {% comment %}
       Cannot negate group of conditions, so negation of conditions handled in else.
       Could instead do != "VA" and not contains but that would be more complex logic.
     {% endcomment %}
   {% else %}
-    <va-alert status="warning" class="vads-u-margin-bottom--2" id="va-info-alert" uswds="false">
+    <va-alert status="warning" class="vads-u-margin-bottom--2" id="va-info-alert" uswds="true">
       <h2 slot="headline">You are viewing this page as a {{ currentPageVariation }} beneficiary.</h2>
       <div>
-        <p className="vads-u-margin-y--0">
+        <p class="vads-u-margin-y--0">
           <va-link
             data-testid="lovell-switch-link"
             active


### PR DESCRIPTION
## Summary

This updates the alerts on the Lovell pages from v1 to v3.

## Related issue(s)

- _Link to ticket created in va.gov-cms repo_
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17108

## Testing done

Visual, below

## Screenshots

### Before

<img width="984" alt="Screen Shot 2024-04-12 at 7 29 25 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10790736/d5f2d68d-4ae8-41c4-b15f-355ec1249316">

### After

<img width="1000" alt="Screen Shot 2024-04-12 at 7 29 17 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10790736/d24d508d-2fe3-401f-b400-45e3b1bb3b01">

## What areas of the site does it impact?

Lovell

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
