### PR TITLE
VATEAM-88634: Create a normalization layer for Digital Forms

### DIFF
--- a/src/site/stages/build/drupal/static-data-files/digitalForm/index.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/index.unit.spec.js
@@ -16,7 +16,38 @@ describe('digitalForm', () => {
 
   describe('postProcess', () => {
     it('imports postProcessDigitalForm', () => {
-      expect(() => postProcess('test result')).to.not.throw();
+      const queryResult = `
+{
+  "data": {
+    "nodeQuery": {
+      "entities": [
+        {
+          "nid": 71002,
+          "entityLabel": "Form with One Step",
+          "fieldVaFormNumber": "11111",
+          "fieldOmbNumber": "1111-1111",
+          "fieldChapters": [
+            {
+              "entity": {
+                "entityId": "157904",
+                "type": {
+                  "entity": {
+                    "entityId": "digital_form_name_and_date_of_bi",
+                    "entityLabel": "Name and Date of Birth"
+                  }
+                },
+                "fieldTitle": "The Only Step",
+                "fieldIncludeDateOfBirth": true
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+    `;
+      expect(() => postProcess(queryResult)).to.not.throw();
     });
   });
 });

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/index.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/index.unit.spec.js
@@ -16,37 +16,36 @@ describe('digitalForm', () => {
 
   describe('postProcess', () => {
     it('imports postProcessDigitalForm', () => {
-      const queryResult = `
-{
-  "data": {
-    "nodeQuery": {
-      "entities": [
-        {
-          "nid": 71002,
-          "entityLabel": "Form with One Step",
-          "fieldVaFormNumber": "11111",
-          "fieldOmbNumber": "1111-1111",
-          "fieldChapters": [
-            {
-              "entity": {
-                "entityId": "157904",
-                "type": {
-                  "entity": {
-                    "entityId": "digital_form_name_and_date_of_bi",
-                    "entityLabel": "Name and Date of Birth"
-                  }
-                },
-                "fieldTitle": "The Only Step",
-                "fieldIncludeDateOfBirth": true
-              }
-            }
-          ]
-        }
-      ]
-    }
-  }
-}
-    `;
+      const queryResult = {
+        data: {
+          nodeQuery: {
+            entities: [
+              {
+                nid: 71002,
+                entityLabel: 'Form with One Step',
+                fieldVaFormNumber: '11111',
+                fieldOmbNumber: '1111-1111',
+                fieldChapters: [
+                  {
+                    entity: {
+                      entityId: '157904',
+                      type: {
+                        entity: {
+                          entityId: 'digital_form_name_and_date_of_bi',
+                          entityLabel: 'Name and Date of Birth',
+                        },
+                      },
+                      fieldTitle: 'The Only Step',
+                      fieldIncludeDateOfBirth: true,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      };
+
       expect(() => postProcess(queryResult)).to.not.throw();
     });
   });

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
@@ -36,8 +36,8 @@ const normalizeForm = form => {
 const normalizeForms = forms => forms.map(form => normalizeForm(form));
 
 const postProcessDigitalForm = queryResult => {
-  const resultObject = JSON.parse(queryResult);
-  const forms = extractForms(resultObject);
+  // queryResult was already parsed by graphQLApiClient
+  const forms = extractForms(queryResult);
   const normalizedForms = normalizeForms(forms);
 
   return JSON.stringify(normalizedForms);

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
@@ -38,9 +38,9 @@ const normalizeForms = forms => forms.map(form => normalizeForm(form));
 const postProcessDigitalForm = queryResult => {
   // queryResult was already parsed by graphQLApiClient
   const forms = extractForms(queryResult);
-  const normalizedForms = normalizeForms(forms);
 
-  return JSON.stringify(normalizedForms);
+  // will be turned into JSON by writeProcessedDataFilesToCache
+  return normalizeForms(forms);
 };
 
 module.exports.postProcessDigitalForm = postProcessDigitalForm;

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
@@ -1,9 +1,11 @@
 const extractForms = resultObject => resultObject.data.nodeQuery.entities;
+const formatSubTitle = formNumber => `VA Form ${formNumber}`;
 
 const normalizeForm = form => {
   return {
     id: form.nid,
     title: form.entityLabel,
+    subTitle: formatSubTitle(form.fieldVaFormNumber),
   };
 };
 

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
@@ -1,12 +1,23 @@
 const extractForms = resultObject => resultObject.data.nodeQuery.entities;
 const formatSubTitle = formNumber => `VA Form ${formNumber}`;
 
+const normalizeChapter = ({ entity }) => {
+  return {
+    id: parseInt(entity.entityId, 10),
+    chapterTitle: entity.fieldTitle,
+  };
+};
+
+const normalizeChapters = chapters =>
+  chapters.map(chapter => normalizeChapter(chapter));
+
 const normalizeForm = form => {
   return {
     id: form.nid,
     title: form.entityLabel,
     subTitle: formatSubTitle(form.fieldVaFormNumber),
     ombNumber: form.fieldOmbNumber,
+    chapters: normalizeChapters(form.fieldChapters),
   };
 };
 

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
@@ -25,7 +25,8 @@ const normalizeChapters = chapters =>
 
 const normalizeForm = form => {
   return {
-    id: form.nid,
+    cmsId: form.nid,
+    formId: form.fieldVaFormNumber,
     title: form.entityLabel,
     subTitle: formatSubTitle(form.fieldVaFormNumber),
     ombNumber: form.fieldOmbNumber,

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
@@ -1,3 +1,20 @@
-const postProcessDigitalForm = queryResult => queryResult;
+const extractForms = resultObject => resultObject.data.nodeQuery.entities;
+
+const normalizeForm = form => {
+  return {
+    id: form.nid,
+    title: form.entityLabel,
+  };
+};
+
+const normalizeForms = forms => forms.map(form => normalizeForm(form));
+
+const postProcessDigitalForm = queryResult => {
+  const resultObject = JSON.parse(queryResult);
+  const forms = extractForms(resultObject);
+  const normalizedForms = normalizeForms(forms);
+
+  return JSON.stringify(normalizedForms);
+};
 
 module.exports.postProcessDigitalForm = postProcessDigitalForm;

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
@@ -32,14 +32,12 @@ const normalizeForm = form => {
   };
 };
 
-const normalizeForms = forms => forms.map(form => normalizeForm(form));
-
 const postProcessDigitalForm = queryResult => {
   // queryResult was already parsed by graphQLApiClient
   const forms = extractForms(queryResult);
 
   // will be turned into JSON by writeProcessedDataFilesToCache
-  return normalizeForms(forms);
+  return forms.map(normalizeForm);
 };
 
 module.exports.postProcessDigitalForm = postProcessDigitalForm;

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
@@ -19,16 +19,13 @@ const normalizeChapter = ({ entity }) => {
   };
 };
 
-const normalizeChapters = chapters =>
-  chapters.map(chapter => normalizeChapter(chapter));
-
 const normalizeForm = form => {
   return {
     cmsId: form.nid,
     formId: form.fieldVaFormNumber,
     title: form.entityLabel,
     ombNumber: form.fieldOmbNumber,
-    chapters: normalizeChapters(form.fieldChapters),
+    chapters: form.fieldChapters.map(normalizeChapter),
   };
 };
 

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
@@ -1,3 +1,12 @@
+const extractAdditionalFields = entity => {
+  const additionalFields = {};
+
+  if (entity.type.entity.entityId === 'digital_form_name_and_date_of_bi') {
+    additionalFields.includeDateOfBirth = entity.fieldIncludeDateOfBirth;
+  }
+
+  return additionalFields;
+};
 const extractForms = resultObject => resultObject.data.nodeQuery.entities;
 const formatSubTitle = formNumber => `VA Form ${formNumber}`;
 
@@ -5,6 +14,9 @@ const normalizeChapter = ({ entity }) => {
   return {
     id: parseInt(entity.entityId, 10),
     chapterTitle: entity.fieldTitle,
+    type: entity.type.entity.entityId,
+    pageTitle: entity.type.entity.entityLabel,
+    additionalFields: extractAdditionalFields(entity),
   };
 };
 

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
@@ -8,7 +8,6 @@ const extractAdditionalFields = entity => {
   return additionalFields;
 };
 const extractForms = resultObject => resultObject.data.nodeQuery.entities;
-const formatSubTitle = formNumber => `VA Form ${formNumber}`;
 
 const normalizeChapter = ({ entity }) => {
   return {
@@ -28,7 +27,6 @@ const normalizeForm = form => {
     cmsId: form.nid,
     formId: form.fieldVaFormNumber,
     title: form.entityLabel,
-    subTitle: formatSubTitle(form.fieldVaFormNumber),
     ombNumber: form.fieldOmbNumber,
     chapters: normalizeChapters(form.fieldChapters),
   };

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
@@ -6,6 +6,7 @@ const normalizeForm = form => {
     id: form.nid,
     title: form.entityLabel,
     subTitle: formatSubTitle(form.fieldVaFormNumber),
+    ombNumber: form.fieldOmbNumber,
   };
 };
 

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.unit.spec.js
@@ -5,8 +5,84 @@ import { expect } from 'chai';
 const { postProcessDigitalForm } = require('./postProcessDigitalForm');
 
 describe('postProcessDigitalForm', () => {
-  it('returns queryResult with no changes', () => {
-    const queryResult = { data: { form: {} } };
-    expect(postProcessDigitalForm(queryResult)).to.eq(queryResult);
+  const queryResult = `
+{
+  "data": {
+    "nodeQuery": {
+      "entities": [
+        {
+          "nid": 71002,
+          "entityLabel": "Form with One Step",
+          "fieldVaFormNumber": "11111",
+          "fieldOmbNumber": "1111-1111",
+          "fieldChapters": [
+            {
+              "entity": {
+                "entityId": "157904",
+                "type": {
+                  "entity": {
+                    "entityId": "digital_form_name_and_date_of_bi",
+                    "entityLabel": "Name and Date of Birth"
+                  }
+                },
+                "fieldTitle": "The Only Step",
+                "fieldIncludeDateOfBirth": true
+              }
+            }
+          ]
+        },
+        {
+          "nid": 71004,
+          "entityLabel": "Form with Two Steps",
+          "fieldVaFormNumber": "222222",
+          "fieldOmbNumber": "1212-1212",
+          "fieldChapters": [
+            {
+              "entity": {
+                "entityId": "157906",
+                "type": {
+                  "entity": {
+                    "entityId": "digital_form_name_and_date_of_bi",
+                    "entityLabel": "Name and Date of Birth"
+                  }
+                },
+                "fieldTitle": "First Step",
+                "fieldIncludeDateOfBirth": true
+              }
+            },
+            {
+              "entity": {
+                "entityId": "157907",
+                "type": {
+                  "entity": {
+                    "entityId": "digital_form_name_and_date_of_bi",
+                    "entityLabel": "Name and Date of Birth"
+                  }
+                },
+                "fieldTitle": "Second Step",
+                "fieldIncludeDateOfBirth": false
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+    `;
+
+  let parsedResult;
+
+  beforeEach(() => {
+    const processedResult = postProcessDigitalForm(queryResult);
+    parsedResult = JSON.parse(processedResult);
+  });
+
+  it('returns a normalized JSON object', () => {
+    const testForm = parsedResult[1];
+
+    expect(parsedResult.length).to.eq(2);
+    expect(testForm.id).to.eq(71004);
+    expect(testForm.title).to.eq('Form with Two Steps');
   });
 });

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.unit.spec.js
@@ -82,7 +82,6 @@ describe('postProcessDigitalForm', () => {
     expect(testForm.cmsId).to.eq(71004);
     expect(testForm.formId).to.eq('222222');
     expect(testForm.title).to.eq('Form with Two Steps');
-    expect(testForm.subTitle).to.eq('VA Form 222222');
     expect(testForm.ombNumber).to.eq('1212-1212');
     expect(testForm.chapters.length).to.eq(2);
     expect(testChapter.id).to.eq(157907);

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.unit.spec.js
@@ -85,5 +85,6 @@ describe('postProcessDigitalForm', () => {
     expect(testForm.id).to.eq(71004);
     expect(testForm.title).to.eq('Form with Two Steps');
     expect(testForm.subTitle).to.eq('VA Form 222222');
+    expect(testForm.ombNumber).to.eq('1212-1212');
   });
 });

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.unit.spec.js
@@ -1,101 +1,190 @@
 /* eslint-disable @department-of-veterans-affairs/axe-check-required */
 
 import { expect } from 'chai';
+import sinon from 'sinon';
+import drupalUtils from '../../utilities-drupal';
 
 const { postProcessDigitalForm } = require('./postProcessDigitalForm');
 
 describe('postProcessDigitalForm', () => {
-  const queryResult = {
-    data: {
-      nodeQuery: {
-        entities: [
-          {
-            nid: 71002,
-            entityLabel: 'Form with One Step',
-            fieldVaFormNumber: '11111',
-            fieldOmbNumber: '1111-1111',
-            fieldChapters: [
-              {
-                entity: {
-                  entityId: '157904',
-                  type: {
-                    entity: {
-                      entityId: 'digital_form_name_and_date_of_bi',
-                      entityLabel: 'Name and Date of Birth',
+  context('with a well-formed query result', () => {
+    const queryResult = {
+      data: {
+        nodeQuery: {
+          entities: [
+            {
+              nid: 71002,
+              entityLabel: 'Form with One Step',
+              fieldVaFormNumber: '11111',
+              fieldOmbNumber: '1111-1111',
+              fieldChapters: [
+                {
+                  entity: {
+                    entityId: '157904',
+                    type: {
+                      entity: {
+                        entityId: 'digital_form_name_and_date_of_bi',
+                        entityLabel: 'Name and Date of Birth',
+                      },
                     },
+                    fieldTitle: 'The Only Step',
+                    fieldIncludeDateOfBirth: true,
                   },
-                  fieldTitle: 'The Only Step',
-                  fieldIncludeDateOfBirth: true,
                 },
-              },
-            ],
-          },
-          {
-            nid: 71004,
-            entityLabel: 'Form with Two Steps',
-            fieldVaFormNumber: '222222',
-            fieldOmbNumber: '1212-1212',
-            fieldChapters: [
-              {
-                entity: {
-                  entityId: '157906',
-                  type: {
-                    entity: {
-                      entityId: 'digital_form_name_and_date_of_bi',
-                      entityLabel: 'Name and Date of Birth',
+              ],
+            },
+            {
+              nid: 71004,
+              entityLabel: 'Form with Two Steps',
+              fieldVaFormNumber: '222222',
+              fieldOmbNumber: '1212-1212',
+              fieldChapters: [
+                {
+                  entity: {
+                    entityId: '157906',
+                    type: {
+                      entity: {
+                        entityId: 'digital_form_name_and_date_of_bi',
+                        entityLabel: 'Name and Date of Birth',
+                      },
                     },
+                    fieldTitle: 'First Step',
+                    fieldIncludeDateOfBirth: true,
                   },
-                  fieldTitle: 'First Step',
-                  fieldIncludeDateOfBirth: true,
                 },
-              },
-              {
-                entity: {
-                  entityId: '157907',
-                  type: {
-                    entity: {
-                      entityId: 'digital_form_name_and_date_of_bi',
-                      entityLabel: 'Name and Date of Birth',
+                {
+                  entity: {
+                    entityId: '157907',
+                    type: {
+                      entity: {
+                        entityId: 'digital_form_name_and_date_of_bi',
+                        entityLabel: 'Name and Date of Birth',
+                      },
                     },
+                    fieldTitle: 'Second Step',
+                    fieldIncludeDateOfBirth: false,
                   },
-                  fieldTitle: 'Second Step',
-                  fieldIncludeDateOfBirth: false,
                 },
-              },
-            ],
-          },
-        ],
+              ],
+            },
+          ],
+        },
       },
-    },
-  };
-  let processedResult;
+    };
+    let processedResult;
 
-  beforeEach(() => {
-    processedResult = postProcessDigitalForm(queryResult);
+    beforeEach(() => {
+      processedResult = postProcessDigitalForm(queryResult);
+    });
+
+    it('returns a normalized JSON object', () => {
+      const testForm = processedResult[1];
+      const testChapter = testForm.chapters[1];
+
+      expect(processedResult.length).to.eq(2);
+      expect(testForm.cmsId).to.eq(71004);
+      expect(testForm.formId).to.eq('222222');
+      expect(testForm.title).to.eq('Form with Two Steps');
+      expect(testForm.ombNumber).to.eq('1212-1212');
+      expect(testForm.chapters.length).to.eq(2);
+      expect(testChapter.id).to.eq(157907);
+      expect(testChapter.chapterTitle).to.eq('Second Step');
+      expect(testChapter.type).to.eq('digital_form_name_and_date_of_bi');
+      expect(testChapter.pageTitle).to.eq('Name and Date of Birth');
+      expect(Object.keys(testChapter.additionalFields).length).to.eq(1);
+    });
+
+    context('with a Name and Date of Birth step', () => {
+      it('includes the appropriate fields', () => {
+        const { additionalFields } = processedResult[1].chapters[1];
+
+        expect(additionalFields.includeDateOfBirth).to.eq(false);
+      });
+    });
   });
 
-  it('returns a normalized JSON object', () => {
-    const testForm = processedResult[1];
-    const testChapter = testForm.chapters[1];
+  context('with a malformed query result', () => {
+    let queryResult;
+    let processedResult;
 
-    expect(processedResult.length).to.eq(2);
-    expect(testForm.cmsId).to.eq(71004);
-    expect(testForm.formId).to.eq('222222');
-    expect(testForm.title).to.eq('Form with Two Steps');
-    expect(testForm.ombNumber).to.eq('1212-1212');
-    expect(testForm.chapters.length).to.eq(2);
-    expect(testChapter.id).to.eq(157907);
-    expect(testChapter.chapterTitle).to.eq('Second Step');
-    expect(testChapter.type).to.eq('digital_form_name_and_date_of_bi');
-    expect(testChapter.pageTitle).to.eq('Name and Date of Birth');
-    expect(Object.keys(testChapter.additionalFields).length).to.eq(1);
-  });
+    beforeEach(() => {
+      sinon.stub(drupalUtils, 'logDrupal');
+    });
 
-  context('with a Name and Date of Birth step', () => {
-    it('includes the appropriate fields', () => {
-      const { additionalFields } = processedResult[1].chapters[1];
+    afterEach(() => {
+      drupalUtils.logDrupal.restore();
+    });
 
-      expect(additionalFields.includeDateOfBirth).to.eq(false);
+    context('when the entire query is bad', () => {
+      beforeEach(() => {
+        queryResult = {
+          wrongKey: 'oops! bad data!',
+        };
+        processedResult = postProcessDigitalForm(
+          queryResult,
+          drupalUtils.logDrupal,
+        );
+      });
+
+      it('logs the error', () => {
+        expect(drupalUtils.logDrupal.calledOnce).to.eq(true);
+      });
+
+      it('returns an empty array', () => {
+        expect(processedResult.length).to.eq(0);
+      });
+    });
+
+    context('when only one form is malformed', () => {
+      beforeEach(() => {
+        queryResult = {
+          data: {
+            nodeQuery: {
+              entities: [
+                {
+                  nid: 71002,
+                  entityLabel: 'Form with One Step',
+                  fieldVaFormNumber: '11111',
+                  fieldOmbNumber: '1111-1111',
+                  fieldChapters: [
+                    {
+                      entity: {
+                        entityId: '157904',
+                        type: {
+                          entity: {
+                            entityId: 'digital_form_name_and_date_of_bi',
+                            entityLabel: 'Name and Date of Birth',
+                          },
+                        },
+                        fieldTitle: 'The Only Step',
+                        fieldIncludeDateOfBirth: true,
+                      },
+                    },
+                  ],
+                },
+                {
+                  nid: '71004',
+                  entityLabel: 'This form has problems',
+                  fieldVaFormNumber: 222222,
+                  fieldChapters: 'no chapters',
+                },
+              ],
+            },
+          },
+        };
+        processedResult = postProcessDigitalForm(
+          queryResult,
+          drupalUtils.logDrupal,
+        );
+      });
+
+      it('logs the error', () => {
+        expect(drupalUtils.logDrupal.calledOnce).to.eq(true);
+      });
+
+      it('returns the other forms', () => {
+        expect(processedResult[0].cmsId).to.eq(71002);
+      });
     });
   });
 });

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.unit.spec.js
@@ -84,5 +84,6 @@ describe('postProcessDigitalForm', () => {
     expect(parsedResult.length).to.eq(2);
     expect(testForm.id).to.eq(71004);
     expect(testForm.title).to.eq('Form with Two Steps');
+    expect(testForm.subTitle).to.eq('VA Form 222222');
   });
 });

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.unit.spec.js
@@ -90,5 +90,16 @@ describe('postProcessDigitalForm', () => {
     expect(testForm.chapters.length).to.eq(2);
     expect(testChapter.id).to.eq(157907);
     expect(testChapter.chapterTitle).to.eq('Second Step');
+    expect(testChapter.type).to.eq('digital_form_name_and_date_of_bi');
+    expect(testChapter.pageTitle).to.eq('Name and Date of Birth');
+    expect(Object.keys(testChapter.additionalFields).length).to.eq(1);
+  });
+
+  context('with a Name and Date of Birth step', () => {
+    it('includes the appropriate fields', () => {
+      const { additionalFields } = parsedResult[1].chapters[1];
+
+      expect(additionalFields.includeDateOfBirth).to.eq(false);
+    });
   });
 });

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.unit.spec.js
@@ -68,18 +68,17 @@ describe('postProcessDigitalForm', () => {
       },
     },
   };
-  let parsedResult;
+  let processedResult;
 
   beforeEach(() => {
-    const processedResult = postProcessDigitalForm(queryResult);
-    parsedResult = JSON.parse(processedResult);
+    processedResult = postProcessDigitalForm(queryResult);
   });
 
   it('returns a normalized JSON object', () => {
-    const testForm = parsedResult[1];
+    const testForm = processedResult[1];
     const testChapter = testForm.chapters[1];
 
-    expect(parsedResult.length).to.eq(2);
+    expect(processedResult.length).to.eq(2);
     expect(testForm.id).to.eq(71004);
     expect(testForm.title).to.eq('Form with Two Steps');
     expect(testForm.subTitle).to.eq('VA Form 222222');
@@ -94,7 +93,7 @@ describe('postProcessDigitalForm', () => {
 
   context('with a Name and Date of Birth step', () => {
     it('includes the appropriate fields', () => {
-      const { additionalFields } = parsedResult[1].chapters[1];
+      const { additionalFields } = processedResult[1].chapters[1];
 
       expect(additionalFields.includeDateOfBirth).to.eq(false);
     });

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.unit.spec.js
@@ -2,7 +2,6 @@
 
 import { expect } from 'chai';
 import sinon from 'sinon';
-import drupalUtils from '../../utilities-drupal';
 
 const { postProcessDigitalForm } = require('./postProcessDigitalForm');
 
@@ -106,13 +105,10 @@ describe('postProcessDigitalForm', () => {
   context('with a malformed query result', () => {
     let queryResult;
     let processedResult;
+    let logger;
 
     beforeEach(() => {
-      sinon.stub(drupalUtils, 'logDrupal');
-    });
-
-    afterEach(() => {
-      drupalUtils.logDrupal.restore();
+      logger = sinon.spy();
     });
 
     context('when the entire query is bad', () => {
@@ -120,14 +116,11 @@ describe('postProcessDigitalForm', () => {
         queryResult = {
           wrongKey: 'oops! bad data!',
         };
-        processedResult = postProcessDigitalForm(
-          queryResult,
-          drupalUtils.logDrupal,
-        );
+        processedResult = postProcessDigitalForm(queryResult, logger);
       });
 
       it('logs the error', () => {
-        expect(drupalUtils.logDrupal.calledOnce).to.eq(true);
+        expect(logger.calledOnce).to.eq(true);
       });
 
       it('returns an empty array', () => {
@@ -172,14 +165,11 @@ describe('postProcessDigitalForm', () => {
             },
           },
         };
-        processedResult = postProcessDigitalForm(
-          queryResult,
-          drupalUtils.logDrupal,
-        );
+        processedResult = postProcessDigitalForm(queryResult, logger);
       });
 
       it('logs the error', () => {
-        expect(drupalUtils.logDrupal.calledOnce).to.eq(true);
+        expect(logger.calledOnce).to.eq(true);
       });
 
       it('returns the other forms', () => {

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.unit.spec.js
@@ -80,11 +80,15 @@ describe('postProcessDigitalForm', () => {
 
   it('returns a normalized JSON object', () => {
     const testForm = parsedResult[1];
+    const testChapter = testForm.chapters[1];
 
     expect(parsedResult.length).to.eq(2);
     expect(testForm.id).to.eq(71004);
     expect(testForm.title).to.eq('Form with Two Steps');
     expect(testForm.subTitle).to.eq('VA Form 222222');
     expect(testForm.ombNumber).to.eq('1212-1212');
+    expect(testForm.chapters.length).to.eq(2);
+    expect(testChapter.id).to.eq(157907);
+    expect(testChapter.chapterTitle).to.eq('Second Step');
   });
 });

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.unit.spec.js
@@ -5,72 +5,69 @@ import { expect } from 'chai';
 const { postProcessDigitalForm } = require('./postProcessDigitalForm');
 
 describe('postProcessDigitalForm', () => {
-  const queryResult = `
-{
-  "data": {
-    "nodeQuery": {
-      "entities": [
-        {
-          "nid": 71002,
-          "entityLabel": "Form with One Step",
-          "fieldVaFormNumber": "11111",
-          "fieldOmbNumber": "1111-1111",
-          "fieldChapters": [
-            {
-              "entity": {
-                "entityId": "157904",
-                "type": {
-                  "entity": {
-                    "entityId": "digital_form_name_and_date_of_bi",
-                    "entityLabel": "Name and Date of Birth"
-                  }
+  const queryResult = {
+    data: {
+      nodeQuery: {
+        entities: [
+          {
+            nid: 71002,
+            entityLabel: 'Form with One Step',
+            fieldVaFormNumber: '11111',
+            fieldOmbNumber: '1111-1111',
+            fieldChapters: [
+              {
+                entity: {
+                  entityId: '157904',
+                  type: {
+                    entity: {
+                      entityId: 'digital_form_name_and_date_of_bi',
+                      entityLabel: 'Name and Date of Birth',
+                    },
+                  },
+                  fieldTitle: 'The Only Step',
+                  fieldIncludeDateOfBirth: true,
                 },
-                "fieldTitle": "The Only Step",
-                "fieldIncludeDateOfBirth": true
-              }
-            }
-          ]
-        },
-        {
-          "nid": 71004,
-          "entityLabel": "Form with Two Steps",
-          "fieldVaFormNumber": "222222",
-          "fieldOmbNumber": "1212-1212",
-          "fieldChapters": [
-            {
-              "entity": {
-                "entityId": "157906",
-                "type": {
-                  "entity": {
-                    "entityId": "digital_form_name_and_date_of_bi",
-                    "entityLabel": "Name and Date of Birth"
-                  }
+              },
+            ],
+          },
+          {
+            nid: 71004,
+            entityLabel: 'Form with Two Steps',
+            fieldVaFormNumber: '222222',
+            fieldOmbNumber: '1212-1212',
+            fieldChapters: [
+              {
+                entity: {
+                  entityId: '157906',
+                  type: {
+                    entity: {
+                      entityId: 'digital_form_name_and_date_of_bi',
+                      entityLabel: 'Name and Date of Birth',
+                    },
+                  },
+                  fieldTitle: 'First Step',
+                  fieldIncludeDateOfBirth: true,
                 },
-                "fieldTitle": "First Step",
-                "fieldIncludeDateOfBirth": true
-              }
-            },
-            {
-              "entity": {
-                "entityId": "157907",
-                "type": {
-                  "entity": {
-                    "entityId": "digital_form_name_and_date_of_bi",
-                    "entityLabel": "Name and Date of Birth"
-                  }
+              },
+              {
+                entity: {
+                  entityId: '157907',
+                  type: {
+                    entity: {
+                      entityId: 'digital_form_name_and_date_of_bi',
+                      entityLabel: 'Name and Date of Birth',
+                    },
+                  },
+                  fieldTitle: 'Second Step',
+                  fieldIncludeDateOfBirth: false,
                 },
-                "fieldTitle": "Second Step",
-                "fieldIncludeDateOfBirth": false
-              }
-            }
-          ]
-        }
-      ]
-    }
-  }
-}
-    `;
-
+              },
+            ],
+          },
+        ],
+      },
+    },
+  };
   let parsedResult;
 
   beforeEach(() => {

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.unit.spec.js
@@ -79,7 +79,8 @@ describe('postProcessDigitalForm', () => {
     const testChapter = testForm.chapters[1];
 
     expect(processedResult.length).to.eq(2);
-    expect(testForm.id).to.eq(71004);
+    expect(testForm.cmsId).to.eq(71004);
+    expect(testForm.formId).to.eq('222222');
     expect(testForm.title).to.eq('Form with Two Steps');
     expect(testForm.subTitle).to.eq('VA Form 222222');
     expect(testForm.ombNumber).to.eq('1212-1212');


### PR DESCRIPTION
## Summary

Normalizes how a Digital Form object looks for post-processing.

### Before
```
{
  "data": {
    "nodeQuery": {
      "entities": [
        {
          "nid": 71159,
          "entityLabel": "Form with One Step",
          "fieldVaFormNumber": "1111111",
          "fieldOmbNumber": "1111-1111",
          "fieldChapters": [
            {
              "entity": {
                "entityId": "158252",
                "type": {
                  "entity": {
                    "entityId": "digital_form_name_and_date_of_bi",
                    "entityLabel": "Name and Date of Birth"
                  }
                },
                "fieldTitle": "The Only Step",
                "fieldIncludeDateOfBirth": true
              }
            }
          ]
        },
        {
          "nid": 71160,
          "entityLabel": "Form with Two Steps",
          "fieldVaFormNumber": "2121212",
          "fieldOmbNumber": "1212-1212",
          "fieldChapters": [
            {
              "entity": {
                "entityId": "158253",
                "type": {
                  "entity": {
                    "entityId": "digital_form_name_and_date_of_bi",
                    "entityLabel": "Name and Date of Birth"
                  }
                },
                "fieldTitle": "First Step",
                "fieldIncludeDateOfBirth": true
              }
            },
            {
              "entity": {
                "entityId": "158254",
                "type": {
                  "entity": {
                    "entityId": "digital_form_name_and_date_of_bi",
                    "entityLabel": "Name and Date of Birth"
                  }
                },
                "fieldTitle": "Second Step",
                "fieldIncludeDateOfBirth": false
              }
            }
          ]
        }
      ]
    }
  }
}
```

### After
```
[
  {
    "cmsId": 71159,
    "title": "Form with One Step",
    "formId": "1111111",
    "ombNumber": "1111-1111",
    "chapters": [
      {
        "id": 158252,
        "chapterTitle": "The Only Step",
        "type": "digital_form_name_and_date_of_bi",
        "pageTitle": "Name and Date of Birth",
        "additionalFields": {
          "includeDateOfBirth": true
        }
      }
    ]
  },
  {
    "cmsId": 71160,
    "title": "Form with Two Steps",
    "formId": "2121212",
    "ombNumber": "1212-1212",
    "chapters": [
      {
        "id": 158253,
        "chapterTitle": "First Step",
        "type": "digital_form_name_and_date_of_bi",
        "pageTitle": "Name and Date of Birth",
        "additionalFields": {
          "includeDateOfBirth": true
        }
      },
      {
        "id": 158254,
        "chapterTitle": "Second Step",
        "type": "digital_form_name_and_date_of_bi",
        "pageTitle": "Name and Date of Birth",
        "additionalFields": {
          "includeDateOfBirth": false
        }
      }
    ]
  }
]
```

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#88634

## Testing done

- Added unit tests for the Digital Form post processor
- Updated unit test for the Digital Form query object
- Pulled Drupal data from the integration branch deployment to get the before & after outputs above.

## What areas of the site does it impact?

Only affects the output of `digital-forms.json`, which is not currently generated in production.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Is this the format desired for the normalization layer? Can you foresee any situations where this format will cause issues?
