### PR TITLE
VACMS-18065: Adds fieldLastSavedByAnEditor to entities for sitemap.

### DIFF
--- a/src/site/stages/build/drupal/graphql/bannerAlerts.graphql.js
+++ b/src/site/stages/build/drupal/graphql/bannerAlerts.graphql.js
@@ -18,6 +18,7 @@ const bannerAlerts = `
         fieldAlertEmailUpdatesButton
         fieldAlertInheritanceSubpages
         fieldOperatingStatusSendemail
+        fieldLastSavedByAnEditor
         fieldBannerAlertSituationinfo {
           processed
         }

--- a/src/site/stages/build/drupal/graphql/banners.graphql.js
+++ b/src/site/stages/build/drupal/graphql/banners.graphql.js
@@ -16,6 +16,7 @@ banners: nodeQuery(filter: { conditions: [{ field: "status", value: "1", operato
       fieldDismissibleOption
       fieldTargetPaths
       title
+      fieldLastSavedByAnEditor
     }
   }
 }

--- a/src/site/stages/build/drupal/graphql/entityElementsForPages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/entityElementsForPages.graphql.js
@@ -7,6 +7,7 @@ module.exports = `
     entityPublished
     title
     vid
+    fieldLastSavedByAnEditor
     entityUrl {
       ... on EntityCanonicalUrl {
         breadcrumb {

--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionNewsStories.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionNewsStories.node.graphql.js
@@ -9,6 +9,7 @@ const NEWS_STORIES_RESULTS = `
       title
       fieldFeatured
       fieldIntroText
+      fieldLastSavedByAnEditor
       fieldMedia {
         entity {
           ... on MediaImage {

--- a/src/site/stages/build/drupal/graphql/file-fragments/outreachAssets.graphql.js
+++ b/src/site/stages/build/drupal/graphql/file-fragments/outreachAssets.graphql.js
@@ -11,6 +11,7 @@ const outreachAssets = `
         changed
         fieldFormat
         fieldDescription
+        fieldLastSavedByAnEditor
         fieldListing {
           targetId
         }

--- a/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
@@ -17,6 +17,7 @@ const nodeEvent = `
     entityBundle
     entityId
     entityPublished
+    fieldLastSavedByAnEditor
     entityMetatags {
       __typename
       key
@@ -202,6 +203,7 @@ const nodeEventWithoutBreadcrumbs = `
     entityBundle
     entityId
     entityPublished
+    fieldLastSavedByAnEditor
     entityMetatags {
       __typename
       key

--- a/src/site/stages/build/drupal/graphql/promoBanners.graphql.js
+++ b/src/site/stages/build/drupal/graphql/promoBanners.graphql.js
@@ -9,6 +9,7 @@ const promoBanners = `
       entityId
       entityPublished
       title
+      fieldLastSavedByAnEditor
       fieldLink {
         url {
           path

--- a/src/site/stages/build/drupal/graphql/vamcPoliciesPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vamcPoliciesPage.graphql.js
@@ -4,6 +4,7 @@ const policiesPageFragment = `
     status
     changed    
     entityBundle
+    fieldLastSavedByAnEditor
     entityUrl {
       path
     }    

--- a/src/site/stages/build/drupal/graphql/vetCenter.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vetCenter.graphql.js
@@ -25,6 +25,7 @@ const vetCenterFragment = `
         fieldFacilityLocatorApiId
         fieldOperatingStatusFacility
         fieldOperatingStatusMoreInfo
+        fieldLastSavedByAnEditor
         fieldVetCenterFeatureContent {
            entity {
                 ... on ParagraphFeaturedContent {

--- a/src/site/stages/build/drupal/graphql/vetCenterLocations.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vetCenterLocations.graphql.js
@@ -20,6 +20,7 @@ fragment vetCenterLocationsFragment on NodeVetCenterLocationsList {
   entityBundle
   entityLabel
   fieldIntroText
+  fieldLastSavedByAnEditor
   fieldNearbyMobileVetCenters {
     entity {
       ... on NodeVetCenter {


### PR DESCRIPTION
## Summary

- Adds the fieldLastSavedByAnEditor to Drupal entity pages queries to allow this date to make its way to the sitemap. The corresponding change to incorporate this field into the sitemap has already been made, this PR just adds the field to existing GraphQL queries that reflect nodes with this field present.

## Related issue(s)
Relates to: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16333

## Testing done

- Tested that new sitemap reflects the field_last_saved_by_an_editor value for a sampling of nodes 

## What areas of the site does it impact?
Sitemap
GraphQL queries for Drupal detail pages

## QA

**All testing to be perfomred on [this Tugboat](https://tugboat.vfs.va.gov/6661edf417e38363d3d17ac5), not the RI on this PR.**

Nodes Last Changed By A Script:
| Type | Node ID | Changed | Editor Last Changed |
|--------|--------|--------|--------|
| Event | [43137](https://main-ssvjwnze6ybgmnncgodvaj7rot8qtxfe.demo.cms.va.gov/wichita-health-care/events/43137) | Oct 12, 2022 | Oct. 17 2022 |
| News Story | [49700](https://main-ssvjwnze6ybgmnncgodvaj7rot8qtxfe.demo.cms.va.gov/birmingham-health-care/stories/epic-turnout-birmingham-va-welcomes-hundreds-of-new-applicants) | Oct. 12 2022 | Oct. 17 2022 |

Nodes Last Changed By An Editor:
| Type | Node ID | Changed | Editor Last Changed |
|--------|--------|--------|--------|
| Page | [2](https://main-ssvjwnze6ybgmnncgodvaj7rot8qtxfe.demo.cms.va.gov/health-care/about-va-health-benefits/vision-care/blind-low-vision-rehab-services) | Oct. 12 2022 | Jun. 13 2019 |
| Person Profile | [7742](https://main-ssvjwnze6ybgmnncgodvaj7rot8qtxfe.demo.cms.va.gov/gulf-coast-health-care/staff-profiles/michael-d-payne-jr) | Oct. 13 2022 | Jun. 13 2019 |
| VA Form | [5694](https://main-ssvjwnze6ybgmnncgodvaj7rot8qtxfe.demo.cms.va.gov/find-forms/about-form-26-8736a) | Jun. 12 2023 | Sep. 17 2020 |
| Event | [20103](https://main-ssvjwnze6ybgmnncgodvaj7rot8qtxfe.demo.cms.va.gov/chillicothe-health-care/events/chillicothe-placeholder-event) | Oct. 13 2022 | Jun. 23 2022 |
| News Story | [377](https://main-ssvjwnze6ybgmnncgodvaj7rot8qtxfe.demo.cms.va.gov/pittsburgh-health-care/stories/we-honor-outstanding-doctors) | Oct. 13 2022 | Nov. 12 2019 |

Test Steps:
Using each of the above nodes, confirm that the 'Editor Last Changed' date matches in the [sitemap](https://web-ssvjwnze6ybgmnncgodvaj7rot8qtxfe.demo.cms.va.gov/sitemap.xml) (you will need to use the browser's find tool to search for the path to the node)

For instance, the first node, 43137, has a path of '/wichita-health-care/events/43137'. Searching for this page reveals a 'lastmod' entry of 2022-10-17 which matches the date in the 'Editor Last Changed' column for this node. The formatting of the date is not expected to match.

<img width="1178" alt="Screenshot 2024-06-18 at 7 48 09 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/221539/fee890b8-9f3e-4d16-86a7-4a1d31781af9">

<img width="741" alt="Screenshot 2024-06-18 at 7 52 46 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/221539/b2134da7-c398-48be-bb62-885d7dfb0bc0">

## Acceptance criteria
- [ ] Content-build build succeeds (tests that graphql changes haven't broken the build)
- [ ] Sitemap entires for test nodes (above) have expected values.