### PR TITLE
VACMS-18518: Remove dupe analytics from VAMC location pages

### DIFF
--- a/src/site/includes/operatingStatusFlagsLinks.drupal.liquid
+++ b/src/site/includes/operatingStatusFlagsLinks.drupal.liquid
@@ -2,9 +2,6 @@
   <va-alert status="info" slim visible>
     <va-link
       class="vads-u-font-weight--bold operating-status-link"
-      onclick="recordEvent({
-      'event': 'nav-info-box-click',
-      'infoBoxText': 'Facility notice'});"
       href="{{ facilitySidebar.links.0.url.path }}/operating-status"
       text="Facility notice"
     />
@@ -13,9 +10,6 @@
   <va-alert status="warning" slim visible>
     <va-link
       class="vads-u-font-weight--bold operating-status-link"
-      onclick="recordEvent({
-      'event': 'nav-info-box-click',
-      'infoBoxText': 'Facility limited'});"
       href="{{ facilitySidebar.links.0.url.path }}/operating-status"
       text="Limited services and hours"
     />
@@ -24,9 +18,6 @@
   <va-alert status="error" slim visible>
     <va-link
       class="vads-u-font-weight--bold operating-status-link"
-      onclick="recordEvent({
-      'event': 'nav-info-box-click',
-      'infoBoxText': 'Facility closed'});"
       href="{{ facilitySidebar.links.0.url.path }}/operating-status"
       text="Facility closed"
     />


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary
This PR removes custom analytics from previously converted va-link components. This will make sure we only capture GA once.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18518

## Testing done
Tested locally that only events are being recorded once.

## Screenshots

<img width="1296" alt="Locations___VA_Charleston_Health_Care___Veterans_Affairs" src="https://github.com/user-attachments/assets/71b1dcb8-c322-4b19-ba7f-5f6a3ddc3d02">
<img width="1341" alt="Locations___VA_Charleston_Health_Care___Veterans_Affairs" src="https://github.com/user-attachments/assets/1ad24ec4-260a-49e5-b90a-78ba3bf62a88">
<img width="1318" alt="Locations___VA_Charleston_Health_Care___Veterans_Affairs" src="https://github.com/user-attachments/assets/21427fab-73c2-49d7-aa6b-aad3c9e8f45d">


## What areas of the site does it impact?
VAMC Location Pages

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)


