### PR TITLE
VACMS-18186: CLP GA update to remove custom analytics from va-links

### DIFF
--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -299,14 +299,14 @@
               <div class="vads-u-background-color--gray-light-alt vads-u-height--full vads-u-padding--2 vads-u-display--flex vads-u-flex-direction--column vads-u-justify-content--space-between medium-screen:vads-u-margin-x--1 medium-screen:vads-u-margin-y--0">
                 <h3 class="vads-u-margin--0">{{ resource.entity.name }}</h3>
                 <p class="vads-u-flex--1">{{ resource.entity.fieldDescription }}</p>
-                <a
+                <va-link
                   aria-label="Download {{ resource.entity.name }} PDF"
                   download
                   href="{{ resource.entity.fieldMediaExternalFile.uri }}"
                   onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Downloadable resources', 'clp-section-title': '{{ fieldClpResourcesHeader | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': 'Download {{ resource.entity.name | encode }}' });"
                 >
                 Download (PDF)
-              </a>
+                </va-link>
               </div>
             </div>
           {% endfor %}

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -303,10 +303,9 @@
                   aria-label="Download {{ resource.entity.name }} PDF"
                   download
                   href="{{ resource.entity.fieldMediaExternalFile.uri }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Downloadable resources', 'clp-section-title': '{{ fieldClpResourcesHeader | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': 'Download {{ resource.entity.name | encode }}' });"
+                  text="Download (PDF)"
                 >
-                Download (PDF)
-                </va-link>
+              </va-link>
               </div>
             </div>
           {% endfor %}

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -114,9 +114,7 @@
               />
               <h3 class="vads-u-padding-x--2 vads-u-margin-top--2">
                 <va-link
-                  disable-analytics
                   href="{{ promo.entity.fieldPromoLink.entity.fieldLink.uri }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'What you can do', 'clp-section-title': '{{ fieldClpWhatYouCanDoHeader | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ promo.entity.fieldPromoLink.entity.fieldLink.title | encode }}' });"
                   text="{{ promo.entity.fieldPromoLink.entity.fieldLink.title }}"
                 ></va-link>
               </h3>
@@ -174,11 +172,8 @@
             {% if fieldClpVideoPanelMoreVideo.entity.fieldButtonLink.url.path and fieldClpVideoPanelMoreVideo.entity.fieldButtonLabel %}
               <p>
                 <va-link
-                  disable-analytics
                   class="vads-c-action-link--blue"
                   href="{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLink.url.path }}"
-                  disable-analytics
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Video', 'clp-section-title': '{{ fieldClpVideoPanelHeader | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLabel | encode }}' });"
                   text="{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLabel | strip }}"
                   >
                 </va-link>
@@ -201,9 +196,7 @@
               {{ fieldClpSpotlightIntroText }}
               {% if fieldClpSpotlightCta.entity.fieldButtonLink.url.path and fieldClpSpotlightCta.entity.fieldButtonLabel %}
                 <va-link
-                  disable-analytics
                   href="{{ fieldClpSpotlightCta.entity.fieldButtonLink.url.path }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Spotlight', 'clp-section-title': '{{ fieldClpSpotlightHeader | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpSpotlightCta.entity.fieldButtonLabel | encode }}' });"
                   text="{{ fieldClpSpotlightCta.entity.fieldButtonLabel }}"
                 ></va-link>
               {% endif %}
@@ -217,9 +210,7 @@
                 <div class="vads-u-padding--2">
                   <h3 class="vads-u-margin-top--0">
                     <va-link
-                      disable-analytics
                       href="{{ linkTeaser.entity.fieldLink.uri }}"
-                      onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Spotlight', 'clp-section-title': '{{ fieldClpSpotlightHeader | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ linkTeaser.entity.fieldLink.title | encode }}' });"
                       text="{{ linkTeaser.entity.fieldLink.title }}"
                       ></va-link>
                   </h3>
@@ -261,9 +252,7 @@
                     <div class="vads-u-margin-top--2 medium-screen:vads-u-margin-top--0">
                       <h3 class="vads-u-margin-top--0">
                         <va-link
-                          disable-analytics
                           href="{{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.uri }}"
-                          onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Stories', 'clp-section-title': '{{ fieldClpStoriesHeader | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.title | encode }}' });"
                           text="{{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.title }}"
                         ></va-link>
                       </h3>
@@ -362,9 +351,7 @@
                 <h3 class="vads-u-margin-top--0">
                   {% if eventReference.entity.entityUrl.path and eventReference.entity.title %}
                     <va-link
-                      disable-analytics
                       href="{{ eventReference.entity.entityUrl.path }}"
-                      onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Events', 'clp-section-title': '{{ fieldClpEventsHeader | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ eventReference.entity.title | encode }}' });"
                       text="{{ eventReference.entity.title }}"
                     ></va-link>
                   {% elsif %}
@@ -651,8 +638,6 @@
                   {{ benefitCategory.entity.fieldTitleIcon | getHubIcon: '3', 'vads-u-margin-right--1' }}
                   <h3 class="vads-u-margin--0 vads-u-font-size--h4">
                   <va-link
-                    disable-analytics
-                    onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'VA Benefits', 'clp-section-title': 'Learn more about related VA benefits', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ benefitCategory.entity.title | encode }}' });"
                     href="{{ benefitCategory.entity.entityUrl.path }}"
                     text="{{ benefitCategory.entity.title }}"
                   >

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -299,13 +299,14 @@
               <div class="vads-u-background-color--gray-light-alt vads-u-height--full vads-u-padding--2 vads-u-display--flex vads-u-flex-direction--column vads-u-justify-content--space-between medium-screen:vads-u-margin-x--1 medium-screen:vads-u-margin-y--0">
                 <h3 class="vads-u-margin--0">{{ resource.entity.name }}</h3>
                 <p class="vads-u-flex--1">{{ resource.entity.fieldDescription }}</p>
