### PR TITLE
17815 find forms icons

### DIFF
--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -96,16 +96,10 @@
           lang="{{ fieldVaFormLanguage }}"
           >
             <va-icon
-              class="vads-u-color--link"
+              class="vads-u-margin-right--0p5"
               icon="file_download"
-              size="4"
-              aria-hidden="true"
+              size="3"
             ></va-icon>
-            <i
-              aria-hidden="true"
-              class="fas fa-download fa-lg vads-u-margin-right--1 va-form-layout--remove-pointer-events"
-              role="presentation"
-            > </i>
           {% assign translatedDownloadText = fieldVaFormLanguage | deriveLanguageTranslation: 'downloadVaForm', fieldVaFormNumber %}
           {{ translatedDownloadText }} (PDF)
         </a>
@@ -162,10 +156,11 @@
                   data-form-number="{{ vaForm.entity.fieldVaFormNumber }}"
                   lang="{{ vaForm.entity.fieldVaFormLanguage }}"
                   >
-                    <i
-                      aria-hidden="true"
-                      class="fas fa-download fa-lg vads-u-margin-right--1 va-form-layout--remove-pointer-events"
-                    > </i>
+                    <va-icon
+                      class="vads-u-margin-right--0p5"
+                      icon="file_download"
+                      size="3"
+                    ></va-icon>
                     {% assign translatedDownloadText = vaForm.entity.fieldVaFormLanguage | deriveLanguageTranslation: 'downloadVaForm', vaForm.entity.fieldVaFormNumber %}
                     {{ translatedDownloadText }} (PDF)
                 </a>

--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -95,6 +95,12 @@
           data-form-number="{{ fieldVaFormNumber }}"
           lang="{{ fieldVaFormLanguage }}"
           >
+            <va-icon
+              class="vads-u-color--link"
+              icon="file_download"
+              size="4"
+              aria-hidden="true"
+            ></va-icon>
             <i
               aria-hidden="true"
               class="fas fa-download fa-lg vads-u-margin-right--1 va-form-layout--remove-pointer-events"


### PR DESCRIPTION
## Summary
Update the `<i>` elements in the content-build portion of the Find Forms app to `<va-icon>`. This is only for the form detail pages. vets-website handles the search / search results portion of this app.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17815

## Testing done
Tested locally at `/find-forms/about-form-10-10m/`. The content-build portion of this application is the Form detail pages only.

## Screenshots

### Download icon
<img width="739" alt="Screenshot 2024-05-09 at 11 02 40 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/8705b446-99d9-42f0-93b5-5c760cbcc9a5">

