### PR TITLE
10-7959f-2 Skeleton

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1835,5 +1835,15 @@
       "vagovprod": false,
       "layout": "page-react.html"
     }
+  },
+  {
+    "appName": "Foreign Medical Program Cover",
+    "entryName": "fmp-cover-sheet",
+    "rootUrl": "/health-care/foreign-medical-program/file-claim-form-10-7959f-2",
+    "productId": "66edb145-7655-4137-a74d-dfb20f4e752a",
+     "template": {
+      "vagovprod": false,
+      "layout": "page-react.html"
+    }
   }
 ]


### PR DESCRIPTION
## Summary
This PR adds 7959f-2 to registry.json so we can build the form out.

## Related issue(s)


## Testing done
Manual testing

## Screenshots
![Screenshot 2024-04-29 at 9 51 54 AM](https://github.com/department-of-veterans-affairs/content-build/assets/20195737/782bfa68-1dd8-47f6-ad99-b649802f92ea)

## What areas of the site does it impact?
This form only 

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
NA