### PR TITLE
VACMS 18326 content-build fontawesome removal

### DIFF
--- a/src/site/includes/operation_status_information.liquid
+++ b/src/site/includes/operation_status_information.liquid
@@ -1,19 +1,19 @@
 {% if fieldOperatingStatusFacility == 'notice' %}
     <span class="operating-status-flag operating-status-flag-notice operating-status usa-alert usa-alert-info background-color-only vads-u-margin-top--1 vads-u-padding-y--1 vads-u-padding-x--1p5">
-      <i class="fa fa-info-circle" aria-hidden="true"></i>
+      <va-icon icon="info" size="3" class="os-icon"></va-icon>
         Facility notice
-      <i class="fa fa-chevron-right vads-u-padding-left--0p5" aria-hidden="true"></i>
+      <va-icon icon="chevron_right" size="3" class="os-chevron-right vads-u-padding-left--0p5"></va-icon>
     </span>
     {% elsif fieldOperatingStatusFacility == 'limited' %}
     <span class="operating-status-flag operating-status-flag-warning operating-status usa-alert usa-alert-warning background-color-only vads-u-margin-top--1 vads-u-padding-y--1 vads-u-padding-x--1p5">
-      <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+      <va-icon icon="warning" size="3" class="os-icon"></va-icon>
         Limited services and hours
-      <i class="fa fa-chevron-right vads-u-padding-left--0p5" aria-hidden="true"></i>
+      <va-icon icon="chevron_right" size="3" class="os-chevron-right vads-u-padding-left--0p5"></va-icon>
     </span>
     {% elsif fieldOperatingStatusFacility == 'closed' %}
     <span class="operating-status-flag operating-status-flag-error operating-status usa-alert usa-alert-error background-color-only vads-u-margin-top--1 vads-u-padding-y--1 vads-u-padding-x--1p5">
-      <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+      <va-icon icon="error" size="3" class="os-icon"></va-icon>
         Facility Closed
-      <i class="fa fa-chevron-right vads-u-padding-left--0p5" aria-hidden="true"></i>
+      <va-icon icon="chevron_right" size="3" class="os-chevron-right vads-u-padding-left--0p5"></va-icon>
     </span>
 {% endif %}

--- a/src/site/layouts/health_care_facility_status.drupal.liquid
+++ b/src/site/layouts/health_care_facility_status.drupal.liquid
@@ -19,22 +19,15 @@
                             {{office.title}}
                         </h2>
                             {% if office.fieldOperatingStatusFacility == 'normal' %}
-                            <span
-                                class="operating-status usa-alert usa-alert-success background-color-only vads-u-margin-top--1 vads-u-padding--1p5">
-                                <b><i class="fa fa-info-circle" aria-hidden="true"></i> Normal services and hours</b>
-                            </span>
+                                    Normal services and hours
                             {% elsif office.fieldOperatingStatusFacility == 'limited' %}
-
-                            <span
-                                class="operating-status usa-alert usa-alert-warning background-color-only vads-u-margin-top--1 vads-u-padding--1p5">
-                                <b><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Limited services and hours</b>
-                            </span>
-
+                                <va-alert slim="true" status="warning">
+                                    Limited services and hours
+                                </va-alert>
                             {% elsif office.fieldOperatingStatusFacility == 'closed' %}
-                            <span
-                                class="operating-status usa-alert usa-alert-error background-color-only vads-u-margin-top--1 vads-u-padding--1p5">
-                                <b><i class="fa fa-exclamation-circle" aria-hidden="true"></i> Facility Closed</b>
-                            </span>
+                                <va-alert slim="true" status="error">
+                                    Facility closed
+                                </va-alert>
                             {% endif %}
                         {% endfor %}
                     </section>

--- a/src/site/paragraphs/staff_profile.drupal.liquid
+++ b/src/site/paragraphs/staff_profile.drupal.liquid
@@ -5,9 +5,9 @@
        class="vads-u-display--flex vads-u-margin-bottom--4 vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row">
     <div
         class="vads-u-flex--auto medium-screen:vads-u-margin-right--3 vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0">
-      {% if bio.fieldMedia == emtpy %}
+      {% if bio.fieldMedia != emtpy %}
         <div class="circular-profile-image bio-paragraph-image vads-u-position--relative vads-u-background-color--gray-lightest vads-u-display--block">
-            <div class="circular-profile-missing-icon"><va-icon size="9" icon="person"></va-icon></div>
+            <div class="circular-profile-missing-icon"><va-icon size="5" icon="person"></va-icon></div>
         </div>
       {% else %}
         {% assign image = bio.fieldMedia.entity.image %}

