### PR TITLE
VACMS-18783 Promo Banner duplicate event removal

### DIFF
--- a/src/site/components/banners.drupal.liquid
+++ b/src/site/components/banners.drupal.liquid
@@ -30,9 +30,6 @@
 <!-- Promo Banners -->
 {% for promoBanner in visiblePromoBanners %}
   <va-promo-banner
-    onclick="recordEvent({ event: 'promo-banner-event', 'promo-banner-action': 'Footer alert - {{promoBanner.title}}'})"
-    aria-label="{{ promoBanner.title }}"
-    role="region"
     data-template="components/banners.drupal.liquid"
     id="{{ promoBanner.entityId }}"
     href="{{ promoBanner.fieldLink.url.path }}"


### PR DESCRIPTION
## Summary
Remove duplicate Google Analytics event on the `<va-promo-banner>` in content-build. There are no prod (or lower environment) examples for this that I could find, so I put one on a Tugboat for testing.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18783

## Testing done
Tested on this Tugboat: https://web-w4azz2khpzdi53uymp1gxkpi0fbqdlqu.demo.cms.va.gov/ on the homepage. There's a promo banner at the bottom of the screen.

## Screenshots
<img width="511" alt="Screenshot 2024-08-01 at 3 54 09 PM" src="https://github.com/user-attachments/assets/9839c9f2-cb57-4fcb-80e6-9c921acd1486">
<img width="1241" alt="Screenshot 2024-08-01 at 3 55 02 PM" src="https://github.com/user-attachments/assets/ef06b507-bf3e-4a54-9690-53a2bf340779">
<img width="528" alt="Screenshot 2024-08-01 at 3 55 21 PM" src="https://github.com/user-attachments/assets/d9dec371-4870-45fa-a8ec-ac37e4576566">