### PR TITLE
VACMS 18497 and 18500 - changed to va-link components, encoded text, and removed recordEvents

### DIFF
--- a/src/site/teasers/event_featured.drupal.liquid
+++ b/src/site/teasers/event_featured.drupal.liquid
@@ -8,7 +8,7 @@
 
   <div data-template="teasers/event_featured">
     <{{header}} class="vads-u-margin-top--0 vad-u-margin-bottom-1 vads-u-font-size--md medium-screen:vads-u-font-size--lg">
-      <a href="{{ node.entityUrl.path }}">{{ node.title }}</a>
+      <va-link href="{{ node.entityUrl.path }}" text="{{ node.title | encode }}"></va-link>
     </{{header}}>
     <p class="vads-u-margin-bottom--1p5 vads-u-margin-top--0">
       {{ node.fieldDescription | truncatewords: 60, "..." }}</p>
@@ -42,7 +42,7 @@
         </div>
         <div class="usa-width-five-sixths">
           <p class="vads-u-margin-top--0 vads-u-margin-bottom--1">
-            <a onclick="recordEvent({ event: 'nav-featured-content-link-click' });" href="{{ node.fieldFacilityLocation.entity.entityUrl.path }}">{{ node.fieldFacilityLocation.entity.title }}</a>
+            <va-link href="{{ node.fieldFacilityLocation.entity.entityUrl.path }}" text="{{ node.fieldFacilityLocation.entity.title | encode }}"></va-link>
           </p>
           {% if node.fieldLocationHumanreadable != empty %}
             <span>{{ node.fieldLocationHumanreadable }}</span>

--- a/src/site/teasers/news_story_page_feature.drupal.liquid
+++ b/src/site/teasers/news_story_page_feature.drupal.liquid
@@ -5,8 +5,9 @@
 
 <div data-template="teasers/news_story_page_feature" id="featured-content-{{ node.entityId }}" class="featured-story usa-grid usa-grid-full vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4 vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-border-left--7px vads-u-border-color--primary-alt-lightest">
     <div class="usa-width-one-half medium-screen:vads-u-padding-left--2">
-        <{{ header }}
-            class="vads-u-font-size--md medium-screen:vads-u-font-size--lg vads-u-margin-top--0 medium-screen:vads-u-margin-bottom--0p5"><a onClick="recordEvent({ event: 'nav-featured-content-link-click' });" href="{{ node.entityUrl.path }}">{{ node.title }}</a></{{ header }}>
+        <{{ header }} class="vads-u-font-size--md medium-screen:vads-u-font-size--lg vads-u-margin-top--0 medium-screen:vads-u-margin-bottom--0p5">
+            <va-link href="{{ node.entityUrl.path }}" text="{{ node.title | encode }}"></va-link>
+        </{{ header }}>
         <p class="vads-u-margin-y--0">{{ node.fieldIntroText | truncatewords: 60, "..." }}</p>
     </div>
     <div class="usa-width-one-half {% if isStoriesPage %}stories-list{% endif %} vads-u-order--first medium-screen:vads-u-order--initial vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0">


### PR DESCRIPTION
## Summary

- Changed `<a>` tags to `<va-link>` tags and encoded text attributes and removed recordEvent for featured event (unused) and news story (unused)
- Sitewide team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18497
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18500

## Testing done

- Used anchor tags with recordEvents
- Unable to manually test, due to lack of usage

## Screenshots

- We don't include these partial templates anywhere

## What areas of the site does it impact?

Doesn't impact an existing area of the site, affects featured event and featured news story but not the teasers on VAMC region pages, those are updated already.

## Acceptance criteria
- [x] Element: event location link
  - [x] upgrade to web component
  - [x] enable web component analytics
- [x] Element: news story title
  - [x] upgrade to web component
  - [x] enable web component analytics
- [ ] a11y review

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (unauthenticated)

## Requested Feedback

Check code. Unable to display partial templates due to lack of usage, but potential usage in the future (teasers for featured events and news)