### PR TITLE
Remove event thumbnail query

### DIFF
--- a/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
@@ -404,14 +404,6 @@ const nodeEventWithoutBreadcrumbs = `
               width
             }
           }
-          thumbnail {
-            alt
-            height
-            targetId
-            title
-            url
-            width
-          }
         }
       }
     }

--- a/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeEvent.graphql.js
@@ -196,14 +196,6 @@ const nodeEvent = `
               width
             }
           }
-          thumbnail {
-            alt
-            height
-            targetId
-            title
-            url
-            width
-          }
         }
       }
     }


### PR DESCRIPTION
## Summary
This removes "thumbnail" from event node queries. The thumbnail is not used anywhere, but its data is included in event listings pages, which means it is downloaded and shipped with content release. Moreover, the query does not specify any image style, which means it downloads the original, full-size image.

Removing this query reduces the size of the delivery to www.va.gov by 3GB, which will provide some speed gains for content build. 

## Testing done

This content-build branch was deployed to a Tugboat CMS instance via the 'release content' mechanism. The output can be viewed here: https://web-pdflieeh7fv4apxbldfpsaulkisc9g5l.demo.cms.va.gov/

https://web-pdflieeh7fv4apxbldfpsaulkisc9g5l.demo.cms.va.gov/outreach-and-events/events/ is a good example of many events and the lack of effect this change to the query appears to have. 

