### PR TITLE
19090 Good/bad rating messaging update

### DIFF
--- a/src/site/filters/medalliaSurveysConfig.js
+++ b/src/site/filters/medalliaSurveysConfig.js
@@ -37,6 +37,10 @@ const medalliaSurveys = {
       production: SURVEY_NUMBERS.VISIT_SUMMARY_PROD,
       staging: SURVEY_NUMBERS.VISIT_SUMMARY_STAGING,
     },
+    '/resources': {
+      production: SURVEY_NUMBERS.DEFAULT_PROD_SURVEY,
+      staging: SURVEY_NUMBERS.DEFAULT_STAGING_SURVEY,
+    },
   },
 };
 

--- a/src/site/includes/how-do-you-rate.drupal.liquid
+++ b/src/site/includes/how-do-you-rate.drupal.liquid
@@ -33,7 +33,6 @@
     </va-button>
   </div>
 
-  <!-- Thank you message -->
   <p
     aria-hidden="true"
     id="thank-you-message"

--- a/src/site/includes/how-do-you-rate.drupal.liquid
+++ b/src/site/includes/how-do-you-rate.drupal.liquid
@@ -1,27 +1,23 @@
 
 {% assign ratingOptionsQuestion = "How do you rate your experience on this page?" %}
 
-{% if buildtype !== 'vagovprod' or isPreview %}
 <div  class="vads-u-padding-top--3 vads-u-padding-bottom--1 vads-u-display--flex vads-u-flex-direction--column vads-u-padding-x--1 desktop-lg:vads-u-padding-x--0">
   <va-radio
   id="rating-radio"
   label="{{ ratingOptionsQuestion }}"
   label-header-level="2"
-  uswds
   error=""
   >
     <va-radio-option
       id="good"
       label="Good"
       name="rating"
-      uswds
       value="Good"
     ></va-radio-option>
     <va-radio-option
       id="bad"
       label="Bad"
       name="rating"
-      uswds
       value="Bad"
     ></va-radio-option>
   </va-radio>
@@ -32,22 +28,27 @@
       class="vads-u-width--full medium-screen:vads-u-width--auto vads-u-margin--0 vads-u-margin-top--2p5"
       id="rating-submit"
       onclick="onRatingSubmit()"
-      uswds
       text="Submit feedback"
     >
     </va-button>
   </div>
 
   <!-- Thank you message -->
-  <p aria-hidden="true" id="thank-you-message" class="vads-u-display--none vads-u-margin--0">Thank you for your feedback.</p>
+  <p
+    aria-hidden="true"
+    id="thank-you-message"
+    class="vads-u-display--none vads-u-margin--0"
+  >
+    Want to share more feedback? We'll use it to keep improving VA.gov for all Veterans and their families.
+    <button 
+      onClick="KAMPYLE_ONSITE_SDK.showForm('{{ buildtype | getSurvey: entityUrl.path }}')"   
+      type="button"
+      class="va-button-link"
+    >
+      Complete our 3-question survey.
+    </button>
+  </p>
 </div>
-
-
-
-{% else %}
-  <div data-widget-type="how-do-you-rate"></div>
-
-{% endif %}
 
 <script nonce="**CSP_NONCE**" type="text/javascript">
   function deriveOptionLabel(goodChecked, badChecked) {


### PR DESCRIPTION
## Summary

Update success message after a user submits good/bad rating on Resources & support pages to encourage higher participation in completing Medallia survey.

Slack thread for context: https://dsva.slack.com/archives/CNCEXNXK4/p1726076748485399

- Removed `uswds` from components as that is default now
- Removed the `buildtype` check to alternatively render a vets-website React widget as this widget does not exist, and not sure it ever did? Here's a DSVA Github search for the `how-do-you-rate`, noting that there are no instances in vets-website where this widget would connect.
  - https://github.com/search?q=org%3Adepartment-of-veterans-affairs%20how-do-you-rate&type=code
  - This widget code was added 3 years ago in [this PR](https://github.com/department-of-veterans-affairs/content-build/commit/8cf4259006086ea1b2141fac5b784e7c3a738818) but I couldn't find a companion vets-website PR with the widget added.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19090

## Testing done

Tested the below URLs locally and in the review instance. The form submission and Medallia survey modal should work as expected.

- R&S detail page: /resources/career-resources-for-military-and-surviving-spouses
- R&S FAQ page: /resources/your-intent-to-file-a-va-claim
- R&S reusable Q&A: /resources/the-pact-act-and-your-va-benefits/
- R&S step-by-step: /resources/how-to-create-an-idme-account-for-va
- R&S checklist: /resources/what-to-bring-to-create-your-online-sign-in-account

The below URLs can be **mostly** tested in a Tugboat, but the Medallia survey modal will not open as it does not work in Tugboat environments. Worth noting that these content types do not have any published prod data so they are not high stakes to test at this level.
- R&S video list: https://web-nf9da3locdfpojy1bdfrtnspsvcmmrxb.demo.cms.va.gov/resources/test-video-list/
- R&S image list: https://web-nf9da3locdfpojy1bdfrtnspsvcmmrxb.demo.cms.va.gov/resources/test-image-list/

## Screenshots

### DOM
<img width="553" alt="Screenshot 2024-09-30 at 12 03 48 PM" src="https://github.com/user-attachments/assets/6c7466c0-bb4a-413c-a4f6-875f5e9a64c4">

### Analytics on-click
This did not change in this PR; I just added this for complete verification.
<img width="432" alt="Screenshot 2024-09-30 at 12 27 20 PM" src="https://github.com/user-attachments/assets/5096941d-dea4-4829-b225-5b3a8fcf3012">

### Desktop
<img width="1085" alt="Screenshot 2024-09-30 at 12 02 31 PM" src="https://github.com/user-attachments/assets/c0bb25ec-d7d0-486f-a941-564f2e39ced3">
<img width="1087" alt="Screenshot 2024-09-30 at 12 02 36 PM" src="https://github.com/user-attachments/assets/a21ab962-90ae-4f5e-b6c7-ce9dc233c37d">
<img width="1087" alt="Screenshot 2024-09-30 at 12 02 41 PM" src="https://github.com/user-attachments/assets/09abb5ab-a482-47b1-92fc-3dab22032d64">

### Mobile
<img width="403" alt="Screenshot 2024-09-30 at 12 02 54 PM" src="https://github.com/user-attachments/assets/2ca6d8d9-943d-45d1-a775-889667034c0b">
<img width="399" alt="Screenshot 2024-09-30 at 12 03 00 PM" src="https://github.com/user-attachments/assets/c5a82246-2922-4872-9c6a-7d64467c6829">
<img width="398" alt="Screenshot 2024-09-30 at 12 03 05 PM" src="https://github.com/user-attachments/assets/d9cf4205-3b04-46b5-a755-edd3a9166fae">

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria
- [x] Verify if how do you rate widget is used on any NON-R&S content types, and escalate to Product for scope decision if so
- [x] As a visitor, selecting a radio button option, and clicking the existing Submit Feedback button displays new success text: "Want to share more feedback? We'll use it to keep improving VA.gov for all Veterans and their families. [Complete our 3-question survey]."
- [x] Clicking the "Complete our 3-question survey" link opens the Medallia 3-question survey
- [x] New success message is shown on each template
- [x] After submission, focus is forced onto the updated thank you message
- [x] VA UX lead design review
- [x] a11y review

### Quality Assurance & Testing

- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution