### PR TITLE
VACMS-18876 Fix breadcrumbs on checklist pages

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -673,26 +673,20 @@ module.exports = function registerFilters() {
     return breadcrumbs;
   };
 
-  liquid.filters.deriveLcBreadcrumbs = (
-    breadcrumbs,
-    string,
-    currentPath,
-    pageTitle,
-  ) => {
+  liquid.filters.deriveLcBreadcrumbs = breadcrumbs => {
     // Remove any resources crumb - we don't want the drupal page title.
     const filteredCrumbs = breadcrumbs.filter(
       crumb => crumb.url.path !== '/resources',
     );
-    // Add the resources crumb with the correct crumb title.
-    filteredCrumbs.push({
-      url: { path: '/resources', routed: false },
-      text: 'Resources and support',
-    });
 
-    if (pageTitle) {
-      filteredCrumbs.push({
-        url: { path: currentPath, routed: true },
-        text: string,
+    const firstBreadcrumbIsHome =
+      breadcrumbs?.[0].text.toLowerCase() === 'home';
+
+    if (firstBreadcrumbIsHome) {
+      // Add the resources crumb with the correct crumb title after "home"
+      filteredCrumbs.splice(1, 0, {
+        url: { path: '/resources', routed: false },
+        text: 'Resources and support',
       });
     }
 

--- a/src/site/includes/breadcrumbs.drupal.liquid
+++ b/src/site/includes/breadcrumbs.drupal.liquid
@@ -6,7 +6,7 @@
   {% endif %}
 
   {% if constructLcBreadcrumbs == true %}
-    {% assign crumbs = entityUrl.breadcrumb | deriveLcBreadcrumbs: title, entityUrl.path, titleInclude %}
+    {% assign crumbs = entityUrl.breadcrumb | deriveLcBreadcrumbs %}
   {% endif %}
 
   {% assign crumbs = crumbs | formatForBreadcrumbs: title, entityUrl.path, hideHomeBreadcrumb, customHomeCrumbText  %}
@@ -15,6 +15,7 @@
 
   <script>
     const bcComponent = document.querySelector('va-breadcrumbs');
+
     if (bcComponent) {
       bcComponent.setAttribute('breadcrumb-list', {{ crumbs }});
     }


### PR DESCRIPTION
## Summary
Two templates use the `constructLcBreadcrumbs` flag when generating breadcrumbs:
- basic_landing_page.drupal.liquid (only maps to `/resources`)
- checklist.drupal.liquid

Two other templates use this flag, but do not have any prod usage:
- media_list_images.drupal.liquid
- media_list_videos.drupal.liquid

The utility function that formatted breadcrumbs with the `constructLcBreadcrumbs` flag removed any crumbs with a `/resources` path because (according to a comment in the code) they pulled in the Drupal page title. Then, the utility pushed the proper Resources & Support home page breadcrumb into the array (but at the end). **Then**, it would take the current path's breadcrumb and add it to the end.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18876

## Testing done
Tested the following URLs directly affected by changes to the utility:

`/resources/what-to-bring-to-create-your-online-sign-in-account/`
|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |  <img width="463" alt="Screenshot 2024-09-09 at 12 28 51 PM" src="https://github.com/user-attachments/assets/4a0e5d63-fbc5-4619-aa50-8eb5b6a8625c">  |  <img width="462" alt="Screenshot 2024-09-09 at 12 29 08 PM" src="https://github.com/user-attachments/assets/8b1473eb-a67f-45cd-a680-b93954fba385"> |
| Desktop |  <img width="999" alt="Screenshot 2024-09-09 at 12 28 43 PM" src="https://github.com/user-attachments/assets/cc18f644-34e3-4c3e-8c2a-5d3c49b0800e"> |  <img width="1001" alt="Screenshot 2024-09-09 at 12 28 59 PM" src="https://github.com/user-attachments/assets/5f14d14d-8a96-4b82-8911-04ca813ef0e8"> |

`/resources/what-to-bring-to-create-your-online-sign-in-account-esp/`
|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |  <img width="462" alt="Screenshot 2024-09-09 at 12 26 09 PM" src="https://github.com/user-attachments/assets/99e79d9f-5f35-45f1-bfd0-5f697728df8a"> |  <img width="461" alt="Screenshot 2024-09-09 at 12 26 46 PM" src="https://github.com/user-attachments/assets/e02afff9-2bfb-4b74-9591-62fdf1375203"> |
| Desktop |  <img width="1002" alt="Screenshot 2024-09-09 at 12 26 27 PM" src="https://github.com/user-attachments/assets/44c4ee0f-6f64-49b5-9dad-55dad19340ee"> |  <img width="1002" alt="Screenshot 2024-09-09 at 12 26 59 PM" src="https://github.com/user-attachments/assets/dbed697c-fb01-4050-b5e9-d0fc7882aa76"> |

Tested the following URLs **NOT** affected by these changes (regression check):
- `/southeast-louisiana-health-care/about-us/leadership/`
- `/outreach-and-events/`
- `/resources/reimbursed-va-travel-expenses-and-mileage-rate/`
- `/find-forms/about-form-10-6001a/`
- `/puget-sound-health-care/policies`