### PR TITLE
VACMS-18287 Remove new tab behavior per DST guidelines

### DIFF
--- a/src/site/components/hub-page-link-list.html
+++ b/src/site/components/hub-page-link-list.html
@@ -24,7 +24,7 @@ each link
   <ul id="{{ hublink.id }}" class="hub-page-link-list">
   {% for link in hublink.links %}
     <li class="hub-page-link-list__item">
-        <a href="{{ link.url }}" class="no-external-icon" {% if link.target %} target="{{ link.target }}" {% endif %} />
+        <a href="{{ link.url }}" />
         <span class="hub-page-link-list__header">
          {{ link.label }}
           <img class="all-link-arrow" src="/img/arrow-right-blue.svg" alt="right-arrow" />

--- a/src/site/components/navigation-sidebar.html
+++ b/src/site/components/navigation-sidebar.html
@@ -46,7 +46,7 @@ Used to display a side navigation bar of pages in a collection.
             {% unless relatedPages.metadata.name == page.display_title or relatedPages.metadata.name == page.title or page.hideFromSidebar %}
               <li {% if page.path == path %}class="active-level"{% endif %}>
                 {% if page.href != empty %}
-                  <a href="{{ page.href }}"{% if page.target != empty %}target="{{page.target}}"{% endif %} onClick="recordEvent({ event: 'nav-sidenav' });">
+                  <a href="{{ page.href }}" onClick="recordEvent({ event: 'nav-sidenav' });">
                     {% if page.display_title != empty %}
                       {{ page.display_title }}
                     {% else %}
@@ -70,7 +70,7 @@ Used to display a side navigation bar of pages in a collection.
                       {% unless cpage.hideFromSidebar %}
                         <li {% if cpage.path == path %}class="active-level"{% endif %}>
                           {% if cpage.href != empty %}
-                            <a href="{{ cpage.href }}"{% if cpage.target != empty %}target="{{cpage.target}}"{% endif %} onClick="recordEvent({ event: 'nav-sidenav' });">
+                            <a href="{{ cpage.href }}" onClick="recordEvent({ event: 'nav-sidenav' });">
                               {% if cpage.display_title != empty %}
                                 {{ cpage.display_title }}
                               {% else %}

--- a/src/site/includes/common-and-popular.html
+++ b/src/site/includes/common-and-popular.html
@@ -36,10 +36,8 @@
       </li>
       <li class="vads-u-padding-y--1">
         <a
-          target="_blank"
           href="https://www.veteranscrisisline.net/"
-          rel="noopener noreferrer"
-          class="external no-external-icon"
+          class="external"
         >
           Contact the Veterans Crisis Line
         </a>

--- a/src/site/includes/directions-google-maps.liquid
+++ b/src/site/includes/directions-google-maps.liquid
@@ -16,8 +16,7 @@ directionsLinkOnClickPropValue
 <div>
   <a
     {{ onClick | strip }}
-    href="https://maps.google.com?saddr=Current+Location&amp;daddr={{ directionsLinkAddress | strip }}"
-    target="_blank">
+    href="https://maps.google.com?saddr=Current+Location&amp;daddr={{ directionsLinkAddress | strip }}">
     Get directions on Google Maps
     <span class="sr-only">to {{ directionsLinkTitle | strip }}</span>
   </a>

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -269,8 +269,6 @@
                 class="vads-c-action-link--blue"
                 href="{{ fieldClpStoriesCta.entity.fieldButtonLink.url }}"
                 onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Stories', 'clp-section-title': '{{ fieldClpStoriesHeader | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpStoriesCta.entity.fieldButtonLabel | encode }}' });"
-                rel="noreferrer noopener"
-                target="_blank"
               >
                 See more stories
               </a>
@@ -394,8 +392,6 @@
                         <a
                           href="{{ eventReference.entity.fieldFacilityLocation.entity.entityUrl.path }}"
                           onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Events', 'clp-section-title': '{{ fieldClpEventsHeader | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ eventReference.entity.fieldFacilityLocation.entity.title | encode }}' });"
-                          rel="noreferrer noopener"
-                          target="_blank"
                         >
                           {{ eventReference.entity.fieldFacilityLocation.entity.title }}
                         </a>
@@ -406,8 +402,6 @@
                         <a
                           href="{{ eventReference.entity.fieldLink.uri }}"
                           onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Events', 'clp-section-title': '{{ fieldClpEventsHeader | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ eventReference.entity.fieldEventCta | encode }}' });"
-                          rel="noreferrer noopener"
-                          target="_blank"
                         >
                           {{ eventReference.entity.fieldEventCta }}
                         </a>
@@ -565,11 +559,9 @@
             <div class="vads-l-col--12 medium-screen:vads-l-col--4">
               <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
                 <a
-                  aria-label="{{ fieldRelatedOffice.entity.fieldEmailUpdatesLink.title }} (opens in a new tab)"
+                  aria-label="{{ fieldRelatedOffice.entity.fieldEmailUpdatesLink.title }}"
                   href="{{ fieldRelatedOffice.entity.fieldEmailUpdatesLink.url.path }}"
                   onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldRelatedOffice.entity.fieldExternalLink.title | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldRelatedOffice.entity.fieldEmailUpdatesLink.title | encode }}' });"
