### PR TITLE
VACMS-16964 Operating status alert link fix

### DIFF
--- a/src/site/includes/operatingStatusFlagsLinks.drupal.liquid
+++ b/src/site/includes/operatingStatusFlagsLinks.drupal.liquid
@@ -1,8 +1,7 @@
 {% if fieldOperatingStatusFacility == 'notice' %}
   <va-alert status="info" slim visible>
     <va-link
-      active
-      class="operating-status-link"
+      class="vads-u-font-weight--bold operating-status-link"
       onclick="recordEvent({
       'event': 'nav-info-box-click',
       'infoBoxText': 'Facility notice'});"
@@ -13,8 +12,7 @@
 {% elsif fieldOperatingStatusFacility == 'limited' %}
   <va-alert status="warning" slim visible>
     <va-link
-      active
-      class="operating-status-link"
+      class="vads-u-font-weight--bold operating-status-link"
       onclick="recordEvent({
       'event': 'nav-info-box-click',
       'infoBoxText': 'Facility limited'});"
@@ -25,8 +23,7 @@
 {% elsif fieldOperatingStatusFacility == 'closed' %}
   <va-alert status="error" slim visible>
     <va-link
-      active
-      class="operating-status-link"
+      class="vads-u-font-weight--bold operating-status-link"
       onclick="recordEvent({
       'event': 'nav-info-box-click',
       'infoBoxText': 'Facility closed'});"


### PR DESCRIPTION
## Summary
On the Facility locations page, where operating statuses exist, we previously implemented an active link inside of a slim alert. Because the active link has animation on it (when it is hovered, the caret moves to the right), it expands the colored background of the alert behind it. We converted the link to a regular link with a bold text treatment instead.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16964

## Testing done
Tested on `/charleston-health-care/locations/`

https://github.com/department-of-veterans-affairs/content-build/assets/19175324/5c1eb9a4-2cb1-4e7b-957b-61d4f50b8591