### PR TITLE
18345 Campaign Landing Pages: remove custom GA events where possible

### DIFF
--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -16,13 +16,12 @@
               <p class="va-introtext vads-u-color--white">{{ fieldHeroBlurb }}</p>
 
               {% if fieldPrimaryCallToAction %}
-                <a
-                  class="vads-c-action-link--white vads-u-margin-top--2"
+                <va-link-action
+                  class="vads-u-margin-top--2"
                   href="{{ fieldPrimaryCallToAction.entity.fieldButtonLink.url.path }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'hero', 'clp-section-title': '{{ title | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldPrimaryCallToAction.entity.fieldButtonLabel | encode }}' });"
-                >
-                  {{ fieldPrimaryCallToAction.entity.fieldButtonLabel }}
-                </a>
+                  type="reverse"
+                  text="{{ fieldPrimaryCallToAction.entity.fieldButtonLabel }}"
+                />
               {% endif %}
             </div>
             <div class="vads-u-display--none small-desktop-screen:vads-u-display--block">
@@ -43,13 +42,11 @@
             <h2 class="vads-u-margin--0 vads-u-margin-bottom--2">Why this matters to you</h2>
             <p class="va-introtext vads-u-margin-top--0 vads-u-margin-bottom--2">{{ fieldClpWhyThisMatters }}</p>
             {% if fieldSecondaryCallToAction %}
-              <a
-                class="vads-c-action-link--blue"
+              <va-link-action
                 href="{{ fieldSecondaryCallToAction.entity.fieldButtonLink.url.path }}"
-                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Why this matters to you', 'clp-section-title': '{{ fieldClpWhyThisMatters | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldSecondaryCallToAction.entity.fieldButtonLabel | encode }}' });"
-              >
-                {{ fieldSecondaryCallToAction.entity.fieldButtonLabel | strip }}
-              </a>
+                type="secondary"
+                text="{{ fieldSecondaryCallToAction.entity.fieldButtonLabel | strip }}"
+              />
             {% endif %}
           </div><!-- /Content -->
 
@@ -264,14 +261,12 @@
             {% endif %}
 
             <!-- Call to action -->
-            {% if fieldClpStoriesCta.entity.fieldButtonLink.url %}
-              <a
-                class="vads-c-action-link--blue"
-                href="{{ fieldClpStoriesCta.entity.fieldButtonLink.url }}"
-                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Stories', 'clp-section-title': '{{ fieldClpStoriesHeader | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpStoriesCta.entity.fieldButtonLabel | encode }}' });"
-              >
-                See more stories
-              </a>
+            {% if fieldClpStoriesCta.uri %}
+              <va-link-action
+                href="{{ fieldClpStoriesCta.uri }}"
+                type="secondary"
+                text="See more stories"
+              />
             {% endif %}
           </div>
         </div>
@@ -313,13 +308,11 @@
         {% if fieldClpResourcesCta.entity.fieldButtonLink and fieldClpResourcesCta.entity.fieldButtonLabel %}
           <div class="vads-l-row">
             <div class="vads-u-col--12">
-              <a
-                class="vads-c-action-link--blue"
+              <va-link-action
                 href="{{ fieldClpResourcesCta.entity.fieldButtonLink.url.path }}"
-                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Downloadable resources', 'clp-section-title': '{{ fieldClpResourcesHeader | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpResourcesCta.entity.fieldButtonLabel | encode }}' });"
-              >
-                {{ fieldClpResourcesCta.entity.fieldButtonLabel | strip }}
-              </a>
+                type="secondary"
+                text="{{ fieldClpResourcesCta.entity.fieldButtonLabel | strip }}"
+              />
             </div>
           </div>
         {% endif %}
@@ -389,38 +382,31 @@
                     <div class="vads-u-display--flex vads-u-flex-direction--column">
                       <!-- Facility link -->
                       {% if eventReference.entity.fieldFacilityLocation.entity.entityUrl.path and eventReference.entity.fieldFacilityLocation.entity.title %}
-                        <a
+                        <va-link
                           href="{{ eventReference.entity.fieldFacilityLocation.entity.entityUrl.path }}"
-                          onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Events', 'clp-section-title': '{{ fieldClpEventsHeader | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ eventReference.entity.fieldFacilityLocation.entity.title | encode }}' });"
-                        >
-                          {{ eventReference.entity.fieldFacilityLocation.entity.title }}
-                        </a>
+                          text="{{ eventReference.entity.fieldFacilityLocation.entity.title }}"
+                        />
                       {% endif %}
 
                       <!-- Event link -->
                       {% if eventReference.entity.fieldLink.uri and eventReference.entity.fieldEventCta %}
-                        <a
+                        <va-link
                           href="{{ eventReference.entity.fieldLink.uri }}"
-                          onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Events', 'clp-section-title': '{{ fieldClpEventsHeader | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ eventReference.entity.fieldEventCta | encode }}' });"
-                        >
-                          {{ eventReference.entity.fieldEventCta }}
-                        </a>
+                          text="{{ eventReference.entity.fieldEventCta }}"
+                        />
                       {% endif %}
-
 
                       <!-- Online event link -->
-                      {% if eventReference.entity.fieldUrlOfAnOnlineEvent.uri %}
-                        <a
-                          href="{{ eventReference.entity.fieldUrlOfAnOnlineEvent.uri }}"
-                          onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Events', 'clp-section-title': '{{ fieldClpEventsHeader | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ eventReference.entity.fieldUrlOfAnOnlineEvent.uri | encode }}' });"
-                        >
-                      {% endif %}
-                        <!-- Event address -->
-                        {% if eventReference.entity.fieldLocationHumanreadable != empty %}
+                      {% if eventReference.entity.fieldLocationHumanreadable != empty %}
+                        {% if eventReference.entity.fieldUrlOfAnOnlineEvent.uri %}
+                          <va-link
+                            href="{{ eventReference.entity.fieldUrlOfAnOnlineEvent.uri }}"
+                            text="{{ eventReference.entity.fieldLocationHumanreadable }}"
+                          />
+                        {% else %}
+                          <!-- Event address -->
                           <p class="vads-u-margin--0">{{ eventReference.entity.fieldLocationHumanreadable }}</p>
                         {% endif %}
-                      {% if eventReference.entity.fieldUrlOfAnOnlineEvent.uri %}
-                        </a>
                       {% endif %}
                     </div>
                   </div>
@@ -527,13 +513,12 @@
         {% if fieldClpFaqCta.entity.fieldButtonLink.url.path and fieldClpFaqCta.entity.fieldButtonLabel %}
           <div class="vads-l-row">
             <div class="vads-u-col--12">
-              <a
-                class="vads-c-action-link--blue"
+              <va-link-action
+                class="vads-u-margin-top--1"
                 href="{{ fieldClpFaqCta.entity.fieldButtonLink.url.path }}"
-                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'FAQ', 'clp-section-title': 'Frequently asked questions', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpFaqCta.entity.fieldButtonLabel | encode }}' });"
-              >
-                {{ fieldClpFaqCta.entity.fieldButtonLabel | strip }}
-              </a>
+                type="secondary"
+                text="{{ fieldClpFaqCta.entity.fieldButtonLabel | strip }}"
+              />
             </div>
           </div>
         {% endif %}
@@ -558,14 +543,11 @@
           {% if fieldRelatedOffice.entity.fieldEmailUpdatesLink.url.path and fieldRelatedOffice.entity.fieldEmailUpdatesLink.title %}
             <div class="vads-l-col--12 medium-screen:vads-l-col--4">
               <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
-                <a
-                  aria-label="{{ fieldRelatedOffice.entity.fieldEmailUpdatesLink.title }}"
+                <va-icon icon="mail" size="3" class="vads-u-color--link-default vads-u-padding-right--1"></va-icon>
+                <va-link
                   href="{{ fieldRelatedOffice.entity.fieldEmailUpdatesLink.url.path }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldRelatedOffice.entity.fieldExternalLink.title | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldRelatedOffice.entity.fieldEmailUpdatesLink.title | encode }}' });"
-                >
-                  <va-icon icon="mail" size="3" class="vads-u-color--link-default vads-u-padding-right--1"></va-icon>
-                  {{ fieldRelatedOffice.entity.fieldEmailUpdatesLink.title }}
-                </a>
+                  text="{{ fieldRelatedOffice.entity.fieldEmailUpdatesLink.title }}"
+                />
               </div>
             </div>
           {% endif %}
@@ -573,14 +555,11 @@
           {% if socialLinksObject.twitter.value %}
             <div class="vads-l-col--12 medium-screen:vads-l-col--4">
               <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
-                <a
-                  aria-label="Twitter, {{ fieldRelatedOffice.entity.fieldExternalLink.title }}"
+                <va-icon icon="x" size="3" class="vads-u-color--link-default vads-u-padding-right--1"></va-icon>
+                <va-link
                   href="https://twitter.com/{{ socialLinksObject.twitter.value }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldRelatedOffice.entity.fieldExternalLink.title | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldRelatedOffice.entity.fieldExternalLink.title | encode }} Twitter' });"
-                >
-                  <va-icon icon="x" size="3" class="vads-u-color--link-default vads-u-padding-right--1"></va-icon>
-                  {{ fieldRelatedOffice.entity.fieldExternalLink.title }} X (formerly Twitter)
-                </a>
+                  text="{{ fieldRelatedOffice.entity.fieldExternalLink.title }} X (formerly Twitter)"
+                />
               </div>
             </div>
           {% endif %}
@@ -588,14 +567,11 @@
           {% if socialLinksObject.facebook.value %}
             <div class="vads-l-col--12 medium-screen:vads-l-col--4">
               <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
-                <a
-                  aria-label="Facebook, {{ fieldRelatedOffice.entity.fieldExternalLink.title }}"
+                <va-icon icon="facebook" size="3" class="vads-u-color--link-default vads-u-padding-right--1"></va-icon>
+                <va-link
                   href="https://facebook.com/{{ socialLinksObject.facebook.value }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldRelatedOffice.entity.fieldExternalLink.title | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldRelatedOffice.entity.fieldExternalLink.title | encode }} Facebook' });"
-                >
-                  <va-icon icon="facebook" size="3" class="vads-u-color--link-default vads-u-padding-right--1"></va-icon>
-                  {{ fieldRelatedOffice.entity.fieldExternalLink.title }} Facebook
-                </a>
+                  text="{{ fieldRelatedOffice.entity.fieldExternalLink.title }} Facebook"
+                />
               </div>
             </div>
           {% endif %}
@@ -603,14 +579,11 @@
           {% if socialLinksObject.youtube.value %}
             <div class="vads-l-col--12 medium-screen:vads-l-col--4">
               <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
-                <a
-                  aria-label="YouTube, {{ fieldRelatedOffice.entity.fieldExternalLink.title }}"
+                <va-icon icon="youtube" size="3" class="vads-u-color--link-default vads-u-padding-right--1"></va-icon>
+                <va-link
                   href="https://youtube.com/{{ socialLinksObject.youtube.value }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldRelatedOffice.entity.fieldExternalLink.title | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldRelatedOffice.entity.fieldExternalLink.title | encode }} YouTube' });"
-                >
-                  <va-icon icon="youtube" size="3" class="vads-u-color--link-default vads-u-padding-right--1"></va-icon>
-                  {{ fieldRelatedOffice.entity.fieldExternalLink.title }} YouTube
-                </a>
+                  text="{{ fieldRelatedOffice.entity.fieldExternalLink.title }} YouTube"
+                />
               </div>
             </div>
           {% endif %}
@@ -618,14 +591,11 @@
           {% if socialLinksObject.linkedin.value %}
             <div class="vads-l-col--12 medium-screen:vads-l-col--4">
               <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
-                <a
-                  aria-label="Linkedin, {{ fieldRelatedOffice.entity.fieldExternalLink.title }}"
+                <va-icon icon="linkedin" size="3" class="vads-u-color--link-default vads-u-padding-right--1"></va-icon>
+                <va-link
                   href="https://linkedin.com/{{ socialLinksObject.linkedin.value }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldRelatedOffice.entity.fieldExternalLink.title | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldRelatedOffice.entity.fieldExternalLink.title | encode }} Linkedin' });"