-                  rel="noreferrer noopener"
-                  target="_blank"
                 >
                   <va-icon icon="mail" size="3" class="vads-u-color--link-default vads-u-padding-right--1"></va-icon>
                   {{ fieldRelatedOffice.entity.fieldEmailUpdatesLink.title }}
@@ -582,11 +574,9 @@
             <div class="vads-l-col--12 medium-screen:vads-l-col--4">
               <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
                 <a
-                  aria-label="Twitter, {{ fieldRelatedOffice.entity.fieldExternalLink.title }} (opens in a new tab)"
+                  aria-label="Twitter, {{ fieldRelatedOffice.entity.fieldExternalLink.title }}"
                   href="https://twitter.com/{{ socialLinksObject.twitter.value }}"
                   onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldRelatedOffice.entity.fieldExternalLink.title | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldRelatedOffice.entity.fieldExternalLink.title | encode }} Twitter' });"
-                  rel="noreferrer noopener"
-                  target="_blank"
                 >
                   <va-icon icon="x" size="3" class="vads-u-color--link-default vads-u-padding-right--1"></va-icon>
                   {{ fieldRelatedOffice.entity.fieldExternalLink.title }} X (formerly Twitter)
@@ -599,11 +589,9 @@
             <div class="vads-l-col--12 medium-screen:vads-l-col--4">
               <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
                 <a
-                  aria-label="Facebook, {{ fieldRelatedOffice.entity.fieldExternalLink.title }} (opens in a new tab)"
+                  aria-label="Facebook, {{ fieldRelatedOffice.entity.fieldExternalLink.title }}"
                   href="https://facebook.com/{{ socialLinksObject.facebook.value }}"
                   onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldRelatedOffice.entity.fieldExternalLink.title | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldRelatedOffice.entity.fieldExternalLink.title | encode }} Facebook' });"
-                  rel="noreferrer noopener"
-                  target="_blank"
                 >
                   <va-icon icon="facebook" size="3" class="vads-u-color--link-default vads-u-padding-right--1"></va-icon>
                   {{ fieldRelatedOffice.entity.fieldExternalLink.title }} Facebook
@@ -616,11 +604,9 @@
             <div class="vads-l-col--12 medium-screen:vads-l-col--4">
               <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
                 <a
-                  aria-label="YouTube, {{ fieldRelatedOffice.entity.fieldExternalLink.title }} (opens in a new tab)"
+                  aria-label="YouTube, {{ fieldRelatedOffice.entity.fieldExternalLink.title }}"
                   href="https://youtube.com/{{ socialLinksObject.youtube.value }}"
                   onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldRelatedOffice.entity.fieldExternalLink.title | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldRelatedOffice.entity.fieldExternalLink.title | encode }} YouTube' });"
-                  rel="noreferrer noopener"
-                  target="_blank"
                 >
                   <va-icon icon="youtube" size="3" class="vads-u-color--link-default vads-u-padding-right--1"></va-icon>
                   {{ fieldRelatedOffice.entity.fieldExternalLink.title }} YouTube
@@ -633,11 +619,9 @@
             <div class="vads-l-col--12 medium-screen:vads-l-col--4">
               <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
                 <a
-                  aria-label="Linkedin, {{ fieldRelatedOffice.entity.fieldExternalLink.title }} (opens in a new tab)"
+                  aria-label="Linkedin, {{ fieldRelatedOffice.entity.fieldExternalLink.title }}"
                   href="https://linkedin.com/{{ socialLinksObject.linkedin.value }}"
                   onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldRelatedOffice.entity.fieldExternalLink.title | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldRelatedOffice.entity.fieldExternalLink.title | encode }} Linkedin' });"
-                  rel="noreferrer noopener"
-                  target="_blank"
                 >
                   <va-icon icon="linkedin" size="3" class="vads-u-color--link-default vads-u-padding-right--1"></va-icon>
                   {{ fieldRelatedOffice.entity.fieldExternalLink.title }} Linkedin
@@ -650,11 +634,9 @@
             <div class="vads-l-col--12 medium-screen:vads-l-col--4">
               <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
                 <a
-                  aria-label="Instagram, {{ fieldRelatedOffice.entity.fieldExternalLink.title }} (opens in a new tab)"
+                  aria-label="Instagram, {{ fieldRelatedOffice.entity.fieldExternalLink.title }}"
                   href="https://instagram.com/{{ socialLinksObject.instagram.value }}"
                   onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldRelatedOffice.entity.fieldExternalLink.title | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldRelatedOffice.entity.fieldExternalLink.title | encode }} Instagram' });"
-                  rel="noreferrer noopener"
-                  target="_blank"
                 >
                   <va-icon icon="instagram" size="3" class="vads-u-color--link-default vads-u-padding-right--1"></va-icon>
                   {{ fieldRelatedOffice.entity.fieldExternalLink.title }} Instagram

--- a/src/site/layouts/home.html
+++ b/src/site/layouts/home.html
@@ -107,7 +107,7 @@
           <div class="homepage-image-wrapper">
             <img class="lazy" width="552" data-src="{{ story.img }}" alt="{{ story.alt }}" />
           </div>
-          <h4 class="homepage-news-story-title"><a class="no-external-icon" href="{{ story.href }}"
+          <h4 class="homepage-news-story-title"><a href="{{ story.href }}"
               onClick="recordEvent({ event: 'nav-footer-news-story' });" />{{ story.title }}</a></h4>
           <p class="homepage-news-story-desc">{{ story.description }}</p>
         </div>

--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -89,7 +89,6 @@
         {% endif %}
         <a
           href="{{ fieldVaFormUrl.uri }}"
-          target="_blank"
           download
           data-widget-type="find-va-forms-pdf-download-helper"
           data-form-number="{{ fieldVaFormNumber }}"
@@ -160,7 +159,6 @@
 
                 <a
                   href="{{ vaForm.entity.fieldVaFormUrl.uri }}"
-                  target="_blank"
                   download
                   data-widget-type="find-va-forms-pdf-download-helper"
                   data-form-number="{{ vaForm.entity.fieldVaFormNumber }}"


### PR DESCRIPTION
## Summary
Per Design System guidance, links should only open in a new tab if the user will lose some data or progress. This PR includes updates to:

**Find Forms**
- Removes `target` and `rel` attributes from download links
- Removes new tab from GSA Forms Library link as the user will not lose data from an empty search results page

**Hub pages sidebar**
- Removes target behavior on sidebar links. There's no way to set this data in Drupal (as these are statically-generated sidebars), so this property wouldn't be used.

**Old homepage**
- Removes target behavior from `common-and-popular.html`, which is a file used on the old homepage (before the launch of the redesign in June 2023).

**Campaign Landing Page**
- Removes new tab from "See more stories" link in the stories section (no prod examples)
- Removes new tab from facilities link in the events section (no prod examples)
- Removes new tab from "Connect with us" social media links

Additionally, removes the `no-external-icon` class from a few files as it doesn't do anything or have any style declarations in Github: https://github.com/search?q=org%3Adepartment-of-veterans-affairs%20.no-external-icon&type=code

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18287

## Testing done
Tested the applications locally at:
- `/find-forms`: Search for forms, click on a form detail page, and inspect the download link
- `/find-forms`: Search for a term that will have zero results and inspect the "no results" message below the input, specifically the "GSA Forms Library" link
- `/education/about-gi-bill-benefits/post-9-11/`: Inspect the links in the left sidebar
- `/initiatives/protecting-veterans-from-fraud/`: Inspect the social media links at the bottom of the page

## Screenshots

<details><summary>Find Forms</summary>
<img width="258" alt="Screenshot 2024-06-24 at 5 21 59 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/0f177e2b-8d52-412c-ae35-fb10843db6d6">
<img width="354" alt="Screenshot 2024-06-24 at 5 22 05 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/01f0859e-0571-4ace-a7d1-a3ab5ddc721b">

<img width="477" alt="Screenshot 2024-06-24 at 5 24 28 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/46d46f8d-0600-408b-a103-1a744ee1a14c">
<img width="344" alt="Screenshot 2024-06-24 at 5 22 32 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/4e72b630-36c2-45ef-8180-ed35240251ba">
<img width="349" alt="Screenshot 2024-06-24 at 5 25 09 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/1df009c0-790b-4928-a15a-2b4d332b6937">

<img width="322" alt="Screenshot 2024-06-24 at 5 26 25 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/ad4f1fdf-54e9-4b20-a8f9-0fe612ca9d3b">
<img width="413" alt="Screenshot 2024-06-24 at 5 26 32 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/41104ad0-9ddf-4ece-b221-301341674fdd">
</details>
<details><summary>Hub pages sidebar</summary>
<img width="253" alt="Screenshot 2024-06-24 at 5 30 48 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/eaeb11fd-5b2d-4eb4-b861-e3bd5d6d504c">
<img width="323" alt="Screenshot 2024-06-24 at 5 30 54 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/96def9e6-63dd-4b9a-adf8-15febf0d7b42">


</details>

<details><summary>Campaign Landing Pages</summary>
<img width="925" alt="Screenshot 2024-06-24 at 5 45 40 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/ee5f5ac8-8902-406e-9f0e-0ce9dad5eb5a">
<img width="329" alt="Screenshot 2024-06-24 at 5 48 32 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/339497ef-a110-42cf-83db-91d5818265dd">
<img width="333" alt="Screenshot 2024-06-24 at 5 48 19 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/cb3dab4f-a88e-4d99-9b0a-70e80395b92b">
<img width="333" alt="Screenshot 2024-06-24 at 5 48 11 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/cc722f9f-f71b-481a-a498-2bb96c098989">
<img width="332" alt="Screenshot 2024-06-24 at 5 48 05 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/15db2769-b116-4d8f-9d25-c11b1f4542dd">
<img width="327" alt="Screenshot 2024-06-24 at 5 47 59 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/f0b7e643-1f45-49f9-bf21-62a82177badb">



</details>