### PR TITLE
Remove coronavirus apps from registry

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -787,46 +787,6 @@
     }
   },
   {
-    "appName": "Coronavirus Research - Volunteer",
-    "entryName": "coronavirus-research",
-    "rootUrl": "/coronavirus-research/volunteer",
-    "template": {
-      "vagovprod": true,
-      "layout": "page-react.html",
-      "includeBreadcrumbs": true,
-      "breadcrumbs_override": [
-        {
-          "path": "coronavirus-research/",
-          "name": "Participating in coronavirus research at VA"
-        },
-        {
-          "path": "coronavirus-research/volunteer/",
-          "name": "Sign up to volunteer"
-        }
-      ]
-    }
-  },
-  {
-    "appName": "Coronavirus Research - Update",
-    "entryName": "coronavirus-research-update",
-    "rootUrl": "/coronavirus-research/volunteer/update",
-    "template": {
-      "vagovprod": true,
-      "layout": "page-react.html",
-      "includeBreadcrumbs": true,
-      "breadcrumbs_override": [
-        {
-          "path": "coronavirus-research/",
-          "name": "Participating in coronavirus research at VA"
-        },
-        {
-          "path": "coronavirus-research/volunteer/update/",
-          "name": "Update your information"
-        }
-      ]
-    }
-  },
-  {
     "appName": "Ask a Question",
     "entryName": "ask-a-question",
     "rootUrl": "/ask-a-question",


### PR DESCRIPTION
## Summary

- Removes the `coronavirus-research` and `coronavirus-research-update` apps from the registry, as they have been deprecated and are now redirected:

```
OITECHRolleA@HAC-LT3537169 OITECHRolleA % curl -s -D - https://www.va.gov/coronavirus-research/volunteer|grep '^HTTP\|^Location'
HTTP/1.1 301 Moved Permanently
Location: https://www.research.va.gov/for_veterans/
OITECHRolleA@HAC-LT3537169 OITECHRolleA % curl -s -D - https://www.va.gov/coronavirus-research/volunteer/update|grep '^HTTP\|^Location'
HTTP/1.1 301 Moved Permanently
Location: https://www.research.va.gov/for_veterans/
```

This is being done ahead of removing the vets-website apps [per guidance](https://github.com/department-of-veterans-affairs/vets-website/blob/main/.github/PULL_REQUEST_TEMPLATE.md).

## Related issue(s)

department-of-veterans-affairs/va.gov-team#83785