-                >
-                  <va-icon icon="linkedin" size="3" class="vads-u-color--link-default vads-u-padding-right--1"></va-icon>
-                  {{ fieldRelatedOffice.entity.fieldExternalLink.title }} Linkedin
-                </a>
+                  text="{{ fieldRelatedOffice.entity.fieldExternalLink.title }} LinkedIn"
+                />
               </div>
             </div>
           {% endif %}
@@ -633,14 +603,11 @@
           {% if socialLinksObject.instagram.value %}
             <div class="vads-l-col--12 medium-screen:vads-l-col--4">
               <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
-                <a
-                  aria-label="Instagram, {{ fieldRelatedOffice.entity.fieldExternalLink.title }}"
+                <va-icon icon="instagram" size="3" class="vads-u-color--link-default vads-u-padding-right--1"></va-icon>
+                <va-link
                   href="https://instagram.com/{{ socialLinksObject.instagram.value }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldRelatedOffice.entity.fieldExternalLink.title | encode }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldRelatedOffice.entity.fieldExternalLink.title | encode }} Instagram' });"
-                >
-                  <va-icon icon="instagram" size="3" class="vads-u-color--link-default vads-u-padding-right--1"></va-icon>
-                  {{ fieldRelatedOffice.entity.fieldExternalLink.title }} Instagram
-                </a>
+                  text="{{ fieldRelatedOffice.entity.fieldExternalLink.title }} Instagram"
+                />
               </div>
             </div>
           {% endif %}


### PR DESCRIPTION
## Summary
Removes custom Google Analytics events from Campaign Landing pages links wherever we can convert to a `va-link` or `va-link-action` (and inherit the baked-in analytics from the web component).

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18345

## Testing done
Tested locally across several CLPs:

- `/initiatives/veterans-experience-action-centers/`
- `/initiatives/covid-flu/`
- `/initiatives/emergency-room-911-or-urgent-care/`
- `/initiatives/sign-in-securely-with-logingov/`
- `/initiatives/protecting-veterans-from-fraud/ `

### Tugboat
We didn't have any prod examples of events on CLP pages, so I added a couple for this CLP on Tugboat: https://web-pwutmkwvjamnjxaxwctdwffyc9ynclqr.demo.cms.va.gov/initiatives/emergency-room-911-or-urgent-care/

## Screenshots

<details><summary>/initiatives/veterans-experience-action-centers/ Hero CTA</summary>
<img width="523" alt="Screenshot 2024-06-25 at 3 40 54 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/32f4212c-19b1-42d2-bb38-af1ee5f548b6">
<img width="556" alt="Screenshot 2024-06-25 at 3 42 12 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/26678585-804e-48e3-9726-6b311b0812db">
<img width="528" alt="Screenshot 2024-06-25 at 3 40 48 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/31ea8b5d-4d7d-459d-a09f-55768e03f71f">

</details>

<details><summary>/initiatives/covid-flu/ Why This Matters CTA</summary>
<img width="701" alt="Screenshot 2024-06-25 at 3 42 21 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/2d9354c6-9e51-4a78-93b8-5d8db7f27793">
<img width="554" alt="Screenshot 2024-06-25 at 3 42 28 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/990e1609-2300-4196-ab7c-d30338f602b4">
<img width="490" alt="Screenshot 2024-06-25 at 5 20 01 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/d5ac9efc-7595-41e9-8119-3727dead79c7">

</details>

<details><summary>/initiatives/emergency-room-911-or-urgent-care/ Downloadable Resources CTA</summary>

<img width="1086" alt="Screenshot 2024-06-25 at 3 52 54 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/b55616ea-de2d-4be8-ba84-5766a86c580f">
<img width="583" alt="Screenshot 2024-06-25 at 3 53 04 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/6300c54f-8e61-4e67-b8db-71b761ddb62c">
<img width="508" alt="Screenshot 2024-06-25 at 3 53 16 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/51954d97-6c36-4083-bf84-f5756eea1b22">

