### PR TITLE
Mkerns 84964 update breadcrumb

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -338,8 +338,8 @@
       "private": true,
       "breadcrumbs_override": [
         {
-          "name": "VA.gov home",
-          "path": "/"
+          "path": "/",
+          "name": "VA.gov home"
         },
         {
           "path": "my-health/",

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -339,7 +339,7 @@
       "breadcrumbs_override": [
         {
           "name": "VA.gov home",
-          "path": ""
+          "path": "/"
         },
         {
           "path": "my-health/",

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -339,7 +339,7 @@
       "breadcrumbs_override": [
         {
           "path": "my-health/",
-          "name": "My Health"
+          "name": "My HealtheVet"
         },
         {
           "path": "my-health/update-benefits-information-form-10-10ezr",

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -338,6 +338,10 @@
       "private": true,
       "breadcrumbs_override": [
         {
+          "name": "VA.gov home",
+          "path": ""
+        },
+        {
           "path": "my-health/",
           "name": "My HealtheVet"
         },


### PR DESCRIPTION
## Summary

- The update to the registry.json for renaming the EZR breadcrumb affects all EZR pages using breadcrumbs and potentially other site areas depending on the file's dependencies.

## Related issue(s)

- _Link to ticket created in [va.gov-team repo_
department-of-veterans-affairs/va.gov-team#0000](https://app.zenhub.com/workspaces/10-10-health-apps-5fff0cfd1462b6000e320fc7/issues/gh/department-of-veterans-affairs/va.gov-team/84964)

## Screenshots

|         | Before | After |
| ------- | -------- | -------- |

| Desktop |    ![image](https://github.com/department-of-veterans-affairs/content-build/assets/131277002/e431c9ae-2eb7-4d6b-a2df-a28f2361e89a)    |   ![image](https://github.com/department-of-veterans-affairs/content-build/assets/131277002/a0bfab21-723e-47b9-8415-8f09b244aa66)   |

## What areas of the site does it impact?

The update to the registry.json in the content-build primarily impacts the breadcrumb navigation for the EZR pages, specifically changing its label from 'My Health' to 'My HealtheVet.' This change directly affects all pages within the EZR section that utilize breadcrumb navigation to reflect the new naming convention.

## Acceptance criteria

### Quality Assurance & Testing

- [x] Update breadcrumb from "My Health" to "My HealtheVet"
