### PR TITLE
Remove duplicate registration of Health Care Application

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -246,35 +246,6 @@
   {
     "appName": "1010ez Health Care Application form",
     "entryName": "hca",
-    "rootUrl": "/health-care/apply/application",
-    "template": {
-      "title": "Apply for Health Care",
-      "layout": "page-react.html",
-      "display_title": "Apply Now",
-      "description": "Apply for VA health care benefits. Find out which documents you’ll need, and start your online application today.",
-      "body_class": "page-healthcare",
-      "in_maintenance": false,
-      "maintenance_line1": "We’re sorry. The health care application is currently down while we fix a few things. We’ll be back up as soon as we can.",
-      "maintenance_line2": "In the meantime, you can call <a href=\"tel:+18772228387\">1-877-222-8387</a>, Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (<abbr title=\"eastern time\">ET</abbr>) and press 2 to complete this application over the phone.",
-      "collection": "healthCare",
-      "spoke": "Get benefits",
-      "order": 4,
-      "includeBreadcrumbs": true,
-      "breadcrumbs_override": [
-        {
-          "path": "health-care/",
-          "name": "Health care"
-        },
-        {
-          "path": "health-care/apply/application",
-          "name": "Apply for VA health care"
-        }
-      ]
-    }
-  },
-  {
-    "appName": "1010ez Health Care Application form",
-    "entryName": "hca",
     "rootUrl": "/health-care/apply-for-health-care-form-10-10ez",
     "template": {
       "title": "Apply for Health Care",


### PR DESCRIPTION
## Summary

The Health Enrollment team recently completed an update to the root URL for the 10-10EZ (Application for Health Benefits). In order to complete that update without any downtime, a duplicate registration needed to be added with the new root URL. This PR removes the original registration record for the `hca` app.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#31768

## Acceptance criteria

- Registry is free of duplicate app entries for the Health Care Application

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution