### PR TITLE
VACMS-18362: raise content-release build step time to 50m.

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -91,7 +91,7 @@ jobs:
     runs-on: [self-hosted, asg]
     needs:
       - validate-build-status
-    timeout-minutes: 60
+    timeout-minutes: 70
     defaults:
       run:
         working-directory: content-build
@@ -206,7 +206,7 @@ jobs:
         run: |
           set -eo pipefail
           NODE_OPTIONS=--max-old-space-size=${{ env.MAXIMUM_HEAP }} yarn build:content_release --buildtype=${{ env.BUILDTYPE }} --asset-source=local --drupal-address=${{ env.DRUPAL_ADDRESS }} --drupal-user=${{ env.DRUPAL_USERNAME }} --drupal-password="${{ env.DRUPAL_PASSWORD }}" --pull-drupal --drupal-max-parallel-requests=15 --no-drupal-proxy ${{env.VERBOSE_BUILD}} | tee build-output.txt
-        timeout-minutes: 40
+        timeout-minutes: 50
         env:
           NODE_ENV: production
           DEBUG: ${{ secrets.ACTIONS_RUNNER_DEBUG }}


### PR DESCRIPTION
## Summary

- increases the timeout of the build step. This has been hitting its timeout limit recently.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18362

## Testing done

There is no testing to do; it raises the limit.

