### PR TITLE
VACMS-17825 Outreach materials va-icon upgrades

### DIFF
--- a/src/site/layouts/publication_listing.drupal.liquid
+++ b/src/site/layouts/publication_listing.drupal.liquid
@@ -198,28 +198,24 @@
                       {% if entity.derivedFields.absoluteUrl %}
                       {% assign url = entity.derivedFields.absoluteUrl %}
                       {% endif %}
-                      <a
-                        aria-label="Download {{extension | upcase}} {{entity.title}}"
-                        class="file-download-with-icon"
-                        target="_blank"
+                      <va-link
+                        download
                         href="{{url}}"
-                        download="{{url | fileDisplayName}}"
-                        {% if extension == 'pdf' %}
-                          type="application/{{ extension }}"
-                        {% endif %}
-                      ><i
-                          class="fas fa-download vads-u-padding-right--1"></i>Download
-                        {{extension | upcase}}
-                        ({{entity.fieldMedia.entity.fieldDocument.entity.filesize | fileSize}})</a>
+                        text="Download {{extension | upcase}}
+                        ({{entity.fieldMedia.entity.fieldDocument.entity.filesize | fileSize}})"
+                      ></va-link>
                       {% endif %}
 
                       {% if entity.fieldMedia.entity.entityBundle == 'video' %}
-                      <a aria-label="Go to video about {{entity.title}}"
-                        class="video-link" target="_blank"
-                        href="{{entity.fieldMedia.entity.fieldMediaVideoEmbedField}}"><i
-                          class="fas fa-play-circle vads-u-padding-right--1"></i>Go
-                        to
-                        video</a>
+                      <va-icon
+                        class="vads-u-color--link-default"
+                        icon="youtube"
+                        size="3"
+                      ></va-icon>
+                      <va-link
+                        href="{{entity.fieldMedia.entity.fieldMediaVideoEmbedField}}"
+                        text="Go to video"
+                      ></va-link>
                       {% endif %}
 
                       {% if entity.fieldMedia.entity.entityBundle == 'image' %}
@@ -227,13 +223,12 @@
                       {% if entity.derivedFields.absoluteUrl %}
                       {% assign url = entity.derivedFields.absoluteUrl %}
                       {% endif %}
-                      <a aria-label="Download {{url | fileExt | upcase}} {{entity.title}}"
-                        class="file-download-with-icon" target="_blank"
-                        href="{{url}}" download="{{url}}"><i
-                          class="fas fa-download vads-u-padding-right--1"></i>Download
-                        {{url | fileExt | upcase}}
-                        ({{entity.fieldMedia.entity.image.entity.filesize | fileSize}})
-                      </a>
+                      <va-link
+                        download="{{url}}"
+                        href="{{url}}"
+                        text="Download {{url | fileExt | upcase}}
+                        ({{entity.fieldMedia.entity.image.entity.filesize | fileSize}})"
+                      ></va-link>
                       {% endif %}
 
                     </div>


### PR DESCRIPTION
## Summary
Upgrade all Font Awesome icons to use va-icon.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17825

## Testing done
Tested document, image and video links locally at `/outreach-and-events/outreach-materials/`

## Screenshots
### Document
<img width="373" alt="Screenshot 2024-05-22 at 12 59 44 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/7bd5f64a-102d-411e-b9a9-d282d5a0f318">
<img width="484" alt="Screenshot 2024-05-22 at 1 01 30 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/06f85ff5-23e6-4818-b86d-712765353bfc">


### Video
<img width="374" alt="Screenshot 2024-05-22 at 1 00 25 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/60801b6c-7305-4670-a627-814f695a2f75">
<img width="485" alt="Screenshot 2024-05-22 at 1 01 50 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/f0959769-e644-4836-a120-0b7b28276e38">


### Image
<img width="372" alt="Screenshot 2024-05-22 at 1 00 40 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/32e0db6f-fbd9-4b34-b48a-c8de5a594b45">
<img width="480" alt="Screenshot 2024-05-22 at 1 02 03 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/03fe2b47-1fe0-49d5-9363-8979afb997f4">
