### PR TITLE
VACMS-17817 Resources & Support va-icon cleanup

### DIFF
--- a/src/site/components/browse-by-audience.drupal.liquid
+++ b/src/site/components/browse-by-audience.drupal.liquid
@@ -8,9 +8,7 @@
     {% for audienceTag in audienceTags %}
       {% if forloop.index <= pageSize %}
         <li class="vads-u-margin-y--2">
-          <a class="vads-u-font-weight--bold vads-u-text-decoration--none" href="{{ audienceTag.entityUrl.path }}/">
-            {{ audienceTag.name }} <i role="presentation" aria-hidden="true" class="fa fa-chevron-right vads-u-margin-left--1"></i>
-          </a>
+          <va-link active href="{{ audienceTag.entityUrl.path }}/" text="{{ audienceTag.name }}"></va-link>
         </li>
       {% endif %}
     {% endfor %}
@@ -28,10 +26,7 @@
             <ul class="usa-unstyled-list" role="list">
               {% for audienceTag in remainingAudienceTags %}
                 <li class="vads-u-margin-y--2">
-                  <a class="vads-u-font-weight--bold vads-u-text-decoration--none" href="{{ audienceTag.path.alias }}/">
-                    {{ audienceTag.name }}
-                    <i role="presentation" aria-hidden="true" class="fa fa-chevron-right vads-u-margin-left--1"> </i>
-                  </a>
+                  <va-link active href="{{ audienceTag.path.alias }}/" text="{{ audienceTag.name }}"></va-link>
                 </li>
               {% endfor %}
             </ul>

--- a/src/site/layouts/media_list_images.drupal.liquid
+++ b/src/site/layouts/media_list_images.drupal.liquid
@@ -75,7 +75,7 @@
                               href="{{ mediaImage.entity.image.url }}"
                               target="_blank"
                             >
-                              <i aria-hidden="true" class="fas fa-expand-arrows-alt" role="img"></i>
+                              <va-icon icon="zoom_out_map" size="3"></va-icon>
                             </a>
                             <img
                               alt="{{ alt }}"
@@ -126,7 +126,7 @@
                                     href="{{ remainingImage.entity.image.url }}"
                                     target="_blank"
                                   >
-                                    <i aria-hidden="true" class="fas fa-expand-arrows-alt" role="img"></i>
+                                    <va-icon icon="zoom_out_map" size="3"></va-icon>
                                   </a>
                                   <img
                                     alt="{{ alt }}"

--- a/src/site/paragraphs/lists_of_links.drupal.liquid
+++ b/src/site/paragraphs/lists_of_links.drupal.liquid
@@ -23,7 +23,6 @@
           {% if vaParagraph.entity.fieldLink.url.path %}
             <li class="vads-u-padding-y--1">
               <va-link active href="{{ vaParagraph.entity.fieldLink.url.path }}" text="{{ vaParagraph.entity.fieldLink.title }}">
-                <i class="fa fa-chevron-right vads-u-padding-left--0p5 vads-u-font-size--sm" aria-hidden="true" role="presentation"></i>
               </va-link>
             </li>
           {% endif %}


### PR DESCRIPTION
## Summary
Update Resources & Support icons on the content-build side to `va-icon`.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17817

## Testing done
Tested locally.

In order to test the `media_list_images` template, you need to run `yarn preview` locally and go to `localhost:3002/?preview?nodeId=6954`. There is no production content for this template, but it only exists on the R&S page and we do have some content in lower environments.

The icon in the `list_of_links` template was left behind when we converted the `Go to all articles` links to active va-links. The icon wasn't showing up visually, but it is in the DOM in prod. See screenshots in the below section. This can be tested at `/resources`.

The `browse_by_audience` template isn't used in prod, but when it is implemented, it looks just like the browse by topic section, so as long as that section is working ok and implemented identically in the `browse_by_audience` template, we can have confidence it will work if it is implemented.

## Screenshots

### media_list_images (not production content)
<img width="383" alt="Screenshot 2024-05-15 at 3 59 37 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/4c6d5137-22fd-43c7-91e1-467ba357b83d">
<img width="410" alt="Screenshot 2024-05-15 at 3 59 33 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/1fc709c5-c778-4fd4-8f4f-bdc6360d7e3a">

### list_of_links

#### In production
The icon is present next to the active link, but it does not appear
<img width="1437" alt="Screenshot 2024-05-15 at 4 02 34 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/a1c6ced0-f4f2-436b-a88f-f565bb5fb180">

#### Locally
The icon that is not appearing has been removed and the active link still works

<img width="1439" alt="Screenshot 2024-05-15 at 4 02 10 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/45ae1df0-04e5-4a7f-bc04-3789ac391e97">