### PR TITLE
Turn on production flag for rollout

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1724,7 +1724,7 @@
     "rootUrl": "/my-health/travel-claim-status",
     "productId": "1e585463-5625-4868-b5f5-58ee0490ea28",
     "template": {
-      "vagovprod": false,
+      "vagovprod": true,
       "layout": "page-react.html"
     }
   },


### PR DESCRIPTION
We are rolling out the Travel Pay Reimbursement status page and need to set the "vagovprod" flag to true in order to do a friends/family test.