### PR TITLE
VACMS-16999 VAMC Detail page web components

### DIFF
--- a/src/site/assets/sass/style.scss
+++ b/src/site/assets/sass/style.scss
@@ -53,7 +53,16 @@
 }
 
 // START: Styles for mobile app promo banner
+#alert-with-additional-info {
 
+  *:first-child,
+  *:last-child {
+    margin-bottom: 0 !important;
+    margin-top: 0 !important;
+  }
+}
+
+// START: Styles for mobile app promo banner
 .smartbanner {
   position: absolute;
   top: 0;

--- a/src/site/blocks/alert.drupal.liquid
+++ b/src/site/blocks/alert.drupal.liquid
@@ -25,15 +25,11 @@
         NOTE: .additional-info-container is a class utilized by
         createAdditionalInfoWidget.js to add toggle functionality to info alerts
       {% endcomment %}
-      <div data-alert-box-title="{{ alert.fieldAlertTitle }}" data-label="{{ alert.fieldAlertContent.entity.fieldTextExpander }}" class="form-expanding-group borderless-alert additional-info-container">
-        <div class="additional-info-title">
-          {{ alert.fieldAlertContent.entity.fieldTextExpander }}
-        </div>
-
-        {% if alert.fieldAlertContent.entity.fieldWysiwyg %}
-          <div class="additional-info-content usa-alert-text" hidden>{{ alert.fieldAlertContent.entity.fieldWysiwyg.processed }}</div>
-        {% endif %}
-      </div>
+      {% if alert.fieldAlertContent.entity.fieldWysiwyg %}
+        <va-additional-info id="alert-with-additional-info" disable-border="true" trigger="{{ alert.fieldAlertContent.entity.fieldTextExpander }}">
+          <div>{{ alert.fieldAlertContent.entity.fieldWysiwyg.processed }}</div>
+        </va-additional-info>
+      {% endif %}
     {% endif %}
   </va-alert>
 {% endif %}

--- a/src/site/facilities/health_care_region_detail_content.drupal.liquid
+++ b/src/site/facilities/health_care_region_detail_content.drupal.liquid
@@ -53,6 +53,7 @@
       {% include "src/site/facilities/facility_social_links.drupal.liquid" with regionNickname = fieldOffice.entity.title %}
     {% endif %}
   {% endif %}
+  <va-back-to-top></va-back-to-top>
   <!-- Last updated & feedback button-->
   {% include "src/site/includes/above-footer-elements.drupal.liquid" %}
 </article>

--- a/src/site/facilities/health_care_region_detail_content.drupal.liquid
+++ b/src/site/facilities/health_care_region_detail_content.drupal.liquid
@@ -22,7 +22,7 @@
 
 
   {% if fieldTableOfContentsBoolean != empty and fieldTableOfContentsBoolean %}
-    <va-on-this-page class="vads-u-margin-left--1 vads-u-margin-bottom--0 vads-u-padding-bottom--0"></va-on-this-page>
+    <va-on-this-page></va-on-this-page>
   {% endif %}
 
   {% if fieldFeaturedContent != empty and fieldFeaturedContent.length > 0 %}

--- a/src/site/layouts/health_care_region_detail_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_detail_page.drupal.liquid
@@ -13,6 +13,7 @@
         {% include 'src/site/facilities/health_care_region_detail_content.drupal.liquid' %}
       </div>
     </div>
+    <va-back-to-top></va-back-to-top>
   </main>
 </div>
 {% include "src/site/includes/footer.html" %}

--- a/src/site/layouts/health_care_region_detail_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_detail_page.drupal.liquid
@@ -13,7 +13,6 @@
         {% include 'src/site/facilities/health_care_region_detail_content.drupal.liquid' %}
       </div>
     </div>
-    <va-back-to-top></va-back-to-top>
   </main>
 </div>
 {% include "src/site/includes/footer.html" %}

--- a/src/site/paragraphs/downloadable_file.drupal.liquid
+++ b/src/site/paragraphs/downloadable_file.drupal.liquid
@@ -27,6 +27,7 @@
         <va-link
             download="{{url}}"
             href="{{url}}"
+            filetype="{{ fileExt }}"
             text="{{entity.fieldTitle}} ({{url | fileExt | upcase}})"
         ></va-link>
     {% endif %}
@@ -37,6 +38,7 @@
         <va-link
             download="{{url | fileDisplayName}}"
             href="{{url}}"
+            filetype="{{ externsion }}"
             text="{{entity.fieldTitle}} ({{extension | upcase}})"
         ></va-link>
     {% endif %}

--- a/src/site/paragraphs/downloadable_file.drupal.liquid
+++ b/src/site/paragraphs/downloadable_file.drupal.liquid
@@ -27,7 +27,6 @@
         <va-link
             download="{{url}}"
             href="{{url}}"
-            filetype="{{ fileExt }}"
             text="{{entity.fieldTitle}} ({{url | fileExt | upcase}})"
         ></va-link>
     {% endif %}
@@ -38,7 +37,6 @@
         <va-link
             download="{{url | fileDisplayName}}"
             href="{{url}}"
-            filetype="{{ externsion }}"
             text="{{entity.fieldTitle}} ({{extension | upcase}})"
         ></va-link>
     {% endif %}

--- a/src/site/paragraphs/downloadable_file.drupal.liquid
+++ b/src/site/paragraphs/downloadable_file.drupal.liquid
@@ -24,36 +24,33 @@
     {% if entity.fieldMedia.entity.entityBundle == 'image' %}
 
         {% assign url = entity.fieldMedia.entity.image.url %}
-
-        <a class="file-download-with-icon" target="_blank"
-           href="{{url}}" download="{{url}}">
-            <i class="fas fa-download vads-u-margin--0p5" aria-label="Download" role="img"></i>
-            {{entity.fieldTitle}} ({{url | fileExt | upcase}})
-        </a>
+        <va-link
+            download="{{url}}"
+            href="{{url}}"
+            text="{{entity.fieldTitle}} ({{url | fileExt | upcase}})"
+        ></va-link>
     {% endif %}
 
     {% if entity.fieldMedia.entity.entityBundle == 'document' %}
         {% assign url = entity.fieldMedia.entity.fieldDocument.entity.url %}
         {% assign extension = url | fileExt %}
-        <a
-            class="file-download-with-icon"
-            target="_blank"
-            href="{{url}}"
+        <va-link
             download="{{url | fileDisplayName}}"
-            {% if extension == 'pdf' %}
-                type="application/{{extension}}"
-            {% endif %}
-        >
-            <i class="fas fa-download vads-u-margin--0p5" aria-label="Download" role="img"></i>
-            {{entity.fieldTitle}} ({{extension | upcase}})
-        </a>
+            href="{{url}}"
+            text="{{entity.fieldTitle}} ({{extension | upcase}})"
+        ></va-link>
     {% endif %}
 
     {% if entity.fieldMedia.entity.entityBundle == 'video' %}
-        <a class="video-link" target="_blank"
-           href="{{entity.fieldMedia.entity.fieldMediaVideoEmbedField}}">
-            <i class="fas fa-play-circle vads-u-margin--0p5" aria-hidden="true" role="img"></i>{{entity.fieldTitle}}
-        </a>
+        <va-icon
+            class="vads-u-color--link-default"
+            icon="youtube"
+            size="3"
+            ></va-icon>
+        <va-link
+            href="{{entity.fieldMedia.entity.fieldMediaVideoEmbedField}}"
+            text="{{entity.fieldTitle}}"
+        ></va-link>
     {% endif %}
 </div>
 

--- a/src/site/paragraphs/process.drupal.liquid
+++ b/src/site/paragraphs/process.drupal.liquid
@@ -12,11 +12,9 @@
 {% endcomment %}
 
 <div data-template="paragraphs/process" data-entity-id="{{ entity.entityId }}" class="process schemaform-process">
-    <ol>
-    {% assign count = 1 %}
-        {% for item in entity.fieldSteps %}
-           <li class="process-step list-{{ count | numToWord }}"> {{ item.processed }} </li>
-           {% assign count = count | plus: 1 %}
-        {% endfor %}
-    </ol>
+  <va-process-list>
+    {% for item in entity.fieldSteps %}
+        <va-process-list-item>{{ item.processed }}</va-process-list-item>
+    {% endfor %}
+  </va-process-list>
 </div>


### PR DESCRIPTION
## Summary
Use web components on VAMC detail pages where possible.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16999

## Testing done
Tested locally at these routes:
- /boston-health-care/make-an-appointment/
- /boston-health-care/contact-us/
- /boston-health-care/about-us/
- /boston-health-care/work-with-us/
- /minneapolis-health-care/make-an-appointment/
- /minneapolis-health-care/contact-us/
- /minneapolis-health-care/about-us/
- /minneapolis-health-care/work-with-us/

Also tested a page [**via Tugboat**](https://web-v9l0sy4euftr8m5pebq4pxezfbvbxcnz.demo.cms.va.gov/western-colorado-health-care/about-us/important-useful-information/) for the process list web component.

## Screenshots

<details><summary>Additional info inside alert component</summary>

### Desktop
<img width="693" alt="Screenshot 2024-05-22 at 4 53 03 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/c6872c82-cbbb-44f1-a042-70390bc1c8fb">
<img width="706" alt="Screenshot 2024-05-22 at 4 53 08 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/ae3ed636-5239-4142-8cf6-49548ededd1d">

### Mobile
<img width="377" alt="Screenshot 2024-05-22 at 4 53 37 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/62bd75ec-47fb-4986-a18c-43c72550033e">

### DOM
<img width="506" alt="Screenshot 2024-05-22 at 4 53 30 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/2904d634-d93b-4344-b44e-b6d46c4849fe">

</details>

<details><summary>Back to top component</summary>
<img width="629" alt="Screenshot 2024-05-22 at 4 53 45 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/70c734d6-556d-4a0f-9b62-30a3b4fa2234">
<img width="377" alt="Screenshot 2024-05-22 at 4 53 37 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/14cf8763-ee7c-4a70-a2b4-f617f724d94f">

</details>

<details><summary>Downloadable files (on Minneapolis About Us page)</summary>
<img width="757" alt="Screenshot 2024-05-22 at 5 09 57 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/ba8f0b62-0abf-4abe-86e7-046f8c11b3f0">
<img width="422" alt="Screenshot 2024-05-22 at 5 10 30 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/2e6d1595-b19a-45de-a5a5-8efabb96f5b8">

</details>

<details><summary>Process list</summary>

### Desktop
<img width="605" alt="Screenshot 2024-05-28 at 10 46 28 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/73b4f006-a5a8-4d92-a1f6-fe8ba9521d22">

### Mobile
<img width="380" alt="Screenshot 2024-05-28 at 10 46 33 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/0a81eed3-9fbb-4947-ad97-dfadd2c1e5b4">

### DOM
<img width="450" alt="Screenshot 2024-05-28 at 10 46 24 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/17f07b2b-fe8a-43ea-acc2-58549748c783">

</details>