### PR TITLE
VACMS-18393 VBA hours fix

### DIFF
--- a/src/site/paragraphs/service_location.drupal.liquid
+++ b/src/site/paragraphs/service_location.drupal.liquid
@@ -260,11 +260,10 @@
           <h{{ serviceLocationH }}>{{ email.entity.fieldEmailLabel }}</h{{ serviceLocationH }}>
         {% endif %}
         <va-link
-          aria-label="{{ email.entity.fieldEmailAddress }}"
           data-template="paragraphs/service_location"
           href="mailto:{{ email.entity.fieldEmailAddress }}"
           text="{{ email.entity.fieldEmailAddress }}"
-        </va-link>
+        ></va-link>
       </p>
     {% endfor %}
   {% endif %}


### PR DESCRIPTION
## Summary
Hours on VBA service accordions were not showing up. We were also missing complete contact information. One of the services had two email addresses added, and only one of them appeared. This pointed me to a syntax issue with the `<va-link>` being used for email that allowed the template to fail silently and not complete rendering the rest of the code.

This fixes the syntax error and renders the missing contact information and the hours (and any other information that would come after the contact information in this template).

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18393

## Testing done
Tested locally with a Tugboat instance:
https://web-cmugn5ieupsmz1cyrrmcwiwcawfidlrx.demo.cms.va.gov/philadelphia-va-regional-benefit-office/

1. Go to `/philadelphia-va-regional-benefit-office/`
2. Open the accordion for "Pre-need burial planning"
3. Verify at the bottom of the accordion that full hours appear (Mon - Sun)
4. Verify that the second email address ("Email 2") appears
5. Open the "Transition assistance" accordion
6. Verify at the bottom that no hours appear (as per the CMS data)
7. Verify that three email addresses appear

## Screenshots

### `/philadelphia-va-regional-benefit-office/` hours and contact data for "Pre-need burial assistance"
<img width="500" alt="Screenshot 2024-07-12 at 10 11 40 AM" src="https://github.com/user-attachments/assets/22479a69-7b97-487a-a35e-f51ee7834f4d">

<img width="500" alt="Screenshot 2024-07-12 at 10 11 47 AM" src="https://github.com/user-attachments/assets/b077a50d-f6b1-4559-8dc4-fc0768506241">

| Before | After |
| ---- | ---- |
| <img width="691" alt="Screenshot 2024-07-12 at 10 19 19 AM" src="https://github.com/user-attachments/assets/32758cf4-9471-45f8-8d79-9fb961d720e7"> | <img width="731" alt="Screenshot 2024-07-12 at 10 11 07 AM" src="https://github.com/user-attachments/assets/32ad97e2-5688-40ee-845d-876672fb85eb"> |

### `/philadelphia-va-regional-benefit-office/` hours and contact data for "Transition assistance"
<img width="500" alt="Screenshot 2024-07-12 at 10 12 07 AM" src="https://github.com/user-attachments/assets/aada4ae9-7f32-4ab5-88d5-5c08dd9a1441">

<img width="500" alt="Screenshot 2024-07-12 at 10 21 26 AM" src="https://github.com/user-attachments/assets/75d5d381-c63a-4188-a918-2241ead9b5ab">

| Before | After |
| ---- | ---- |
| <img width="701" alt="Screenshot 2024-07-12 at 10 23 03 AM" src="https://github.com/user-attachments/assets/d4b892bf-8308-44d7-b455-387dbc94c25d"> | <img width="729" alt="Screenshot 2024-07-12 at 10 12 16 AM" src="https://github.com/user-attachments/assets/83215ce5-3a3e-4edb-bea3-5dfb9f67d0d6"> |



## What areas of the site does it impact?

VBA facilities