### PR TITLE
VATEAM-87714: Add KISS configuration for Digital Forms

### DIFF
--- a/src/site/stages/build/drupal/static-data-files/config.js
+++ b/src/site/stages/build/drupal/static-data-files/config.js
@@ -1,5 +1,5 @@
 const {
-  query: quertyDigitalForm,
+  query: queryDigitalForms,
   postProcess: postProcessDigitalForm,
 } = require('./digitalForm');
 const {
@@ -37,7 +37,7 @@ const DATA_FILES = [
   {
     description: 'Digital Forms',
     filename: 'digital-forms.json',
-    query: quertyDigitalForm,
+    query: queryDigitalForms,
     queryType: 'graphql',
     postProcess: postProcessDigitalForm,
   },

--- a/src/site/stages/build/drupal/static-data-files/config.js
+++ b/src/site/stages/build/drupal/static-data-files/config.js
@@ -2,6 +2,7 @@ const {
   query: queryDigitalForms,
   postProcess: postProcessDigitalForm,
 } = require('./digitalForm');
+
 const {
   query: queryVamcEhrSystem,
   postProcess: postProcessVamcEhrSystem,

--- a/src/site/stages/build/drupal/static-data-files/config.js
+++ b/src/site/stages/build/drupal/static-data-files/config.js
@@ -1,4 +1,8 @@
 const {
+  query: quertyDigitalForm,
+  postProcess: postProcessDigitalForm,
+} = require('./digitalForm');
+const {
   query: queryVamcEhrSystem,
   postProcess: postProcessVamcEhrSystem,
 } = require('./vamcEhrSystem');
@@ -30,6 +34,13 @@ const DATA_FILE_PATH = 'data/cms';
  * }
  */
 const DATA_FILES = [
+  {
+    description: 'Digital Forms',
+    filename: 'digital-forms.json',
+    query: quertyDigitalForm,
+    queryType: 'graphql',
+    postProcess: postProcessDigitalForm,
+  },
   {
     description: 'VAMC EHR System',
     filename: 'vamc-ehr.json',

--- a/src/site/stages/build/drupal/static-data-files/config.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/config.unit.spec.js
@@ -1,0 +1,15 @@
+/* eslint-disable @department-of-veterans-affairs/axe-check-required */
+
+import { expect } from 'chai';
+import { DATA_FILES } from './config';
+
+describe('config', () => {
+  describe('DATA_FILES', () => {
+    it('includes Digital Forms', () => {
+      expect(
+        DATA_FILES.filter(dataFile => dataFile.description === 'Digital Forms')
+          .length,
+      ).to.eq(1);
+    });
+  });
+});

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/digitalForm.graphql.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/digitalForm.graphql.js
@@ -1,4 +1,4 @@
-import nameAndDateOfBirth from './nameAndDateOfBirth.graphql';
+const nameAndDateOfBirth = require('./nameAndDateOfBirth.graphql');
 
 /*
  *

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/digitalForm.graphql.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/digitalForm.graphql.js
@@ -1,0 +1,24 @@
+/*
+ *
+ * The "Digital Form" Content Type in the VA.gov CMS
+ *
+ */
+module.exports = `
+  fragment digitalForm on NodeDigitalForm {
+    nid
+    entityLabel
+    fieldVaFormNumber
+    fieldOmbNumber
+    fieldChapters {
+      entity {
+        entityId
+        type {
+          entity {
+            entityId
+            entityLabel
+          }
+        }
+      }
+    }
+  }
+`;

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/digitalForm.graphql.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/digitalForm.graphql.js
@@ -1,9 +1,13 @@
+import nameAndDateOfBirth from './nameAndDateOfBirth.graphql';
+
 /*
  *
  * The "Digital Form" Content Type in the VA.gov CMS
  *
  */
 module.exports = `
+  ${nameAndDateOfBirth}
+
   fragment digitalForm on NodeDigitalForm {
     nid
     entityLabel
@@ -18,6 +22,7 @@ module.exports = `
             entityLabel
           }
         }
+        ...nameAndDateOfBirth
       }
     }
   }

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/digitalForm.graphql.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/digitalForm.graphql.unit.spec.js
@@ -1,0 +1,18 @@
+/* eslint-disable @department-of-veterans-affairs/axe-check-required */
+
+import { expect } from 'chai';
+import digitalForm from './digitalForm.graphql';
+
+describe('digitalForm fragment', () => {
+  it('includes form fields', () => {
+    expect(digitalForm).to.have.string('nid');
+    expect(digitalForm).to.have.string('entityLabel');
+    expect(digitalForm).to.have.string('fieldVaFormNumber');
+    expect(digitalForm).to.have.string('fieldOmbNumber');
+    expect(digitalForm).to.have.string('fieldChapters');
+  });
+
+  describe('chapter fragments', () => {
+    it('imports the nameAndDateOfBirth fragment');
+  });
+});

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/digitalForm.graphql.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/digitalForm.graphql.unit.spec.js
@@ -13,6 +13,9 @@ describe('digitalForm fragment', () => {
   });
 
   describe('chapter fragments', () => {
-    it('imports the nameAndDateOfBirth fragment');
+    it('imports the nameAndDateOfBirth fragment', () => {
+      expect(digitalForm).to.have.string('fragment nameAndDateOfBirth');
+      expect(digitalForm).to.have.string('...nameAndDateOfBirth');
+    });
   });
 });

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/nameAndDateOfBirth.graphql.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/nameAndDateOfBirth.graphql.js
@@ -1,0 +1,14 @@
+/*
+ *
+ * The "Name and Date of Birth" Digital Form pattern.
+ *
+ * Pattern documentation:
+ * https://design.va.gov/patterns/ask-users-for/names
+ *
+ */
+module.exports = `
+  fragment nameAndDateOfBirth on ParagraphDigitalFormNameAndDateOfBi {
+    fieldTitle
+    fieldIncludeDateOfBirth
+  }
+`;

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/nameAndDateOfBirth.graphql.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/nameAndDateOfBirth.graphql.unit.spec.js
@@ -1,0 +1,14 @@
+/* eslint-disable @department-of-veterans-affairs/axe-check-required */
+
+import { expect } from 'chai';
+import nameAndDateOfBirth from './nameAndDateOfBirth.graphql';
+
+describe('nameAndDateOfBirth fragment', () => {
+  it('includes fieldTitle', () => {
+    expect(nameAndDateOfBirth).to.have.string('fieldTitle');
+  });
+
+  it('includes fieldIncludeDateOfBirth', () => {
+    expect(nameAndDateOfBirth).to.have.string('fieldIncludeDateOfBirth');
+  });
+});

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/index.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/index.js
@@ -1,0 +1,17 @@
+const query = `
+  query ($onlyPublishedContent: Boolean!) {
+    nodeQuery(
+      filter: {
+        conditions: [
+          { field: "status", value: "1", enabled: $onlyPublishedContent },
+          { field: "type", value: "digital_form" }
+        ]
+      }
+    ) {
+      entities {
+      }
+    }
+  }
+`;
+
+module.exports = { query };

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/index.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/index.js
@@ -1,5 +1,5 @@
-import digitalForm from './fragments/digitalForm.graphql';
-import { postProcessDigitalForm } from './postProcessDigitalForm';
+const digitalForm = require('./fragments/digitalForm.graphql');
+const { postProcessDigitalForm } = require('./postProcessDigitalForm');
 
 const query = `
   ${digitalForm}

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/index.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/index.js
@@ -1,4 +1,5 @@
 import digitalForm from './fragments/digitalForm.graphql';
+import { postProcessDigitalForm } from './postProcessDigitalForm';
 
 const query = `
   ${digitalForm}
@@ -19,4 +20,7 @@ const query = `
   }
 `;
 
-module.exports = { query };
+module.exports = {
+  query,
+  postProcess: postProcessDigitalForm,
+};

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/index.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/index.js
@@ -1,4 +1,8 @@
+import digitalForm from './fragments/digitalForm.graphql';
+
 const query = `
+  ${digitalForm}
+
   query ($onlyPublishedContent: Boolean!) {
     nodeQuery(
       filter: {
@@ -9,6 +13,7 @@ const query = `
       }
     ) {
       entities {
+        ... digitalForm
       }
     }
   }

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/index.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/index.unit.spec.js
@@ -1,7 +1,7 @@
 /* eslint-disable @department-of-veterans-affairs/axe-check-required */
 
 import { expect } from 'chai';
-import { query } from './index';
+import { query, postProcess } from './index';
 
 describe('digitalForm', () => {
   describe('query', () => {
@@ -15,6 +15,8 @@ describe('digitalForm', () => {
   });
 
   describe('postProcess', () => {
-    it('imports postProcessDigitalForm');
+    it('imports postProcessDigitalForm', () => {
+      expect(() => postProcess('test result')).to.not.throw();
+    });
   });
 });

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/index.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/index.unit.spec.js
@@ -8,7 +8,10 @@ describe('digitalForm', () => {
     it('returns digital_form entities', () => {
       expect(query).to.have.string('digital_form');
     });
-    it('imports the digitalForm fragment');
+    it('imports the digitalForm fragment', () => {
+      expect(query).to.have.string('fragment digitalForm');
+      expect(query).to.have.string('... digitalForm');
+    });
   });
 
   describe('postProcess', () => {

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/index.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/index.unit.spec.js
@@ -1,0 +1,17 @@
+/* eslint-disable @department-of-veterans-affairs/axe-check-required */
+
+import { expect } from 'chai';
+import { query } from './index';
+
+describe('digitalForm', () => {
+  describe('query', () => {
+    it('returns digital_form entities', () => {
+      expect(query).to.have.string('digital_form');
+    });
+    it('imports the digitalForm fragment');
+  });
+
+  describe('postProcess', () => {
+    it('imports postProcessDigitalForm');
+  });
+});

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
@@ -1,0 +1,3 @@
+const postProcessDigitalForm = queryResult => queryResult;
+
+module.exports.postProcessDigitalForm = postProcessDigitalForm;

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.unit.spec.js
@@ -1,0 +1,12 @@
+/* eslint-disable @department-of-veterans-affairs/axe-check-required */
+
+import { expect } from 'chai';
+
+const { postProcessDigitalForm } = require('./postProcessDigitalForm');
+
+describe('postProcessDigitalForm', () => {
+  it('returns queryResult with no changes', () => {
+    const queryResult = { data: { form: {} } };
+    expect(postProcessDigitalForm(queryResult)).to.eq(queryResult);
+  });
+});


### PR DESCRIPTION
## Summary

Creates the `data/cms/digital-forms.json` endpoint to statically generate all published Digital Forms in Drupal.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#87714

## Testing done

- Created unit tests for the `static-data-files` config, the `digitalForm` query object, its query fragments, and the new post processor.
- Tested the new data file type against a PR CMS environment and successfully pulled down published Digital Forms.

## What areas of the site does it impact?

None at the moment as the Digital Forms frontend is not currently live in the production environment.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Normalization of the Drupal data will come in department-of-veterans-affairs/va.gov-team#88634