### PR TITLE
Add DataDog RUM init to decision review templates

### DIFF
--- a/src/site/includes/decision-reviews-rum.html
+++ b/src/site/includes/decision-reviews-rum.html
@@ -1,0 +1,54 @@
+<script
+  nonce="**CSP_NONCE**"
+  type="text/javascript"
+  defer
+  src="https://www.datadoghq-browser-agent.com/us1/v5/datadog-rum.js"
+></script>
+<script nonce="**CSP_NONCE**" type="text/javascript">
+// All of the page urls we want to monitor include www.va.gov (production only)
+if (window.DD_RUM && window.location?.hostname === 'www.va.gov') {
+  /**
+   * Unauthenticated Static pages may be crawled by bots, so we won't initialize
+   * RUM sessions. The following code is from DataDog:
+   * https://docs.datadoghq.com/real_user_monitoring/guide/identify-bots-in-the-ui
+   */
+  // regex patterns to identify known bot instances (5/2024):
+  const botPattern = '(googlebot\/|bot|Googlebot-Mobile|Googlebot-Image|Google favicon|Mediapartners-Google|bingbot|slurp|java|wget|curl|Commons-HttpClient|Python-urllib|libwww|httpunit|nutch|phpcrawl|msnbot|jyxobot|FAST-WebCrawler|FAST Enterprise Crawler|biglotron|teoma|convera|seekbot|gigablast|exabot|ngbot|ia_archiver|GingerCrawler|webmon |httrack|webcrawler|grub.org|UsineNouvelleCrawler|antibot|netresearchserver|speedy|fluffy|bibnum.bnf|findlink|msrbot|panscient|yacybot|AISearchBot|IOI|ips-agent|tagoobot|MJ12bot|dotbot|woriobot|yanga|buzzbot|mlbot|yandexbot|purebot|Linguee Bot|Voyager|CyberPatrol|voilabot|baiduspider|citeseerxbot|spbot|twengabot|postrank|turnitinbot|scribdbot|page2rss|sitebot|linkdex|Adidxbot|blekkobot|ezooms|dotbot|Mail.RU_Bot|discobot|heritrix|findthatfile|europarchive.org|NerdByNature.Bot|sistrix crawler|ahrefsbot|Aboundex|domaincrawler|wbsearchbot|summify|ccbot|edisterbot|seznambot|ec2linkfinder|gslfbot|aihitbot|intelium_bot|facebookexternalhit|yeti|RetrevoPageAnalyzer|lb-spider|sogou|lssbot|careerbot|wotbox|wocbot|ichiro|DuckDuckBot|lssrocketcrawler|drupact|webcompanycrawler|acoonbot|openindexspider|gnam gnam spider|web-archive-net.com.bot|backlinkcrawler|coccoc|integromedb|content crawler spider|toplistbot|seokicks-robot|it2media-domain-crawler|ip-web-crawler.com|siteexplorer.info|elisabot|proximic|changedetection|blexbot|arabot|WeSEE:Search|niki-bot|CrystalSemanticsBot|rogerbot|360Spider|psbot|InterfaxScanBot|Lipperhey SEO Service|CC Metadata Scaper|g00g1e.net|GrapeshotCrawler|urlappendbot|brainobot|fr-crawler|binlar|SimpleCrawler|Livelapbot|Twitterbot|cXensebot|smtbot|bnf.fr_bot|A6-Indexer|ADmantX|Facebot|Twitterbot|OrangeBot|memorybot|AdvBot|MegaIndex|SemanticScholarBot|ltx71|nerdybot|xovibot|BUbiNG|Qwantify|archive.org_bot|Applebot|TweetmemeBot|crawler4j|findxbot|SemrushBot|yoozBot|lipperhey|y!j-asr|Domain Re-Animator Bot|AddThis)';
+  const regex = new RegExp(botPattern, 'i');
+
+  // Don't initialize RUM if a bot is crawling the page
+  const isBot = regex.test(navigator.userAgent);
+
+  /**
+   * Initialize DataDog Real User Monitoring (RUM) sessions
+   * https://docs.datadoghq.com/real_user_monitoring/browser/#cdn-sync
+   */
+  if (
+    !isBot &&
+    // is DataDog is already initialized?
+    !window.DD_RUM?.getInitConfiguration()
+  ) {
+    window.DD_RUM.init({
+      site: 'ddog-gov.com',
+      env: 'production',
+      version: '1.0.0',
+      service: 'benefits--???',
+      clientToken: '<CLIENT_TOKEN>',
+      applicationId: '<APPLICATION_ID>',
+
+      sessionSampleRate: conditionalSampleRate,
+      sessionReplaySampleRate: conditionalReplaySampleRate,
+
+      trackInteractions: true,
+      trackUserInteractions: true,
+      trackFrustrations: true,
+      trackResources: true,
+      trackLongTasks: true,
+
+      // https://docs.datadoghq.com/real_user_monitoring/session_replay/browser/privacy_options/
+      defaultPrivacyLevel: 'mask-user-input', // 'allow',
+    });
+    window.DD_RUM.startSessionReplayRecording();
+  }
+}
+</script>

