### PR TITLE
Remove duplicate registry entry for caregiver application

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -158,29 +158,6 @@
   {
     "appName": "10-10CG",
     "entryName": "1010cg-application-caregiver-assistance",
-    "rootUrl": "/family-member-benefits/apply-for-caregiver-assistance-form-10-10cg",
-    "template": {
-      "title": "Caregiver Application for Benefits",
-      "vagovprod": true,
-      "vagovstaging": true,
-      "vagovdev": true,
-      "localhost": true,
-      "includeBreadcrumbs": true,
-      "breadcrumbs_override": [
-        {
-          "path": "family-member-benefits/comprehensive-assistance-for-family-caregivers",
-          "name": "Family member benefits"
-        },
-        {
-          "path": "family-member-benefits/apply-for-caregiver-assistance-form-10-10cg",
-          "name": "Apply for the Program of Comprehensive Assistance for Family Caregivers"
-        }
-      ]
-    }
-  },
-  {
-    "appName": "10-10CG",
-    "entryName": "1010cg-application-caregiver-assistance",
     "rootUrl": "/family-and-caregiver-benefits/health-and-disability/comprehensive-assistance-for-family-caregivers/apply-form-10-10cg",
     "template": {
       "title": "Caregiver Application for Benefits",


### PR DESCRIPTION
## Summary

The Health Enrollment team recently completed an update to the root URL for the 10-10CG (Application for Caregiver Benefits). In order to complete that update without any downtime, a duplicate registration needed to be added with the new root URL. This PR removes the original registration record for the `caregivers` app.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#81588

## Acceptance criteria

- Registry is free of duplicate app entries for the Caregiver Benefits Application

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution