### PR TITLE
VACMS-17094 Resources & Support CTA fix

### DIFF
--- a/src/site/includes/support_resources_cta_list.drupal.liquid
+++ b/src/site/includes/support_resources_cta_list.drupal.liquid
@@ -1,0 +1,13 @@
+{% if fieldButtons.length > 1 %}
+  <ul class="vads-u-margin-y--3 usa-unstyled-list">
+    {% for fieldButton in fieldButtons %}
+      <li class="vads-u-margin-bottom--2">
+        {% include "src/site/paragraphs/action_link.drupal.liquid" with entity = fieldButton.entity %}
+      </li>
+    {% endfor %}
+  </ul>
+{% elsif fieldButtons.length == 1 %}
+  {% for fieldButton in fieldButtons %}
+    {% include "src/site/paragraphs/action_link.drupal.liquid" with entity = fieldButton.entity %}
+  {% endfor %}
+{% endif %}

--- a/src/site/layouts/basic_landing_page.drupal.liquid
+++ b/src/site/layouts/basic_landing_page.drupal.liquid
@@ -18,15 +18,9 @@
             {% include "src/site/paragraphs/alert_single.drupal.liquid" with entity = fieldAlertSingle.entity %}
           {% endif %}
 
-          <!-- Buttons -->
-          {% if fieldButtons != empty %}
-            <ul class="vads-u-margin-y--3 usa-unstyled-list">
-              {% for fieldButton in fieldButtons %}
-                <li class="vads-u-margin-bottom--2">
-                  {% include "src/site/paragraphs/action_link.drupal.liquid" with entity = fieldButton.entity %}
-                </li>
-              {% endfor %}
-            </ul>
+          <!-- CTA list -->
+          {% if fieldButtons.length %}
+            {% include "src/site/includes/support_resources_cta_list.drupal.liquid" %}
           {% endif %}
 
           <!-- TOC -->
@@ -56,15 +50,9 @@
       </article>
 
       <div class="usa-width-three-fourths">
-        <!-- Repeated buttons -->
-        {% if fieldButtonsRepeat %}
-          <ul class="vads-u-margin-top--3 usa-unstyled-list">
-            {% for fieldButton in fieldButtons %}
-              <li class="vads-u-margin-bottom--2">
-                {% include "src/site/paragraphs/action_link.drupal.liquid" with entity = fieldButton.entity %}
-              </li>
-            {% endfor %}
-          </ul>
+        <!-- Repeated CTA list -->
+        {% if fieldButtons.length and fieldButtonsRepeat %}
+          {% include "src/site/includes/support_resources_cta_list.drupal.liquid" %}
         {% endif %}
       </div>
 

--- a/src/site/layouts/checklist.drupal.liquid
+++ b/src/site/layouts/checklist.drupal.liquid
@@ -26,14 +26,10 @@
               {% include "src/site/paragraphs/alert_single.drupal.liquid" with entity = fieldAlertSingle.entity %}
             {% endif %}
 
-            <!-- Buttons -->
-            <ul class="vads-u-margin-y--3 usa-unstyled-list">
-              {% for fieldButton in fieldButtons %}
-                <li class="vads-u-margin-bottom--2">
-                  {% include "src/site/paragraphs/action_link.drupal.liquid" with entity = fieldButton.entity %}
-                </li>
-              {% endfor %}
-            </ul>
+            <!-- CTA list -->
+            {% if fieldButtons.length %}
+              {% include "src/site/includes/support_resources_cta_list.drupal.liquid" %}
+            {% endif %}
 
             <!-- Checklist sections -->
             {% assign checklistSectionIndex = 0 %}
@@ -72,15 +68,9 @@
               {% assign checklistSectionIndex = checklistSectionIndex + 1 %}
             {% endfor %}
 
