### PR TITLE
VACMS 18724 - Adds mission explainer to Vet Centers

### DIFF
--- a/src/site/layouts/vet_center.drupal.liquid
+++ b/src/site/layouts/vet_center.drupal.liquid
@@ -33,7 +33,7 @@
           {% endif %}
 
           {% if fieldMissionExplainer.fetched %}
-            <va-summary-box>
+            <va-summary-box class="vads-u-margin-bottom--4 medium-screen:vads-u-margin-bottom--0">
               <h2 slot="headline">{{ fieldMissionExplainer.fetched.fieldMagicheadHeading.0.value  }}</h2>
               {{ fieldMissionExplainer.fetched.fieldMagicheadBody.0.value }}
             </va-summary-box>

--- a/src/site/layouts/vet_center.drupal.liquid
+++ b/src/site/layouts/vet_center.drupal.liquid
@@ -25,10 +25,18 @@
                alt="Small group of diverse Veterans talking and smiling with a Vet center counselor, American flag in the background." 
                width="1000" height="287" class="vads-u-padding-y--1p5" 
           />
+
           {% if fieldIntroText != empty %}
             <div class="va-introtext">
               <p>{{ fieldIntroText }}</p>
             </div>
+          {% endif %}
+
+          {% if fieldMissionExplainer.fetched %}
+            <va-summary-box>
+              <h2 slot="headline">{{ fieldMissionExplainer.fetched.fieldMagicheadHeading.0.value  }}</h2>
+              {{ fieldMissionExplainer.fetched.fieldMagicheadBody.0.value }}
+            </va-summary-box>
           {% endif %}
 
           <va-on-this-page></va-on-this-page>

--- a/src/site/stages/build/drupal/graphql/vetCenter.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vetCenter.graphql.js
@@ -140,6 +140,9 @@ const vetCenterFragment = `
             }
           }
         }
+        fieldMissionExplainer {
+          fetched
+        }
       }`;
 
 const getVetCenterSlice = (operationName, offset, limit) => {


### PR DESCRIPTION
# DO NOT MERGE UNTIL NOTIFICATIONS MADE TO VET CENTER EDITORS

## Summary

- Adds mission explainer query to graphQL and pulls it into the layout for Vet Centers.
- Sitewide team (owns Vet Center facility pages and queries)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18724

## Testing done

- No mission explainer prior
- Verify mission explainer exists on Vet Center pages that have the centralized content (in some tugboats there may be some that do not have it, but in prod and staging all do now)

## Screenshots

<details>
<summary>Vet Center Page with mission explainer (Boston Vet Center) - Desktop (above 768px)</summary>
<img width="572" alt="Screenshot 2024-10-10 at 2 43 24 PM" src="https://github.com/user-attachments/assets/53c18aca-7286-4ee3-ad38-01b413f84811">

</details>

<details>
<summary>Vet Center Page with mission explainer (Boston Vet Center) - below 768px</summary>
<img width="1458" alt="Screenshot 2024-10-10 at 2 45 34 PM" src="https://github.com/user-attachments/assets/a280cda7-fe7c-490f-974d-7c4922b6eca4">
</details>

<details>
<summary>Vet Center Page missing mission explainer in tugboat (looks exactly the same as current Vet Center) - fixed in prod and staging so this does not occur but added to show logic exists if some VC removes it somehow </summary>
<img width="1728" alt="Screenshot 2024-10-07 at 10 12 12 PM" src="https://github.com/user-attachments/assets/becbc8be-34ba-4354-8598-20708c8fdf74">
</details>


## What areas of the site does it impact?

Affects Vet Center pages

## Acceptance criteria

- [x] Blue Summary Box exists at the top all VetCenter facility pages
- [x] Includes content from Mission Explainer content block created in https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18723
- [x] The blue summary box must use the existing "Summary Box" design component and follow all applicable annotations [indicated here in Figma](https://www.figma.com/design/EVd3q06ukAbVS61Q8MwRAT/Vet-Centers?node-id=930-13596&m=dev).

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Check https://web-rdikukigkjapf0z74ocsofi8izmc2gmo.demo.cms.va.gov/boston-vet-center/
If this is reset before you view, re-release content on that tugboat with 2307 as the PR for content-build.

Check page/component at 767px or lower and 769px or greater. At 767px or lower, should have a margin of 32px below mission explainer and above va-on-this-page component (with a border). At 769px or greater, should not have this margin, because the lack of border makes it appear far enough away from the va-on-this-page content