### PR TITLE
Migrate 21a application into ARP application

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1782,10 +1782,12 @@
   {
     "appName": "Accredited Representative Portal",
     "entryName": "representative",
-    "rootUrl": "/representative",
+    "rootUrl": "/attorney-claims-agent-form-21a",
     "productId": "89100c00-5b5f-46fd-bd98-d3b35f220958",
     "template": {
       "vagovprod": false,
+      "title": "Apply to become a VA accredited attorney or claims agent",
+      "description": "Apply to become a VA accredited attorney or claims agent (VA Form 21a)",
       "layout": "accredited-representative-portal.html"
     }
   },
@@ -1868,33 +1870,6 @@
       "vagovprod": false,
       "layout": "page-react.html",
       "includeBreadcrumbs": true
-    }
-  },
-  {
-    "appName": "Apply to become a VA accredited attorney or claims agent",
-    "entryName": "21a",
-    "rootUrl": "/accreditation/attorney-claims-agent-form-21a",
-    "productId": "55b00994-6f3c-4527-98be-5a90e37eec01",
-    "template": {
-      "vagovprod": false,
-      "title": "Apply to become a VA accredited attorney or claims agent",
-      "description": "Apply to become a VA accredited attorney or claims agent (VA Form 21a)",
-      "layout": "page-react.html",
-      "includeBreadcrumbs": true,
-      "breadcrumbs_override": [
-        {
-          "name": "Home",
-          "path": ""
-        },
-        {
-          "name": "VA accreditation representatives",
-          "path": "accreditation"
-        },
-        {
-          "name": "Apply to become a VA accredited attorney or claims agent",
-          "path": "accreditation/attorney-claims-agent-form-21a"
-        }
-      ]
     }
   }
 ]


### PR DESCRIPTION
### Note: This PR to delete the 21a application entry in content-build registry.json must be merged **before** [87799 ARF migrate 21a into ARP #30835](https://github.com/department-of-veterans-affairs/vets-website/pull/30835)

## Summary

- Summarize the changes that have been made to the platform: All changes are in files owned by ARF
  - Migrate 21a application into ARP application
  - 21a will be the only content of ARP for likely the next 3 to 6 months
  - Therefore it made sense to update the ARP URL, title, and description to be about the 21a
  - The URL aligns with the [V3 designs](https://www.figma.com/design/2afIGOMII0uRI5ck1dWo1w/Form-21a---Apply-for-Accreditation-(CA-%26-Attorneys)?node-id=1483-194954&t=gYrHHwrHOvXthOGr-4) in which on 21a release there will be no page before the 21a introduction page so a url like `va.gov/representative/attorney-claims-agent-form-21a` or `va.gov/representative/accreditation/attorney-claims-agent-form-21a` would mean that we would need to build out a /representative page and/or /accreditation page. We are hopeful to have the subdomain representative.va.gov by release.
 - The lack of breadcrumbs aligns with the [V3 designs](https://www.figma.com/design/2afIGOMII0uRI5ck1dWo1w/Form-21a---Apply-for-Accreditation-(CA-%26-Attorneys)?node-id=1483-194954&t=gYrHHwrHOvXthOGr-4)
- Which team do you work for?
  -  Accredited Representative Facing Team 

## Related issue(s)

- [Migrate 21a into ARP#87799](https://app.zenhub.com/workspaces/accredited-representative-facing-team-65453a97a9cc36069a2ad1d6/issues/gh/department-of-veterans-affairs/va.gov-team/87799)
- [[ARF] Digital Form 21a](https://app.zenhub.com/workspaces/accredited-representative-facing-team-65453a97a9cc36069a2ad1d6/issues/gh/department-of-veterans-affairs/va.gov-team/83627)

## Testing done

- Describe what the old behavior was prior to the change
  - Before this change the 21a used the layout "page-react.html" and therefore thee VA.gov header and footer and therefore the VA.gov user
  - The 21a form was functional
- Describe the steps required to verify your changes are working as expected
  - Still in progress 

## Screenshots

### Mobile

#### Before
https://staging.va.gov/representative
<img width="390" alt="Screenshot 2024-07-15 at 9 06 16 AM" src="https://github.com/user-attachments/assets/c840f673-d814-4331-939c-4975d7502b03">
https://staging.va.gov/representative/poa-requests
<img width="388" alt="Screenshot 2024-07-15 at 9 06 32 AM" src="https://github.com/user-attachments/assets/092240ae-6c9d-428c-98a1-40599364f9f1">

#### After
Still in progress since need to fix this error:
<img width="1502" alt="Screenshot 2024-07-15 at 9 08 49 AM" src="https://github.com/user-attachments/assets/77b4d2d2-82af-4205-97cf-cfd18ab1d4b6">
If I update src/applications/accredited-representative-portal/accreditation/21a/containers/App.jsx to:
```
<Header />
<h1>Form 21a</h1>
{/* <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
  {children}
</RoutedSavableApp> */}
<Footer />
```
<img width="387" alt="Screenshot 2024-07-15 at 9 07 51 AM" src="https://github.com/user-attachments/assets/59b919ba-7ee5-4598-9ed5-2c6bc0de1082">

### Desktop

#### Before
<img width="925" alt="Screenshot 2024-07-15 at 9 10 29 AM" src="https://github.com/user-attachments/assets/9aba60b2-d0e7-498a-b9e9-cd15ea3035d5">
<img width="926" alt="Screenshot 2024-07-15 at 9 10 47 AM" src="https://github.com/user-attachments/assets/3550c94b-af5c-448a-9ca4-019155f3d097">

#### After
Same Error
If I update src/applications/accredited-representative-portal/accreditation/21a/containers/App.jsx to:
<img width="971" alt="Screenshot 2024-07-15 at 9 11 27 AM" src="https://github.com/user-attachments/assets/74721e32-81cf-4987-8406-4029f421aab0">

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
- Considered creating our own save in progress helper functions so that we don't have to move our app back to react-router V3. There could also be a better way to handle this dependency clash. 
- Unknown what is causing error:
<img width="934" alt="Screenshot 2024-07-15 at 9 14 01 AM" src="https://github.com/user-attachments/assets/2c57dacf-1d5a-43ef-9a38-de7c1418431e">
- Still need to update (21a already has its own e2e tests so this may not be necessary), comment out, or skip our poa-requests e2e tests

