### PR TITLE
remove useLocalStylesAndComponents

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1183,8 +1183,7 @@
       "noNavOrLogin": true,
       "noMegamenu": true,
       "minimalFooter": true
-    },
-    "useLocalStylesAndComponents": true
+    }
   },
   {
     "appName": "Travel Claim",


### PR DESCRIPTION
## Summary

- Removes the useLocalStylesAndComponents key from the pre check in app

## Related issue(s)

- [department-of-veterans-affairs/va.gov-team#72870](https://github.com/department-of-veterans-affairs/va.gov-team/issues/72870)

## Testing done
 
Locally Pre check in imports css and components properly

## What areas of the site does it impact?

Check-in -> Pre Check-in

## Acceptance criteria

- [ ] The pre check in app imports css and components like every other app

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions