### PR TITLE
Add entry for Caregiver application URL update

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -179,6 +179,33 @@
     }
   },
   {
+    "appName": "10-10CG",
+    "entryName": "1010cg-application-caregiver-assistance",
+    "rootUrl": "/family-and-caregiver-benefits/health-and-disability/comprehensive-assistance-for-family-caregivers/apply-form-10-10cg",
+    "template": {
+      "title": "Caregiver Application for Benefits",
+      "vagovprod": true,
+      "vagovstaging": true,
+      "vagovdev": true,
+      "localhost": true,
+      "includeBreadcrumbs": true,
+      "breadcrumbs_override": [
+        {
+          "path": "family-and-caregiver-benefits",
+          "name": "Family and caregiver benefits"
+        },
+        {
+          "path": "family-and-caregiver-benefits/health-and-disability",
+          "name": "Health and disability benefits for family and caregivers"
+        },
+        {
+          "path": "family-and-caregiver-benefits/health-and-disability/comprehensive-assistance-for-family-caregivers/apply-form-10-10cg",
+          "name": "Apply for the Program of Comprehensive Assistance for Family Caregivers"
+        }
+      ]
+    }
+  },
+  {
     "appName": "Terms of use",
     "entryName": "terms-of-use",
     "rootUrl": "/terms-of-use",


### PR DESCRIPTION
## Summary

The Health Enrollment (1010) team has been asked to update the root URL of the Family Caregivers Application to match the new location within VA.gov where this application will live. This PR adds a duplicate entry to the registry with the updated root URL and breadcrumbs to begin the process of migrating the app to the new URL.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#81299

## Acceptance criteria

- Application is accessible at both URL locations during initial phases of migration

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution