### PR TITLE
Dependabot: Address URL & regex sanitization.

### DIFF
--- a/script/pr-check.js
+++ b/script/pr-check.js
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 /* eslint-disable no-console */
 const { Octokit } = require('@octokit/rest');
-const { isEmpty, sortBy, uniqBy } = require('lodash');
+const { isEmpty, sortBy, uniqBy, escapeRegExp } = require('lodash');
 
 const {
   BOT_NAME, // Name of the bot for the auth token we are using
@@ -147,7 +147,7 @@ function identifyAdditions(diffLines) {
  */
 function findPattern(arr) {
   return Promise.resolve(
-    arr.filter(({ line }) => new RegExp(CODE_PATTERN).test(line)),
+    arr.filter(({ line }) => new RegExp(escapeRegExp(CODE_PATTERN)).test(line)),
   ).then(matchList =>
     isEmpty(matchList)
       ? finish(

--- a/src/site/stages/build/drupal/api.js
+++ b/src/site/stages/build/drupal/api.js
@@ -52,14 +52,14 @@ function getDrupalClient(buildOptions, clientOptionsArg) {
     'Content-Type': 'application/json',
   };
   const agent = new SocksProxyAgent('socks://127.0.0.1:2001');
-  const addressHost = new URL(address).host;
+  const addressHost = new URL(address).hostname;
 
   return {
     // We have to point to aws urls on Jenkins, so the only
     // time we'll be using cms.va.gov addresses is locally,
     // when we need a proxy
     usingProxy:
-      addressHost.includes('cms.va.gov') && !buildOptions['no-drupal-proxy'],
+      addressHost.match(/cms\.va\.gov$/) && !buildOptions['no-drupal-proxy'],
 
     getSiteUri() {
       return address;

--- a/src/site/stages/build/drupal/api.js
+++ b/src/site/stages/build/drupal/api.js
@@ -52,13 +52,14 @@ function getDrupalClient(buildOptions, clientOptionsArg) {
     'Content-Type': 'application/json',
   };
   const agent = new SocksProxyAgent('socks://127.0.0.1:2001');
+  const addressHost = new URL(address).host;
 
   return {
     // We have to point to aws urls on Jenkins, so the only
     // time we'll be using cms.va.gov addresses is locally,
     // when we need a proxy
     usingProxy:
-      address.includes('cms.va.gov') && !buildOptions['no-drupal-proxy'],
+      addressHost.includes('cms.va.gov') && !buildOptions['no-drupal-proxy'],
 
     getSiteUri() {
       return address;

--- a/src/site/stages/build/plugins/modify-dom/update-external-links.js
+++ b/src/site/stages/build/plugins/modify-dom/update-external-links.js
@@ -33,7 +33,7 @@ module.exports = {
         const relAttr = link.attr('rel');
         const targetAttr = link.attr('target');
         const hrefAttr = link.attr('href') || '';
-        const hrefAttrHost = new URL(hrefAttr).host;
+        const hrefAttrHost = new URL(hrefAttr).hostname;
 
         // We want to make sure links that open in a new tab
         // always have noopener, but data-allow-opener is an
@@ -53,8 +53,8 @@ module.exports = {
         if (
           typeof link.attr('data-same-tab') === 'undefined' &&
           !isNonVADomainThatOpensInSameTab(hrefAttr) &&
-          ((!hrefAttrHost.includes('va.gov') &&
-            !hrefAttrHost.includes('vets.gov')) ||
+          ((!hrefAttrHost.match(/va\.gov$/) &&
+            !hrefAttrHost.match(/vets\.gov$/)) ||
             isVADomainThatOpensInNewTab(hrefAttr)) &&
           !targetAttr &&
           targetAttr !== '_blank'

--- a/src/site/stages/build/plugins/modify-dom/update-external-links.js
+++ b/src/site/stages/build/plugins/modify-dom/update-external-links.js
@@ -33,7 +33,7 @@ module.exports = {
         const relAttr = link.attr('rel');
         const targetAttr = link.attr('target');
         const hrefAttr = link.attr('href') || '';
-        const hrefAttrHost = new URL(hrefAttr).hostname;
+        const hrefAttrHost = new URL(hrefAttr.trim()).hostname;
 
         // We want to make sure links that open in a new tab
         // always have noopener, but data-allow-opener is an

--- a/src/site/stages/build/plugins/modify-dom/update-external-links.js
+++ b/src/site/stages/build/plugins/modify-dom/update-external-links.js
@@ -33,6 +33,7 @@ module.exports = {
         const relAttr = link.attr('rel');
         const targetAttr = link.attr('target');
         const hrefAttr = link.attr('href') || '';
+        const hrefAttrHost = new URL(hrefAttr).host;
 
         // We want to make sure links that open in a new tab
         // always have noopener, but data-allow-opener is an
@@ -52,7 +53,8 @@ module.exports = {
         if (
           typeof link.attr('data-same-tab') === 'undefined' &&
           !isNonVADomainThatOpensInSameTab(hrefAttr) &&
-          ((!hrefAttr.includes('va.gov') && !hrefAttr.includes('vets.gov')) ||
+          ((!hrefAttrHost.includes('va.gov') &&
+            !hrefAttrHost.includes('vets.gov')) ||
             isVADomainThatOpensInNewTab(hrefAttr)) &&
           !targetAttr &&
           targetAttr !== '_blank'

--- a/src/site/stages/build/plugins/rewrite-cms-aws-urls.js
+++ b/src/site/stages/build/plugins/rewrite-cms-aws-urls.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-param-reassign, no-continue */
+const { escapeRegExp } = require('lodash');
 
 function rewriteAWSUrls(options) {
   return (files, metalsmith, done) => {
@@ -10,7 +11,10 @@ function rewriteAWSUrls(options) {
         .forEach(fileName => {
           const file = files[fileName];
           let contents = file.contents.toString();
-          const regex = new RegExp(options['drupal-address'], 'g');
+          const regex = new RegExp(
+            escapeRegExp(options['drupal-address']),
+            'g',
+          );
           contents = contents.replace(regex, file.drupalSite);
 
           file.contents = Buffer.from(contents);

--- a/src/site/stages/build/plugins/rewrite-va-domains.js
+++ b/src/site/stages/build/plugins/rewrite-va-domains.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-param-reassign, no-continue */
+const { escapeRegExp } = require('lodash');
 const { sleep } = require('../../../../../script/utils');
 
 function createRedirects(options) {
@@ -12,7 +13,7 @@ function createRedirects(options) {
         const file = files[fileName];
         let contents = file.contents.toString();
         options.domainReplacements.forEach(domain => {
-          const regex = new RegExp(domain.from, 'g');
+          const regex = new RegExp(escapeRegExp(domain.from), 'g');
           contents = contents.replace(regex, domain.to);
         });
 


### PR DESCRIPTION
## Summary

Addresses a collection of Dependabot refactor requests
https://github.com/department-of-veterans-affairs/content-build/security/code-scanning/34
https://github.com/department-of-veterans-affairs/content-build/security/code-scanning/35
https://github.com/department-of-veterans-affairs/content-build/security/code-scanning/36
Link here for an explanation of these: https://github.com/department-of-veterans-affairs/content-build/security/code-scanning/34#:~:text=Constructing%20a%20regular,CWE%2D400.

https://github.com/department-of-veterans-affairs/content-build/security/code-scanning/2
https://github.com/department-of-veterans-affairs/content-build/security/code-scanning/9
https://github.com/department-of-veterans-affairs/content-build/security/code-scanning/10
Link here for an explanation of these: https://github.com/department-of-veterans-affairs/content-build/security/code-scanning/10#:~:text=Sanitizing%20untrusted%20URLs,CWE%2D20.

This should not be merged without being deployed to a testing environment; working on that.
