### PR TITLE
VACMS-18346: Update go to the online tool link in VA Froms

### DIFF
--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -129,13 +129,12 @@
         {% if fieldVaFormToolUrl %}
           <h3 data-testid="va_form--online-tool">Online tool</h3>
           <p>{{ fieldVaFormToolIntro }}</p>
-          <a
-            class="vads-c-action-link--blue"
+          <va-link-action
             href="{{ fieldVaFormToolUrl.uri }}"
-            onclick="recordEvent({ event: 'cta-primary-button-click' });"
+            text=" Go to the online tool"
+            type="secondary"
           >
-            Go to the online tool
-          </a>
+          </va-link-action>
         {% endif %}
 
 

--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -131,7 +131,7 @@
           <p>{{ fieldVaFormToolIntro }}</p>
           <va-link-action
             href="{{ fieldVaFormToolUrl.uri }}"
-            text=" Go to the online tool"
+            text="Go to the online tool"
             type="secondary"
           >
           </va-link-action>


### PR DESCRIPTION
## Summary
With the release of the action link support from DST we want to update our action links to use the new component.

This PR changes the action-link for the find forms go to the online tool <a>

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18346

## Testing done
Tested locally at ` /find-forms/about-form-21-526ez/`
## Screenshots
<img width="1509" alt="About_VA_Form_21-526EZ___Veterans_Affairs" src="https://github.com/department-of-veterans-affairs/content-build/assets/42885441/2dbe28cf-d6d4-4f84-a202-37d386c752e0">


## What areas of the site does it impact?
Find Forms

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
