### PR TITLE
VACMS-18416 Homepage custom analytics removal

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -59,12 +59,6 @@ _Note: This field is mandatory for UI changes (non-component work should NOT hav
 
 - [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
 
-### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:
-
-- [ ] The header does not contain any web-components
-- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
-- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
-
 ## Requested Feedback
 
 (OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_

--- a/src/site/includes/common-tasks.drupal.liquid
+++ b/src/site/includes/common-tasks.drupal.liquid
@@ -29,20 +29,9 @@
                         size="3"
                       ></va-icon>
                       <va-link
-                        disable-analytics
-                        onclick="recordMultipleEvents([
-                          {
-                            event: 'nav-zone-one',
-                            'nav-path': '->{% if link.url.path != empty %}{{ link.url.path }}{% else %}{{ link.label }}{% endif %}',
-                            'click-text': '{{ link.label | strip }}',
-                          },
-                          { 
-                            event: 'homepage-search-tools-click', action: 'Other search tools - {{link.label}}' 
-                          }
-                        ]);"
                         href="{{ link.url.path }}"
                         text="{{ link.label }}" 
-                      />
+                      ></va-link>
                     </li>
                   {% endif %}
                 {% endfor %}
@@ -65,19 +54,9 @@
                 {% if link.url.path and link.label %}
                   <li>
                       <va-link
-                        disable-analytics
-                        onclick="recordMultipleEvents([
-                          {
-                          event: 'nav-zone-one',
-                          'nav-path': '->{% if link.url.path != empty %}{{ link.url.path }}{% else %}{{ link.label }}{% endif %}',
-                          'click-text': '{{ link.label | strip }}',
-                          },
-                          { 
-                            event: 'homepage-popular-links-click', action: 'Top Pages - {{link.label}}' }
-                        ]);"
                         href="{{ link.url.path }}"
                         text="{{ link.label }}"
-                      />
+                      ></va-link>
                   </li>
                 {% endif %}
               {% endfor %}

--- a/src/site/includes/hero.drupal.liquid
+++ b/src/site/includes/hero.drupal.liquid
@@ -24,10 +24,11 @@
             </p>
 
             {% if fieldPromoCta.entity.fieldButtonLabel and fieldPromoCta.entity.fieldButtonLink.url.path %}
-              <a onclick="recordEvent({ event: 'homepage-benefit-link-click', action: 'Homepage benefit promo - {{fieldPromoCta.entity.fieldButtonLabel}}' })"
-                class="vads-c-action-link--white" href="{{ fieldPromoCta.entity.fieldButtonLink.url.path }}">
-                  {{fieldPromoCta.entity.fieldButtonLabel}}
-              </a>
+              <va-link-action
+                type="reverse"
+                href="{{ fieldPromoCta.entity.fieldButtonLink.url.path }}"
+                text="{{fieldPromoCta.entity.fieldButtonLabel}}"
+              ></va-link-action>
             {% endif %}
           </div>
         </div>
