### PR TITLE
VACMS-17816 Benefit Hub landing page icon updates

### DIFF
--- a/src/site/assets/sass/style.scss
+++ b/src/site/assets/sass/style.scss
@@ -29,6 +29,17 @@
   }
 }
 
+.hub-icon {
+  border-radius: 50%;
+  height: 32px;
+  min-width: 32px;
+
+  &.large {
+    height: 40px;
+    min-width: 40px;
+  }
+}
+
 // START: Styles for mobile app promo banner
 
 .smartbanner {

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1925,4 +1925,92 @@ module.exports = function registerFilters() {
     }
     return true;
   };
+
+  // In some instances, we get a dynamic hub name from Drupal
+  // In order to use a <va-icon>, we need to map the hub name from Drupal
+  // to its hub icon in the Design System (https://design.va.gov/foundation/icons)
+  // This filter gives us a <va-icon> pointing to the correct hub icon
+  //
+  // Visual example: /initiatives/vote/ under "Learn more about related VA benefits"
+  liquid.filters.getHubIcon = (hub, iconSize, iconClasses) => {
+    const hubIcons = {
+      'health-care': {
+        icon: 'medical_services',
+        backgroundColor: 'hub-health-care',
+      },
+      careers: {
+        icon: 'work',
+        backgroundColor: 'hub-careers',
+      },
+      'life-insurance': {
+        icon: 'shield',
+        backgroundColor: 'hub-life-insurance',
+      },
+      'service-member': {
+        icon: 'flag',
+        backgroundColor: 'hub-service-member',
+      },
+      disability: {
+        icon: 'description',
+        backgroundColor: 'hub-disability',
+      },
+      pension: {
+        icon: 'handshake',
+        backgroundColor: 'hub-pension',
+      },
+      burials: {
+        icon: 'star',
+        backgroundColor: 'hub-burials',
+      },
+      'family-member': {
+        icon: 'groups',
+        backgroundColor: 'hub-family-member',
+      },
+      education: {
+        icon: 'school',
+        backgroundColor: 'hub-education',
+      },
+      housing: {
+        icon: 'home',
+        backgroundColor: 'hub-housing',
+      },
+      records: {
+        icon: 'identification',
+        backgroundColor: 'hub-records',
+      },
+      'va-dept-info': {
+        icon: 'location_city',
+        backgroundColor: 'primary-dark',
+      },
+    };
+
+    if (!hub || !hubIcons[hub]) {
+      return null;
+    }
+
+    const hubData = hubIcons[hub];
+
+    return `
+      <va-icon
+        icon="${hubData.icon}"
+        size="${iconSize}"
+        class="icon-small white hub-icon vads-u-background-color--${hubData.backgroundColor} vads-u-display--flex vads-u-align-items--center vads-u-justify-content--center ${iconClasses}"
+      ></va-icon>
+    `;
+  };
+
+  liquid.filters.formatSocialPlatform = platform => {
+    const twitterString = platform.match(/twitter/i);
+    const youTubeString = platform.match(/youtube/i);
+
+    if (twitterString) {
+      return platform.replace(twitterString, 'X (formerly Twitter)');
+    }
+
+    if (youTubeString) {
+      return platform.replace(youTubeString, 'YouTube');
+    }
+
+    return platform;
+  };
 };

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -3077,3 +3077,29 @@ describe('officeHoursDataFormat', () => {
     expect(liquid.filters.officeHoursDataFormat(data).length, 7);
   });
 });
+
+describe('formatSocialPlatform', () => {
+  it('should properly format a twitter platform', () => {
+    expect(
+      liquid.filters.formatSocialPlatform('Veterans Administration twitter'),
+    ).to.equal('Veterans Administration X (formerly Twitter)');
+  });
+
+  it('should properly format a youtube platform', () => {
+    expect(
+      liquid.filters.formatSocialPlatform('Veterans Administration Youtube'),
+    ).to.equal('Veterans Administration YouTube');
+    expect(
+      liquid.filters.formatSocialPlatform('Veterans Administration youtube'),
+    ).to.equal('Veterans Administration YouTube');
+    expect(
+      liquid.filters.formatSocialPlatform('Veterans Administration YOUTUBE'),
+    ).to.equal('Veterans Administration YouTube');
+  });
+
+  it('should return a non-youtube platform without formatting', () => {
+    expect(
+      liquid.filters.formatSocialPlatform('Veterans Administration Instagram'),
+    ).to.equal('Veterans Administration Instagram');
+  });
+});

--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -7,8 +7,8 @@
     <div class="usa-grid usa-grid-full">
       <article class="usa-width-two-thirds">
         {% if fieldTitleIcon %}
-          <div class="inline hub-main-icon">
-            <i aria-hidden="true" class="icon-large white hub-icon-{{ fieldTitleIcon }} hub-background-{{ fieldTitleIcon }}"></i>
+          <div class="inline hub-main-icon vads-u-margin-right--1 vads-u-margin-bottom--1">
+            {{ fieldTitleIcon | getHubIcon: '3', 'large' }}
           </div>
 
           <div class="inline hub-main-title">
@@ -173,19 +173,17 @@
 
               <section>
                 <h3 class="vads-u-font-size--h4">Get updates</h3>