--- a/src/site/includes/decision-reviews-rum.html
+++ b/src/site/includes/decision-reviews-rum.html
@@ -32,21 +32,20 @@ if (window.DD_RUM && window.location?.hostname === 'www.va.gov') {
       site: 'ddog-gov.com',
       env: 'production',
       version: '1.0.0',
-      service: 'benefits--???',
-      clientToken: '<CLIENT_TOKEN>',
-      applicationId: '<APPLICATION_ID>',
+      service: 'benefits-decision-review-static-pages',
+      clientToken: 'pub17c22ff5e9e7e51f7ac28b828741e21a',
+      applicationId: '133801ec-0b13-4a6f-9689-bd937a1ddf27',
 
-      sessionSampleRate: conditionalSampleRate,
-      sessionReplaySampleRate: conditionalReplaySampleRate,
+      sessionSampleRate: 10, // {% if decisionReviewRum %}
+      sessionReplaySampleRate: 20,
 
       trackInteractions: true,
       trackUserInteractions: true,
-      trackFrustrations: true,
       trackResources: true,
       trackLongTasks: true,
 
       // https://docs.datadoghq.com/real_user_monitoring/session_replay/browser/privacy_options/
-      defaultPrivacyLevel: 'mask-user-input', // 'allow',
+      defaultPrivacyLevel: 'mask-user-input',
     });
     window.DD_RUM.startSessionReplayRecording();
   }

--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -61,7 +61,7 @@
         {% endif %}
 
         <va-accordion bordered uswds>
-          <va-accordion-item 
+          <va-accordion-item
             class="va-accordion-item"
             level="2"
             open="true"
@@ -101,7 +101,7 @@
                         </a>
                       {% elsif service.fieldLink.url.path %}
                         <a
-                          href="{{ service.fieldLink.url.path }}" 
+                          href="{{ service.fieldLink.url.path }}"
                           onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Ask questions' });"
                         >
                         <span>{{ service.title }}</span>
@@ -151,8 +151,8 @@
               id="{{ fieldRelatedOffice.entity.fieldExternalLink.title | hashReference: 60 }}">
               {% if fieldRelatedOffice.entity.fieldExternalLink.url.path != empty %}
                 <h3 class="va-nav-linkslist-list vads-u-font-size--h4">
-                  <va-link 
-                    href="{{ fieldRelatedOffice.entity.fieldExternalLink.url.path }}" 
+                  <va-link
+                    href="{{ fieldRelatedOffice.entity.fieldExternalLink.url.path }}"
                     text="{{ fieldRelatedOffice.entity.fieldExternalLink.title }}"
                   />
                 </h3>
@@ -162,8 +162,8 @@
                 <h3 class="vads-u-font-size--h4">Get updates</h3>
                   <p>
                     <va-icon icon="mail" size="3" class="vads-u-color--link-default vads-u-padding-right--0p5"></va-icon>
