### PR TITLE
Turn feedback button on for check-in applications.

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1164,7 +1164,7 @@
     "template": {
       "vagovprod": true,
       "layout": "page-react.html",
-      "includeFeedbackButton": false,
+      "includeFeedbackButton": true,
       "includeBreadcrumbs": false,
       "noNavOrLogin": true,
       "noMegamenu": true,
@@ -1178,7 +1178,7 @@
     "template": {
       "vagovprod": true,
       "layout": "page-react.html",
-      "includeFeedbackButton": false,
+      "includeFeedbackButton": true,
       "includeBreadcrumbs": false,
       "noNavOrLogin": true,
       "noMegamenu": true,
@@ -1192,7 +1192,7 @@
     "rootUrl": "/my-health/appointment-travel-claim",
     "template": {
       "layout": "page-react.html",
-      "includeFeedbackButton": false,
+      "includeFeedbackButton": true,
       "includeBreadcrumbs": false,
       "noNavOrLogin": true,
       "noMegamenu": true,


### PR DESCRIPTION
## Summary

Turns on the feedback button for the check-in teams applications. This includes pre-check-in, day-of check-in, and travel-claim.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#79934

## Testing done

n/a

## Screenshots

n/a

## What areas of the site does it impact?

pre-check-in, day-of check-in, and travel-claim applications.

## Acceptance criteria

- [ ] The `includeFeedbackButton` config for pre-check-in is `true`
- [ ] The `includeFeedbackButton` config for check-in is `true`
- [ ] The `includeFeedbackButton` config for travel-claim is `true`

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

