### PR TITLE
2879 - Removing no-longer-needed hub-icons from legacy template files

### DIFF
--- a/src/site/includes/education-sco.html
+++ b/src/site/includes/education-sco.html
@@ -10,11 +10,6 @@ Education SCO (Merger)
          <div class="vads-l-col--12 medium-screen:vads-u-padding-x--2p5 medium-screen:vads-l-col--8">
         <article class="new-grid">
           <div class="medium-screen:vads-u-display--flex">
-            {% if hub != empty %}
-            <div class="hub-main-icon vads-u-margin-right--1p5 vads-u-margin-top--1">
-              <i class="icon-large white hub-icon-{{hub}} hub-background-{{hub}}"></i>
-            </div>
-            {% endif %}
             <div class="hub-main-title">
               <h1>
               {{ heading }}
@@ -31,7 +26,7 @@ Education SCO (Merger)
           {% if crosslinks != empty %}
             {% include "src/site/components/merger-crosslinks.html" %}
           {% endif %}
-          
+
         <!-- Last updated & feedback button -->
           {% include "src/site/includes/above-footer-elements.drupal.liquid" %}
         </article>

--- a/src/site/layouts/home.html
+++ b/src/site/layouts/home.html
@@ -12,8 +12,7 @@
       <div class="hub-links-row">
         {% for card in cards %}
         <div class="hub-links-container" data-e2e="bucket">
-          <h2 class="heading-level-3 vads-u-margin-top--0"><i
-              class="icon-large-baseline icon-heading hub-icon-{{card.hub}} hub-color-{{card.hub}} vads-u-margin-right--0p5"></i>{{
+          <h2 class="heading-level-3 vads-u-margin-top--0">{{
             card.heading }}</h2>
           <ul class="hub-links-list vads-u-margin-bottom--0">
             {% assign parentCard = card %}
@@ -43,8 +42,7 @@
       <div class="usa-grid usa-grid-full homepage-benefits-row">
         {% for hub in hubs %}
         <div class="usa-width-one-third" data-e2e="hub">
-          <h3 class="heading-level-4"><a href="{{ hub.url }}" onclick="recordEvent({ event: 'nav-linkslist' });"><i
-                class="icon-small icon-heading hub-icon-{{hub.hub}} hub-background-{{hub.hub}} white vads-u-margin-right--0p5"></i>{{hub.heading}}</a>
+          <h3 class="heading-level-4"><a href="{{ hub.url }}" onclick="recordEvent({ event: 'nav-linkslist' });">{{hub.heading}}</a>
             </h4>
             <p class="vads-u-margin-top--0">{{hub.description}}</p>
         </div>


### PR DESCRIPTION
## Summary

- Removing no-longer-needed hub-icons from legacy template files
- I work for the DST

## Related issue(s)

- Relates to [#2879](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2879)

## Testing done

- None

## Screenshots

N/A

## What areas of the site does it impact?

Affects two legacy files, removing code that was no longer being utilized.

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [X] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [X] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [X] The header does not contain any web-components
- [X] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [X] I reached out in the `#sitewide-public-websites` Slack channel for questions
