### PR TITLE
VACMS-18213 Alphabetize VBA services

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -730,6 +730,38 @@ module.exports = function registerFilters() {
   // sort a list of objects by a certain property in the object
   liquid.filters.sortObjectsBy = (entities, path) => _.sortBy(entities, path);
 
+  // VBA facilities have accordions with headers that can come from two different
+  // object keys depending on the type of service (facilityService or regionalService)
+  // This sorts alphabetically regardless of key
+  liquid.filters.sortObjectsWithConditionalKeys = entities => {
+    const getFieldToCompare = obj => {
+      let serviceDetails = obj;
+
+      if (obj?.facilityService) {
+        serviceDetails = obj.facilityService;
+      } else if (obj?.regionalService) {
+        serviceDetails = obj.regionalService;
+      }
+
+      return serviceDetails.fieldServiceNameAndDescripti.entity.name;
+    };
+
+    return entities.sort((a, b) => {
+      const name1 = getFieldToCompare(a);
+      const name2 = getFieldToCompare(b);
+
+      if (name1 < name2) {
+        return -1;
+      }
+
+      if (name1 > name2) {
+        return 1;
+      }
+
+      return 0;
+    });
+  };
+
   liquid.filters.getValueFromObjPath = (obj, path) => _.get(obj, path);
 
   // get a value from a path of an object in an array

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -1470,6 +1470,92 @@ describe('sortObjectsBy', () => {
   });
 });
 
+describe('sortObjectsWithConditionalKeys', () => {
+  const objectsToSort = [
+    {
+      facilityService: {
+        fieldServiceNameAndDescripti: {
+          entity: {
+            name: 'Homeless Veteran Care',
+          },
+        },
+      },
+    },
+    {
+      regionalService: {
+        fieldServiceNameAndDescripti: {
+          entity: {
+            name: 'VetSuccess on Campus',
+          },
+        },
+      },
+    },
+    {
+      regionalService: {
+        fieldServiceNameAndDescripti: {
+          entity: {
+            name: 'Disability compensation',
+          },
+        },
+      },
+    },
+    {
+      facilityService: {
+        fieldServiceNameAndDescripti: {
+          entity: {
+            name: 'Home loans',
+          },
+        },
+      },
+    },
+  ];
+
+  const sortedObjects = [
+    {
+      regionalService: {
+        fieldServiceNameAndDescripti: {
+          entity: {
+            name: 'Disability compensation',
+          },
+        },
+      },
+    },
+    {
+      facilityService: {
+        fieldServiceNameAndDescripti: {
+          entity: {
+            name: 'Home loans',
+          },
+        },
+      },
+    },
+    {
+      facilityService: {
+        fieldServiceNameAndDescripti: {
+          entity: {
+            name: 'Homeless Veteran Care',
+          },
+        },
+      },
+    },
+    {
+      regionalService: {
+        fieldServiceNameAndDescripti: {
+          entity: {
+            name: 'VetSuccess on Campus',
+          },
+        },
+      },
+    },
+  ];
+
+  it('sorts objects alphabetically by key', () => {
+    expect(
+      liquid.filters.sortObjectsWithConditionalKeys(objectsToSort),
+    ).to.deep.equal(sortedObjects);
+  });
+});
+
 describe('concat', () => {
   it('concatenates all arrays passed as arguments', () => {
     const a1 = [];

--- a/src/site/includes/vba_facilities/services.liquid
+++ b/src/site/includes/vba_facilities/services.liquid
@@ -1,4 +1,6 @@
 {% if vbaServices.length > 0 %}
+  {% assign alphaVbaServices = vbaServices | sortObjectsWithConditionalKeys %}
+
   <h2 class="vads-u-line-height--1 vads-u-margin-bottom--3">
     {{ vbaTitle }}
   </h2>
@@ -9,7 +11,7 @@
       bordered
       id="vba-regional-facilities-accordion-{{ vbaTitle | hashReference: 60 }}"
       data-testid="vba-accordion-{{vbaTitle}}">
-      {% for entity in vbaServices %}
+      {% for entity in alphaVbaServices %}
         {% if entity.facilityService %}
           {% capture entityId %}{{ entity.facilityService.fieldServiceNameAndDescripti.entity.entityId | hashReference: 60 }}-{{ entity.fieldServiceNameAndDescripti.entity.name | hashReference: 60 }}{% endcapture %}
         {% else %}
@@ -35,7 +37,7 @@
         {% endif %}
 
         {% if entity.regionalService.fieldServiceNameAndDescripti.entity.fieldRegionalServiceHeader %}
-          {% if !facilitySercviceHeader and entity.regionalService.fieldServiceNameAndDescripti.entity.fieldFacilityServiceDescripti.entity %}
+          {% if !facilityServiceHeader and entity.regionalService.fieldServiceNameAndDescripti.entity.fieldFacilityServiceDescripti.entity %}
             {% assign facilityServiceHeader = entity.regionalService.fieldServiceNameAndDescripti.entity.fieldFacilityServiceHeader %}
             {% assign facilityServiceDescription = entity.regionalService.fieldServiceNameAndDescripti.entity.fieldFacilityServiceDescripti %}
           {% endif %}

--- a/src/site/layouts/vba_facility.drupal.liquid
+++ b/src/site/layouts/vba_facility.drupal.liquid
@@ -211,7 +211,6 @@
           </div>
 
           {% assign allVbaServices = reverseFieldVbaRegionFacilityListNode.entities | processVbaServices: reverseFieldOfficeNode.entities %}
-
           {% include "src/site/includes/vba_facilities/services.liquid" with
             vbaTitle = "Veteran benefits"
             vbaServices = allVbaServices.veteranBenefits


### PR DESCRIPTION
## Summary
VBA services needed to be alphabetized. We couldn't follow the simple pattern of adding the liquid sortObjectBy utility because the data objects for services are of two different flavors. One has a key `facilityService` and the other has a key of `regionalService`. sortObjectBy requires a consistent key to be passed in, so I made a utility function specifically for this "dynamic keys" purpose.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18213

## Testing done
Published these two VBA facilities and their services in a Tugboat and tested locally:
- https://web-pwutmkwvjamnjxaxwctdwffyc9ynclqr.demo.cms.va.gov/national-capital-region-va-regional-benefit-office/
- https://web-pwutmkwvjamnjxaxwctdwffyc9ynclqr.demo.cms.va.gov/honolulu-va-regional-benefit-office-at-spark-m-matsunaga-department-of-veterans-affairs-medical-center/

## Screenshots
National Capital
<img width="749" alt="Screenshot 2024-06-28 at 10 59 46 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/c15b5ee9-de32-41cc-bb57-733dd5f87d97">

Honolulu
<img width="763" alt="Screenshot 2024-06-28 at 10 59 51 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/38a013ef-f575-4ade-8cfe-0979821d612b">



## What areas of the site does it impact?

VBA facilities only

## Acceptance criteria

- [x] Determine the order services should be showing in
- [x] Determine if that order is being implemented properly on the FE
- [x] Services should be alphabetized within each section, as they are on VAMCs
- [ ] Requires design review
- [ ] a11y review

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added