### PR TITLE
VACMS 13937 - VAMC and Vet Center Accordions with text to select a subject

### DIFF
--- a/src/site/includes/health_services_listing_services.liquid
+++ b/src/site/includes/health_services_listing_services.liquid
@@ -4,6 +4,7 @@
 {% if servicesListOrderedByName.length > 0 %}
   <section data-label="{{typeOfCare}}">
     <h2>{{ typeOfCare }}</h2>
+    <p>Select a topic to learn more.</p>
     <div class="service-accordion-output">
       <va-accordion bordered uswds="true">
       {% for service in servicesListOrderedByName %}

--- a/src/site/includes/health_services_listing_services.liquid
+++ b/src/site/includes/health_services_listing_services.liquid
@@ -1,6 +1,5 @@
 {% assign servicesList = clinicalHealthServices | filterBy: "fieldServiceNameAndDescripti.entity.fieldServiceTypeOfCare", typeOfCare, false %}
 {% assign servicesListOrderedByName = servicesList | sortObjectsBy: "fieldServiceNameAndDescripti.entity.name" %}
-
 {% if servicesListOrderedByName.length > 0 %}
   <section data-label="{{typeOfCare}}">
     <h2>{{ typeOfCare }}</h2>

--- a/src/site/includes/vet_centers/health_services.liquid
+++ b/src/site/includes/vet_centers/health_services.liquid
@@ -16,6 +16,6 @@
     <h2 id="other-services" class="vads-u-margin-top--0 vads-u-font-size--lg small-screen:vads-u-font-size--xl
     vads-u-margin-bottom--2">Other services</h2>
   {% endif %}
-  <p> Click on a service for more details. </p>
+  <p>Select a topic to learn more.</p>
   {% include "src/site/includes/vet_centers/services.liquid" with services = servicesListOrdered %}
 {% endif %}

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -145,7 +145,7 @@
               <h2 id="prepare-for-your-visit"
                   class="vads-u-margin-top--0 vads-u-font-size--lg small-screen:vads-u-font-size--xl vads-u-margin-bottom--2">
                 Prepare for your visit</h2>
-              <p>Click on a topic for more details.</p>
+              <p>Select a topic to learn more.</p>
               <va-accordion section-heading="Prepare for your visit" bordered>
                 {% for accordionItem in fieldLocationServices %}
                   {% assign item = accordionItem.entity %}
@@ -180,8 +180,7 @@
           {% if fieldLocalHealthCareService != empty and fieldLocalHealthCareService.length %}
             <h2 id="health-care-offered-here"
                 class="vads-u-font-size--xl vads-u-margin-top--5">Health services offered here</h2>
-            <p>Click on a service for more details like location, contact, and appointment
-              information.</p>
+            <p>Select a topic to learn more.</p>
             <section class="local-health-services" id="local-health-services" data-label="Health services">
 
               {% assign localHealthServices = fieldLocalHealthCareService | sortObjectsBy: 'entity.fieldRegionalHealthService.entity.fieldServiceNameAndDescripti.entity.name' %}

--- a/src/site/layouts/vet_center.drupal.liquid
+++ b/src/site/layouts/vet_center.drupal.liquid
@@ -145,7 +145,7 @@
           {% if fieldPrepareForVisit.length > 0 %}
             <h2 id="prepare-for-your-visit" class="vads-u-margin-top--0 vads-u-font-size--lg
           small-screen:vads-u-font-size--xl vads-u-margin-bottom--2">Prepare for your visit</h2>
-            <p> Click on a topic for more details. </p>
+            <p>Select a topic to learn more.</p>
             <div class="vads-u-margin-bottom--3">
               <va-accordion bordered
                 id="prepare-for-your-visit-accordion-{{ entity.entity.fieldHeader }}"


### PR DESCRIPTION
## Summary

- Adds text below header to identify that a user should select a topic for more information in the form of the statement: "Select a topic to learn more."
- Sitewide team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13937

## Testing done

- Manually tested several VAMC and Vet Center locations

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

<details>
<summary>VAMC Prepare for your visit (desktop) - in PR</summary>
<img width="675" alt="Screenshot 2024-07-16 at 3 14 23 PM" src="https://github.com/user-attachments/assets/48fb1cc3-ad38-41bf-ab48-e709728eba2b">
</details>


<details>
<summary>VAMC Prepare for your visit (mobile) - in PR</summary>
<img width="403" alt="Screenshot 2024-07-16 at 3 14 33 PM" src="https://github.com/user-attachments/assets/1b2df26e-524b-400e-bdae-5152bd22f8c7">
</details>

<details>
<summary>VAMC Prepare for your visit (desktop) - current</summary>
<img width="717" alt="Screenshot 2024-07-16 at 3 15 59 PM" src="https://github.com/user-attachments/assets/0b5006bc-9605-4154-8340-48af75a9ee34">
</details>


<details>
<summary>VAMC Health Services (desktop) in PR</summary>
<img width="691" alt="Screenshot 2024-07-16 at 3 17 09 PM" src="https://github.com/user-attachments/assets/f4515250-9404-4add-948b-cd8cca31eecc">
</details>


<details>
<summary>VAMC Health Services (mobile) in PR</summary>
<img width="398" alt="Screenshot 2024-07-16 at 3 18 00 PM" src="https://github.com/user-attachments/assets/eea31905-76cc-43d5-ae12-2929a7e8bf97">
</details>


<details>
<summary>VAMC Health Services (desktop) - current</summary>
<img width="718" alt="Screenshot 2024-07-16 at 3 18 57 PM" src="https://github.com/user-attachments/assets/e40cd00b-93a5-4a3a-afb5-d74a65d3c216">
</details>


<details>
<summary>Vet Center Prepare for your visit (desktop) - current</summary>
<img width="751" alt="Screenshot 2024-07-16 at 3 20 24 PM" src="https://github.com/user-attachments/assets/075fb780-e61e-49a7-af1d-e761ebdc5f15">
</details>


<details>
<summary>Vet Center Prepare for your visit (desktop) - in PR</summary>
<img width="700" alt="Screenshot 2024-07-16 at 3 21 44 PM" src="https://github.com/user-attachments/assets/6a7c38a9-08fc-4179-addf-6cb9e9568b90">
</details>


<details>
<summary>Vet Center Services (desktop) - in PR</summary>
<img width="805" alt="Screenshot 2024-07-16 at 3 22 35 PM" src="https://github.com/user-attachments/assets/f5208bf3-078a-4dea-a8f9-dd474db7d118">
</details>


<details>
<summary>Vet Center Services (desktop) - current</summary>
<img width="717" alt="Screenshot 2024-07-16 at 3 23 33 PM" src="https://github.com/user-attachments/assets/d22520e1-41f2-450b-9981-3e4fcb7a2253">
</details>

## What areas of the site does it impact?

VAMC and Vet Center pages (unauthenticated)

## Acceptance criteria


### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (unauthenticated)

## Requested Feedback

View screenshots or RI or build locally (can use regular build step pulling from any tugboat or the default).
Go to
http://1a0644201a521249e3b19ac3dd9f0b29.review.vetsgov-internal/boston-vet-center/
and
http://1a0644201a521249e3b19ac3dd9f0b29.review.vetsgov-internal/philadelphia-health-care/locations/corporal-michael-j-crescenz-department-of-veterans-affairs/