### PR TITLE
VACMS-16998 Operating status web components

### DIFF
--- a/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
+++ b/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
@@ -25,47 +25,18 @@
             <div class="usa-grid usa-grid-full vads-u-margin-y--1p5">
               <div class="vads-l-row">
                 <div class="vads-u-margin-right--2p5">
-                  <a class="vads-u-padding-x--5 usa-button vads-u-margin-top--1 vads-u-margin--0 vads-u-width--full vads-u-font-size--md"
-                     href="{{ fieldOffice.entity.fieldLinkFacilityEmergList.url.path }}">
-                    Subscribe to emergency notifications</a>
+                  <a
+                    class="vads-u-margin-top--1 vads-u-margin--0 vads-c-action-link--green"
+                    href="{{ fieldOffice.entity.fieldLinkFacilityEmergList.url.path }}"
+                  >
+                    Subscribe to emergency notifications
+                  </a>
                 </div>
               </div>
             </div>
           {% endif %}
           <section class="table-of-contents" class="vads-u-margin-bottom--5">
-	          <va-on-this-page class="vads-u-margin-left--1 vads-u-margin-bottom--0 vads-u-padding-bottom--0"/>
-            <ul class="usa-unstyled-list" role="list">
-
-              {% if fieldBannerAlert.0.entity.status != false and fieldBannerAlert.0.entity.fieldSituationUpdates.0.entity %}
-                <li class="vads-u-margin-bottom--2">
-                  <a class="vads-u-display--flex vads-u-text-decoration--none" href="#situation-updates"
-                     onclick="recordEvent({ event: 'nav-jumplink-click' });">
-                    <i class="fas fa-arrow-down va-c-font-size--xs vads-u-margin-top--1 vads-u-margin-right--1"></i>
-                    Situation updates and information
-                  </a>
-                </li>
-              {% endif %}
-
-              {% if fieldFacilityOperatingStatus.length > 0 %}
-                <li class="vads-u-margin-bottom--2">
-                  <a class="vads-u-display--flex vads-u-text-decoration--none" href="#operating-statuses"
-                     onclick="recordEvent({ event: 'nav-jumplink-click' });">
-                    <i class="fas fa-arrow-down va-c-font-size--xs vads-u-margin-top--1 vads-u-margin-right--1"></i>
-                    Facility operating statuses
-                  </a>
-                </li>
-              {% endif %}
-
-              {% if fieldLink.0.uri or fieldOperatingStatusEmergInf.processed %}
-                <li class="vads-u-margin-bottom--2">
-                  <a class="vads-u-display--flex vads-u-text-decoration--none" href="#emergency-resources"
-                     onclick="recordEvent({ event: 'nav-jumplink-click' });">
-                    <i class="fas fa-arrow-down va-c-font-size--xs vads-u-margin-top--1 vads-u-margin-right--1"></i>
-                    Emergency resources
-                  </a>
-                </li>
-              {% endif %}
-            </ul>
+	          <va-on-this-page class="vads-u-margin-left--1 vads-u-margin-bottom--0 vads-u-padding-bottom--0" />
           </section>
 
           {% assign situationUpdates = fieldBannerAlert | hasContentAtPath: 'entity.fieldSituationUpdates' %}
@@ -80,34 +51,28 @@
                 {% for status in fieldFacilityOperatingStatus %}
                   {% assign statusId = status.entity.entityId %}
                   <dt class="vads-l-col--12 medium-screen:vads-l-col--5 vads-u-margin--0 vads-u-padding-y--3 vads-u-display--flex operating-status-title vads-u-border-top--1px vads-u-border-color--gray-light">
-                    <a class="facility-title-width vads-u-font-weight--bold" onclick="recordEvent({
-                                                              'event':'nav-health-care-facility-status-click'});"
-                        href="{{ status.entity.entityUrl.path }}">{{ status.entity.title }}</a>
+                    <va-link
+                      class="facility-title-width vads-u-font-weight--bold"
+                      onclick="recordEvent({'event':'nav-health-care-facility-status-click'});"
+                      href="{{ status.entity.entityUrl.path }}"
+                      text="{{ status.entity.title }}"
+                    />
                   </dt>
                   <dd class="vads-l-col--12 medium-screen:vads-l-col--7 medium-screen:vads-u-border-top--1px vads-u-border-color--gray-light">
                     <div class="operating-status-info vads-u-padding-y--1p5 vads-u-padding-x--0">
                       {% if status.entity.fieldOperatingStatusFacility == 'notice' %}
