### PR TITLE
VACMS-17436: Update links for manage your health care section

### DIFF
--- a/src/site/assets/sass/style.scss
+++ b/src/site/assets/sass/style.scss
@@ -55,7 +55,7 @@
 }
 
 .health-online-desktop-link {
-  @media (max-width: 768px) {
+  @media (max-width: 767px) {
     display: none !important;
   }
 }

--- a/src/site/assets/sass/style.scss
+++ b/src/site/assets/sass/style.scss
@@ -54,6 +54,18 @@
   word-wrap: break-word;
 }
 
+.health-online-desktop-link {
+  @media (max-width: 767px) {
+    display: none !important;
+  }
+}
+
+.health-online-mobile-link {
+  @media (min-width: 767px) {
+    display: none !important;
+  }
+}
+
 // START: Styles for mobile app promo banner
 #alert-with-additional-info {
 

--- a/src/site/assets/sass/style.scss
+++ b/src/site/assets/sass/style.scss
@@ -55,13 +55,13 @@
 }
 
 .health-online-desktop-link {
-  @media (max-width: 767px) {
+  @media (max-width: 768px) {
     display: none !important;
   }
 }
 
 .health-online-mobile-link {
-  @media (min-width: 767px) {
+  @media (min-width: 768px) {
     display: none !important;
   }
 }

--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -57,9 +57,9 @@
           {% if fieldAdministration.entity.entityId != '1039' %}
           <section>
             {% if fieldAdministration.entity.entityId == '1040' %}
-              <h3>Manage your VA health online</h3>
+              <h2>Manage your VA health online</h2>
             {% else %}
-              <h3>Manage your health online</h3>
+              <h2>Manage your health online</h2>
             {% endif %}
             <div class="vads-u-display--flex medium-screen:vads-u-flex-direction--row vads-u-flex-direction--column">
               <div class="vads-u-margin-right--0 medium-screen:vads-u-margin-right--3">
@@ -102,6 +102,18 @@
                     text="Schedule and manage health appointments"
                   ></va-link>
                 </div>
+                <div class="vads-facility-hub-cta vads-u-display--flex vads-u-align-items--center">
+                  <va-icon
+                    class="vads-u-color--link-default vads-facility-hub-cta-circle vads-u-margin-right--1"
+                    size="3"
+                    icon="chat"
+                  ></va-icon>
+                  <va-link
+                    aria-hidden="true"
+                    href="https://mobile.va.gov/app/va-health-chat"
+                    text="Download VA Health Chat"
+                  ></va-link>
+                </div>
               </div>
               <div>
                 <div class="vads-facility-hub-cta vads-u-display--flex vads-u-align-items--center">
@@ -141,6 +153,18 @@
                     onClick="recordEvent({ event: 'cta-hub-link-click' });"
                     href="/health-care/order-hearing-aid-batteries-and-accessories/"
                     text="Order hearing aid batteries and accessories"
+                  ></va-link>
+                </div>
+                <div class="vads-facility-hub-cta vads-u-display--flex vads-u-align-items--center">
+                  <va-icon
+                    class="vads-u-color--link-default vads-facility-hub-cta-circle vads-u-margin-right--1"
+                    size="3"
+                    icon="phone"
+                  ></va-icon>
+                  <va-link
+                    aria-hidden="true"
+                    href="https://www.va.gov/health/connect-to-va-care/index.asp"
+                    text="Connect to VA care"
                   ></va-link>
                 </div>
               </div>

--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -109,7 +109,6 @@
                     icon="chat"
                   ></va-icon>
                   <va-link
-                    aria-hidden="true"
                     href="https://mobile.va.gov/app/va-health-chat"
                     text="Download VA Health Chat"
                   ></va-link>
@@ -162,7 +161,6 @@
                     icon="phone"
                   ></va-icon>
                   <va-link
-                    aria-hidden="true"
                     href="https://www.va.gov/health/connect-to-va-care/index.asp"
                     text="Connect to VA care"
                   ></va-link>

--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -102,7 +102,7 @@
                     text="Schedule and manage health appointments"
                   ></va-link>
                 </div>
-                <div class="vads-facility-hub-cta vads-u-display--flex vads-u-align-items--center">
+                <div class="vads-facility-hub-cta vads-u-display--flex vads-u-align-items--center health-online-desktop-link">
                   <va-icon
                     class="vads-u-color--link-default vads-facility-hub-cta-circle vads-u-margin-right--1"
                     size="3"
@@ -152,6 +152,17 @@
                     onClick="recordEvent({ event: 'cta-hub-link-click' });"
                     href="/health-care/order-hearing-aid-batteries-and-accessories/"
                     text="Order hearing aid batteries and accessories"
+                  ></va-link>
+                </div>
+                <div class="vads-facility-hub-cta vads-u-display--flex vads-u-align-items--center health-online-mobile-link">
+                  <va-icon
+                    class="vads-u-color--link-default vads-facility-hub-cta-circle vads-u-margin-right--1"
+                    size="3"
+                    icon="chat"
+                  ></va-icon>
+                  <va-link
+                    href="https://mobile.va.gov/app/va-health-chat"
+                    text="Download VA Health Chat"
                   ></va-link>
                 </div>
                 <div class="vads-facility-hub-cta vads-u-display--flex vads-u-align-items--center">

--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -67,7 +67,7 @@
                   <va-icon
                     class="vads-u-color--link-default vads-facility-hub-cta-circle vads-u-margin-right--1"
                     size="3"
-                    icon="medication"
+                    icon="pill"
                   ></va-icon>
                   <va-link
                     disable-analytics
@@ -80,7 +80,7 @@
                   <va-icon
                     class="vads-u-color--link-default vads-facility-hub-cta-circle vads-u-margin-right--1"
                     size="3"
-                    icon="chat"
+                    icon="forum"
                   ></va-icon>
                   <va-link
                     disable-analytics


### PR DESCRIPTION
## Summary
For this PR we are adding 2 new links under the Manage your health care section.

Download VA Health Chat and Connect to VA Care.

Also we changed the header as well to an h2 to fix an a11y defect.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17436

## Testing done
Tested locally at `/greater-los-angeles-health-care/`

Verified links are working and redirecting to correct address.

## Screenshots
![VA_Greater_Los_Angeles_Health_Care___Veterans_Affairs](https://github.com/user-attachments/assets/3e32a4f9-d08c-4a47-9002-1017830f9766)


## What areas of the site does it impact?

VA Health Care system pages

## Acceptance criteria

### Add VA Health Chat
- [x] add 'chat' USWDS v3 icon 
- [x] include `aria-hidden="true"` on icon
- [x] add link text "Download VA Health Chat" with a link [https://mobile.va.gov/app/va-health-chat]
### Add VA Health connect 
- [x] add 'phone' USWDS v3 icon 
- [x] include `aria-hidden="true"` on icon
- [x] add link text "Connect to VA care" with a link https://www.va.gov/health/connect-to-va-care/index.asp

### Additional Acceptance Criteria
- [ ] all existing links remain
- [ ] new links should appear below existing links
- [ ] Change header to h2 (currently h3) 

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)