-            <!-- Buttons -->
-            {% if fieldButtonsRepeat %}
-              <ul class="vads-u-margin-top--3 usa-unstyled-list">
-                {% for fieldButton in fieldButtons %}
-                  <li class="vads-u-margin-bottom--2">
-                    {% include "src/site/paragraphs/action_link.drupal.liquid" with entity = fieldButton.entity %}
-                  </li>
-                {% endfor %}
-              </ul>
+            <!-- Repeated CTA list -->
+            {% if fieldButtons.length and fieldButtonsRepeat %}
+              {% include "src/site/includes/support_resources_cta_list.drupal.liquid" %}
             {% endif %}
           </article>
 

--- a/src/site/layouts/faq_multiple_q_a.drupal.liquid
+++ b/src/site/layouts/faq_multiple_q_a.drupal.liquid
@@ -47,14 +47,10 @@
               {% include "src/site/paragraphs/alert_single.drupal.liquid" with entity = fieldAlertSingle.entity %}
             {% endif %}
 
-            <!-- Buttons -->
-            <ul class="vads-u-margin-y--3 usa-unstyled-list">
-              {% for fieldButton in fieldButtons %}
-                <li class="vads-u-margin-bottom--2">
-                  {% include "src/site/paragraphs/action_link.drupal.liquid" with entity = fieldButton.entity %}
-                </li>
-              {% endfor %}
-            </ul>
+            <!-- CTA list -->
+            {% if fieldButtons.length %}
+              {% include "src/site/includes/support_resources_cta_list.drupal.liquid" %}
+            {% endif %}
 
             <!-- TOC -->
             {% if fieldTableOfContentsBoolean %}
@@ -119,15 +115,9 @@
               {% endif %}
             {% endfor %}
 
-            <!-- Repeated buttons -->
-            {% if fieldButtonsRepeat %}
-              <ul class="vads-u-margin-top--3 usa-unstyled-list">
-                {% for fieldButton in fieldButtons %}
-                  <li class="vads-u-margin-bottom--2">
-                    {% include "src/site/paragraphs/action_link.drupal.liquid" with entity = fieldButton.entity %}
-                  </li>
-                {% endfor %}
-              </ul>
+            <!-- Repeated CTA list -->
+            {% if fieldButtons.length and fieldButtonsRepeat %}
+              {% include "src/site/includes/support_resources_cta_list.drupal.liquid" %}
             {% endif %}
           </article>
 

--- a/src/site/layouts/media_list_images.drupal.liquid
+++ b/src/site/layouts/media_list_images.drupal.liquid
@@ -24,14 +24,10 @@
               {% include "src/site/paragraphs/alert_single.drupal.liquid" with entity = fieldAlertSingle.entity %}
             {% endif %}
 
-            <!-- Buttons -->
-            <ul class="vads-u-margin-y--3 usa-unstyled-list">
-              {% for fieldButton in fieldButtons %}
-                <li class="vads-u-margin-bottom--2">
-                  {% include "src/site/paragraphs/action_link.drupal.liquid" with entity = fieldButton.entity %}
-                </li>
-              {% endfor %}
-            </ul>
+            <!-- CTA list -->
+            {% if fieldButtons.length %}
+              {% include "src/site/includes/support_resources_cta_list.drupal.liquid" %}
+            {% endif %}
 
             <!-- Section Header -->
             {% if fieldMediaListImages.entity.fieldSectionHeader %}
@@ -157,15 +153,9 @@
               {% endif %}
             </dl>
 
-            <!-- Repeated buttons -->
-            {% if fieldButtonsRepeat %}
-              <ul class="vads-u-margin-top--3 usa-unstyled-list">
-                {% for fieldButton in fieldButtons %}
-                  <li class="vads-u-margin-bottom--2">
-                    {% include "src/site/paragraphs/action_link.drupal.liquid" with entity = fieldButton.entity %}
-                  </li>
-                {% endfor %}
-              </ul>
+            <!-- Repeated CTA list -->
+            {% if fieldButtons.length and fieldButtonsRepeat %}
+              {% include "src/site/includes/support_resources_cta_list.drupal.liquid" %}
             {% endif %}
           </article>
           <!-- ================ -->