-                  <ul class="va-nav-linkslist-list social">
-                    <li>
-                      <i aria-hidden="true" class="va-c-social-icon fas fa-envelope vads-u-padding-right--1"></i>
-                      <va-link 
-                        disable-analytics
-                        class="vads-u-text-decoration--underline" 
-                        href="{{ fieldRelatedOffice.entity.fieldEmailUpdatesLink.url.path }}" 
-                        onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });"
-                        text="{{ fieldRelatedOffice.entity.fieldEmailUpdatesLink.title }}"
-                        >
-                      </va-link>
-                    </li>
-                </ul>
+                  <p>
+                    <va-icon icon="mail" size="3" class="vads-u-color--link-default vads-u-padding-right--0p5"></va-icon>
+                    <va-link 
+                      disable-analytics
+                      class="vads-u-text-decoration--underline" 
+                      href="{{ fieldRelatedOffice.entity.fieldEmailUpdatesLink.url.path }}" 
+                      onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });"
+                      text="{{ fieldRelatedOffice.entity.fieldEmailUpdatesLink.title }}"
+                      >
+                    </va-link>
+                  </p>
               </section>
 
               <section>
@@ -196,44 +194,28 @@
 
                   {% for socialPlatform in socialPlatforms %}
                     {% assign socialLink = socialLinks | get: socialPlatform  %}
+                    {% assign platform = socialPlatform | capitalize %}
+                    
+                    {% if socialPlatform == "twitter" %}
+                      {% assign socialIcon = "x" %}
+                    {% else %}
+                      {% assign socialIcon = socialPlatform %}
+                    {% endif %}
+
                     {% if socialLink.value %}
-                      {% if socialPlatform = "youtube_channel" %}
-                        <li>
-                          <i aria-hidden="true" class="va-c-social-icon fab fa-youtube vads-u-padding-right--1"></i>
-                          <va-link 
-                            disable-analytics
-                            class="vads-u-text-decoration--underline" 
-                            href="http://youtube.com/channel/{{ socialLink.value }}" 
-                            onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });"
-                            text="{{ fieldRelatedOffice.entity.fieldExternalLink.title }} {{ socialPlatform | remove: '_' | capitalize }}"
-                          >
-                          </va-link>
-                        </li>
-                      {% elsif socialPlatform == "youtube" %}
-                        <li>
-                          <i aria-hidden="true" class="va-c-social-icon fab fa-{{ socialPlatform }} vads-u-padding-right--1"></i>
-                          <va-link 
-                            disable-analytics
-                            class="vads-u-text-decoration--underline" 
-                            href="http://{{ socialPlatform }}.com/{{ socialLink.value }}" 
-                            onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });"
-                            text="{{ fieldRelatedOffice.entity.fieldExternalLink.title }} YouTube"
-                          >
-                          </va-link>
-                        </li>
-                      {% else %}
-                        <li>
-                          <i aria-hidden="true" class="va-c-social-icon fab fa-{{ socialPlatform }} vads-u-padding-right--1"></i>
-                          <va-link 
-                            disable-analytics
-                            class="vads-u-text-decoration--underline" 
-                            href="http://{{ socialPlatform }}.com/{{ socialLink.value }}" 
-                            onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });" 
-                            text="{{ fieldRelatedOffice.entity.fieldExternalLink.title }} {{ socialPlatform | capitalize }}"
-                          >
-                          </va-link>
-                        </li>
-                      {% endif %}
+                      <li>
+                        <va-icon
+                          icon="{{ socialIcon }}"
+                          size="3"
+                          class="vads-u-color--link-default vads-u-padding-right--0p5"></va-icon>
+                        <va-link 
+                          disable-analytics
+                          href="{{"http://{{ socialPlatform }}.com/{{ socialLink.value }}"}}" 
+                          onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });" 
+                          text="{{ fieldRelatedOffice.entity.fieldExternalLink.title }} {{ platform | formatSocialPlatform }}"
+                        >
+                        </va-link>
+                      </li>
                     {% endif %}
                   {% endfor %}
                 </ul>


### PR DESCRIPTION
## Summary
Update all Benefit Hub landing page icons to use `<va-icon>`.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17816

## Testing done
Tested all benefit hubs locally across breakpoints:
```
/health-care
/disability
/education
/careers-employment
/pension
/housing-assistance
/life-insurance
/burials-memorials
/records
/service-member-benefits
/family-member-benefits
```


## Screenshots

### Hub icons
<img width="200" alt="Screenshot 2024-05-13 at 11 46 57 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/064fbd7d-2c0a-49bb-bd28-f65b69d0424f">
<img width="600" alt="Screenshot 2024-05-13 at 11 47 35 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/43df9449-8452-4a24-9b2a-cf1a8f80ec92">
<img width="600" alt="Screenshot 2024-05-13 at 11 48 05 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/cac597b8-9ec6-482e-9958-48ebd0b79c1a">
<img width="800" alt="Screenshot 2024-05-13 at 11 48 28 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/e538aab5-ca8d-4241-b95d-f7eba65291a9">
<img width="1000" alt="Screenshot 2024-05-13 at 11 48 43 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/fef5f257-46cb-454a-ac8e-caa5e16c5cd9">
</details>

### Social media icons
<img width="332" alt="Screenshot 2024-05-15 at 11 17 15 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/30596ada-822c-42b2-b679-2f282448b473">

