### PR TITLE
VACMS-16062, 16063 Accessibility fixes for VAMC Staff Profile pages

### DIFF
--- a/src/site/navigation/facility_no_drupal_page_sidebar_nav.drupal.liquid
+++ b/src/site/navigation/facility_no_drupal_page_sidebar_nav.drupal.liquid
@@ -28,25 +28,27 @@
       <a href="{{ deepLinksObj.parent.url.path }}">{{ deepLinksObj.parent.label }}</a>
     </div>
 
-    <ul class="usa-sidenav-list">
-      {% for link in deepLinks %}
-      <li {% if entityUrl.path == link.url.path %} class="active-level" {% endif %}>
-        <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
-          href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
-        {% if link.links.length %}
-          <ul class="usa-sidenav-sub_list">
-            {% for link in link.links %}
-              <li>
-                <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
-                  href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
-              </li>
-            {% endfor %}
-          </ul>
-          </li>
-        {% else %}
-          </li>
-        {% endif %}
-      {% endfor %}
-    </ul>
+    {% if deepLinks.length %}
+      <ul class="usa-sidenav-list">
+        {% for link in deepLinks %}
+        <li {% if entityUrl.path == link.url.path %} class="active-level" {% endif %}>
+          <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
+            href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
+          {% if link.links.length %}
+            <ul class="usa-sidenav-sub_list">
+              {% for link in link.links %}
+                <li>
+                  <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
+                    href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
+                </li>
+              {% endfor %}
+            </ul>
+            </li>
+          {% else %}
+            </li>
+          {% endif %}
+        {% endfor %}
+      </ul>
+    {% endif %}
   </div>
 </nav>

--- a/src/site/navigation/facility_no_drupal_page_sidebar_nav.drupal.liquid
+++ b/src/site/navigation/facility_no_drupal_page_sidebar_nav.drupal.liquid
@@ -6,8 +6,13 @@
     For an example of how to make a string look like this, look at in `src/site/layouts/person_profile.drupal.liquid` where sidebarData is being assigned.
 {% endcomment %}
 
-<nav data-template="navigation/facility_no_drupal_page_sidebar_nav" id="va-detailpage-sidebar" data-drupal-sidebar
-     class="va-c-facility-sidebar usa-width-one-fourth va-sidebarnav">
+<nav
+  aria-label="Secondary"
+  data-template="navigation/facility_no_drupal_page_sidebar_nav"
+  id="va-detailpage-sidebar"
+  data-drupal-sidebar
+  class="va-c-facility-sidebar usa-width-one-fourth va-sidebarnav"
+>
   <div>
     <button class="va-btn-close-icon va-sidebarnav-close" type="button" aria-label="Close this menu"></button>
 


### PR DESCRIPTION
## Summary
Accessibility fixes:
1. Add an `aria-label="Secondary"` label to the `<nav>` element on Staff Profile sidebars to differentiate it from other navigations on the same page.
2. Conditionally render the `<ul>` element in the `<nav>`, only if deep links exist

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16062
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16063

## Testing done
Tested locally at `/salem-health-care/staff-profiles/allen-r-moye/`:
1. Visit the above page and inspect the sidebar navigation
2. Verify the `<nav>` element has `aria-label="Secondary"`
3. Verify the `<nav>` element does not have an empty `<ul>` inside it
4. Use Mac Voiceover or another screen reader to validate that the aria label is read aloud when getting to this element and no empty list is detected

## Screenshots
<img width="274" alt="Screenshot 2024-07-11 at 11 25 07 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/4ebaf38e-22ae-4d03-a5b0-b12d1d05b418">

<img width="471" alt="Screenshot 2024-07-11 at 11 54 20 AM" src="https://github.com/department-of-veterans-affairs/content-build/assets/19175324/7e8fc8db-c27a-4ec0-ae51-d12f3149f12f">

## What areas of the site does it impact?

VAMC staff profile pages only.

## Acceptance criteria
- [x] Add `aria-label="Secondary"` to the `<nav>` element
- [x] Add a conditional that removes the `<ul>` if it's empty.
- [ ] @laflannery has reviewed