--- a/src/site/layouts/media_list_videos.drupal.liquid
+++ b/src/site/layouts/media_list_videos.drupal.liquid
@@ -24,14 +24,10 @@
               {% include "src/site/paragraphs/alert_single.drupal.liquid" with entity = fieldAlertSingle.entity %}
             {% endif %}
 
-            <!-- Buttons -->
-            <ul class="vads-u-margin-y--3 usa-unstyled-list">
-              {% for fieldButton in fieldButtons %}
-                <li class="vads-u-margin-bottom--2">
-                  {% include "src/site/paragraphs/action_link.drupal.liquid" with entity = fieldButton.entity %}
-                </li>
-              {% endfor %}
-            </ul>
+            <!-- CTA list -->
+            {% if fieldButtons.length %}
+              {% include "src/site/includes/support_resources_cta_list.drupal.liquid" %}
+            {% endif %}
 
             <!-- Videos List -->
             <h2>{{ fieldMediaListVideos.entity.fieldSectionHeader | default: 'Videos' }}</h2>
@@ -75,15 +71,9 @@
               {% endfor %}
             </ul>
 
-            <!-- Repeated buttons -->
-            {% if fieldButtonsRepeat %}
-              <ul class="vads-u-margin-top--3 usa-unstyled-list">
-                {% for fieldButton in fieldButtons %}
-                  <li class="vads-u-margin-bottom--2">
-                    {% include "src/site/paragraphs/action_link.drupal.liquid" with entity = fieldButton.entity %}
-                  </li>
-                {% endfor %}
-              </ul>
+            <!-- Repeated CTA list -->
+            {% if fieldButtons.length and fieldButtonsRepeat %}
+              {% include "src/site/includes/support_resources_cta_list.drupal.liquid" %}
             {% endif %}
           </article>
 

--- a/src/site/layouts/q_a.drupal.liquid
+++ b/src/site/layouts/q_a.drupal.liquid
@@ -27,14 +27,10 @@
               {% include "src/site/paragraphs/alert_single.drupal.liquid" with entity = fieldAlertSingle.entity %}
             {% endif %}
 
-            <!-- Buttons -->
-            <ul class="vads-u-margin-top--3 usa-unstyled-list">
-              {% for fieldButton in fieldButtons %}
-                <li class="vads-u-margin-bottom--2">
-                  {% include "src/site/paragraphs/action_link.drupal.liquid" with entity = fieldButton.entity %}
-                </li>
-              {% endfor %}
-            </ul>
+            <!-- CTA list -->
+            {% if fieldButtons.length %}
+              {% include "src/site/includes/support_resources_cta_list.drupal.liquid" %}
+            {% endif %}
           </article>
 
           <!-- Tags -->

--- a/src/site/layouts/step_by_step.drupal.liquid
+++ b/src/site/layouts/step_by_step.drupal.liquid
@@ -24,14 +24,10 @@
               {% include "src/site/paragraphs/alert_single.drupal.liquid" with entity = fieldAlertSingle.entity %}
             {% endif %}
 
-            <!-- Buttons -->
-            <ul class="vads-u-margin-top--3 usa-unstyled-list vads-u-display--flex vads-u-justify-content--center medium-screen:vads-u-display--block">
-              {% for fieldButton in fieldButtons %}
-                <li class="vads-u-margin-bottom--2">
-                  {% include "src/site/paragraphs/action_link.drupal.liquid" with entity = fieldButton.entity %}
-                </li>
-              {% endfor %}
-            </ul>
+            <!-- CTA list -->
+            {% if fieldButtons.length %}
+              {% include "src/site/includes/support_resources_cta_list.drupal.liquid" %}
+            {% endif %}
 
             <!-- Steps -->
             {% for fieldStepsItem in fieldSteps %}
@@ -86,15 +82,9 @@
               </ol>
             {% endfor %}
 