@@ -36,12 +37,6 @@
         <!-- start second column for  bplogin card -->
         <script>
         function openLoginModal() {
-          // Uncomment custom event and delete generic event once analytics team has implemented
-          // recordEvent({ event: "homepage-create-account", action: "Homepage Create Account CTA" });
-          recordMultipleEvents([
-            { event: 'cta-button-click', 'button-type': 'primary', 'button-click-label': '{{ createAccountBlock.entityLabel }}'  },
-            { event: "homepage-create-account", action: "{{ createAccountBlock.fieldPrimaryCtaButtonText }}" }
-          ]);
           const params = (new URL(document.location)).searchParams;
           params.set("next", "loginModal")
           document.location = "?" + params.toString();
@@ -56,16 +51,13 @@
                 {{ createAccountBlock.fieldCtaSummaryText }}
               </h2>
               <va-button
-                disable-analytics
                 class="vads-u-margin-bottom--3"
                 text="{{ createAccountBlock.fieldPrimaryCtaButtonText }}"
                 onclick="openLoginModal()"
               ></va-button>
               {% for link in createAccountBlock.fieldRelatedInfoLinks %}
                 <va-link
-                  disable-analytics
                   href="{{ link.url.path }}"
-                  onclick="recordEvent({ event: 'cta-button-click', 'button-type': 'secondary', 'button-click-label': '{{ link.title }}',  });"
                   text="{{ link.title }}"
                 ></va-link>
               {% endfor %}
@@ -91,34 +83,25 @@
               <h2 class="vads-u-color--white vads-u-font-size--lg small-desktop-screen:vads-u-font-size--xl">
                 Access and manage your VA benefits and health care
               </h2>
-              <a
-                onclick="recordEvent({ event: 'cta-button-click', 'button-type': 'secondary', 'button-click-label': 'Learn how an account helps you',  });"
-                class="vads-u-color--white vads-u-display--block vads-u-font-weight--normal"
+              <va-link
+                reverse
+                class="vads-u-display--block vads-u-font-weight--normal"
                 href="/resources/creating-an-account-for-vagov/"
-              >
-                Learn how an account helps you
-              </a>
+                text="Learn how an account helps you"
+              ></va-link>
               <script>
               function openLoginModal() {
-                // Uncomment custom event and delete generic event once analytics team has implemented
-                // recordEvent({ event: "homepage-create-account", action: "Homepage Create Account CTA" });
-                recordMultipleEvents([
-                  { event: 'cta-button-click', 'button-type': 'primary', 'button-click-label': '{{ createAccountBlock.entityLabel }}'  },
-                  { event: "homepage-create-account", action: "{{ createAccountBlock.fieldPrimaryCtaButtonText }}" }
-                ]);
                 const params = (new URL(document.location)).searchParams;
                 params.set("next", "loginModal")
                 document.location = "?" + params.toString();
               }
               </script>
-              <button
-                class="vads-u-background-color--white vads-u-color--primary"
+              <va-button
+                class="vads-u-margin-top--2"
                 onclick="openLoginModal()"
                 text="Create an account"
-                type="button"
-              >
-                Create an account
-              </button>
+                secondary
+              ></va-button>
             </div>
         </div>
         <!-- end first column -->

--- a/src/site/includes/homepage-benefits.drupal.liquid
+++ b/src/site/includes/homepage-benefits.drupal.liquid
@@ -16,12 +16,9 @@
           <h3 class="heading-level-4 vads-u-display--flex vads-u-align-items--center">
             {{ hub.entity.fieldIcon | getHubIcon: '3', 'vads-u-margin-right--1' }}
             <va-link
-              disable-analytics
               href="{{ hub.url.path }}"
-              onclick="recordEvent({ event: 'nav-linkslist', action: 'Benefit hub - {{ hub.label }}' });"
               text="{{ hub.label }}"
-            >
-            </va-link>
+            ></va-link>
           </h3>
           <p class="vads-u-margin-top--0">{{ hub.entity.fieldLinkSummary }}</p>
         </div> 

--- a/src/site/includes/news-spotlight.drupal.liquid
+++ b/src/site/includes/news-spotlight.drupal.liquid
@@ -22,13 +22,6 @@
           {% if fieldPromoHeadline and fieldLink.url.path %}
             <h3 class="vads-u-font-family--serif vads-u-margin-top--0 vads-u-font-size--xl">
               <va-link
-                onclick="recordMultipleEvents([
-                  {
-                    event: 'nav-zone-one',
-                      'click-text': '{{ fieldPromoHeadline }}',
-                  },
-                  { event: 'homepage-news-promo-title-click', action: 'Homepage News Promo - {{ fieldPromoHeadline }} - Title' }
-                ]);"
                 href="{{ fieldLink.url.path }}"
                 text="{{ fieldPromoHeadline | encode }}"
                 reverse
@@ -42,37 +35,17 @@
               {{ fieldPromoText }}
             {% endif %}
             {% if fieldLinkLabel and fieldLink.url.path %}
