### PR TITLE
1210-update-title

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -907,7 +907,7 @@
     }
   },
   {
-    "appName": "Virtual Agent",
+    "appName": "VA Chatbot",
     "entryName": "virtual-agent",
     "rootUrl": "contact-us/virtual-agent",
     "template": {


### PR DESCRIPTION
Update Virtual Agent appName to VA Chatbot

**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

- Changed appName in registry.json from "Virtual Agent" to "VA Chatbot"
- VA Chatbot team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va-virtual-agent/issues/1210

## Testing done

- Title tag in contact-us page was set to Virtual Agent | Veteran Affairs
- Title tag is now set to VA Chatbot | Veteran Affairs
