### PR TITLE
VACMS-18715: content release datadog metrics

### DIFF
--- a/.github/workflows/daily-release-warning.yml
+++ b/.github/workflows/daily-release-warning.yml
@@ -2,7 +2,7 @@ name: Daily Release Warning
 
 on:
   schedule:
-    - cron: 0 17 * * 1-5
+    - cron: 0 14 * * 1-5
 
 concurrency:
   group: daily-release-warning

--- a/.github/workflows/daily-release-warning.yml
+++ b/.github/workflows/daily-release-warning.yml
@@ -36,7 +36,7 @@ jobs:
         uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@8c496a4b0c9158d18edcd9be8722ed0f79e8c5b4 # main
         continue-on-error: true
         with:
-          payload: '{"attachments": [{"color": "#07711E","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "Stand by, production release for content-build coming up in 60 minutes. Please review staging before then. View what's coming here: <https://github.com/${{ github.repository }}/compare/${{ steps.get-latest-tag.outputs.LATEST_TAG_VERSION }}...main>"}}]}]}'
+          payload: '{"attachments": [{"color": "#07711E","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "Stand by, production release for content-build coming up in 60 minutes. Please review staging before then. View what''s coming here: <https://github.com/${{ github.repository }}/compare/${{ steps.get-latest-tag.outputs.LATEST_TAG_VERSION }}...main>"}}]}]}'
           channel_id: ${{ env.CONTENT_BUILD_CHANNEL_ID }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/gha-metrics.yml
+++ b/.github/workflows/gha-metrics.yml
@@ -2,8 +2,7 @@ name: 'Send GHA metrics to Datadog'
 on:
   workflow_run:
     workflows:
-#      - 'Content Release'
-      - '**'
+      - 'Content Release'
     types:
       - completed
 jobs:

--- a/.github/workflows/gha-metrics.yml
+++ b/.github/workflows/gha-metrics.yml
@@ -1,0 +1,33 @@
+name: 'Send GHA metrics to Datadog'
+on:
+  workflow_run:
+    workflows:
+#      - 'Content Release'
+      - '**'
+    types:
+      - completed
+jobs:
+  send:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Get Datadog api key from Parameter Store
+        uses: department-of-veterans-affairs/action-inject-ssm-secrets@d8e6de3bde4dd728c9d732baef58b3c854b8c4bb # latest
+        with:
+          ssm_parameter: /dsva-vagov/content-build/GHA_CONTENT_BUILD_DATADOG_API_KEY
+          env_variable_name: GHA_CONTENT_BUILD_DATADOG_API_KEY
+
+      - name: Send GitHub Actions metrics to DataDog
+        uses: int128/datadog-actions-metrics@432f143460957c07e730f9f082af7d5063e99f84 # v1.88.0
+        with:
+          datadog-api-key: ${{ env.GHA_CONTENT_BUILD_DATADOG_API_KEY }}
+          collect-job-metrics: true
+          collect-step-metrics: true
+          datadog-site: ddog-gov.com


### PR DESCRIPTION
## Summary

- This adds a new workflow that sends workflow metrics for the Content Release workflow to Datadog upon Content Release completion. 
- Also corrects some problems found with the Daily Release Warning workflow. 

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18715

