### PR TITLE
Adds 10-7959f-1-FMP  to registry

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1882,5 +1882,16 @@
       "vagovprod": false,
       "layout": "page-react.html"
     }
+  },
+  {
+    "appName": "Register for the Foreign Medical Program (FMP)",
+    "entryName": "10-7959f-1-FMP",
+    "rootUrl": "/health-care/foreign-medical-program/register-form-10-7959f-1",
+    "template": {
+      "title": "Register for the Foreign Medical Program (FMP)",
+      "layout": "page-react.html",
+      "vagovprod": true,
+      "description": "FMP Registration Form (VA Form 10-7959f-1)."
+    }
   }
 ]


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

- _Adds 10-7959f-1-FMP  to registry 
- _Sets deploy flag to true
This  is in preparation  for production testing, At time of deploy,  feature flag should be off or accessible only  by specific users.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/91311