### PR TITLE
Dependents 81049: Add registry entry for 686c-674 v2

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -311,6 +311,26 @@
     }
   },
   {
+    "appName": "686C-674-v2",
+    "entryName": "686C-674-v2",
+    "rootUrl": "/view-change-dependents/add-remove-form-21-686c-v2",
+    "template": {
+      "layout": "page-react.html",
+      "vagovprod": true,
+      "includeBreadcrumbs": true,
+      "breadcrumbs_override": [
+        {
+          "path": "view-change-dependents/",
+          "name": "View or change dependents on your VA disability benefits"
+        },
+        {
+          "path": "view-change-dependents/add-remove-form-21-686c-v2/",
+          "name": "Add or remove dependents with VA Form 21-686C"
+        }
+      ]
+    }
+  },
+  {
     "appName": "21-526EZ disability compensation claim form",
     "entryName": "526EZ-all-claims",
     "rootUrl": "/disability/file-disability-claim-form-21-526ez",


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

- Adds entry point for 686c v2

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/81049

## Testing done

Visited /view-change-dependents/add-remove-form-21-686c-v2 and saw form application load

## Screenshots


|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