-                <va-link
+                <a
                   aria-label="Download {{ resource.entity.name }} PDF"
                   download
                   href="{{ resource.entity.fieldMediaExternalFile.uri }}"
-                  text="Download (PDF)"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Downloadable resources', 'clp-section-title': '{{ fieldClpResourcesHeader | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': 'Download {{ resource.entity.name | encode }}' });"
                 >
-              </va-link>
+                Download (PDF)
+              </a>
               </div>
             </div>
           {% endfor %}


### PR DESCRIPTION
## Summary

The va-link component has been enhanced to provide destination and can be used now for applicable Campaign Landing Page features, along with removal of the GA custom events.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18186

## Testing done
Testing done in review instance at urls listed below

- [ ] **Element with custom events:** (What you can do) "Learn how to get your flu shot" link
/initiatives/covid-flu
- [ ] **Element with custom events:** (Spotlight) "Why is VA helping Veterans to vote?" link
/initiatives/vote/
- [ ] **Element with custom events:** (Stories) "Staying safe when considering employment with a foreign organization" link
/initiatives/protecting-veterans-from-fraud/
- [ ] **Element with custom events:** (VA Benefits) "VA health benefits" link
/initiatives/protecting-veterans-from-fraud/



## Screenshots
(What you can do) "Learn how to get your flu shot"
![Cursor_and_Flu_And_COVID-19__One_Visit__Two_Vaccines___Veterans_Affairs](https://github.com/department-of-veterans-affairs/content-build/assets/42885441/fdabf59d-ac68-48d1-ac2a-9b9d679e771b)

(Spotlight) "Why is VA helping Veterans to vote?"
![How_Veterans_Can_Register_To_Vote___Veterans_Affairs](https://github.com/department-of-veterans-affairs/content-build/assets/42885441/fe5261ab-53f9-4c44-926a-1f6eca890f02)

(Stories) "Staying safe when considering employment with a foreign organization" 
![Protecting_Veterans_From_Fraud___Veterans_Affairs](https://github.com/department-of-veterans-affairs/content-build/assets/42885441/44de1a45-1705-4550-a9f6-c626014f3f29)

(VA Benefits) "VA health Benefits" 
![Protecting_Veterans_From_Fraud___Veterans_Affairs](https://github.com/department-of-veterans-affairs/content-build/assets/42885441/e421effd-1cc5-4c92-88b1-febf93747db0)


## What areas of the site does it impact?

CLP Pages

## Acceptance criteria
- [ ] a11y Review
