### PR TITLE
Vet Center test fix

### DIFF
--- a/src/site/layouts/tests/vet_center/vet_center_locations_operating_status.unit.spec.js
+++ b/src/site/layouts/tests/vet_center/vet_center_locations_operating_status.unit.spec.js
@@ -26,9 +26,13 @@ describe('Vet Center Locations Operating Status', () => {
   });
 
   it('should not render a normal operating status for satellite', async () => {
+    const updatedNormalFixture = { ...fixture };
+    updatedNormalFixture.fieldOffice.entity.reverseFieldOfficeNode.entities[0].fieldOperatingStatusFacility =
+      'normal';
+    updatedNormalFixture.fieldOffice.entity.reverseFieldOfficeNode.entities[0].fieldOperatingStatusMoreInfo = null;
     const rendered = await renderHTML(
       'src/site/layouts/vet_center_locations_list.drupal.liquid',
-      fixture,
+      updatedNormalFixture,
     );
     const operatingStatus = queryAllByTestId(
       rendered,


### PR DESCRIPTION
## Summary

- Fixes random failing Vet Center test
- Run Vet Center Operating Status tests multiple times and it will occasionally fail.
- Modify tests to change expected values in each run for the centralized fixture JSON.
- Sitewide Facilities

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17994

## Testing done

- Test would fail when 4th test ran before 3rd
- Test that tests run in multiple orderings.

## Screenshots

N/A

## What areas of the site does it impact?

Testing of Vet Center Operating Status

## Acceptance criteria

- [x] Tests run in any order

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A)

## Requested Feedback

Check that tests run in any order