-              {% comment %}
-                We can convert this link to <va-link> when DST has addressed screen reader text with va-links
-                https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1644
-              {% endcomment %}
-              <a
-                onclick="recordMultipleEvents([
-                  {
-                    event: 'nav-zone-one',
-                      'click-text': '{{ fieldLinkLabel | strip }}',
-                  },
-                  { event: 'homepage-news-promo-click', action: 'Homepage news promo - {{  fieldPromoHeadline }} - CTA' }
-                ]);"
-                href="{{ fieldLink.url.path }}" class="vads-u-color--white">
-                {{fieldLinkLabel}}
-                <span class="sr-only">
-                  about {{fieldPromoHeadline}}
-                </span>
-              </a>
+              <va-link
+                reverse
+                label="{{fieldLinkLabel}} about {{fieldPromoHeadline}}"
+                href="{{ fieldLink.url.path }}"
+                text="{{fieldLinkLabel}}"
+              /></va-link>
             {% endif %}
           </p>
 
           <div>
             <va-link
-              onclick="recordMultipleEvents([
-                {
-                  event: 'nav-zone-one',
-                  'nav-path': '->{% if fieldLink.url.path != empty %}{{ fieldLink.url.path }}{% else %}{{ fieldLinkLabel }}{% endif %}',
-                  'click-text': 'More VA news',
-                },
-                { event: 'homepage-news-promo-more-news-click', action: 'Homepage news promo - More VA News' }
-              ]);"
               href="https://news.va.gov/"
               text="More VA news"
               active

--- a/src/site/includes/tests/hero/hero.unit.spec.js
+++ b/src/site/includes/tests/hero/hero.unit.spec.js
@@ -26,8 +26,6 @@ describe('template: homepage hero', () => {
         'This new law expands and extends eligibility for care and benefits for Veterans and survivors related to toxic exposures.',
       ),
     ).to.exist;
-    expect(getByText(heroHTML, 'Learn what the PACT Act means for you')).to
-      .exist;
   });
 
   it('should correctly render the fallback hero when the promo information is not provided', async () => {
@@ -40,8 +38,6 @@ describe('template: homepage hero', () => {
     expect(
       getByText(heroHTML, 'Access and manage your VA benefits and health care'),
     ).to.exist;
-    expect(getByText(heroHTML, 'Learn how an account helps you')).to.exist;
-    expect(getByText(heroHTML, 'Create an account')).to.exist;
     expect(getAllByRole(heroHTML, 'img').length).to.eq(3);
   });
 });


### PR DESCRIPTION
## Summary
Removed custom analytics from most of the home page's elements.

- Hero banner: "Learn what the PACT Act means for you" link
- Hero banner: "Learn how an account helps you" link
- Hero banner: "Create account" button
- Hero banner fallback: "Learn how an account helps you" link
- Hero banner fallback: "Create an account" button
- Other search tools links
- Top pages links
- News: "VA's mission to better serve all" link
- News: "Read the full article" link
- News: "More VA news" link
- Hub links

Also removed the Teamsites section of the PR template since we don't need to worry about this from a content-build perspective anymore.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18416

## Testing done

