### PR TITLE
VACMS 17904 - Remove Lovell switcher include in VBA pages

### DIFF
--- a/src/site/layouts/vba_facility.drupal.liquid
+++ b/src/site/layouts/vba_facility.drupal.liquid
@@ -16,10 +16,6 @@
 
       <div class="usa-width-three-fourths">
         <article class="usa-content va-l-facility-detail">
-          {% include "src/site/includes/lovell-switch-link.drupal.liquid" with
-            entityUrl = entityUrl
-          %}
-
           <h1>{{ title }}</h1>
 
           {% if fieldCcVbaFacilityOverview %}


### PR DESCRIPTION
## Summary

- Remove the Lovell switcher include in template for VBA
- Sitewide team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17904

## Testing done

- Checked VBA facility (Portland) post change
- Go to VBA page, there should be no difference visibly or code-wise

## Screenshots

No rendered code changes, only liquid changes

## What areas of the site does it impact?

VBA Page liquid templates

## Acceptance criteria

- [x] Lovell code should not appear in VBA templates

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed (N/A)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (unauthenticated)

## Requested Feedback

View template and rendered page. See that rendered page does not change (either on local dev or RI)

E.g. compare
http://3d87d1c04b6d897bac2787eb7bccfe54.review.vetsgov-internal/portland-va-regional-benefit-office/
and 
https://va.gov/portland-va-regional-benefit-office/