### PR TITLE
VATEAM-90733: Normalize OMB info fields

### DIFF
--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/digitalForm.graphql.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/digitalForm.graphql.js
@@ -13,6 +13,10 @@ module.exports = `
     entityLabel
     fieldVaFormNumber
     fieldOmbNumber
+    fieldRespondentBurden
+    fieldExpirationDate {
+      value
+    }
     fieldChapters {
       entity {
         entityId

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/digitalForm.graphql.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/digitalForm.graphql.unit.spec.js
@@ -8,8 +8,13 @@ describe('digitalForm fragment', () => {
     expect(digitalForm).to.have.string('nid');
     expect(digitalForm).to.have.string('entityLabel');
     expect(digitalForm).to.have.string('fieldVaFormNumber');
-    expect(digitalForm).to.have.string('fieldOmbNumber');
     expect(digitalForm).to.have.string('fieldChapters');
+  });
+
+  it('include OMB info', () => {
+    expect(digitalForm).to.have.string('fieldOmbNumber');
+    expect(digitalForm).to.have.string('fieldRespondentBurden');
+    expect(digitalForm).to.have.string('fieldExpirationDate');
   });
 
   describe('chapter fragments', () => {

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
@@ -11,6 +11,11 @@ const extractAdditionalFields = entity => {
 };
 const extractForms = resultObject => resultObject?.data?.nodeQuery?.entities;
 
+const formatDate = dateString =>
+  // Depending on what time zone our servers operate on, we may need to adjust
+  // this offset.
+  new Date(Date.parse(`${dateString}T04:00-05:00`)).toLocaleDateString();
+
 const normalizeChapter = ({ entity }) => {
   return {
     id: parseInt(entity.entityId, 10),
@@ -27,7 +32,11 @@ const normalizeForm = (form, logger = logDrupal) => {
       cmsId: form.nid,
       formId: form.fieldVaFormNumber,
       title: form.entityLabel,
-      ombNumber: form.fieldOmbNumber,
+      ombInfo: {
+        expDate: formatDate(form.fieldExpirationDate.value),
+        ombNumber: form.fieldOmbNumber,
+        resBurden: form.fieldRespondentBurden,
+      },
       chapters: form.fieldChapters.map(normalizeChapter),
     };
   } catch (error) {

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
@@ -11,10 +11,11 @@ const extractAdditionalFields = entity => {
 };
 const extractForms = resultObject => resultObject?.data?.nodeQuery?.entities;
 
-const formatDate = dateString =>
-  // Depending on what time zone our servers operate on, we may need to adjust
-  // this offset.
-  new Date(Date.parse(`${dateString}T04:00-05:00`)).toLocaleDateString();
+const formatDate = dateString => {
+  const removeLeadingZero = s => s.replace(/^0+/, '');
+  const [year, month, day] = dateString.split('-');
+  return `${removeLeadingZero(month)}/${removeLeadingZero(day)}/${year}`;
+};
 
 const normalizeChapter = ({ entity }) => {
   return {

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.unit.spec.js
@@ -6,67 +6,76 @@ import sinon from 'sinon';
 const { postProcessDigitalForm } = require('./postProcessDigitalForm');
 
 describe('postProcessDigitalForm', () => {
+  const oneStepEntity = {
+    nid: 71002,
+    entityLabel: 'Form with One Step',
+    fieldVaFormNumber: '11111',
+    fieldOmbNumber: '1111-1111',
+    fieldRespondentBurden: 48,
+    fieldExpirationDate: {
+      value: '2025-06-11',
+    },
+    fieldChapters: [
+      {
+        entity: {
+          entityId: '157904',
+          type: {
+            entity: {
+              entityId: 'digital_form_name_and_date_of_bi',
+              entityLabel: 'Name and Date of Birth',
+            },
+          },
+          fieldTitle: 'The Only Step',
+          fieldIncludeDateOfBirth: true,
+        },
+      },
+    ],
+  };
+
   context('with a well-formed query result', () => {
+    const twoStepEntity = {
+      nid: 71004,
+      entityLabel: 'Form with Two Steps',
+      fieldVaFormNumber: '222222',
+      fieldOmbNumber: '1212-1212',
+      fieldRespondentBurden: 30,
+      fieldExpirationDate: {
+        value: '2027-01-29',
+      },
+      fieldChapters: [
+        {
+          entity: {
+            entityId: '157906',
+            type: {
+              entity: {
+                entityId: 'digital_form_name_and_date_of_bi',
+                entityLabel: 'Name and Date of Birth',
+              },
+            },
+            fieldTitle: 'First Step',
+            fieldIncludeDateOfBirth: true,
+          },
+        },
+        {
+          entity: {
+            entityId: '157907',
+            type: {
+              entity: {
+                entityId: 'digital_form_name_and_date_of_bi',
+                entityLabel: 'Name and Date of Birth',
+              },
+            },
+            fieldTitle: 'Second Step',
+            fieldIncludeDateOfBirth: false,
+          },
+        },
+      ],
+    };
+
     const queryResult = {
       data: {
         nodeQuery: {
-          entities: [
-            {
-              nid: 71002,
-              entityLabel: 'Form with One Step',
-              fieldVaFormNumber: '11111',
-              fieldOmbNumber: '1111-1111',
-              fieldChapters: [
-                {
-                  entity: {
-                    entityId: '157904',
-                    type: {
-                      entity: {
-                        entityId: 'digital_form_name_and_date_of_bi',
-                        entityLabel: 'Name and Date of Birth',
-                      },
-                    },
-                    fieldTitle: 'The Only Step',
-                    fieldIncludeDateOfBirth: true,
-                  },
-                },
-              ],
-            },
-            {
-              nid: 71004,
-              entityLabel: 'Form with Two Steps',
-              fieldVaFormNumber: '222222',
-              fieldOmbNumber: '1212-1212',
-              fieldChapters: [
-                {
-                  entity: {
-                    entityId: '157906',
-                    type: {
-                      entity: {
-                        entityId: 'digital_form_name_and_date_of_bi',
-                        entityLabel: 'Name and Date of Birth',
-                      },
-                    },
-                    fieldTitle: 'First Step',
-                    fieldIncludeDateOfBirth: true,
-                  },
-                },
-                {
-                  entity: {
-                    entityId: '157907',
-                    type: {
-                      entity: {
-                        entityId: 'digital_form_name_and_date_of_bi',
-                        entityLabel: 'Name and Date of Birth',
-                      },
-                    },
-                    fieldTitle: 'Second Step',
-                    fieldIncludeDateOfBirth: false,
-                  },
-                },
-              ],
-            },
-          ],
+          entities: [oneStepEntity, twoStepEntity],
         },
       },
     };
@@ -84,13 +93,23 @@ describe('postProcessDigitalForm', () => {
       expect(testForm.cmsId).to.eq(71004);
       expect(testForm.formId).to.eq('222222');
       expect(testForm.title).to.eq('Form with Two Steps');
-      expect(testForm.ombNumber).to.eq('1212-1212');
       expect(testForm.chapters.length).to.eq(2);
       expect(testChapter.id).to.eq(157907);
       expect(testChapter.chapterTitle).to.eq('Second Step');
       expect(testChapter.type).to.eq('digital_form_name_and_date_of_bi');
       expect(testChapter.pageTitle).to.eq('Name and Date of Birth');
       expect(Object.keys(testChapter.additionalFields).length).to.eq(1);
+    });
+
+    it('includes an OMB info object', () => {
+      const { ombInfo } = processedResult[1];
+      const formattedDate = new Date(
+        Date.parse(`${twoStepEntity.fieldExpirationDate.value}T04:00-05:00`),
+      ).toLocaleDateString();
+
+      expect(ombInfo.ombNumber).to.eq(twoStepEntity.fieldOmbNumber);
+      expect(ombInfo.expDate).to.eq(formattedDate);
+      expect(ombInfo.resBurden).to.eq(twoStepEntity.fieldRespondentBurden);
     });
 
     context('with a Name and Date of Birth step', () => {
@@ -134,27 +153,7 @@ describe('postProcessDigitalForm', () => {
           data: {
             nodeQuery: {
               entities: [
-                {
-                  nid: 71002,
-                  entityLabel: 'Form with One Step',
-                  fieldVaFormNumber: '11111',
-                  fieldOmbNumber: '1111-1111',
-                  fieldChapters: [
-                    {
-                      entity: {
-                        entityId: '157904',
-                        type: {
-                          entity: {
-                            entityId: 'digital_form_name_and_date_of_bi',
-                            entityLabel: 'Name and Date of Birth',
-                          },
-                        },
-                        fieldTitle: 'The Only Step',
-                        fieldIncludeDateOfBirth: true,
-                      },
-                    },
-                  ],
-                },
+                oneStepEntity,
                 {
                   nid: '71004',
                   entityLabel: 'This form has problems',

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.unit.spec.js
@@ -33,6 +33,8 @@ describe('postProcessDigitalForm', () => {
   };
 
   context('with a well-formed query result', () => {
+    const expDate = '2027-01-29';
+
     const twoStepEntity = {
       nid: 71004,
       entityLabel: 'Form with Two Steps',
@@ -40,7 +42,7 @@ describe('postProcessDigitalForm', () => {
       fieldOmbNumber: '1212-1212',
       fieldRespondentBurden: 30,
       fieldExpirationDate: {
-        value: '2027-01-29',
+        value: expDate,
       },
       fieldChapters: [
         {
@@ -103,9 +105,8 @@ describe('postProcessDigitalForm', () => {
 
     it('includes an OMB info object', () => {
       const { ombInfo } = processedResult[1];
-      const formattedDate = new Date(
-        Date.parse(`${twoStepEntity.fieldExpirationDate.value}T04:00-05:00`),
-      ).toLocaleDateString();
+      // expDate is 2027-01-29
+      const formattedDate = '1/29/2027';
 
       expect(ombInfo.ombNumber).to.eq(twoStepEntity.fieldOmbNumber);
       expect(ombInfo.expDate).to.eq(formattedDate);


### PR DESCRIPTION
## Summary

- Normalizes the OMB info fields created by department-of-veterans-affairs/va.gov-cms#19078

### Example output
```json
  {
    "formId": "12345",
    // ...
    "ombInfo": {
      "expDate": "8/29/2025",
      "ombNumber": "1234-5678",
      "resBurden": 30
    },
    "chapters": [
      // ...
    ]
  }
```

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#90733

## Testing done

- Added OMB info unit tests to the Digital Form post processor and the Digital Form GraphQL query
- Pulled local Drupal data and confirmed the resulting output from `content-build`

## What areas of the site does it impact?

Only affects the output of digital-forms.json, which is not currently generated in production.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

I made the decision to format the Expiration Date at this stage. As far as I can tell, we won't need it as anything other than a formatted string in the Form Renderer app, and this seems like the least expensive place to do that formatting. I am open to other suggestions.