### PR TITLE
Remove old supply reordering entry

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -404,15 +404,6 @@
     }
   },
   {
-    "appName": "Order hearing aid batteries and accessories",
-    "entryName": "order-form-2346",
-    "rootUrl": "/health-care/order-hearing-aid-batteries-and-accessories/order-form-2346",
-    "template": {
-      "layout": "page-react.html",
-      "vagovprod": true
-    }
-  },
-  {
     "appName": "Request for Higher-Level Review",
     "entryName": "0996-higher-level-review",
     "rootUrl": "/decision-reviews/higher-level-review/request-higher-level-review-form-20-0996",


### PR DESCRIPTION
## Summary

This app was moved to `health-care-supply-reordering` some time ago and needs to be cleaned up. 

All requests for the old path are redirected, see: 

https://vagov.ddog-gov.com/logs?query=order-form-2346%20service%3Aelb&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1718732940319&to_ts=1720028940319&live=true