### PR TITLE
VACMS-17886 VBA Office social media icons update

### DIFF
--- a/src/site/facilities/vba_social_links.drupal.liquid
+++ b/src/site/facilities/vba_social_links.drupal.liquid
@@ -2,93 +2,105 @@
   <h2 class="vads-u-margin-bottom--2">Get updates from {{ regionNickname }}</h2>
   <div class="va-c-list-link-teasers usa-grid usa-grid-full">
     {% if fieldGovdeliveryIdEmerg != empty or fieldNews != empty %}
-      <div class="usa-width-one-half social-links">
+      <div class="usa-width-one-half">
         {% if fieldNews != empty %}
-          <div class="social-links-email vads-u-margin-bottom--2">
-            <a
-              class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none"
-              rel="noreferrer"
-              href="{{ fieldNews.uri }}">
-              <i class="fas fa-envelope vads-u-margin-right--1" aria-hidden="true"></i>
-              <span class="vads-u-text-decoration--underline">{{ fieldNews.title }}</span>
-            </a>
+          <div class="vads-u-display--flex vads-u-align-items--flex-start vads-u-margin-bottom--2">
+            <va-icon
+              icon="mail"
+              size="3"
+              class="vads-u-color--link-default vads-u-margin-right--1"></va-icon>
+            <va-link 
+              href="{{ fieldNews.uri }}" 
+              text="{{ fieldNews.title }}"
+            >
+            </va-link>
           </div>
         {% endif %}
 
         {% if fieldGovdeliveryIdEmerg != empty %}
-          <div class="social-links-email vads-u-margin-bottom--2">
-            <a
-              class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none"
-              rel="noreferrer"
-              href="https://public.govdelivery.com/accounts/USVHA/subscriber/new?topic_id={{ fieldGovdeliveryIdEmerg }}">
-              <i class="fas fa-envelope vads-u-margin-right--1" aria-hidden="true"></i>
-              <span class="vads-u-text-decoration--underline">Subscribe to {{ regionNickname }} emergency notifications</span>
-            </a>
+          <div class="vads-u-display--flex vads-u-align-items--flex-start vads-u-margin-bottom--2">
+            <va-icon
+              icon="mail"
+              size="3"
+              class="vads-u-color--link-default vads-u-margin-right--1"></va-icon>
+            <va-link 
+              href="https://public.govdelivery.com/accounts/USVHA/subscriber/new?topic_id={{ fieldGovdeliveryIdEmerg }}" 
+              text="Subscribe to {{ regionNickname }} emergency notifications"
+            >
+            </va-link>
           </div>
         {% endif %}
         {% if fieldFacebook != empty %}
-          <div class="social-links social-links-facebook vads-u-padding-bottom--2">
-            <a
-              class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none"
-              rel="noreferrer"
-              href="{{ fieldFacebook.uri }}">
-              <i class="fab fa-facebook-square vads-u-margin-right--1" aria-hidden="true"></i>
-              <span class="vads-u-text-decoration--underline">{{ fieldFacebook.title }}</span>
-            </a>
+          <div class="vads-u-display--flex vads-u-align-items--flex-start vads-u-margin-bottom--2">
+            <va-icon
+              icon="facebook"
+              size="3"
+              class="vads-u-color--link-default vads-u-margin-right--1"></va-icon>
+            <va-link 
+              href="{{ fieldFacebook.uri }}" 
+              text="{{ fieldFacebook.title }}"
+            >
+            </va-link>
           </div>
         {% endif %}
       </div>
     {% endif %}
 
     {% if fieldFacebook != empty | | fieldTwitter != empty | | fieldFlickr != empty | | fieldInstagram != empty %}
-      <div class="usa-width-one-half social-links">
+      <div class="usa-width-one-half">
         <div class="">
-
-
           {% if fieldTwitter != empty %}
-            <div class="social-links social-links-twitter vads-u-margin-bottom--2">
-              <a
-                class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none"
-                rel="noreferrer"
-                href="{{ fieldTwitter.uri }}">
-                <i class="fab fa-twitter vads-u-text-decoration--none vads-u-margin-right--1" aria-hidden="true"></i>
-                <span class="vads-u-text-decoration--underline">{{ fieldTwitter.title }}</span>
-              </a>
+            <div class="vads-u-display--flex vads-u-align-items--flex-start vads-u-margin-bottom--2">
+              <va-icon
+                icon="x"
+                size="3"
+                class="vads-u-color--link-default vads-u-margin-right--1"></va-icon>
+              <va-link 
+                href="{{ fieldTwitter.uri }}" 
+                text="{{ fieldTwitter.title }}"
+              >
+              </va-link>
             </div>
           {% endif %}
           {% if fieldFlickr != empty %}
