### PR TITLE
VACMS-16998 Fix operating status double quotes

### DIFF
--- a/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
+++ b/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
@@ -55,7 +55,7 @@
                       class="facility-title-width vads-u-font-weight--bold"
                       onclick="recordEvent({'event':'nav-health-care-facility-status-click'});"
                       href="{{ status.entity.entityUrl.path }}"
-                      text="{{ status.entity.title }}"
+                      text="{{ status.entity.title | encode }}"
                     />
                   </dt>
                   <dd class="vads-l-col--12 medium-screen:vads-l-col--7 medium-screen:vads-u-border-top--1px vads-u-border-color--gray-light">


### PR DESCRIPTION
## Summary
Facility names must be encoded in the templates as they can sometimes contain special characters (particularly double quotes).

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16998

## Testing done
Tested at `/miami-health-care/operating-status/`

## Screenshots
<img width="342" alt="Screenshot 2024-05-07 at 9 28 53 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/5849d977-064d-410b-bd8e-d637707696e9">
<img width="688" alt="Screenshot 2024-05-07 at 9 28 49 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/da89579f-7df9-4c29-a3e6-1ff99a2d5219">

## What areas of the site does it impact?
Facilities Operating Status pages