### PR TITLE
VACMS-14652 About Form header fix

### DIFF
--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -80,9 +80,13 @@
               {{ fieldVaFormUsage.processed }}
             </div>
           {% endif %}
+
+          <h3 class="vads-u-margin-bottom--2" data-testid="va_form--downloadable-pdf">Downloadable PDF</h3>
         {% endif %}
 
-        <h3 class="vads-u-margin-bottom--2" data-testid="va_form--downloadable-pdf">Downloadable PDF</h3>
+        {% if !fieldVaFormUsage %}
+          <h2 class="vads-u-margin-bottom--2" data-testid="va_form--downloadable-pdf">Downloadable PDF</h2>
+        {% endif %}
         <a
           href="{{ fieldVaFormUrl.uri }}"
           target="_blank"


### PR DESCRIPTION
## Summary
On the "About ___ Form" pages, there is an optional section called "When to use this form." If that section does not exist, the next header is "Downloadable PDF," but it should be an `<h2>` when the "When to use this form" section does not exist. This fixes the header hierarchy.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14652

## Testing done
Tested these pages locally:

### With the "When to use this form" header
<details><summary>/find-forms/about-form-10-10cg/</summary>
<img width="800" alt="Screenshot 2024-04-22 at 11 08 18 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/d2da9980-1149-48be-bd9a-febf17ad095c">
<img width="350" alt="Screenshot 2024-04-22 at 11 08 06 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/da0256cf-23cf-4906-8014-c8139dc04131">
</details>

<details><summary>/find-forms/about-form-21-4142/</summary>
<img width="800" alt="Screenshot 2024-04-22 at 11 07 59 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/0fde476b-bc8c-4ebb-9ada-27f958272a7e">
</details>

### Without the "When to use this form" header
<details><summary>/find-forms/about-form-10-10sh/</summary>
<img width="800" alt="Screenshot 2024-04-22 at 11 08 25 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/0a51778d-cb48-40f8-bbf2-5c0287254591">
<img width="350" alt="Screenshot 2024-04-22 at 11 07 42 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/8b596d32-cfad-435d-adff-372ad5f3c0c4">
</details>

<details><summary>/find-forms/about-form-10-0491j/</summary>
<img width="903" alt="Screenshot 2024-04-22 at 11 07 34 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/cd6d9220-d440-4209-9776-a6327b341727">
</details>

## Acceptance criteria
- [x] Heading structure does not skip levels regardless of which content sections are present on the page.
- [ ] Accessibility review