--- a/src/site/paragraphs/staff_profile.drupal.liquid
+++ b/src/site/paragraphs/staff_profile.drupal.liquid
@@ -5,11 +5,11 @@
        class="vads-u-display--flex vads-u-margin-bottom--4 vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row">
     <div
         class="vads-u-flex--auto medium-screen:vads-u-margin-right--3 vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0">
-      {% if bio.fieldMedia == emtpy %}
-        <span
-            class="circular-profile-image bio-paragraph-image vads-u-position--relative vads-u-background-color--gray-lightest vads-u-display--block">
-      <span class="fas fa-user circular-profile-missing-icon"></span>
-    </span>
+      {% if bio.fieldMedia != emtpy %}
+        {% comment %} TODO CHANGE BACK {% endcomment %}
+        <div class="circular-profile-image bio-paragraph-image vads-u-position--relative vads-u-background-color--gray-lightest vads-u-display--block">
+            <div class="circular-profile-missing-icon"><va-icon size="9" icon="person"></va-icon></div>
+        </div>
       {% else %}
         {% assign image = bio.fieldMedia.entity.image %}
         <img class="circular-profile-image bio-paragraph-image" src="{{ image.derivative.url }}" alt="{{ image.alt }}"

--- a/src/site/paragraphs/staff_profile.drupal.liquid
+++ b/src/site/paragraphs/staff_profile.drupal.liquid
@@ -5,8 +5,7 @@
        class="vads-u-display--flex vads-u-margin-bottom--4 vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row">
     <div
         class="vads-u-flex--auto medium-screen:vads-u-margin-right--3 vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0">
-      {% if bio.fieldMedia != emtpy %}
-        {% comment %} TODO CHANGE BACK {% endcomment %}
+      {% if bio.fieldMedia == emtpy %}
         <div class="circular-profile-image bio-paragraph-image vads-u-position--relative vads-u-background-color--gray-lightest vads-u-display--block">
             <div class="circular-profile-missing-icon"><va-icon size="9" icon="person"></va-icon></div>
         </div>

--- a/src/site/paragraphs/staff_profile.drupal.liquid
+++ b/src/site/paragraphs/staff_profile.drupal.liquid
@@ -5,9 +5,9 @@
        class="vads-u-display--flex vads-u-margin-bottom--4 vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row">
     <div
         class="vads-u-flex--auto medium-screen:vads-u-margin-right--3 vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0">
-      {% if bio.fieldMedia != emtpy %}
+      {% if bio.fieldMedia == emtpy %}
         <div class="circular-profile-image bio-paragraph-image vads-u-position--relative vads-u-background-color--gray-lightest vads-u-display--block">
-            <div class="circular-profile-missing-icon"><va-icon size="5" icon="person"></va-icon></div>
+            <div class="circular-profile-missing-icon"><va-icon size="6" icon="person"></va-icon></div>
         </div>
       {% else %}
         {% assign image = bio.fieldMedia.entity.image %}


### PR DESCRIPTION
## Summary

- Removes fontawesome and replaces with va-icon
- Sitewide Facilities

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18326

## Testing done

- Checked manually. Forced display of some of the features locally to expose (could not find example of staff_profile without a photo)
- Check manually on tugboat (will try to create a staff profile with no image)

## Screenshots

<details>
<summary>Staff Profile without images with PR</summary>
<img src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/fb92156d-093c-49c2-a7be-8c3d523a4910" />
</details>

<details>
<summary>Staff Profiles past - fontawesome</summary>
<img width="558" alt="Screenshot 2024-06-15 at 4 31 48 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/c5d15a9b-4a13-467e-9032-572e28947152" />
</details>


<details>
<summary>(outdated should be removed)Operation Status page - old</summary>
<img width="922" alt="Screenshot 2024-06-18 at 4 10 44 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/90ed692e-241c-476b-a1e9-89f9ecacd477">
<img width="434" alt="Screenshot 2024-06-18 at 4 10 32 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/f137651a-c47f-48b1-ad04-6a6fb1a8d3b1">
</details>


<details>
<summary>(outdated should be removed)Operation Status page - with PR (follows pattern from operating status page)</summary>
<img width="435" alt="Screenshot 2024-06-18 at 4 10 17 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/1ca55465-493f-4fab-9134-8ac544ef9f85">
<img width="1066" alt="Screenshot 2024-06-18 at 4 10 05 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/db776137-0f1f-486d-b2cd-0d2b81134901">
</details>
## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

Check that in conjunction with vets-website PR of same name that Staff profiles without photos show new va-icon and that icon is centered in gray circle. Check that Operating status page shows normal text for normal notices and slim alerts for all others. 