### PR TITLE
VACMS-18202: Update to remove custom ga for va-link

### DIFF
--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -195,9 +195,7 @@
                   <li>
                     <h3 class="vads-u-font-size--h4">
                       <va-link
-                        disable-analytics
                         href="{{ vaFormLinkTeaser.entity.fieldLink.url.path }}"
-                        onclick="recordEvent({ event: 'nav-linkslist', 'links-list-header': '{{ vaFormLinkTeaser.entity.fieldLink.title | escape }}', 'links-list-section-header': '{{ linkTeasersHeader | escape }}' })"
                         text="{{ vaFormLinkTeaser.entity.fieldLink.title }}"
                       />
                     </h3>
@@ -209,9 +207,7 @@
                 <li>
                   <h3 class="vads-u-font-size--h4">
                     <va-link
-                      disable-analytics
                       href="/change-direct-deposit"
-                      onclick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Change your direct deposit information', 'links-list-section-header': '{{ linkTeasersHeader | escape }}' })"
                       text="Change your direct deposit information"
                     />
                   </h3>
@@ -220,9 +216,7 @@
                 <li>
                   <h3 class="vads-u-font-size--h4">
                     <va-link
-                      disable-analytics
                       href="/change-address"
-                      onclick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Change your address', 'links-list-section-header': '{{ linkTeasersHeader | escape }}' })"
                       text="Change your address"
                     />
                   </h3>
@@ -231,9 +225,7 @@
                 <li>
                   <h3 class="vads-u-font-size--h4">
                     <va-link
-                      disable-analytics
                       href="/records/get-military-service-records/"
-                      onclick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Request your military records, including DD214', 'links-list-section-header': '{{ linkTeasersHeader | escape }}' })"
                       text="Request your military records, including DD214"
                     />
                   </h3>
@@ -242,9 +234,7 @@
                 <li>
                   <h3 class="vads-u-font-size--h4">
                     <va-link
-                      disable-analytics
                       href="/records/"
-                      onclick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Get your VA records and documents online', 'links-list-section-header': '{{ linkTeasersHeader | escape }}' })"
                       text="Get your VA records and documents online"
                     />
                   </h3>


### PR DESCRIPTION
## Summary
Update find forms page to use va-link instead of `<a/>`. Also by doing this we will default to use the built in GA and remove custom GA from all initial implementations. 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18202

## Testing done
Tested in review instance with url `/find-forms/?q=526ez`
## Screenshots
<details>
<summary>Change your direct deposit information</summary>
<img width="1507" alt="Find_A_VA_Form___Veterans_Affairs" src="https://github.com/department-of-veterans-affairs/content-build/assets/42885441/7fa63d74-4fdc-467b-9be9-309f2fda7e5f">
</details>

<details>
<summary>Change your address in your VA gov profile</summary>
<img width="1496" alt="Find_A_VA_Form___Veterans_Affairs" src="https://github.com/department-of-veterans-affairs/content-build/assets/42885441/037df82c-fd70-4955-b596-c8898f3c3f27">
</details>

<details>
<summary>Get your VA records and documents online</summary>
<img width="1500" alt="Find_A_VA_Form___Veterans_Affairs" src="https://github.com/department-of-veterans-affairs/content-build/assets/42885441/59db9dce-fa3a-407f-a433-5c3bf9eaf66c">
</details>

<details>
<summary>Request your military records, including DD214</summary>
<img width="1498" alt="Find_A_VA_Form___Veterans_Affairs" src="https://github.com/department-of-veterans-affairs/content-build/assets/42885441/78e184cc-3353-4d43-aaf8-6868dd0a9730">
</details>

<details>
<summary>File a VA disability claim</summary>
<img width="1498" alt="Find_A_VA_Form___Veterans_Affairs" src="https://github.com/department-of-veterans-affairs/content-build/assets/42885441/e8001bde-4295-4906-a6dc-cad66fd431b2">
</details>



## What areas of the site does it impact?
VA find forms page

## Acceptance criteria