-                    <va-link 
-                      href="{{ fieldRelatedOffice.entity.fieldEmailUpdatesLink.url.path }}" 
+                    <va-link
+                      href="{{ fieldRelatedOffice.entity.fieldEmailUpdatesLink.url.path }}"
                       text="{{ fieldRelatedOffice.entity.fieldEmailUpdatesLink.title }}"
                     />
                   </p>
@@ -178,7 +178,7 @@
                   {% for socialPlatform in socialPlatforms %}
                     {% assign socialLink = socialLinks | get: socialPlatform  %}
                     {% assign platform = socialPlatform | capitalize %}
-                    
+
                     {% if socialPlatform == "twitter" %}
                       {% assign socialIcon = "x" %}
                     {% else %}
@@ -191,8 +191,8 @@
                           icon="{{ socialIcon }}"
                           size="3"
                           class="vads-u-color--link-default vads-u-padding-right--0p5"></va-icon>
-                        <va-link 
-                          href="http://{{ socialPlatform }}.com/{{ socialLink.value }}" 
+                        <va-link
+                          href="http://{{ socialPlatform }}.com/{{ socialLink.value }}"
                           text="{{ fieldRelatedOffice.entity.fieldExternalLink.title }} {{ platform | formatSocialPlatform }}"
                         >
                         </va-link>
@@ -213,6 +213,10 @@
   {% include "src/site/includes/veteran-banner.html" %}
   </main>
 </div>
+
+{% if decisionReviewRum %}
+  {% include "src/site/includes/decision-reviews-rum.html" %}
+{% endif %}
 
 {% include "src/site/includes/footer.html" %}
 {% include "src/site/includes/debug.drupal.liquid" %}

--- a/src/site/layouts/page.drupal.liquid
+++ b/src/site/layouts/page.drupal.liquid
@@ -55,12 +55,12 @@
                 {% include "src/site/paragraphs/q_a_group_collapsible_content.drupal.liquid" with entity = block.entity %}
               {% else %}
                 {% include "src/site/paragraphs/q_a_group_content.drupal.liquid" with entity = block.entity %}
-              {% endif %}  
+              {% endif %}
             {% else %}
               {% assign bundleComponent = "src/site/paragraphs/" | append: block.entity.entityBundle %}
               {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
               {% include {{ bundleComponentWithExtension }} with entity = block.entity %}
-            {% endif %}  
+            {% endif %}
           {% endfor %}
           {% if fieldRelatedLinks != empty %}
             <div class="row">
@@ -82,6 +82,9 @@
   </div>
 </div>
 
+{% if decisionReviewRum %}
+  {% include "src/site/includes/decision-reviews-rum.html" %}
+{% endif %}
 
 {% include "src/site/includes/footer.html" %}
 {% include "src/site/includes/debug.drupal.liquid" %}

--- a/src/site/layouts/step_by_step.drupal.liquid
+++ b/src/site/layouts/step_by_step.drupal.liquid
@@ -118,5 +118,9 @@
   </main>
 </div>
 
+{% if decisionReviewRum %}
+  {% include "src/site/includes/decision-reviews-rum.html" %}
+{% endif %}
+
 {% include "src/site/includes/footer.html" %}
 {% include "src/site/includes/debug.drupal.liquid" %}

--- a/src/site/layouts/support_resources_detail_page.drupal.liquid
+++ b/src/site/layouts/support_resources_detail_page.drupal.liquid
@@ -89,5 +89,9 @@
   </main>
 </div>
 
+{% if decisionReviewRum %}
+  {% include "src/site/includes/decision-reviews-rum.html" %}
+{% endif %}
+
 {% include "src/site/includes/footer.html" %}
 {% include "src/site/includes/debug.drupal.liquid" %}

--- a/src/site/stages/build/drupal/page.js
+++ b/src/site/stages/build/drupal/page.js
@@ -333,6 +333,9 @@ function compilePage(page, contentData) {
     },
   } = contentData;
 
