### PR TITLE
VACMS-18505 Remove duplicate GA event from Press Releases page

### DIFF
--- a/src/site/layouts/press_release.drupal.liquid
+++ b/src/site/layouts/press_release.drupal.liquid
@@ -86,8 +86,11 @@
                     <section class="vads-u-margin-bottom--3">
                         {{ fieldOffice.entity.fieldPressReleaseBlurb.processed }}
                     </section>
-                    <va-link active onClick="recordEvent({ event: 'nav-secondary-button-click' });"
-                       href="{{ fieldListing.entity.entityUrl.path }}" text="See all news releases" />
+                    <va-link
+                        active
+                        href="{{ fieldListing.entity.entityUrl.path }}"
+                        text="See all news releases" 
+                    />
                 </article>
                 <!-- Last updated & feedback button-->
                   {% include "src/site/includes/above-footer-elements.drupal.liquid" %}


### PR DESCRIPTION
## Summary
Remove duplicate (custom) Google Analytics event from "See all news releases" link at the bottom of the Press Releases page.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18505

## Testing done
Tested locally at `/kansas-city-health-care/news-releases/pact-act-awareness-event-at-honor-va-clinic-for-all-veterans-on-march-6/` using the [Adswerve plugin](https://chromewebstore.google.com/detail/adswerve-datalayer-inspec/kmcbdogdandhihllalknlcjfpdjcleom).

## Screenshots
<img width="406" alt="Screenshot 2024-07-25 at 11 32 55 AM" src="https://github.com/user-attachments/assets/cd4b9bc5-fc39-4cf7-9a52-8fab783d924a">
<img width="472" alt="Screenshot 2024-07-25 at 11 32 43 AM" src="https://github.com/user-attachments/assets/9b8a7130-a0ac-41e4-95b2-bfdb35a47453">

## What areas of the site does it impact?

Press releases page