### PR TITLE
VACMS-17821 Campaign Landing Pages va-icon update

### DIFF
--- a/src/site/assets/sass/style.scss
+++ b/src/site/assets/sass/style.scss
@@ -31,13 +31,8 @@
 
 .hub-icon {
   border-radius: 50%;
-  height: 32px;
-  min-width: 32px;
-
-  &.large {
-    height: 40px;
-    min-width: 40px;
-  }
+  height: 40px !important;
+  min-width: 40px !important;
 }
 
 // START: Styles for mobile app promo banner

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -73,13 +73,13 @@
               <div data-template="includes/social-share" id="va-c-social-share">
                 <ul class="usa-unstyled-list" role="list">
                   <li class="vads-u-margin-bottom--2p5">
-                    <i class="va-c-social-icon fab fa-facebook vads-u-margin-right--0p5" aria-hidden="true"></i>
+                    <va-icon icon="facebook" size="3" class="vads-u-color--link-default"></va-icon>
                     <va-link class="va-js-share-link" href="https://www.facebook.com/sharer/sharer.php?href={{ hostUrl }}{{ entityUrl.path }}" text="Share on Facebook">
                     </va-link>
                   </li>
                   <li>
-                    <i class="va-c-social-icon fab fa-twitter vads-u-margin-right--0p5" aria-hidden="true"></i>
-                    <va-link class="va-js-share-link" href="https://twitter.com/intent/tweet?text={{ title }}&url={{ hostUrl }}{{ entityUrl.path }}" text="Share on Twitter">
+                    <va-icon icon="x" size="3" class="vads-u-color--link-default"></va-icon>
+                    <va-link class="va-js-share-link" href="https://twitter.com/intent/tweet?text={{ title }}&url={{ hostUrl }}{{ entityUrl.path }}" text="Share on X (formerly Twitter)">
                     </va-link>
                   </li>
                 </ul>
@@ -536,7 +536,7 @@
                   rel="noreferrer noopener"
                   target="_blank"
                 >
-                  <i aria-hidden="true" class="fas fa-envelope vads-u-padding-right--1"></i>
+                  <va-icon icon="mail" size="3" class="vads-u-color--link-default vads-u-padding-right--1"></va-icon>
                   {{ fieldRelatedOffice.entity.fieldEmailUpdatesLink.title }}
                 </a>
               </div>
@@ -553,8 +553,8 @@
                   rel="noreferrer noopener"
                   target="_blank"
                 >
-                  <i aria-hidden="true" class="fab fa-twitter vads-u-padding-right--1"></i>
-                  {{ fieldRelatedOffice.entity.fieldExternalLink.title }} Twitter
+                  <va-icon icon="x" size="3" class="vads-u-color--link-default vads-u-padding-right--1"></va-icon>
+                  {{ fieldRelatedOffice.entity.fieldExternalLink.title }} X (formerly Twitter)
                 </a>
               </div>
             </div>
@@ -570,7 +570,7 @@
                   rel="noreferrer noopener"
                   target="_blank"
                 >
-                <i aria-hidden="true" class="fab fa-facebook vads-u-padding-right--1"></i>
+                  <va-icon icon="facebook" size="3" class="vads-u-color--link-default vads-u-padding-right--1"></va-icon>
                   {{ fieldRelatedOffice.entity.fieldExternalLink.title }} Facebook
                 </a>
               </div>
@@ -587,7 +587,7 @@
                   rel="noreferrer noopener"
                   target="_blank"
                 >
-                  <i aria-hidden="true" class="fab fa-youtube vads-u-padding-right--1"></i>
+                  <va-icon icon="youtube" size="3" class="vads-u-color--link-default vads-u-padding-right--1"></va-icon>
                   {{ fieldRelatedOffice.entity.fieldExternalLink.title }} YouTube
                 </a>
               </div>
@@ -604,7 +604,7 @@
                   rel="noreferrer noopener"
                   target="_blank"
                 >
-                  <i aria-hidden="true" class="fab fa-linkedin vads-u-padding-right--1"></i>
+                  <va-icon icon="linkedin" size="3" class="vads-u-color--link-default vads-u-padding-right--1"></va-icon>
                   {{ fieldRelatedOffice.entity.fieldExternalLink.title }} Linkedin
                 </a>
               </div>
