### PR TITLE
 Mc sidenav icon fix

### DIFF
--- a/src/site/assets/sass/style.scss
+++ b/src/site/assets/sass/style.scss
@@ -251,7 +251,7 @@
     }
   }
 }
-
+// fix for sidenav btn
 .va-sidenav-btn-close {
   background-size: 0.625rem 0.625rem;
   background-color: transparent;
@@ -262,6 +262,12 @@
   padding: 1.375rem;
   margin: 0;
   width: .625rem;
+}
+
+@media (min-width: 767px) {
+  .va-sidenav-btn-close {
+    display: none;
+  }
 }
 
 // END: Styles for mobile app promo banner  

--- a/src/site/assets/sass/style.scss
+++ b/src/site/assets/sass/style.scss
@@ -252,7 +252,7 @@
   }
 }
 
-.va-btn-close {
+.va-sidenav-btn-close {
   background-size: 0.625rem 0.625rem;
   background-color: transparent;
   height: 1.375rem;

--- a/src/site/assets/sass/style.scss
+++ b/src/site/assets/sass/style.scss
@@ -252,4 +252,16 @@
   }
 }
 
+.va-btn-close {
+  background-size: 0.625rem 0.625rem;
+  background-color: transparent;
+  height: 1.375rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.375rem;
+  margin: 0;
+  width: .625rem;
+}
+
 // END: Styles for mobile app promo banner  

--- a/src/site/navigation/sidebar_nav.drupal.liquid
+++ b/src/site/navigation/sidebar_nav.drupal.liquid
@@ -1,7 +1,7 @@
 <nav data-template="navigation/sidebar_nav" aria-label="Secondary" id="va-detailpage-sidebar" data-drupal-sidebar="true" class="va-drupal-sidebarnav usa-width-one-fourth va-sidebarnav">
     <div>
 
-        <button class="va-btn-close va-sidebarnav-close" type="button" aria-label="Close this menu">
+        <button class="va-sidenav-btn-close va-sidebarnav-close" type="button" aria-label="Close this menu">
             <va-icon icon="close" size="3" class="vads-u-color--gray-dark"></va-icon>
         </button>
 

--- a/src/site/navigation/sidebar_nav.drupal.liquid
+++ b/src/site/navigation/sidebar_nav.drupal.liquid
@@ -1,7 +1,9 @@
 <nav data-template="navigation/sidebar_nav" aria-label="Secondary" id="va-detailpage-sidebar" data-drupal-sidebar="true" class="va-drupal-sidebarnav usa-width-one-fourth va-sidebarnav">
     <div>
 
-        <button class="va-btn-close-icon va-sidebarnav-close" type="button" aria-label="Close this menu"></button>
+        <button class="va-btn-close va-sidebarnav-close" type="button" aria-label="Close this menu">
+            <va-icon icon="close" size="3" class="vads-u-color--gray-dark"></va-icon>
+        </button>
 
         {% for link in sidebar.links %}
             {% if forloop.first == true %}


### PR DESCRIPTION
## Description
It was discovered that the close icon in the sidenav mobile menu wasn't rendering correctly. This PR fixes that by using va-icon and a custom css class specifically inside content-build

Bug ticket - https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2991

## Screenshots
<details><summary>va-icon correctly rendering</summary>

![image](https://github.com/department-of-veterans-affairs/content-build/assets/15097156/403728a4-8d7a-466d-89ab-d1c1ab9f35e0)

</details>

<details><summary>screen capture</summary>

[Screencast from 07-05-2024 10:28:00 AM.webm](https://github.com/department-of-veterans-affairs/content-build/assets/15097156/72dbfb4a-8eb0-45fc-a0c1-0a3060651cee)

</details>