### PR TITLE
VACMS-17986 VBA accordion IDs fix

### DIFF
--- a/src/site/includes/vba_facilities/services.liquid
+++ b/src/site/includes/vba_facilities/services.liquid
@@ -64,7 +64,7 @@
           uswds
           bordered
           class="va-accordion-item"
-          id="vba-service-item-{{ entityId }}"
+          id="{{ entityName | hashReference: 60 }}"
           header="{{ entityName }}"
           data-label="{{ entityName }}"
           data-template="vba_facilities/services"

--- a/src/site/layouts/vba_facility.drupal.liquid
+++ b/src/site/layouts/vba_facility.drupal.liquid
@@ -163,7 +163,7 @@
                 {% for prepareObj in fieldPrepareForVisit %}
                   <va-accordion-item uswds
                     class="va-accordion-item"
-                    id="vba-service-item-{{ prepareObj.entity.id }}"
+                    id="{{ prepareObj.entity.fieldHeader | hashReference: 60 }}"
                     header="{{ prepareObj.entity.fieldHeader }}"
                     level="3">
                     {{ prepareObj.entity.fieldRichWysiwyg.processed | drupalToVaPath | phoneLinks }}


### PR DESCRIPTION
## Summary
Updates the IDs on `va-accordion-item`s on VBA pages to match the title of the accordion. This enables editors to use a simpler and more reliable deep link (to an accordion item) on a page rather than trying to target a random ID generated for the accordion item.

On prod currently (note random numbers in the IDs):
<img width="433" alt="Screenshot 2024-08-07 at 6 26 51 PM" src="https://github.com/user-attachments/assets/fc7967ec-ec82-4d97-9274-d925ccdcd797">
<img width="432" alt="Screenshot 2024-08-07 at 6 27 01 PM" src="https://github.com/user-attachments/assets/5b40bf7c-6be1-47f1-a0cd-3f17f9d717cf">


## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17986

## Testing done
1. Go to `/portland-va-regional-benefit-office/`
2. Inspect each accordion item's ID and validate that it is a kebab case version of the title (e.g. an accordion with the title "Disability compensation" should have an ID  of "disability-compensation")
3. Verify that a deep link to an accordion (e.g. `/portland-va-regional-benefit-office/#disability-compensation`) jumps to the accordion with that title at the top of the screen

## Screenshots
<img width="762" alt="Screenshot 2024-08-07 at 6 23 46 PM" src="https://github.com/user-attachments/assets/00e254ea-cd50-4bc2-bc81-438076975c25">

<img width="457" alt="Screenshot 2024-08-07 at 6 23 43 PM" src="https://github.com/user-attachments/assets/5f0158e3-ce01-411b-9992-4c57dec82b3e">

<img width="758" alt="Screenshot 2024-08-07 at 6 24 55 PM" src="https://github.com/user-attachments/assets/ddcaa765-0bab-4499-a99a-f7475bbc45c8">
<img width="432" alt="Screenshot 2024-08-07 at 6 31 31 PM" src="https://github.com/user-attachments/assets/e9a3a0af-8664-4ce1-a75a-33b18728a3a6">



## What areas of the site does it impact?

VBA Facilities pages only

## Acceptance criteria

- [x] IDs of the VBA service accordions should use term name (rather than taxonomy ID)
- [ ] a11y review