### PR TITLE
VACMS 17954 - remove italics from common conditions

### DIFF
--- a/src/site/facilities/facility_health_service.drupal.liquid
+++ b/src/site/facilities/facility_health_service.drupal.liquid
@@ -19,7 +19,7 @@
       >
         {% if serviceTaxonomy.fieldCommonlyTreatedCondition %}
           <div class="vads-u-margin-bottom--2">
-            <span class="vads-u-font-style--italic">Common conditions: </span>{{ serviceTaxonomy.fieldCommonlyTreatedCondition }}
+            Common conditions: {{ serviceTaxonomy.fieldCommonlyTreatedCondition }}
           </div>
         {% endif %}
 

--- a/src/site/facilities/facility_health_service.drupal.liquid
+++ b/src/site/facilities/facility_health_service.drupal.liquid
@@ -18,9 +18,9 @@
         id="{{ serviceTaxonomy.entityBundle }}-{{ serviceTaxonomy.entityId }}"
       >
         {% if serviceTaxonomy.fieldCommonlyTreatedCondition %}
-          <div class="vads-u-margin-bottom--2">
+          <p class="vads-u-margin-bottom--2">
             Common conditions: {{ serviceTaxonomy.fieldCommonlyTreatedCondition }}
-          </div>
+          </p>
         {% endif %}
 
         {% if serviceSection.name == "Lovell - TRICARE" and serviceTaxonomy.fieldTricareDescription %}

--- a/src/site/facilities/health_service.drupal.liquid
+++ b/src/site/facilities/health_service.drupal.liquid
@@ -16,7 +16,7 @@
             <div id="{{ serviceTaxonomy.entityBundle }}-{{ serviceTaxonomy.entityId }}">
                 {% if serviceTaxonomy.fieldCommonlyTreatedCondition %}
                     <div class="vads-u-margin-bottom--2">
-                        <span class="vads-u-font-style--italic">Common conditions: </span>{{ serviceTaxonomy.fieldCommonlyTreatedCondition }}
+                        Common conditions: {{ serviceTaxonomy.fieldCommonlyTreatedCondition }}
                     </div>
                 {% endif %}
                 {% if section.name == "Lovell - TRICARE" and serviceTaxonomy.fieldTricareDescription %}

--- a/src/site/facilities/health_service.drupal.liquid
+++ b/src/site/facilities/health_service.drupal.liquid
@@ -15,9 +15,9 @@
             </h3>
             <div id="{{ serviceTaxonomy.entityBundle }}-{{ serviceTaxonomy.entityId }}">
                 {% if serviceTaxonomy.fieldCommonlyTreatedCondition %}
-                    <div class="vads-u-margin-bottom--2">
+                    <p class="vads-u-margin-bottom--2">
                         Common conditions: {{ serviceTaxonomy.fieldCommonlyTreatedCondition }}
-                    </div>
+                    </p>
                 {% endif %}
                 {% if section.name == "Lovell - TRICARE" and serviceTaxonomy.fieldTricareDescription %}
                     <description>{{ serviceTaxonomy.fieldTricareDescription | phoneLinks }}</description>


### PR DESCRIPTION
## Summary

- Removes span with italics font style on common conditions
- Sitewide team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17954

## Testing done

- Old behavior was italics text for the words "Common conditions" in health services

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Service Accordions |    <img width="762" alt="Screenshot 2024-08-14 at 1 55 07 PM" src="https://github.com/user-attachments/assets/2dcd17c4-bcc0-4017-9c7a-96b92ccc8584">    |       <img width="741" alt="Screenshot 2024-08-14 at 1 54 50 PM" src="https://github.com/user-attachments/assets/f622f96e-c34e-4880-b39c-c1f56f11b232"> |

## What areas of the site does it impact?

Health Services of region and VAMC facility. 

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (unauthenticated)

## Requested Feedback

Check RI`/boston-health-care/locations/brockton-va-medical-center/#geriatrics`
and
`/boston-health-care/health-services/` (scroll down to Geriatrics, no hash shortcuts)