### PR TITLE
VACMS-18364 Fix style issue with icons on Benefit Hub landing pages

### DIFF
--- a/src/site/assets/sass/style.scss
+++ b/src/site/assets/sass/style.scss
@@ -32,7 +32,9 @@
 .hub-icon {
   border-radius: 50%;
   height: 40px !important;
+  width: 40px !important;
   min-width: 40px !important;
+  max-width: 40px !important;
 }
 
 .social-links {

--- a/src/site/includes/education-sco.html
+++ b/src/site/includes/education-sco.html
@@ -10,11 +10,9 @@ Education SCO (Merger)
          <div class="vads-l-col--12 medium-screen:vads-u-padding-x--2p5 medium-screen:vads-l-col--8">
         <article class="new-grid">
           <div class="medium-screen:vads-u-display--flex">
-            <div class="hub-main-title">
-              <h1>
-              {{ heading }}
-              </h1>
-            </div>
+            <h1>
+            {{ heading }}
+            </h1>
           </div>
           {{ contents }}
 

--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -7,12 +7,9 @@
     <div class="usa-grid usa-grid-full">
       <article class="usa-width-two-thirds">
         {% if fieldTitleIcon %}
-          <div class="inline hub-main-icon vads-u-margin-right--1 vads-u-margin-bottom--1">
-            {{ fieldTitleIcon | getHubIcon: '3' }}
-          </div>
-
-          <div class="inline hub-main-title">
-            <h1>{{ title }}</h1>
+          <div class="medium-screen:vads-u-display--flex vads-u-margin-y--1 vads-u-align-items--flex-start">
+            <span class="vads-u-margin-top--1">{{ fieldTitleIcon | getHubIcon: '3' }}</span>
+            <h1 class="vads-u-margin-top--1 medium-screen:vads-u-margin-left--1 medium-screen:vads-u-margin-y--0">{{ title }}</h1>
           </div>
         {% else %}
           <h1>{{ title }}</h1>


### PR DESCRIPTION
## Summary
A pull request to remove an old iconography stylesheet was merged into vets-website on June 18. Pull request here: https://github.com/department-of-veterans-affairs/vets-website/pull/30301/files#diff-6edcebe654b6b37d8ce2d75bc03d32652f25c62de02dc452bac87e63604dd8ac

As we've seen in many cases, content-build uses styles from vets-website that are otherwise unused in vets-website (likely some tech debt leftover from when content-build and vets-website were a single repo). This caused an oversight when removing that stylesheet and created the style regression seen on Benefit Hub landing pages:

<img width="1029" alt="Screenshot 2024-06-20 at 2 03 31 PM" src="https://github.com/department-of-veterans-affairs/va.gov-cms/assets/19175324/2edad92f-8e24-41df-b651-67e4a93ed48a">
<img width="1030" alt="Screenshot 2024-06-20 at 2 03 26 PM" src="https://github.com/department-of-veterans-affairs/va.gov-cms/assets/19175324/c9b18820-4a63-473c-a7fc-eee51b406620">

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18364

## Testing done
Tested all benefit hub pages locally:
- localhost:3002/health-care
- localhost:3002/disability
- localhost:3002/education
- localhost:3002/careers-employment
- localhost:3002/pension
- localhost:3002/housing-assistance
- localhost:3002/life-insurance
- localhost:3002/burials-memorials
- localhost:3002/records
- localhost:3002/service-member-benefits
- localhost:3002/family-member-benefits

## Screenshots
<details><summary>Desktop benefit hubs</summary>
<img width="649" alt="Screenshot 2024-06-20 at 4 17 42 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/f8cfe975-f014-477b-88c4-5d37e776f09d">
<img width="667" alt="Screenshot 2024-06-20 at 4 17 38 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/5a33eb01-cd63-4b7c-a52d-137a7ada26a2">
<img width="638" alt="Screenshot 2024-06-20 at 4 17 34 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/438d40a0-cd22-4e60-9396-2a035ebc3b06">
<img width="672" alt="Screenshot 2024-06-20 at 4 17 29 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/3d45f513-b5b8-4dcf-be96-794cc1d1133e">
<img width="663" alt="Screenshot 2024-06-20 at 4 17 20 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/75f0a994-c309-480c-9019-ca4ba1c4030b">
<img width="662" alt="Screenshot 2024-06-20 at 4 17 15 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/8cbb604a-ba45-403f-9a63-dc3ed320403f">
<img width="665" alt="Screenshot 2024-06-20 at 4 17 09 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/3494b3af-4854-44b1-9813-88542a166287">
<img width="662" alt="Screenshot 2024-06-20 at 4 17 01 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/ead85aa5-e892-4751-bd8b-f84d06cd9781">
<img width="672" alt="Screenshot 2024-06-20 at 4 16 52 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/e0527439-9bb5-4347-9e49-23e08403cec0">
<img width="671" alt="Screenshot 2024-06-20 at 4 16 44 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/ddd40ffb-0f77-45b1-a04d-41dbd76299ac">
<img width="650" alt="Screenshot 2024-06-20 at 4 16 38 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/89ddcfbe-4c1d-444a-b374-40c1b0ad6389">


</details>

<details><summary>Mobile benefit hubs</summary>
<img width="323" alt="Screenshot 2024-06-20 at 2 15 36 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/3ef6002b-8581-478e-a1a8-6ef456a379a3">
<img width="322" alt="Screenshot 2024-06-20 at 2 15 28 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/0a0aeae9-a0d9-423a-a5fa-8fdf66c550f7">
<img width="321" alt="Screenshot 2024-06-20 at 2 15 15 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/d64f54b6-43bc-4ab8-b415-4797c5d1636f">
<img width="322" alt="Screenshot 2024-06-20 at 2 15 08 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/cc2eba4a-b263-464d-92d5-65a54db6e30e">
<img width="322" alt="Screenshot 2024-06-20 at 2 15 02 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/a2592791-8e08-4e07-8be5-a3ba276dedad">
<img width="321" alt="Screenshot 2024-06-20 at 2 14 53 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/0875708b-d441-43da-8fb1-c656645c1fb2">
<img width="321" alt="Screenshot 2024-06-20 at 2 14 37 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/bb845c1a-e160-4394-bf76-884b0218171e">
<img width="322" alt="Screenshot 2024-06-20 at 2 14 29 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/fbe09149-32bc-4976-be28-9c5274b30383">
<img width="321" alt="Screenshot 2024-06-20 at 2 14 23 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/57416e68-ce46-4af5-8e77-20cda3ecedf6">
<img width="324" alt="Screenshot 2024-06-20 at 2 14 12 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/52dd1f8a-2599-41a3-bdf6-952dd2c9ca18">
<img width="324" alt="Screenshot 2024-06-20 at 2 14 05 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/76a27da1-ddb1-47f4-ba64-083906826b90">

</details>

## What areas of the site does it impact?
All benefit hub pages