### PR TITLE
Add text on find-form page for form upload flow

### DIFF
--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -83,9 +83,9 @@
 
           {% if fieldVaFormUpload %}
             <h3 class="vads-u-margin-bottom--2" data-testid="va_form--downloadable-pdf">Download form</h3>
-            <div class="vads-u-margin-bottom--2">
+            <p class="vads-u-margin-bottom--2">
               Download this PDF form and fill it out. Then submit your completed form on this page. Or you can print the form and mail it to the address listed on the form.
-            </div>
+            </p>
           {% else %}
             <h3 class="vads-u-margin-bottom--2" data-testid="va_form--downloadable-pdf">Downloadable PDF</h3>
           {% endif %}

--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -81,7 +81,14 @@
             </div>
           {% endif %}
 
-          <h3 class="vads-u-margin-bottom--2" data-testid="va_form--downloadable-pdf">Downloadable PDF</h3>
+          {% if fieldVaFormUpload %}
+            <h3 class="vads-u-margin-bottom--2" data-testid="va_form--downloadable-pdf">Download form</h3>
+            <div class="vads-u-margin-bottom--2">
+              Download this PDF form and fill it out. Then submit your completed form on this page. Or you can print the form and mail it to the address listed on the form.
+            </div>
+          {% else %}
+            <h3 class="vads-u-margin-bottom--2" data-testid="va_form--downloadable-pdf">Downloadable PDF</h3>
+          {% endif %}
         {% endif %}
 
         {% if !fieldVaFormUsage %}


### PR DESCRIPTION
## Summary
This PR adds a `<div>` with some text to the find a form page if the form has the Form Upload flow enabled.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/86813

## Screenshots
Before:
<img width="765" alt="Screenshot 2024-07-10 at 3 25 35 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10481391/13321fd0-63b9-42b2-93aa-89fd8ddf1d4a">

After:
<img width="731" alt="Screenshot 2024-07-10 at 3 25 00 PM" src="https://github.com/department-of-veterans-affairs/content-build/assets/10481391/f61b7d66-06a8-4b40-8f89-47e650731128">