-            <div class="social-links social-links-flickr vads-u-margin-bottom--2">
-              <a
-                class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none"
-                rel="noreferrer"
-                href="{{ fieldFlickr.uri }}">
-                <i class="fab fa-flickr vads-u-text-decoration--none vads-u-margin-right--1" aria-hidden="true"></i>
-                <span class="vads-u-text-decoration--underline">{{ fieldFlickr.title }}</span>
-              </a>
+            <div class="vads-u-display--flex vads-u-align-items--flex-start vads-u-margin-bottom--2">
+              <va-icon
+                icon="flickr"
+                size="3"
+                class="vads-u-color--link-default vads-u-margin-right--1"></va-icon>
+              <va-link 
+                href="{{ fieldFlickr.uri }}" 
+                text="{{ fieldFlickr.title }}"
+              >
+              </va-link>
             </div>
           {% endif %}
 
           {% if fieldInstagram != empty %}
-            <div class="social-links social-links-instagram vads-u-margin-bottom--2">
-              <a
-                class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none"
-                rel="noreferrer"
-                href="{{ fieldInstagram.uri }}">
-                <i class="fab fa-instagram vads-u-text-decoration--none vads-u-margin-right--1" aria-hidden="true"></i>
-                <span class="vads-u-text-decoration--underline">{{ fieldInstagram.title }}</span>
-              </a>
+            <div class="vads-u-display--flex vads-u-align-items--flex-start vads-u-margin-bottom--2">
+              <va-icon
+                icon="instagram"
+                size="3"
+                class="vads-u-color--link-default vads-u-margin-right--1"></va-icon>
+              <va-link 
+                href="{{ fieldInstagram.uri }}" 
+                text="{{ fieldInstagram.title }}"
+              >
+              </va-link>
             </div>
           {% endif %}
 
           {% if fieldYoutube != empty %}
-            <div class="social-links social-links-youtube vads-u-margin-bottom--2">
-              <a
-                class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none"
-                rel="noreferrer"
-                href="{{ fieldYoutube.uri }}">
-                <i class="fab fa-youtube vads-u-text-decoration--none vads-u-margin-right--1" aria-hidden="true"></i>
-                <span class="vads-u-text-decoration--underline">{{ fieldYoutube.title }}</span>
-              </a>
+            <div class="vads-u-display--flex vads-u-align-items--flex-start vads-u-margin-bottom--2">
+              <va-icon
+                icon="youtube"
+                size="3"
+                class="vads-u-color--link-default vads-u-margin-right--1"></va-icon>
+              <va-link 
+                href="{{ fieldYoutube.uri }}" 
+                text="{{ fieldYoutube.title }}"
+              >
+              </va-link>
             </div>
           {% endif %}
         </div>


### PR DESCRIPTION
## Summary
Update social media icons on pre-prod VBA pages to use va-icon.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17886

## Testing done
Tested icons and links locally.

Using `yarn preview`:
`http://localhost:3002/preview?nodeId=4171` 

This is /albuquerque-va-regional-benefit-office [in CMS](https://staging.cms.va.gov/node/4171/edit)

### Tugboat Testing

[Here's the Tugboat URL](https://web-uogdy7lphgtldsuoaduvsz3rqjpp6mms.demo.cms.va.gov/honolulu-va-regional-benefit-office-at-spark-m-matsunaga-department-of-veterans-affairs-medical-center/) you can use to test this with pre-prod data.

## Screenshots
<img width="714" alt="Screenshot 2024-06-04 at 10 49 17 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/e995ebaa-c53a-427b-a731-977684587087">
<img width="378" alt="Screenshot 2024-06-04 at 10 49 22 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/38823429-e7f8-44d7-a5e5-f33548c3864b">


<img width="433" alt="Screenshot 2024-06-04 at 10 39 41 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/e8708f55-3fa3-481e-b02f-58bc754ae947">
<img width="431" alt="Screenshot 2024-06-04 at 10 39 35 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/6c55fd42-b1c0-46c7-ae11-9fd5782b2865">
<img width="442" alt="Screenshot 2024-06-04 at 10 39 26 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/40194b27-c83f-4688-a82a-fca63a0b3935">
<img width="438" alt="Screenshot 2024-06-04 at 10 39 18 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/38c3f0d2-6591-4c30-8a55-f9611745b4e8">