@@ -621,7 +621,7 @@
                   rel="noreferrer noopener"
                   target="_blank"
                 >
-                  <i aria-hidden="true" class="fab fa-instagram vads-u-padding-right--1"></i>
+                  <va-icon icon="instagram" size="3" class="vads-u-color--link-default vads-u-padding-right--1"></va-icon>
                   {{ fieldRelatedOffice.entity.fieldExternalLink.title }} Instagram
                 </a>
               </div>
@@ -646,15 +646,11 @@
         <div class="vads-l-row medium-screen:vads-u-margin-x--neg6">
           {% for benefitCategory in fieldBenefitCategories %}
             <div class="vads-l-col--12 medium-screen:vads-l-col--6 {% if !forloop.first %}vads-u-margin-top--2 medium-screen:vads-u-margin-top--0{% endif %}">
-              <div class="medium-screen:vads-u-margin-x--6">
+              <div class="medium-screen:vads-u-margin-left--6 medium-screen:vads-u-margin-right--5">
                 <div class="vads-u-display--flex vads-u-align-items--center">
-                  <i
-                    aria-hidden="true"
-                    class="vads-u-flex--auto icon-small white vads-u-margin-right--1 hub-icon-{{ benefitCategory.entity.fieldTitleIcon }} hub-background-{{ benefitCategory.entity.fieldTitleIcon }}"
-                  ></i>
+                  {{ benefitCategory.entity.fieldTitleIcon | getHubIcon: '3', 'vads-u-margin-right--1' }}
                   <h3 class="vads-u-margin--0 vads-u-font-size--h4">
                   <va-link
-                    class="vads-u-flex--1"
                     disable-analytics
                     onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'VA Benefits', 'clp-section-title': 'Learn more about related VA benefits', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ benefitCategory.entity.title | encode }}' });"
                     href="{{ benefitCategory.entity.entityUrl.path }}"

--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -8,7 +8,7 @@
       <article class="usa-width-two-thirds">
         {% if fieldTitleIcon %}
           <div class="inline hub-main-icon vads-u-margin-right--1 vads-u-margin-bottom--1">
-            {{ fieldTitleIcon | getHubIcon: '3', 'large' }}
+            {{ fieldTitleIcon | getHubIcon: '3' }}
           </div>
 
           <div class="inline hub-main-title">


### PR DESCRIPTION
## Summary
Update all the icons on Campaign Landing pages to use `<va-icon>`.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17821

## Testing done
Tested locally these CLPs:

- `/initiatives/vote/`
- `/initiatives/veterans-experience-action-centers/`
- `/initiatives/protecting-veterans-from-fraud/`
- `/initiatives/veteran-trust-in-va/`
- `/initiatives/covid-flu/`
- `/initiatives/end-of-life-benefits/`
- `/initiatives/sign-in-securely-with-logingov/`
- `/initiatives/emergency-room-911-or-urgent-care/`

## Screenshots

### Hub icons
<img width="600" alt="Screenshot 2024-05-17 at 11 52 19 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/cd60e1a3-ac9e-41c8-bd1e-8386fa31bde6">
<img width="1000" alt="Screenshot 2024-05-17 at 11 52 24 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/545f8f4a-0267-4d33-b167-ab1bb0bcd081">
<img width="1000" alt="Screenshot 2024-05-17 at 11 52 32 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/4e17ae5d-bc3f-4bd6-8acf-4c45d411d69e">
<img width="1000" alt="Screenshot 2024-05-17 at 11 52 46 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/c74f45d8-6122-4090-9d04-09f9282c0673">
<img width="1000" alt="Screenshot 2024-05-17 at 11 53 13 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/3249eada-8a5e-4f09-9b9d-e5c6b01d01ef">

### Social icons
<img width="902" alt="Screenshot 2024-05-17 at 11 52 36 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/b4cfa1a7-1dfb-4afb-88ca-e1da8eb43591">
<img width="293" alt="Screenshot 2024-05-17 at 11 52 56 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/e2d74675-9629-4c1f-8f45-51d336bece13">

