### PR TITLE
VACMS-17790 Use va-button for email sign up

### DIFF
--- a/src/site/includes/email-update-signup.drupal.liquid
+++ b/src/site/includes/email-update-signup.drupal.liquid
@@ -22,19 +22,11 @@
               type="email"
               use-forms-pattern="single"
             /></va-text-input>
-            <button
-              onclick="recordMultipleEvents([
-                { 
-                  event: 'cta-button-click', 'button-type': 'primary', 'button-click-label': 'Sign up',  
-                },
-                { event: 'homepage-email-sign-up', action: 'Homepage email sign up' }
-                ]);"
-              type="submit"
-              class="vads-u-width--full
-                    medium-screen:vads-u-width--auto
-                    vads-u-display--block vads-u-margin-bottom--2">
-              Sign up
-            </button>
+            <va-button
+              submit
+              class="vads-u-width--full medium-screen:vads-u-width--auto vads-u-display--block vads-u-margin-top--1 vads-u-margin-bottom--2"
+              text="Sign up"
+            />
           </form>
         </div>
       </div>


### PR DESCRIPTION
# DO NOT MERGE
Blocked on DST releasing a fix: https://github.com/department-of-veterans-affairs/component-library/pull/1174

## Summary
Use `va-button` for the "Sign up" button in the newsletter section on the home page. Previously we could not convert to a `va-button` because the `submit` property was not working properly on it and the form would not submit.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17790

## Testing done
My machine has issues with picking up the latest changes from the design system on content-build, so I could not test this locally. I tested in the review instance instead. I went to the homepage, filled in an email address in the input at the bottom of the page, and clicking Sign up. Verified that it does go to https://public.govdelivery.com/accounts/USVACHOOSE/subscribers/qualify with the email address filled in.

## Screenshots

Responsive button behavior:
<img width="424" alt="Screenshot 2024-06-25 at 3 02 02 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/ce8b935e-56a9-4780-8905-052d894e6f31">
<img width="767" alt="Screenshot 2024-06-25 at 3 02 15 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/e6621d13-a16a-4834-bf3d-147d9afad88c">
<img width="1198" alt="Screenshot 2024-06-25 at 3 02 23 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/4ce9fb20-b994-4310-924e-d38743c78540">
<img width="1597" alt="Screenshot 2024-06-25 at 3 02 32 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/0f614134-f8c4-45b4-8bcb-e976e1c54943">