### PR TITLE
VATEAM-93401: Normalize Phone and Email Digital Form pattern output

### DIFF
--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/digitalForm.graphql.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/digitalForm.graphql.js
@@ -1,6 +1,7 @@
 const address = require('./address.graphql');
 const identificationInformation = require('./identificationInformation.graphql');
 const nameAndDateOfBirth = require('./nameAndDateOfBirth.graphql');
+const phoneAndEmail = require('./phoneAndEmail.graphql');
 
 /*
  *
@@ -11,6 +12,7 @@ module.exports = `
   ${address}
   ${identificationInformation}
   ${nameAndDateOfBirth}
+  ${phoneAndEmail}
 
   fragment digitalForm on NodeDigitalForm {
     nid
@@ -33,6 +35,7 @@ module.exports = `
         ...address
         ...identificationInformation
         ...nameAndDateOfBirth
+        ...phoneAndEmail
       }
     }
   }

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/phoneAndEmail.graphql.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/phoneAndEmail.graphql.js
@@ -1,0 +1,14 @@
+/*
+ *
+ * The "Phone and Email Address" Digital Form pattern.
+ *
+ * Pattern documentation:
+ * https://design.va.gov/patterns/ask-users-for/phone-numbers
+ *
+ */
+module.exports = `
+fragment phoneAndEmail on ParagraphDigitalFormPhoneAndEmail {
+  fieldTitle
+  fieldIncludeEmail
+}
+`;

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
@@ -1,26 +1,28 @@
 const { logDrupal } = require('../../utilities-drupal');
 
 const extractAdditionalFields = entity => {
-  const additionalFields = {};
   const { entityId } = entity.type.entity;
 
   switch (entityId) {
     case 'digital_form_address':
-      additionalFields.militaryAddressCheckbox =
-        entity.fieldMilitaryAddressCheckbox;
-      break;
-    case 'digital_form_name_and_date_of_bi':
-      additionalFields.includeDateOfBirth = entity.fieldIncludeDateOfBirth;
-      break;
+      return {
+        militaryAddressCheckbox: entity.fieldMilitaryAddressCheckbox,
+      };
     case 'digital_form_identification_info':
-      additionalFields.includeServiceNumber =
-        entity.fieldIncludeVeteranSService;
-      break;
+      return {
+        includeServiceNumber: entity.fieldIncludeVeteranSService,
+      };
+    case 'digital_form_name_and_date_of_bi':
+      return {
+        includeDateOfBirth: entity.fieldIncludeDateOfBirth,
+      };
+    case 'digital_form_phone_and_email':
+      return {
+        includeEmail: entity.fieldIncludeEmail,
+      };
     default:
-      break;
+      return {};
   }
-
-  return additionalFields;
 };
 const extractForms = resultObject => resultObject?.data?.nodeQuery?.entities;
 

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fixtures/queryResult.json
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fixtures/queryResult.json
@@ -29,7 +29,7 @@
         },
         {
           "nid": 71004,
-          "entityLabel": "Form with Two Steps",
+          "entityLabel": "Form with Many Steps",
           "fieldVaFormNumber": "222222",
           "fieldOmbNumber": "1212-1212",
           "fieldRespondentBurden": 30,
@@ -87,6 +87,19 @@
                 },
                 "fieldTitle": "Identification information",
                 "fieldIncludeVeteranSService": true
+              }
+            },
+            {
+              "entity": {
+                "entityId": "161351",
+                "type": {
+                  "entity": {
+                    "entityId": "digital_form_phone_and_email",
+                    "entityLabel": "Digital Form: Phone and email address"
+                  }
+                },
+                "fieldTitle": "Generated Phone",
+                "fieldIncludeEmail": false
               }
             }
           ]

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/digitalForm.graphql.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/digitalForm.graphql.unit.spec.js
@@ -18,19 +18,16 @@ describe('digitalForm fragment', () => {
   });
 
   describe('chapter fragments', () => {
-    it('imports the address fragment', () => {
-      expect(digitalForm).to.have.string('fragment address');
-      expect(digitalForm).to.have.string('...address');
-    });
-
-    it('imports the identificationInformation fragment', () => {
-      expect(digitalForm).to.have.string('fragment identificationInformation');
-      expect(digitalForm).to.have.string('...identificationInformation');
-    });
-
-    it('imports the nameAndDateOfBirth fragment', () => {
-      expect(digitalForm).to.have.string('fragment nameAndDateOfBirth');
-      expect(digitalForm).to.have.string('...nameAndDateOfBirth');
+    [
+      'address',
+      'identificationInformation',
+      'nameAndDateOfBirth',
+      'phoneAndEmail',
+    ].forEach(fragment => {
+      it(`imports the ${fragment} fragment`, () => {
+        expect(digitalForm).to.have.string(`fragment ${fragment}`);
+        expect(digitalForm).to.have.string(`...${fragment}`);
+      });
     });
   });
 });

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/phoneAndEmail.graphql.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/phoneAndEmail.graphql.unit.spec.js
@@ -1,0 +1,14 @@
+/* eslint-disable @department-of-veterans-affairs/axe-check-required */
+
+import { expect } from 'chai';
+import phoneAndEmail from '../../fragments/phoneAndEmail.graphql';
+
+describe('phoneAndEmail fragment', () => {
+  it('includes fieldTitle', () => {
+    expect(phoneAndEmail).to.have.string('fieldTitle');
+  });
+
+  it('includes fieldIncludeEmail', () => {
+    expect(phoneAndEmail).to.have.string('fieldIncludeEmail');
+  });
+});


### PR DESCRIPTION
## Summary

- Normalizes the Phone and Email Address Paragraph type created by department-of-veterans-affairs/va.gov-cms#19464

### Example output

```json
    {
        "id": 161355,
        "chapterTitle": "Veteran's contact information",
        "type": "digital_form_phone_and_email",
        "pageTitle": "Phone and email address",
        "additionalFields": {
          "includeEmail": true
        }
      }
```

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#93401

## Testing done

- Added unit tests to the Digital Form post processor, the Digital Form GraphQL fragment, and the `phoneAndEmail` GraphQL fragment
- Pulled local Drupal data and confirmed the resulting output from `content-build`

## What areas of the site does it impact?

Only affects the output of `digital-forms.json`.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
