### PR TITLE
VACMS-15312 Remove shifted-vets-banner references

### DIFF
--- a/src/site/includes/veteran-banner.html
+++ b/src/site/includes/veteran-banner.html
@@ -1,9 +1,15 @@
 <div id="vets-banner-1" class="veteran-banner">
-  <div class="veteran-banner-container vads-u-margin-y--0 vads-u-margin-x--auto">
+  <div class="veteran-banner-container vads-u-margin-y--0 vads-u-margin-x--auto" style="max-width: 1280px;">
     <picture>
-      <source srcset="/img/homepage/veterans-banner-mobile-1.png 640w, /img/homepage/veterans-banner-mobile-2.png 920w, /img/homepage/veterans-banner-mobile-3.png 1316w" media="(max-width: 767px)" />
-      <source srcset="/img/homepage/veterans-banner-tablet-1.png 1008w, /img/homepage/veterans-banner-tablet-2.png 1887w" media="(max-width: 1008px)" />
-      <img class="vads-u-width--full" src="/img/homepage/veterans-banner-desktop-1.png" srcset="/img/homepage/veterans-banner-desktop-1.png 1280w, /img/homepage/veterans-banner-desktop-2.png 2494w" loading="lazy" alt="Veteran portraits" />
+      <source
+        srcset="/img/homepage/veterans-banner-mobile-1.png 640w, /img/homepage/veterans-banner-mobile-2.png 920w, /img/homepage/veterans-banner-mobile-3.png 1316w"
+        media="(max-width: 767px)" />
+      <source
+        srcset="/img/homepage/veterans-banner-tablet-1.png 1008w, /img/homepage/veterans-banner-tablet-2.png 1887w"
+        media="(max-width: 1008px)" />
+      <img class="vads-u-width--full" src="/img/homepage/veterans-banner-desktop-1.png"
+        srcset="/img/homepage/veterans-banner-desktop-1.png 1280w, /img/homepage/veterans-banner-desktop-2.png 2494w"
+        loading="lazy" alt="Veteran portraits" />
     </picture>
   </div>
 </div>

--- a/src/site/layouts/home.html
+++ b/src/site/layouts/home.html
@@ -10,22 +10,26 @@
 
       <!-- top row -->
       <div class="hub-links-row">
-      {% for card in cards %}
+        {% for card in cards %}
         <div class="hub-links-container" data-e2e="bucket">
-          <h2 class="heading-level-3 vads-u-margin-top--0"><i class="icon-large-baseline icon-heading hub-icon-{{card.hub}} hub-color-{{card.hub}} vads-u-margin-right--0p5"></i>{{ card.heading }}</h2>
+          <h2 class="heading-level-3 vads-u-margin-top--0"><i
+              class="icon-large-baseline icon-heading hub-icon-{{card.hub}} hub-color-{{card.hub}} vads-u-margin-right--0p5"></i>{{
+            card.heading }}</h2>
           <ul class="hub-links-list vads-u-margin-bottom--0">
             {% assign parentCard = card %}
 
             {% for link in card.links %}
-              <li><a data-nav-path="{{parentCard.heading}}->{% if link.nav_path != empty %}{{link.nav_path}}{% else %}{{ link.title }}{% endif %}" href="{{link.url}}">{{link.title}}</a></li>
+            <li><a
+                data-nav-path="{{parentCard.heading}}->{% if link.nav_path != empty %}{{link.nav_path}}{% else %}{{ link.title }}{% endif %}"
+                href="{{link.url}}">{{link.title}}</a></li>
             {% endfor %}
           </ul>
         </div>
         {% if card.end_row == true and forloop.last != true %}
-        </div>
-        <div class="hub-links-row">
+      </div>
+      <div class="hub-links-row">
         {% endif %}
-      {% endfor %}
+        {% endfor %}
       </div>
     </div>
 
@@ -37,16 +41,18 @@
   <section>
     <section id="homepage-benefits">
       <div class="usa-grid usa-grid-full homepage-benefits-row">
-      {% for hub in hubs %}
+        {% for hub in hubs %}
         <div class="usa-width-one-third" data-e2e="hub">
-          <h3 class="heading-level-4"><a href="{{ hub.url }}" onclick="recordEvent({ event: 'nav-linkslist' });"><i class="icon-small icon-heading hub-icon-{{hub.hub}} hub-background-{{hub.hub}} white vads-u-margin-right--0p5"></i>{{hub.heading}}</a></h4>
-          <p class="vads-u-margin-top--0">{{hub.description}}</p>
+          <h3 class="heading-level-4"><a href="{{ hub.url }}" onclick="recordEvent({ event: 'nav-linkslist' });"><i
+                class="icon-small icon-heading hub-icon-{{hub.hub}} hub-background-{{hub.hub}} white vads-u-margin-right--0p5"></i>{{hub.heading}}</a>
+            </h4>
+            <p class="vads-u-margin-top--0">{{hub.description}}</p>
         </div>
         {% if hub.end_row == true and forloop.last != true %}