+  // Get feature flags.
+  const { cmsFeatureFlags } = global;
+
   // Get page owner
   let owner;
   if (page.fieldAdministration && page.fieldAdministration.entity) {
@@ -519,6 +522,7 @@ function compilePage(page, contentData) {
         banners,
         promoBanners,
         ...pageId,
+        decisionReviewRum: cmsFeatureFlags.FEATURE_DECISION_REVIEW_RUM,
       };
       break;
   }


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > We want to add DataDog Real User Monitoring session to this list of static pages (in impact section). This PR updates the liquid template for each template and adds a new includes file which initializes RUM sessions on the page. This PR will be initially opened in draft mode to allow updates to the variable & add feature toggles. The RUM initialization code is also incomplete, and will be provided once we get data on traffic and percentage of sessions to record.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
  > _Pending_

## Related issue(s)

[See #83078](https://github.com/department-of-veterans-affairs/va.gov-team/issues/83078)

## Testing done

- _Describe what the old behavior was prior to the change_
  > No DataDog RUM session recording, only Google Analytics
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A - no visual changes

## What areas of the site does it impact?

Authenticated & Unauthenticated

| EntityId | Template | Path |
|---|---|---|
| 3071  | [landing_page.drupal.liquid](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/layouts/landing_page.drupal.liquid) | decision-reviews |
| 3011  | [page.drupal.liquid](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/layouts/page.drupal.liquid) | decision-reviews/supplemental-claim |
| 3003  | [page.drupal.liquid](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/layouts/page.drupal.liquid) | decision-reviews/higher-level-review |
| 3029  | [page.drupal.liquid](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/layouts/page.drupal.liquid) | decision-reviews/board-appeal |
| 3010  | [page.drupal.liquid](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/layouts/page.drupal.liquid) | decision-reviews/board-appeal/veterans-law-judge-hearing |
| 3013  | [page.drupal.liquid](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/layouts/page.drupal.liquid) | decision-reviews/board-appeal/after-board-appeal-decision |
| 3008  | [page.drupal.liquid](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/layouts/page.drupal.liquid) | decision-reviews/after-you-request-review |
| 3030  | [page.drupal.liquid](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/layouts/page.drupal.liquid) | decision-reviews/contested-claims |
| 3025  | [page.drupal.liquid](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/layouts/page.drupal.liquid) | decision-reviews/insurance-claims |
| 3016  | [page.drupal.liquid](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/layouts/page.drupal.liquid) | decision-reviews/fiduciary-claims |
| 3102  | [page.drupal.liquid](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/layouts/page.drupal.liquid) | decision-reviews/legacy-appeals |
| 3103  | [page.drupal.liquid](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/layouts/page.drupal.liquid) | decision-reviews/legacy-appeals/priority-review |
| 57215 | [page.drupal.liquid](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/layouts/page.drupal.liquid) | decision-reviews/clinical-appeals |
| 57308 | [page.drupal.liquid](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/layouts/page.drupal.liquid) | decision-reviews/family-caregiver-program-reviews |
| 62667 | [page.drupal.liquid](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/layouts/page.drupal.liquid) | get-help-with-review-request |
| 23290 | [support_resources_detail_page.drupal.liquid](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/layouts/support_resources_detail_page.drupal.liquid) | resources/choosing-a-decision-review-option |
| 50010 | [support_resources_detail_page.drupal.liquid](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/layouts/support_resources_detail_page.drupal.liquid) | resources/decision-reviews-faqs |
| 64063 | [support_resources_detail_page.drupal.liquid](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/layouts/support_resources_detail_page.drupal.liquid) | resources/hearing-coordinators-for-the-board-of-veterans-appeals |
| 8520 | [step_by_step.drupal.liquid](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/layouts/step_by_step.drupal.liquid) | resources/how-to-check-your-va-claim-appeal-or-decision-review-status-online |
| 53778 | [support_resources_detail_page.drupal.liquid](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/layouts/support_resources_detail_page.drupal.liquid) | resources/requesting-a-virtual-hearing-for-a-board-appeal |
| 49994 | [support_resources_detail_page.drupal.liquid](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/layouts/support_resources_detail_page.drupal.liquid) | resources/vas-duty-to-assist |
| 9626 | [support_resources_detail_page.drupal.liquid](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/layouts/support_resources_detail_page.drupal.liquid) | resources/what-your-decision-review-or-appeal-status-means |

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