-                        <span
-                            class="operating-status usa-alert usa-alert-info background-color-only vads-u-margin-top--0 vads-u-padding--1p5">
-                          <i aria-hidden="true" class="fa fa-info-circle"></i>
-                          Facility notice
-                        </span>
+                        <va-alert slim status="info" visible>Facility notice</va-alert>
+
                       {% elsif status.entity.fieldOperatingStatusFacility == 'normal' %}
                         <span class="operating-status normal-hours vads-u-margin-top--1p5 vads-u-display--block">
                           Normal services and hours
                         </span>
+
                       {% elsif status.entity.fieldOperatingStatusFacility == 'limited' %}
-                        <span
-                            class="operating-status usa-alert usa-alert-info background-color-only vads-u-margin-top--0 vads-u-padding--1p5">
-                          <i aria-hidden="true" class="fa fa-info-circle"></i>
-                          Limited services and hours
-                        </span>
+                        <va-alert slim status="warning" visible>Limited services and hours</va-alert>
+
                       {% elsif status.entity.fieldOperatingStatusFacility == 'closed' %}
-                        <span
-                            class="operating-status usa-alert usa-alert-error background-color-only vads-u-margin-top--0 vads-u-padding--1p5">
-                          <i aria-hidden="true" class="fa fa-exclamation-circle"></i>
-                          Facility Closed
-                        </span>
+                        <va-alert slim status="error" visible>Facility Closed</va-alert>
                       {% endif %}
 
                       {% if status.entity.fieldOperatingStatusMoreInfo  and status.entity.fieldOperatingStatusFacility != 'normal' %}
@@ -115,7 +80,6 @@
                           {{ status.entity.fieldOperatingStatusMoreInfo }}
                         </div>
                       {% endif %}
-
                     </div>
                   </dd>
                 {% endfor %}
@@ -134,7 +98,7 @@
                 <h3 class="vads-u-margin-top--3 vads-u-margin-bottom--2 ">Local emergency resources</h3>
                 {% for link in fieldLinks %}
                   <p>
-                    <a href="{{ link.uri }}">{{ link.title }}</a>
+                    <va-link href="{{ link.uri }}" text="{{ link.title }}" />
                   </p>
                 {% endfor %}
               {% endif %}


### PR DESCRIPTION
## Summary
Add web components where possible to VAMC operating status pages.

For some reason, this page also had a duplicated `<ul>` for "On this page" content after the `<va-on-this-page>`. I removed the plain `<ul>` and we are just using the web component for "On this page" now.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16998

## Testing done
Tested most things locally on `/boston-health-care/operating-status/` and `/minneapolis-health-care/operating-status/`. Though it is difficult to try to find VAMCs where facilities are currently not operating or in some sort of alert mode. The slim alert banners and the emergency status notifications (subscription) have been forced to show up in the screenshots below.

## Screenshots

### On this page
<img width="1573" alt="Screenshot 2024-05-02 at 2 29 48 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/891037f7-069b-4b08-8cfa-c11a882608ec">

### Facility operating statuses (links)
<img width="1616" alt="Screenshot 2024-05-02 at 2 29 57 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/d5ea263a-66e3-4744-87bd-a16a99a488ed">

### Facility operating statuses (statuses)
<img width="679" alt="Screenshot 2024-05-03 at 12 56 22 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/e50feb87-e885-46d3-bea4-8550c4779f36">

### Emergency status notifications subscription
Note: I had to force this to show up locally, I'm not aware of a page that currently has this visible.

<img width="688" alt="Screenshot 2024-05-02 at 4 03 31 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/a6b3426b-89ba-4f74-8640-b97f99b8c09f">