### PR TITLE
VACMS-18822: Make label conditional for Google Directions 

### DIFF
--- a/src/site/includes/directions-google-maps.liquid
+++ b/src/site/includes/directions-google-maps.liquid
@@ -7,10 +7,18 @@ directionsLinkOnClickPropValue
 {% endcomment %}
 
 <div>
-  <va-link
-    label="Get directions on Google Maps to {{ directionsLinkTitle | strip }}"
-    href="https://maps.google.com?saddr=Current+Location&amp;daddr={{ directionsLinkAddress | strip }}"
-    text="Get directions on Google Maps"
-  />
-  </va-link>
+  {% if directionsLinkTitle != empty %}
+    <va-link
+      label="Get directions on Google Maps to {{ directionsLinkTitle | strip }}"
+      href="https://maps.google.com?saddr=Current+Location&amp;daddr={{ directionsLinkAddress | strip }}"
+      text="Get directions on Google Maps"
+    />
+    </va-link>
+  {% else %}
+    <va-link
+      href="https://maps.google.com?saddr=Current+Location&amp;daddr={{ directionsLinkAddress | strip }}"
+      text="Get directions on Google Maps"
+    />
+    </va-link>
+  {% endif %}
 </div>

--- a/src/site/includes/directions-google-maps.liquid
+++ b/src/site/includes/directions-google-maps.liquid
@@ -7,18 +7,11 @@ directionsLinkOnClickPropValue
 {% endcomment %}
 
 <div>
-  {% if directionsLinkTitle != empty %}
-    <va-link
+  <va-link
+    {% if directionsLinkTitle != empty %}
       label="Get directions on Google Maps to {{ directionsLinkTitle | strip }}"
-      href="https://maps.google.com?saddr=Current+Location&amp;daddr={{ directionsLinkAddress | strip }}"
-      text="Get directions on Google Maps"
-    />
-    </va-link>
-  {% else %}
-    <va-link
-      href="https://maps.google.com?saddr=Current+Location&amp;daddr={{ directionsLinkAddress | strip }}"
-      text="Get directions on Google Maps"
-    />
-    </va-link>
-  {% endif %}
+    {% endif %}
+    href="https://maps.google.com?saddr=Current+Location&amp;daddr={{ directionsLinkAddress | strip }}"
+    text="Get directions on Google Maps"
+/></va-link>
 </div>


### PR DESCRIPTION
## Summary
This PR adjusts changed made to the get directions on google maps link that will only show an aria-label for locations with a title.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18822

## Testing done
Tested locally
```
/minneapolis-health-care/events/69858/
/minneapolis-health-care/events/69316/
```

## Screenshots
Event with title
<img width="1321" alt="VA_Minneapolis_Health_Care___Farmers_Market_At_Minneapolis_VA_Medical_Center___Veterans_Affairs_and___public-websites-dd-search__Channel__-_Office_of_CTO___VA_-_25_new_items_-_Slack__Main__🏠" src="https://github.com/user-attachments/assets/ab6e4fa6-ab82-4f8a-9282-42bda1cf15fb">


Event without location title
<img width="1118" alt="Cursor_and_VA_Minneapolis_Health_Care___VA_Mobile_Medical_Unit_At_Union_Gospel_Mission___Veterans_Affairs" src="https://github.com/user-attachments/assets/2015bb0f-cf6d-45bf-b2a7-3633bd59e6ff">


## What areas of the site does it impact?

Event Details

## Acceptance criteria
- [ ] A11y Review

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

