### PR TITLE
VACMS 16962 Adds back to top to Billing and Insurance pages

### DIFF
--- a/src/site/layouts/vamc_system_billing_insurance.drupal.liquid
+++ b/src/site/layouts/vamc_system_billing_insurance.drupal.liquid
@@ -77,9 +77,9 @@
             %}
           </div>
           <va-back-to-top></va-back-to-top>
-        </article>
-        <!-- Last updated & feedback button -->
+          <!-- Last updated & feedback button -->
           {% include "src/site/includes/above-footer-elements.drupal.liquid" %}
+        </article>
       </div>
     </div>
   </main>

--- a/src/site/layouts/vamc_system_billing_insurance.drupal.liquid
+++ b/src/site/layouts/vamc_system_billing_insurance.drupal.liquid
@@ -76,6 +76,7 @@
               contentType = fieldCcRelatedLinks.fetchedBundle
             %}
           </div>
+          <va-back-to-top></va-back-to-top>
         </article>
         <!-- Last updated & feedback button -->
           {% include "src/site/includes/above-footer-elements.drupal.liquid" %}


### PR DESCRIPTION
## Summary

- Adds va-back-to-top to Billing and Insurance top-task page
- Sitewide Facilities

## Related issue(s)

- https://app.zenhub.com/workspaces/sitewide-facilities-639f5253e4b702a32376339e/issues/gh/department-of-veterans-affairs/va.gov-cms/16962

## Testing done

- Manual check that DS component appears. Tested that component brings user back to top content on page in mobile and desktop.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

<details>
<summary>Desktop page</summary>
<img src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/445f528c-40f1-4faa-b704-909536450868"/>

</details>

<details>
<summary>Mobile page</summary>
<img src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/141d802a-4eb2-4d74-bee4-86fccd725c06"/>
</details>

## What areas of the site does it impact?

Billing and Insurance VAMC top-task pages

## Acceptance criteria

- [x] VA back-to-top component appears 

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (does not affect authenticated content)

## Requested Feedback

See that component appears either in images or on RI