### PR TITLE
Lift 50 minute timeout on build step and raise build job to 75 minutes.

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -91,7 +91,7 @@ jobs:
     runs-on: [self-hosted, asg]
     needs:
       - validate-build-status
-    timeout-minutes: 70
+    timeout-minutes: 75
     defaults:
       run:
         working-directory: content-build
@@ -206,7 +206,6 @@ jobs:
         run: |
           set -eo pipefail
           NODE_OPTIONS=--max-old-space-size=${{ env.MAXIMUM_HEAP }} yarn build:content_release --buildtype=${{ env.BUILDTYPE }} --asset-source=local --drupal-address=${{ env.DRUPAL_ADDRESS }} --drupal-user=${{ env.DRUPAL_USERNAME }} --drupal-password="${{ env.DRUPAL_PASSWORD }}" --pull-drupal --drupal-max-parallel-requests=15 --no-drupal-proxy ${{env.VERBOSE_BUILD}} | tee build-output.txt
-        timeout-minutes: 50
         env:
           NODE_ENV: production
           DEBUG: ${{ secrets.ACTIONS_RUNNER_DEBUG }}


### PR DESCRIPTION
## Summary
The build step is currently set to 50 minutes maximum and has timed out occasionally recently. It is not consistently over 50 minutes, but network conditions can lead it to rise above that timing.

This lifts the 50 minute timeout. The build job (all the surrounding work that goes along with the build) is set in this PR at 75 minutes. Again, this is for outliers runs where network conditions slow down the build.

## Testing done
No testing needed; these are simply timing changes.

