### PR TITLE
VACMS-18265 Fix social links on Benefit Hub landing pages

### DIFF
--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -208,7 +208,7 @@
                           class="vads-u-color--link-default vads-u-padding-right--0p5"></va-icon>
                         <va-link 
                           disable-analytics
-                          href="{{"http://{{ socialPlatform }}.com/{{ socialLink.value }}"}}" 
+                          href="http://{{ socialPlatform }}.com/{{ socialLink.value }}" 
                           onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });" 
                           text="{{ fieldRelatedOffice.entity.fieldExternalLink.title }} {{ platform | formatSocialPlatform }}"
                         >


### PR DESCRIPTION
## Summary
Fix syntax issue with social media links on Benefit Hub landing pages.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18265

## Testing done
Tested locally at several benefit hubs:
- `/health-care`
- `/disability`
- `/education`

## Screenshots

### Before
<img width="486" alt="Screenshot 2024-06-03 at 9 35 44 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/ac5a2990-68bb-425d-866c-90a84d186afa">


### After
<img width="481" alt="Screenshot 2024-06-03 at 9 30 23 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/d2c997b8-a080-42f1-bcca-6d3afe0d47b4">
<img width="483" alt="Screenshot 2024-06-03 at 9 30 16 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/d86ec1f5-493b-4d04-a8d7-69742369c54b">
<img width="482" alt="Screenshot 2024-06-03 at 9 30 10 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/60d4b2c8-cf05-4101-bd7f-7b567a091822">
<img width="487" alt="Screenshot 2024-06-03 at 9 30 04 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/86c6a1b4-c55b-4cf9-9b5a-af17357aa90b">
<img width="488" alt="Screenshot 2024-06-03 at 9 29 58 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/cf2623cc-1a04-4b8a-a1a0-f2a036cf8b74">