</details>

<details><summary>/initiatives/sign-in-securely-with-logingov/ FAQs CTA</summary>
<img width="729" alt="Screenshot 2024-06-25 at 3 54 58 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/44183f63-b211-4fb3-9fd4-21af759531c0">

<img width="581" alt="Screenshot 2024-06-25 at 3 55 28 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/6bd8726f-8b56-4681-aedc-1ed7a2b0005e">
<img width="512" alt="Screenshot 2024-06-25 at 3 55 17 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/8e7282a4-bc01-4591-93d9-722ed2a7611a">

</details>

<details><summary>/initiatives/protecting-veterans-from-fraud/ See more stories CTA</summary>
<img width="831" alt="Screenshot 2024-06-25 at 5 06 50 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/1be71b1d-a2ef-4ea4-b683-2110689831c3">

<img width="585" alt="Screenshot 2024-06-25 at 5 06 57 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/f8813351-006a-45af-91f6-39cef505aaad">
<img width="510" alt="Screenshot 2024-06-25 at 5 31 09 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/b7206c81-dfe7-4d3b-8fc0-9b2a459c6c87">


</details>

<details><summary>/initiatives/protecting-veterans-from-fraud/ Social links</summary>

### Email updates
<img width="210" alt="Screenshot 2024-06-25 at 4 12 24 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/a0ea80cf-13ea-43c4-a2e2-1ba80230858b">
<img width="567" alt="Screenshot 2024-06-25 at 4 12 46 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/3c718ee1-c448-4419-beac-f4ffe6ac24ed">
<img width="514" alt="Screenshot 2024-06-25 at 4 12 36 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/32f6b5e0-7d85-47f4-ad92-ef618ccda65f">

### YouTube
<img width="246" alt="Screenshot 2024-06-25 at 4 13 06 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/66b1d2b2-6046-431f-89af-14dda3abab6c">
<img width="565" alt="Screenshot 2024-06-25 at 4 13 25 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/9e3e5116-8a7d-4f25-b4b0-db008caf08e9">
<img width="515" alt="Screenshot 2024-06-25 at 4 14 02 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/46b368d5-7f3d-4279-a2c5-d5f1503205a1">


### Twitter
<img width="313" alt="Screenshot 2024-06-25 at 4 14 07 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/e2584e3a-9a57-455a-a841-2978a5cf25ed">
<img width="566" alt="Screenshot 2024-06-25 at 4 14 14 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/2d810807-9ad7-4db8-b576-e786f813a885">
<img width="509" alt="Screenshot 2024-06-25 at 4 16 13 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/e8439a90-82ac-495c-9c23-b75d76998e33">

### Instagram
<img width="267" alt="Screenshot 2024-06-25 at 4 16 16 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/c3501ff5-fff9-4294-a951-fcd12872ccd9">
<img width="569" alt="Screenshot 2024-06-25 at 4 16 38 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/dea25b39-0a64-4df2-8ba6-79edad0c0a56">
<img width="509" alt="Screenshot 2024-06-25 at 4 16 47 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/43ae0edf-57c7-46e4-a902-41c298e93570">


</details>

<details><summary>/initiatives/emergency-room-911-or-urgent-care/ Events links (no prod examples)</summary>
<img width="1071" alt="Screenshot 2024-06-26 at 3 09 38 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/956371dd-4659-405f-b206-89eafa3b446c">
<img width="344" alt="Screenshot 2024-06-26 at 3 09 45 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/06109a70-30e9-442a-968f-d0549f4f070c">
<img width="342" alt="Screenshot 2024-06-26 at 3 09 51 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/3d5144d2-8bb7-40ef-8e0b-65f30eeaf2e4">
<img width="332" alt="Screenshot 2024-06-26 at 3 09 58 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/ddc1517c-f896-44f0-8f92-c2c3e1c62c93">

</details>

## What areas of the site does it impact?
Campaign landing pages only.

## Acceptance criteria
- [x] Custom events removed
- [x] Upgrade to web components where possible