### PR TITLE
VACMS-17083 Enable PACT Act to deploy to prod

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1597,8 +1597,7 @@
     "template": {
       "title": "PACT Act",
       "layout": "page-react.html",
-      "description": "PACT Act application",
-      "vagovprod": false
+      "description": "PACT Act application"
     }
   },
   {


### PR DESCRIPTION
# DO NOT MERGE
This PR is waiting on final content from CAIA and final QA testing.

## Summary
In order to launch the PACT Act wizard to production, we have to remove this flag. Testing cannot be done in lower environments.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17083