-        </div>
-        <div class="usa-grid usa-grid-full homepage-benefits-row">
+      </div>
+      <div class="usa-grid usa-grid-full homepage-benefits-row">
         {% endif %}
-      {% endfor %}
+        {% endfor %}
       </div>
     </section>
 
@@ -65,7 +71,8 @@
         </div>
 
         <div class="usa-width-one-third">
-          <button onclick="recordEvent({ event: 'nav-main-vcl' });" class="homepage-button vcl va-overlay-trigger" data-show="#modal-crisisline">
+          <button onclick="recordEvent({ event: 'nav-main-vcl' });" class="homepage-button vcl va-overlay-trigger"
+            data-show="#modal-crisisline">
             <div class="icon-wrapper vcl"></div>
             <div class="button-inner">
               <span>Talk to a Veterans Crisis Line responder now</span>
@@ -74,7 +81,8 @@
         </div>
 
         <div class="usa-width-one-third" id="myva-login">
-          <button onclick="recordEvent({ event: 'nav-main-sign-in' });" class="homepage-button signin-signup-modal-trigger">
+          <button onclick="recordEvent({ event: 'nav-main-sign-in' });"
+            class="homepage-button signin-signup-modal-trigger">
             <div class="icon-wrapper">
               <i class="fas fa-user-circle homepage-button-icon"></i>
             </div>
@@ -86,35 +94,34 @@
 
       </div>
     </section>
-  </div>
-
-  <section class="usa-grid usa-grid-full">
-    <div class="va-h-ruled--stars"></div>
-  </section>
-
-
-  <section id="homepage-news">
-
-    <div class="usa-grid usa-grid-full">
-    {% for story in news %}
-      <div class="usa-width-one-third homepage-news-story" data-e2e="news">
-        <div class="homepage-image-wrapper">
-          <img class="lazy" width="552" data-src="{{ story.img }}" alt="{{ story.alt }}"/>
-        </div>
-        <h4 class="homepage-news-story-title"><a class="no-external-icon" href="{{ story.href }}"
-          onClick="recordEvent({ event: 'nav-footer-news-story' });"/>{{ story.title }}</a></h4>
-        <p class="homepage-news-story-desc">{{ story.description }}</p>
-      </div>
-      {% if hub.end_row == true and forloop.last != true %}
-      </div>
-      <div class="usa-grid usa-grid-full">
-      {% endif %}
-    {% endfor %}
     </div>
 
-  </section>
+    <section class="usa-grid usa-grid-full">
+      <div class="va-h-ruled--stars"></div>
+    </section>
 
-  <div data-widget-type="shifted-vets-banner"></div>
+
+    <section id="homepage-news">
+
+      <div class="usa-grid usa-grid-full">
+        {% for story in news %}
+        <div class="usa-width-one-third homepage-news-story" data-e2e="news">
+          <div class="homepage-image-wrapper">
+            <img class="lazy" width="552" data-src="{{ story.img }}" alt="{{ story.alt }}" />
+          </div>
+          <h4 class="homepage-news-story-title"><a class="no-external-icon" href="{{ story.href }}"
+              onClick="recordEvent({ event: 'nav-footer-news-story' });" />{{ story.title }}</a></h4>
+          <p class="homepage-news-story-desc">{{ story.description }}</p>
+        </div>
+        {% if hub.end_row == true and forloop.last != true %}
+      </div>
+      <div class="usa-grid usa-grid-full">
+        {% endif %}
+        {% endfor %}
+      </div>
+
+    </section>
+
 
 </main> <!-- end #content -->
 
@@ -129,7 +136,7 @@
       // Check to see if we found the hub link.
       if (hubLinksList[i]) {
         // Add a click handler to the hub link to track clicks in analytics.
-        hubLinksList[i].addEventListener('click', function(event) {
+        hubLinksList[i].addEventListener('click', function (event) {
           recordEvent({
             event: 'nav-zone-one',
             'nav-path': event ? event.target.dataset.navPath : null,


### PR DESCRIPTION
## Summary
The `shifted-vets-banner` (in vets-website) was used on the previous homepage design:

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/0bd20ba7-a46d-4c96-9e9e-87c9b756a173)

Our current Veteran banner at the bottom of the page is built in content-build and does not use `shifted-vets-banner`.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15312

## Testing done

Tugboat for testing the changes to vets-website and content-build: ([content-build PR here](https://github.com/department-of-veterans-affairs/content-build/pull/2029))

https://web-qt5d33etm65pqwd8kjkoisn1yauzdt4d.demo.cms.va.gov/

Tested desktop locally (this banner does not appear on mobile).

<img width="1400" alt="Screenshot 2024-04-23 at 1 08 25 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/0291c0ae-9c47-4fa8-a934-d454a6855eb8">

## What areas of the site does it impact?

Home page only. Though nothing should really be affected since we're removing code that isn't used.