### PR TITLE
add back-to-top to med records template

### DIFF
--- a/src/site/layouts/vamc_system_medical_records_offi.drupal.liquid
+++ b/src/site/layouts/vamc_system_medical_records_offi.drupal.liquid
@@ -116,10 +116,9 @@
             %}
 					</div>
           <va-back-to-top></va-back-to-top>
-
+					<!-- Last updated & feedback button-->
+					{% include "src/site/includes/above-footer-elements.drupal.liquid" %}
 				</article>
-				<!-- Last updated & feedback button-->
-				{% include "src/site/includes/above-footer-elements.drupal.liquid" %}
 			</div>
 		</div>
 	</main>

--- a/src/site/layouts/vamc_system_medical_records_offi.drupal.liquid
+++ b/src/site/layouts/vamc_system_medical_records_offi.drupal.liquid
@@ -115,6 +115,7 @@
                 contentType = fieldCcRelatedLinks.fetchedBundle
             %}
 					</div>
+          <va-back-to-top></va-back-to-top>
 
 				</article>
 				<!-- Last updated & feedback button-->


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

- Adds back-to-top va web component to the vamc medical records template

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16960

## Testing done

- ran local test suite

## Screenshots

<img width="1518" alt="image" src="https://github.com/department-of-veterans-affairs/content-build/assets/61624970/97004532-94dd-4ad8-908a-b5572b8346cf">
<img width="1220" alt="image" src="https://github.com/department-of-veterans-affairs/content-build/assets/61624970/3579b1a4-67da-434f-bd89-c7bf2a86f72f">

## What areas of the site does it impact?
VAMC medical records pages

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
