### PR TITLE
increase Deploy timeout to 25m.

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -392,7 +392,7 @@ jobs:
       - build
     outputs:
       DEPLOY_END_TIME: ${{ steps.export-deploy-end-time.outputs.DEPLOY_END_TIME }}
-    timeout-minutes: 15
+    timeout-minutes: 25
 
     steps:
 


### PR DESCRIPTION
## Summary

Increases the timeout of the deploy step of content-release.yml to 25m for temporary mitigation of content release issues.
