### PR TITLE
10-7959f-1 Update Title to match H1

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1769,7 +1769,7 @@
     }
   },
   {
-    "appName": "Foreign Medical Program (FMP) Registration Form",
+    "appName": "Register for the Foreign Medical Program (FMP)",
     "entryName": "10-7959f-1-FMP",
     "rootUrl": "/health-care/foreign-medical-program/register-form-10-7959f-1",
     "productId": "901c3f1f-2616-46da-89b2-30649821e335",


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary
This PR updates the appName for 7959f-1 to match the H1 which says  Register for the Foreign Medical Program (FMP).

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/91903

## Testing done
e2e and unit

## Screenshots
![Screenshot 2024-09-03 at 10 13 44 AM](https://github.com/user-attachments/assets/c776798f-f065-4569-beb0-9b34b9f4d398)

## What areas of the site does it impact?
this form only 

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
NA