### PR TITLE
VACMS 17686 - regular text for additional office hours info

### DIFF
--- a/src/site/paragraphs/service_location.drupal.liquid
+++ b/src/site/paragraphs/service_location.drupal.liquid
@@ -296,7 +296,7 @@
   
   {% if single.fieldAdditionalHoursInfo %}
     <p class="vads-u-margin-bottom--0">
-      <span data-template="paragraphs/service_location"><i>{{ single.fieldAdditionalHoursInfo }}</i></span>
+      <span data-template="paragraphs/service_location">{{ single.fieldAdditionalHoursInfo }}</span>
     </p>
   {% endif %}
 {% if typeOfLocation == "nonclinical" %}


### PR DESCRIPTION
## Summary

- Italics is not approved styling. Changed text to normal styling for additional office hours info.
- Sitewide Facilities

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17686

## Testing done

- No tests cover italics. No tests added since it doesn't change conditional logic.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

<details>
<summary>Prior additional info</summary>
<img width="452" alt="Screenshot 2024-07-02 at 5 29 04 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/613f5ba8-a26e-4387-879d-de6ea2c8f98d">
</details>

<details>
<summary>PR additional info</summary>
<img width="542" alt="Screenshot 2024-07-02 at 5 24 32 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/5606931/f869cb13-3bec-451d-af11-88a56c8c0527">
</details>



## What areas of the site does it impact?

Service Location paragraphs (VAMC and VBA)

## Acceptance criteria

- [x] Content from the "Additional Hours Options" field is no longer displayed with italics on the FE on VBA
- [x] Content from the "Additional Hours Options" field is no longer displayed with italics on the FE of VAMCs
- [ ] Requires design review

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (N/A)


## Requested Feedback

Check on tugboat on https://web-codylbelkq0gdivw6x7tykigmeqloewe.demo.cms.va.gov/philadelphia-va-regional-benefit-office/

See Disability Compensation service with hours