### PR TITLE
VACMS 13910 - Direct links to hash reference id in system Health Service list

### DIFF
--- a/src/site/facilities/health_service.drupal.liquid
+++ b/src/site/facilities/health_service.drupal.liquid
@@ -34,7 +34,7 @@
                             {% if location.entity.status and facility != empty %}
                                 <li class="vads-u-margin-bottom--2">
                                     <va-link
-                                        href="{{ facility.entityUrl.path }}"
+                                        href="{{ facility.entityUrl.path }}/#{{serviceTaxonomy.name | hashReference: 60}}"
                                         text="{{ facility.title }}"
                                     >
                                     </va-link>


### PR DESCRIPTION
## Summary

- Adds hash to open accordion at hash reference id of taxonomy name, when clicking on facility name from inside a system-level Health Service
- Sitewide team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13910

## Testing done

- Tested all facility service links on `/pittsburgh-health-care/health-services/`
- Manually clicked on all links to determine if any would fail. The hash naming convention is the same for the id, so expected that it would not and confirmed.

## Screenshots

<details>
<summary>PR's links on Health Service listings</summary>
<img src="https://github.com/user-attachments/assets/1a5eb8a5-7288-4e77-8466-b9b1554ae620">
</details>

<details>
<summary>First link clicked on Audiology and speech</summary>
<img src="https://github.com/user-attachments/assets/4fab57d5-7687-4a39-af9b-f4eb8c7d898a">
</details>

<details>
<summary>Second link clicked</summary>
<img src="https://github.com/user-attachments/assets/18e4af58-dc6c-49cd-ba49-d1c20cfaddeb">
</details>

## What areas of the site does it impact?

System Health Service List pages

## Acceptance criteria

- [x] Within a VAMC System Health Service accordion on the [Health Services page](https://www.va.gov/pittsburgh-health-care/health-services/), the links to Facilities under **Available at these locations** should use anchor links to the corresponding service accordion at that Facility, e.g. https://www.va.gov/pittsburgh-health-care/locations/beaver-county-va-clinic/#mental-health-care
- [x] Only Facilities that have a published local version of that service should appear on the System Health service accordion. (Currently true in Prod, don't regress it.)
- [x] ~If no Facilities offer that service... (should the System service even show?)~ - covered in https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17165 (we chose not to do it?)
- [ ] Update VHA DM sync card to make VHA DM aware of the change: 
  - [ ] https://trello.com/c/ve9QID5M/154-sioux-falls-feedback-on-services-phone-numbers-deep-links-from-system-service-to-facility-service-13910
  - [ ] https://trello.com/c/rXhzTuVM/172-blinded-and-low-vision-rehab-health-service-accordion-links-deep-links-13910

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (unauthenticated)

## Requested Feedback

Check on RI `/pittsburgh-health-care/health-services/`