-            <!-- Repeated buttons -->
-            {% if fieldButtonsRepeat %}
-              <ul class="vads-u-margin-top--3 usa-unstyled-list vads-u-display--flex vads-u-justify-content--center medium-screen:vads-u-display--block">
-                {% for fieldButton in fieldButtons %}
-                  <li class="vads-u-margin-bottom--2">
-                    {% include "src/site/paragraphs/action_link.drupal.liquid" with entity = fieldButton.entity %}
-                  </li>
-                {% endfor %}
-              </ul>
+            <!-- Repeated CTA list -->
+            {% if fieldButtons.length and fieldButtonsRepeat %}
+              {% include "src/site/includes/support_resources_cta_list.drupal.liquid" %}
             {% endif %}
           </article>
 

--- a/src/site/layouts/support_resources_detail_page.drupal.liquid
+++ b/src/site/layouts/support_resources_detail_page.drupal.liquid
@@ -28,8 +28,8 @@
               {% include "src/site/paragraphs/alert_single.drupal.liquid" with entity = fieldAlertSingle.entity %}
             {% endif %}
 
+            <!-- CTA list -->
             {% if fieldButtons.length %}
-              <!-- CTA list -->
               {% include "src/site/includes/support_resources_cta_list.drupal.liquid" %}
             {% endif %}
 
@@ -53,8 +53,8 @@
               {% endif %}
             {% endfor %}
 
+            <!-- Repeated CTA list -->
             {% if fieldButtons.length and fieldButtonsRepeat %}
-              <!-- Repeated CTA list -->
               {% include "src/site/includes/support_resources_cta_list.drupal.liquid" %}
             {% endif %}
           </article>

--- a/src/site/layouts/support_resources_detail_page.drupal.liquid
+++ b/src/site/layouts/support_resources_detail_page.drupal.liquid
@@ -28,20 +28,15 @@
               {% include "src/site/paragraphs/alert_single.drupal.liquid" with entity = fieldAlertSingle.entity %}
             {% endif %}
 
-            <!-- Buttons -->
-            <ul class="vads-u-margin-y--3 usa-unstyled-list">
-              {% for fieldButton in fieldButtons %}
-                <li class="vads-u-margin-bottom--2">
-                  {% include "src/site/paragraphs/action_link.drupal.liquid" with entity = fieldButton.entity %}
-                </li>
-              {% endfor %}
-            </ul>
+            {% if fieldButtons.length %}
+              <!-- CTA list -->
+              {% include "src/site/includes/support_resources_cta_list.drupal.liquid" %}
+            {% endif %}
 
             <!-- TOC -->
             {% if fieldTableOfContentsBoolean %}
               <va-on-this-page class="vads-u-margin-left--1 vads-u-margin-bottom--0 vads-u-padding-bottom--0"></va-on-this-page>
             {% endif %}
-
 
             <!-- Content blocks -->
             {% for block in fieldContentBlock %}
@@ -58,17 +53,9 @@
               {% endif %}
             {% endfor %}
 
-
-
-            <!-- Repeated buttons -->
-            {% if fieldButtonsRepeat %}
-              <ul class="vads-u-margin-top--3 usa-unstyled-list">
-                {% for fieldButton in fieldButtons %}
-                  <li class="vads-u-margin-bottom--2">
-                    {% include "src/site/paragraphs/action_link.drupal.liquid" with entity = fieldButton.entity %}
-                  </li>
-                {% endfor %}
-              </ul>
+            {% if fieldButtons.length and fieldButtonsRepeat %}
+              <!-- Repeated CTA list -->
+              {% include "src/site/includes/support_resources_cta_list.drupal.liquid" %}
             {% endif %}
           </article>
 

--- a/src/site/paragraphs/alert_single.drupal.liquid
+++ b/src/site/paragraphs/alert_single.drupal.liquid
@@ -1,4 +1,4 @@
-<div data-template="paragraphs/alert_single">
+<div data-template="paragraphs/alert_single" class="vads-u-margin-bottom--3">
 {% case entity.fieldAlertSelection %}
 
   {% comment %} Reusable {% endcomment %}


### PR DESCRIPTION
## Summary
On Resources & Support pages that only have one CTA, we should not be using a list element to display them. This fixes that (on the top of the page and at the bottom where they can be repeated).


## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17094

## Testing done

### support_resources_detail_page.drupal.liquid
<details><summary>/resources/deciding-how-much-life-insurance-to-get/</summary>

### Top of the page
<img width="738" alt="Screenshot 2024-04-22 at 2 44 45 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/388284d1-06a5-422e-8176-1d17444d5084">
<img width="503" alt="Screenshot 2024-04-22 at 2 44 57 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/e0bbeb93-1574-46b7-9054-548b069450d4">

### Bottom of the page
<img width="765" alt="Screenshot 2024-04-22 at 2 50 50 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/53c3c345-6dcf-4c5d-a64d-9225d2eb2933">
<img width="522" alt="Screenshot 2024-04-22 at 2 50 53 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/b1d9c9ed-4c25-46b3-bb5c-0d5df635e3c7">

</details>

<details><summary>/resources/va-covid-19-debt-relief-options-for-veterans-and-dependents/</summary>

### Top of the page
<img width="839" alt="Screenshot 2024-04-22 at 2 37 29 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/f1d11c27-ab4a-452b-96bc-b30248d92fd6">
<img width="521" alt="Screenshot 2024-04-22 at 2 37 38 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/65e0d96a-d3e7-4a95-a055-ea3f6e02a11e">

### Bottom of the page
<img width="748" alt="Screenshot 2024-04-22 at 2 50 25 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/5469f7f5-6c01-40d3-9410-fc55db0921ff">
<img width="502" alt="Screenshot 2024-04-22 at 2 50 33 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/f0a0b396-45ea-410e-9cb1-7a3c6ea3d9ac">

</details>

### step_by_step.drupal.liquid

<details><summary>/resources/how-to-check-your-va-claim-appeal-or-decision-review-status-online/</summary>

### Top of the page
<img width="563" alt="Screenshot 2024-04-23 at 9 22 21 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/be2fa12a-e8ea-4e51-bf2f-d102f03a282a">
<img width="604" alt="Screenshot 2024-04-23 at 9 22 25 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/fe604745-33b3-43df-b444-972814a768a4">

### Bottom of the page
<img width="509" alt="Screenshot 2024-04-23 at 9 22 29 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/bec060f3-aba2-4234-b6ae-f36f2dfadbea">
<img width="589" alt="Screenshot 2024-04-23 at 9 22 35 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/394b1299-cc5f-46fb-8067-c078cb56e982">
</details>

### faq_multiple_q_a.drupal.liquid

<details><summary>/resources/commissary-and-exchange-privileges-for-veterans/</summary>

### Top of the page (this one does not repeat on the bottom)

<img width="581" alt="Screenshot 2024-04-23 at 9 26 35 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/470d36e8-18e8-4a83-9ac8-4c491c59417e">
<img width="580" alt="Screenshot 2024-04-23 at 9 26 40 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/217f7944-8b38-4273-9743-3f463bb7e85f">


</details>

### q_a.drupal.liquid

<details><summary>/resources/can-i-get-free-health-care-and-prescriptions-as-a-veteran/</summary>

### Top of the page (this one does not repeat on the bottom)
<img width="612" alt="Screenshot 2024-04-23 at 9 32 16 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/57d23c08-f20e-4ad7-9519-3bca5c8e2d6d">
<img width="592" alt="Screenshot 2024-04-23 at 9 32 21 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/e2d45364-a833-4af5-a210-86a0dabd038f">
</details>


## Acceptance criteria
- [x] CTA shows in a list if there are 2 or more, at top and bottom of page
- [x] CTA does not show in a list if there is only 1, at top and bottom of page
- [x] Requires accessibility review