Tested the homepage locally using the [Adswerve plugin](https://chromewebstore.google.com/detail/adswerve-datalayer-inspec/kmcbdogdandhihllalknlcjfpdjcleom).

## Screenshots

<details><summary>Hero banner</summary>

### Current hero banner
<img width="700" alt="Screenshot 2024-07-25 at 2 15 42 PM" src="https://github.com/user-attachments/assets/8bfbca71-98d9-4256-a40a-0b26d5b71489">

#### "Learn what the PACT Act means for you" link

<img width="468" alt="Screenshot 2024-07-25 at 12 01 35 PM" src="https://github.com/user-attachments/assets/0c2caa42-61e3-4b0c-8e38-76adfa200016">
<img width="391" alt="Screenshot 2024-07-25 at 12 01 44 PM" src="https://github.com/user-attachments/assets/4ce02833-ab41-4767-894b-7eb5990fe18d">

#### "Learn how an account helps you" link
<img width="425" alt="Screenshot 2024-07-25 at 12 04 53 PM" src="https://github.com/user-attachments/assets/1df0a84d-04e7-47ef-87de-a795878af33b">
<img width="506" alt="Screenshot 2024-07-25 at 12 05 02 PM" src="https://github.com/user-attachments/assets/63fefd7c-33ed-4f73-839b-26a1702104e2">

### Fallback hero banner (shows if a promo banner is not given)
<img width="700" alt="Screenshot 2024-07-25 at 2 15 38 PM" src="https://github.com/user-attachments/assets/f130bb36-33e9-422c-a03d-e4cce82c4159">

#### "Learn how an account helps you" link
<img width="411" alt="Screenshot 2024-07-25 at 1 55 29 PM" src="https://github.com/user-attachments/assets/0ca6393c-85af-4b74-b2c6-30974582235b">
<img width="492" alt="Screenshot 2024-07-25 at 1 55 39 PM" src="https://github.com/user-attachments/assets/448439e5-4648-4343-b7fc-50273920a938">

</details>

<details><summary>"Create account" button</summary>

#### "Create account" button for active promo banner

<img width="489" alt="Screenshot 2024-07-26 at 12 07 59 PM" src="https://github.com/user-attachments/assets/ad447575-28d8-4851-ae5c-2655aa4347bf">

<img width="563" alt="Screenshot 2024-07-26 at 12 08 09 PM" src="https://github.com/user-attachments/assets/4118e23c-cbda-4c26-8c2b-0cac6b1a4f40">

#### "Create an account" button for fallback promo banner
<img width="500" alt="Screenshot 2024-07-26 at 12 14 18 PM" src="https://github.com/user-attachments/assets/1d7c9aba-472e-4aa8-9c2a-517a1f6eee4f">
<img width="563" alt="Screenshot 2024-07-26 at 12 17 13 PM" src="https://github.com/user-attachments/assets/63620953-ab62-4064-9e2b-34ff25df6bb9">

</details>

<details><summary>Other search tools links</summary>

<img width="444" alt="Screenshot 2024-07-26 at 11 44 36 AM" src="https://github.com/user-attachments/assets/67425ce8-065c-4cae-9887-a92276c1c7a9">
<img width="411" alt="Screenshot 2024-07-25 at 3 03 01 PM" src="https://github.com/user-attachments/assets/072bc19e-47ea-4947-a4bc-f1de5fe26b66">
<img width="499" alt="Screenshot 2024-07-25 at 3 03 14 PM" src="https://github.com/user-attachments/assets/55fb8f20-198c-41b6-92c3-291e9cec884e">
<img width="506" alt="Screenshot 2024-07-25 at 3 03 24 PM" src="https://github.com/user-attachments/assets/293cbc75-de19-4370-a321-305f07c89463">
<img width="511" alt="Screenshot 2024-07-25 at 3 03 35 PM" src="https://github.com/user-attachments/assets/f66afeef-59b1-4b03-8d4d-11bc85f1ed7d">


</details>

<details><summary>Top pages links</summary>
<img width="498" alt="Screenshot 2024-07-26 at 11 46 39 AM" src="https://github.com/user-attachments/assets/78927204-1f00-43f0-8a9c-1b2254dc9cc9">


<img width="426" alt="Screenshot 2024-07-25 at 3 04 56 PM" src="https://github.com/user-attachments/assets/0da7d048-1836-4faa-bd02-6e0ee663a7e5">
<img width="408" alt="Screenshot 2024-07-25 at 3 05 04 PM" src="https://github.com/user-attachments/assets/5e4d3c08-c200-41ad-8d4d-3d2bdddc921f">
<img width="510" alt="Screenshot 2024-07-25 at 3 05 25 PM" src="https://github.com/user-attachments/assets/d6be67db-1094-4e9e-a89c-e5b1329f09f9">
<img width="504" alt="Screenshot 2024-07-25 at 3 05 36 PM" src="https://github.com/user-attachments/assets/1ff493d8-918e-4fa0-9089-84ab16e12eba">
<img width="505" alt="Screenshot 2024-07-25 at 3 05 44 PM" src="https://github.com/user-attachments/assets/92403979-64dc-4411-94cd-0fe73212069e">

<img width="501" alt="Screenshot 2024-07-25 at 3 05 52 PM" src="https://github.com/user-attachments/assets/188d5725-e780-44ca-9d92-e552cffa3408">
<img width="503" alt="Screenshot 2024-07-25 at 3 05 58 PM" src="https://github.com/user-attachments/assets/d75737f9-6fb5-442e-9329-f5312e0a317f">
<img width="504" alt="Screenshot 2024-07-25 at 3 06 18 PM" src="https://github.com/user-attachments/assets/7ef09ed6-d61a-4c10-b528-c675f9e1e85c">
<img width="749" alt="Screenshot 2024-07-25 at 3 08 28 PM" src="https://github.com/user-attachments/assets/1ccf8ea2-7943-4836-b3d3-b8dd0539ff88">
<img width="754" alt="Screenshot 2024-07-25 at 3 08 38 PM" src="https://github.com/user-attachments/assets/c79e57c0-b862-4ba0-8f8f-32851b1afda5">

<img width="747" alt="Screenshot 2024-07-25 at 3 08 46 PM" src="https://github.com/user-attachments/assets/474d02ad-570e-4470-a765-46b53a9dcdb7">
<img width="755" alt="Screenshot 2024-07-25 at 3 08 59 PM" src="https://github.com/user-attachments/assets/efd026b7-5333-4049-a480-6e2e1f92ca81">


</details>

<details><summary>News section</summary>

<img width="612" alt="Screenshot 2024-07-26 at 11 50 17 AM" src="https://github.com/user-attachments/assets/469a2dc1-2208-4bbf-9f23-d764eee2e44c">

#### "VA's mission to better serve all" link
<img width="493" alt="Screenshot 2024-07-25 at 4 28 18 PM" src="https://github.com/user-attachments/assets/104bb5a3-f6db-4805-9f3e-66837ecb21ee">
<img width="583" alt="Screenshot 2024-07-25 at 4 28 25 PM" src="https://github.com/user-attachments/assets/7edc924e-353e-4513-a7e1-9c68c45642b5">

#### "Read the full article" link
<img width="490" alt="Screenshot 2024-07-26 at 11 51 10 AM" src="https://github.com/user-attachments/assets/c22aca8c-4294-47e4-bcb0-d7c9bb9b9aa9">
<img width="580" alt="Screenshot 2024-07-25 at 4 28 09 PM" src="https://github.com/user-attachments/assets/e1603d20-7e4b-4e4a-a96f-c2ee5a858c8e">

#### "More VA News" link
<img width="488" alt="Screenshot 2024-07-25 at 4 24 46 PM" src="https://github.com/user-attachments/assets/7fcbd1eb-a32b-4a34-86bf-0b8bbb4c8472">
<img width="586" alt="Screenshot 2024-07-25 at 4 24 56 PM" src="https://github.com/user-attachments/assets/4ccaf230-d943-476d-aab0-e20824dc033a">

</details>

<details><summary>Hub links</summary>

<img width="526" alt="Screenshot 2024-07-26 at 11 53 50 AM" src="https://github.com/user-attachments/assets/bb270f61-04d8-4b1f-a611-73882526baee">
<img width="526" alt="Screenshot 2024-07-26 at 11 53 50 AM" src="https://github.com/user-attachments/assets/5c673f9b-80ad-4bdb-bc1b-0cde39d43558">
<img width="585" alt="Screenshot 2024-07-26 at 11 53 58 AM" src="https://github.com/user-attachments/assets/b88369df-e6a9-49c6-a604-69e4230a5f55">


</details>