### PR TITLE
VACMS-18417: Update links for Resources & Support Detail Page to use ga built in analytics

### DIFF
--- a/src/site/includes/benefit-hubs-links.drupal.liquid
+++ b/src/site/includes/benefit-hubs-links.drupal.liquid
@@ -8,8 +8,7 @@
           <p class="vads-u-margin--0">
             <strong>
               <va-link
-                disable-analytics
-                onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ relatedBenefitHub.entity.fieldHomePageHubLabel | escape }}', 'links-list-section-header': 'VA benefits' })" href="{{ relatedBenefitHub.entity.path.alias }}"
+                href="{{ relatedBenefitHub.entity.path.alias }}"
                 text="{{ relatedBenefitHub.entity.fieldHomePageHubLabel }}"
               />
                 {{ relatedBenefitHub.entity.fieldHomePageHubLabel }}

--- a/src/site/includes/related-information.drupal.liquid
+++ b/src/site/includes/related-information.drupal.liquid
@@ -11,8 +11,6 @@
         <p class="vads-u-margin--0">
           <strong>
             <va-link 
-              disable-analytics
-              onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ fieldRelatedInformationLink.entity.fieldLink.title | escape }}', 'links-list-section-header': 'Related information'})" 
               href="{{ fieldRelatedInformationLink.entity.fieldLink.url.path }}" 
               text="{{ fieldRelatedInformationLink.entity.fieldLink.title }}"
             />


### PR DESCRIPTION
## Summary
This PR changes Resources & Support Detail Page va-links to use built in analytics since va-link can now support link destination

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18417

## Testing done
Tested that ga events are being captured locally and markup is va-link.

`/resources/can-i-get-a-replacement-gi-bill-benefit-certificate-of-eligibility/`
`/resources/can-i-plan-ahead-for-my-burial-in-a-va-national-cemetery/`


## Screenshots
VA Benefits hub link 
<img width="1506" alt="Can_I_Get_A_Copy_Of_My_Education_Decision_Letter____Veterans_Affairs" src="https://github.com/department-of-veterans-affairs/content-build/assets/42885441/305438ea-4a97-4f6a-8a59-ffb6988952a6">
<img width="569" alt="Cursor_and_VA_Education_And_Training_Benefits___Veterans_Affairs" src="https://github.com/department-of-veterans-affairs/content-build/assets/42885441/505e5839-87a1-46f9-89ab-654113af9153">

Related information links
<img width="1508" alt="Can_I_Get_A_Copy_Of_My_Education_Decision_Letter____Veterans_Affairs" src="https://github.com/department-of-veterans-affairs/content-build/assets/42885441/7c12c35e-5f42-480d-8b2b-fbc718ba09d9">
<img width="566" alt="GI_Bill_Comparison_Tool___Veterans_Affairs" src="https://github.com/department-of-veterans-affairs/content-build/assets/42885441/56d542e5-3016-442d-90b2-077863a18f44">

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria
- [ ] A11y Review

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

