### PR TITLE
[VA-17598] Show VBA "Manage Your Benefits Online" (2)

### DIFF
--- a/src/site/includes/vba_facilities/services.liquid
+++ b/src/site/includes/vba_facilities/services.liquid
@@ -43,8 +43,9 @@
           {% assign regionalServiceDescription = entity.regionalService.fieldServiceNameAndDescripti.entity.fieldRegionalServiceDescripti %}
         {% endif %}
 
+        {% assign onlineSelfService = false %}
         {% if entity.facilityService.fieldServiceNameAndDescripti.entity.fieldOnlineSelfService %}
-          {% assign onlineSelfService = entity.fieldServiceNameAndDescripti.entity.fieldOnlineSelfService %}
+          {% assign onlineSelfService = entity.facilityService.fieldServiceNameAndDescripti.entity.fieldOnlineSelfService %}
         {% elsif entity.regionalService.fieldServiceNameAndDescripti.entity.fieldOnlineSelfService %}
           {% assign onlineSelfService = entity.regionalService.fieldServiceNameAndDescripti.entity.fieldOnlineSelfService %}
         {% endif %}
@@ -68,7 +69,7 @@
             <p>{{ vbaServiceDescription | drupalToVaPath | phoneLinks }}</p>
           {% endif %}
 
-          {% if onlineSelfService.url %}
+          {% if onlineSelfService.title and onlineSelfService.url.path %}
             <h4>
               Manage your benefits online
             </h4>


### PR DESCRIPTION
## Summary

The "Manage Your Benefits Online" link for each VBA service is added if they have the "online self-service" field is filled out. Most of the code was already there, but it needed some tweaking to get it correct.

## Related issue(s)

- _Link to ticket created in va.gov-cms repo_
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17598

## Testing done

Visual, see below

https://github.com/department-of-veterans-affairs/content-build/assets/10790736/b90151d1-d1e5-4bd6-92cf-101569f4c371

* [Link to Tugboat CMS where services were updated.](https://cms-txcrk8bym4a0ivw3xfr8xvdhezmls36f.demo.cms.va.gov/admin/structure/taxonomy/manage/health_care_service_taxonomy/overview?page=1)
* [Link to regional facility page where services are shown.](https://web-txcrk8bym4a0ivw3xfr8xvdhezmls36f.demo.cms.va.gov/cleveland-va-regional-benefit-office/)

## What areas of the site does it impact?

Regional facility services

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed