### PR TITLE
VACMS-11047 Change form last updated language

### DIFF
--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -57,13 +57,8 @@
           {% if fieldVaFormRevisionDate or fieldVaFormIssueDate %}
             <div>
               <dd>
-                <dfn class="vads-u-font-weight--bold vads-u-display--inline">Form last updated:</dfn>
-                {% assign revisionDateIsLatestUpdate = fieldVaFormRevisionDate.value | isLaterThan: fieldVaFormIssueDate.value %}
-                {% if revisionDateIsLatestUpdate %}
-                  {{ fieldVaFormRevisionDate.value | formatDate: 'MMMM YYYY' }}
-                {% else %}
-                  {{ fieldVaFormIssueDate.value | formatDate: 'MMMM YYYY' }}
-                {% endif %}
+                <dfn class="vads-u-font-weight--bold vads-u-display--inline">Form revision date:</dfn>
+                {{ fieldVaFormRevisionDate.value | formatDate: 'MMMM YYYY' }}
               </dd>
             </div>
           {% endif %}


### PR DESCRIPTION
## Summary
Currently, for each form we display `Form last updated` with a month and year. The date for that field can draw from either the **revision date** or the **issued date**. The **revision date** is the date the form was created. The **issue date** is the date that the updated form is uploaded to the form DB. The **issue date** increments any time the **revision date** increments, and may also increment for background changes that do not change the **revision date**, such as updating Adobe certificates for the PDF.

It was reported that some field offices use this `Form last updated` information to verify whether a Veteran has filled out the correct copy of the form. If a Veteran did fill out the correct copy of the form, but the form recently had Adobe certificates updated (for example), it would look like they had filled out an outdated copy of the form.

**Solution**: Only show the `Form revision date` for the form, and only refer to the **revision date** for that value as it will not change unless the form itself has actually changed. If the date is null or the field doesn't exist, it will display `N/A` instead.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11047

## Testing done
Tested a handful of form detail pages.

## Screenshots
<table>
<tr><td><img width="499" alt="Screenshot 2024-09-20 at 3 20 08 PM" src="https://github.com/user-attachments/assets/45d17578-f2fa-4a44-9c44-74fb0037f3f4"></td><td><img width="428" alt="Screenshot 2024-09-20 at 3 07 08 PM" src="https://github.com/user-attachments/assets/f9b8cd9f-9ccc-44c9-b2f7-eadb6202fb19"></td></tr>
<tr><td><img width="514" alt="Screenshot 2024-09-20 at 3 23 42 PM" src="https://github.com/user-attachments/assets/b88b0821-8aef-4a5a-949e-a8e168e7ee07"></td><td><img width="429" alt="Screenshot 2024-09-20 at 3 07 18 PM" src="https://github.com/user-attachments/assets/b77d8717-9f0f-4991-8ff4-de7b91097ed4"></td></tr>
<tr><td><img width="552" alt="Screenshot 2024-09-20 at 3 24 27 PM" src="https://github.com/user-attachments/assets/4540f97a-d763-400b-8657-466220b2db88">
</td><td><img width="329" alt="Screenshot 2024-09-20 at 3 24 04 PM" src="https://github.com/user-attachments/assets/b342661a-5255-4843-98b8-8ad53a001344"></td></tr>
<tr><td><img width="576" alt="Screenshot 2024-09-20 at 3 24 33 PM" src="https://github.com/user-attachments/assets/a392c092-e779-40d7-b80a-88135c12e32d"></td><td><img width="329" alt="Screenshot 2024-09-20 at 3 24 15 PM" src="https://github.com/user-attachments/assets/2ac3b8bb-cd97-4786-9b51-393b9a4ee8b9"></td></tr>
</table>

## What areas of the site does it impact?

Form detail pages only.

## Acceptance criteria

- [x] Label on Form detail page is updated to say Form revision date
- [x] Date that populates this field is ONLY the Revision date field