### PR TITLE
VACMS-18504 Remove duplicate GA event from facility operating status page

### DIFF
--- a/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
+++ b/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
@@ -53,7 +53,6 @@
                   <dt class="vads-l-col--12 medium-screen:vads-l-col--5 vads-u-margin--0 vads-u-padding-y--3 vads-u-display--flex operating-status-title vads-u-border-top--1px vads-u-border-color--gray-light">
                     <va-link
                       class="facility-title-width vads-u-font-weight--bold"
-                      onclick="recordEvent({'event':'nav-health-care-facility-status-click'});"
                       href="{{ status.entity.entityUrl.path }}"
                       text="{{ status.entity.title | encode }}"
                     />


### PR DESCRIPTION
## Summary
Remove duplicate (custom) Google Analytics event from facility name links under "Facility operating statuses" on the operating statuses page.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18504

## Testing done
Tested locally at `/tuscaloosa-health-care/operating-status/` using the [Adswerve plugin](https://chromewebstore.google.com/detail/adswerve-datalayer-inspec/kmcbdogdandhihllalknlcjfpdjcleom).

## Screenshots
<img width="467" alt="Screenshot 2024-07-25 at 11 51 05 AM" src="https://github.com/user-attachments/assets/ff72d18d-c20e-4be2-a83d-2a9be31f2f52">
<img width="368" alt="Screenshot 2024-07-25 at 11 50 54 AM" src="https://github.com/user-attachments/assets/5bba362b-1f62-48a7-8f92-c17df0f77cac">

## What areas of the site does it impact?

Facility operating status pages