### PR TITLE
Run the Daily Production Release at 11AM EDT

### DIFF
--- a/.github/workflows/daily-production-release.yml
+++ b/.github/workflows/daily-production-release.yml
@@ -3,7 +3,7 @@ name: Daily Production Release
 on:
   workflow_dispatch:
   schedule:
-    - cron: 0 19 * * 1-5
+    - cron: 0 15 * * 1-5
 
 concurrency:
   group: daily-prod-release


### PR DESCRIPTION
## Summary

- Changes the crontab value to run 4 hours earlier in the day
- In response to [other deployments announced](https://dsva.slack.com/archives/C03R5SBELQM/p1713293704245769) to be running earlier in the day

## Steps to Implementation
- [x] Update daily production time to 11:00am EST
- [ ] Send out comms to slack channels in in ToT
- [ ] Merge code on Monday (5/13)
- [ ] New production time goes in effect on Tuesday (5/14)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18061