### PR TITLE
VACMS-18512: Update va-link for event details page to remove duplicate events

### DIFF
--- a/src/site/includes/directions-google-maps.liquid
+++ b/src/site/includes/directions-google-maps.liquid
@@ -8,7 +8,7 @@ directionsLinkOnClickPropValue
 
 <div>
   <va-link
-    aria-label="to {{ directionsLinkTitle | strip }}"
+    label="to {{ directionsLinkTitle | strip }}"
     href="https://maps.google.com?saddr=Current+Location&amp;daddr={{ directionsLinkAddress | strip }}"
     text="Get directions on Google Maps"
   />

--- a/src/site/includes/directions-google-maps.liquid
+++ b/src/site/includes/directions-google-maps.liquid
@@ -6,18 +6,11 @@ directionsLinkOnClickPropName
 directionsLinkOnClickPropValue
 {% endcomment %}
 
-{% assign onClick = "" %}
-{% if directionsLinkOnClickPropName != empty and directionsLinkOnClickPropValue != empty %}
-  {% capture onClick %}
-    onclick="recordEvent({ event: 'directions-link-click', '{{ directionsLinkOnClickPropName }}': '{{ directionsLinkOnClickPropValue }}'});"
-  {% endcapture %}
-{% endif %}
-
 <div>
-  <a
-    {{ onClick | strip }}
-    href="https://maps.google.com?saddr=Current+Location&amp;daddr={{ directionsLinkAddress | strip }}">
-    Get directions on Google Maps
-    <span class="sr-only">to {{ directionsLinkTitle | strip }}</span>
-  </a>
+  <va-link
+    aria-label="to {{ directionsLinkTitle | strip }}"
+    href="https://maps.google.com?saddr=Current+Location&amp;daddr={{ directionsLinkAddress | strip }}"
+    text="Get directions on Google Maps"
+  />
+  </va-link>
 </div>

--- a/src/site/includes/directions-google-maps.liquid
+++ b/src/site/includes/directions-google-maps.liquid
@@ -8,7 +8,7 @@ directionsLinkOnClickPropValue
 
 <div>
   <va-link
-    label="to {{ directionsLinkTitle | strip }}"
+    label="Get directions on Google Maps to {{ directionsLinkTitle | strip }}"
     href="https://maps.google.com?saddr=Current+Location&amp;daddr={{ directionsLinkAddress | strip }}"
     text="Get directions on Google Maps"
   />

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -298,7 +298,6 @@
           <va-link
             class="vads-u-display--block vads-u-margin-top--2"
             href="{{ fieldListing.entity.entityUrl.path }}"
-            onclick="recordEvent({ event: 'nav-secondary-button-click' });"
             text="Browse the {{ vamcLocation }} events calendar"
           ></va-link>
         {% endif %}


### PR DESCRIPTION
## Summary
This PR updates the events detail page to remove duplicative ga events and change the directions for google maps links.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18512

## Testing done
Tested locally `/durham-health-care/events/69410/`

## Screenshots

<img width="1509" alt="VA_Greater_Los_Angeles_Health_Care___Veteran_Produce_Distribution_Events___Veterans_Affairs" src="https://github.com/user-attachments/assets/396b9bf0-a249-4c5b-87b8-231857e4460e">


<img width="1502" alt="VA_Greater_Los_Angeles_Health_Care___Veteran_Produce_Distribution_Events___Veterans_Affairs" src="https://github.com/user-attachments/assets/af6f35db-1cbf-4d35-ad6e-597b799e7dc2">


![VA_Durham_Health_Care___Greenville_HCC_PACT_Act_And_PRIDE_Event___Veterans_Affairs](https://github.com/user-attachments/assets/2de9999c-c5e7-4e1a-b60d-b9be56523042)


## What areas of the site does it impact?
Event Detail Page

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
