### PR TITLE
Fix to breadcrumb padding on certain drupal pages.

### DIFF
--- a/src/site/includes/breadcrumbs.drupal.liquid
+++ b/src/site/includes/breadcrumbs.drupal.liquid
@@ -11,7 +11,7 @@
 
   {% assign crumbs = crumbs | formatForBreadcrumbs: title, entityUrl.path, hideHomeBreadcrumb, customHomeCrumbText  %}
 
-  <va-breadcrumbs class="row va-nav-breadcrumbs-list columns" wrapping />
+  <va-breadcrumbs wrapping />
 
   <script>
     const bcComponent = document.querySelector('va-breadcrumbs');


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

- Removing no-longer-needed classes from va-breadcrumbs component in order to fix padding styles
- I work for the DST

## Related issue(s)

One-off fix, no ticket.

## Testing done

- Tested locally using Brave

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |   ![Screenshot 2024-08-16 at 10 16 07 AM](https://github.com/user-attachments/assets/8496b462-7b23-404e-8532-764b26d97f20)    |  ![Screenshot 2024-08-16 at 10 15 30 AM](https://github.com/user-attachments/assets/db3ae288-733c-4058-9a76-e35bf516c707)  |

## What areas of the site does it impact?

Pages that use the breadcrumbs.drupal.liquid template for providing breadcrumbs.

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [X] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [X] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user
