### PR TITLE
Add form upload flow

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1409,6 +1409,16 @@
     }
   },
   {
+    "appName": "Form Upload Flow",
+    "entryName": "form-upload-flow",
+    "rootUrl": "/form-upload",
+    "productId": "88558f52-5c6c-447f-ab78-e006b01a32db",
+    "template": {
+      "vagovprod": false,
+      "layout": "page-react.html"
+    }
+  },
+  {
     "appName": "Submit a lay or witness statement to support a VA claim",
     "entryName": "10210-lay-witness-statement",
     "rootUrl": "/supporting-forms-for-claims/lay-witness-statement-form-21-10210",

--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -104,13 +104,15 @@
           {{ translatedDownloadText }} (PDF)
         </a>
 
-        <div
-          aria-label="Form Upload"
-          data-widget-type="form-upload"
-          data-has-online-tool="{% if fieldVaFormToolUrl %}true{% else %}false{% endif %}"
-          data-form-number="{{ fieldVaFormNumber }}"
-          role="region"
-        ></div>
+        {% if fieldVaFormUpload %}
+          <div
+            aria-label="Form Upload"
+            data-widget-type="form-upload"
+            data-has-online-tool="{% if fieldVaFormToolUrl %}true{% else %}false{% endif %}"
+            data-form-number="{{ fieldVaFormNumber }}"
+            role="region"
+          ></div>
+        {% endif %}
 
         {% if fieldAlert.length %}
           {% for alert in fieldAlert %}

--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -104,6 +104,14 @@
           {{ translatedDownloadText }} (PDF)
         </a>
 
+        <div
+          aria-label="Form Upload"
+          data-widget-type="form-upload"
+          data-has-online-tool="{% if fieldVaFormToolUrl %}true{% else %}false{% endif %}"
+          data-form-number="{{ fieldVaFormNumber }}"
+          role="region"
+        ></div>
+
         {% if fieldAlert.length %}
           {% for alert in fieldAlert %}
             {% if alert.entity != empty %}

--- a/src/site/stages/build/drupal/graphql/vaFormPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vaFormPage.graphql.js
@@ -8,6 +8,7 @@ const vaFormFragment = `
 fragment vaFormPage on NodeVaForm {
   ${entityElementsFromPages}
   changed
+  fieldVaFormUpload
   fieldVaFormName
   fieldVaFormTitle
   fieldVaFormType


### PR DESCRIPTION
## Summary
This PR adds a form upload widget entrypoint to the find a form detail page and a form upload flow application to the registry.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1242

## Testing done
I've run and tested this locally.

## Screenshots

Unauthenticated:
<img width="1025" alt="Screenshot 2024-05-02 at 8 57 02 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10481391/b529545e-0ce9-4835-905d-812285341186">

Authenticated:
<img width="1049" alt="Screenshot 2024-05-02 at 8 57 38 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10481391/5b35fac8-92d2-4679-9c66-c533db8ee36d">

**Note:** The `vets-website` changes are not yet in effect.