### PR TITLE
Swap padding classes from formation to CSS Library

### DIFF
--- a/src/site/includes/common-tasks.drupal.liquid
+++ b/src/site/includes/common-tasks.drupal.liquid
@@ -7,7 +7,7 @@
       <!-- start first column-->
       <div class="vads-l-col--12 medium-screen:vads-l-col--6 vads-u-background-color--white ">
         <div
-          class="vads-u-margin-x--2 medium-desktop-screen:vads-u-margin-x--0 small-desktop-screen:vads-u-padding-right--9 vads-u-padding-bottom--5">
+          class="vads-u-margin-x--2 medium-desktop-screen:vads-u-margin-x--0 desktop:vads-u-padding-right--9 vads-u-padding-bottom--5">
           <h2 class="vads-u-color--gray-dark vads-u-font-family--serif" id="search-tools-header">
             Search
           </h2>

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -7,10 +7,10 @@
   <main>
     <!-- Hero-->
     <div class="va-u-background--gradiant-blue">
-      <div class="vads-l-grid-container vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
+      <div class="vads-l-grid-container vads-u-padding-x--4 desktop-lg:vads-u-padding-x--0">
         <div class="vads-l-col--12 small-screen:vads-l-col--10 medium-screen:vads-l-col--8 small-desktop-screen:vads-l-col--12">
           <div class="vads-u-display--flex small-desktop-screen:vads-l-row">
-            <div class="vads-l-col--12 small-desktop-screen:vads-l-col--6 vads-u-padding-top--4 vads-u-padding-bottom--6 small-desktop-screen:vads-u-padding-right--4">
+            <div class="vads-l-col--12 small-desktop-screen:vads-l-col--6 vads-u-padding-top--4 vads-u-padding-bottom--6 desktop:vads-u-padding-right--4">
               <h1 class="vads-u-color--white">{{ title }}</h1>
               <hr class="va-c-blue-line--large vads-u-border-color--primary-alt vads-u-border--2px vads-u-margin-y--2" />
               <p class="va-introtext vads-u-color--white">{{ fieldHeroBlurb }}</p>
@@ -35,7 +35,7 @@
 
     <!-- Why This Matters -->
     <div class="vads-u-background-color--primary-alt-lightest">
-      <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-bottom--3 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
+      <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-bottom--3 vads-u-padding-x--4 desktop-lg:vads-u-padding-x--0">
         <div class="vads-l-row">
           <!-- Content -->
           <div class="vads-l-col--12 medium-screen:vads-l-col--8">
@@ -89,7 +89,7 @@
     <!-- /Why This Matters -->
 
     <!-- What You Can Do -->
-    <div class="vads-l-grid-container vads-u-padding-y--3 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
+    <div class="vads-l-grid-container vads-u-padding-y--3 vads-u-padding-x--4 desktop-lg:vads-u-padding-x--0">
       <div class="vads-l-row">
         <div class="vads-l-col--12 medium-screen:vads-l-col--9">
           <!-- Title -->
@@ -127,7 +127,7 @@
 
     <!-- Video -->
     {% if fieldClpVideoPanel %}
-      <div class="vads-l-grid-container vads-u-padding-y--3 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
+      <div class="vads-l-grid-container vads-u-padding-y--3 vads-u-padding-x--4 desktop-lg:vads-u-padding-x--0">
         <div class="vads-l-row">
           
           <!-- CONTENT -->
@@ -185,7 +185,7 @@
 
     <!-- Spotlight -->
     {% if fieldClpSpotlightPanel %}
-      <div class="vads-l-grid-container vads-u-padding-y--3 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
+      <div class="vads-l-grid-container vads-u-padding-y--3 vads-u-padding-x--4 desktop-lg:vads-u-padding-x--0">
         <div class="vads-l-row">
           <div class="vads-l-col--12 medium-screen:vads-l-col--9">
             <p class="va-u-text-transform--uppercase vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">Spotlight</p>
@@ -224,7 +224,7 @@
 
     <!-- Stories -->
     {% if fieldClpStoriesPanel %}
-      <div class="vads-l-grid-container vads-u-padding-y--3 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
+      <div class="vads-l-grid-container vads-u-padding-y--3 vads-u-padding-x--4 desktop-lg:vads-u-padding-x--0">
         <div class="vads-l-row">
           <!-- CONTENT -->
           <div class="vads-l-col--12 medium-screen:vads-l-col--9">
@@ -277,7 +277,7 @@
 
     <!-- Downloadable Resources -->
     {% if fieldClpResourcesPanel %}
-      <div class="vads-l-grid-container vads-u-padding-y--3 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
+      <div class="vads-l-grid-container vads-u-padding-y--3 vads-u-padding-x--4 desktop-lg:vads-u-padding-x--0">
         <div class="vads-l-row">
           <div class="vads-l-col--12 medium-screen:vads-l-col--9">
             <!-- Title -->
@@ -323,7 +323,7 @@
 
     <!-- Events -->
     {% if fieldClpEventsPanel %}
-      <div class="vads-l-grid-container vads-u-padding-y--3 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
+      <div class="vads-l-grid-container vads-u-padding-y--3 vads-u-padding-x--4 desktop-lg:vads-u-padding-x--0">
 
         <!-- Content -->
         <div class="vads-l-row">
@@ -423,7 +423,7 @@
 
     <!-- FAQs -->
     {% if fieldClpFaqPanel %}
-      <div class="vads-l-grid-container vads-u-padding-y--3 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
+      <div class="vads-l-grid-container vads-u-padding-y--3 vads-u-padding-x--4 desktop-lg:vads-u-padding-x--0">
         <div class="vads-l-row">
           <div class="vads-l-col--12 medium-screen:vads-l-col--8">
             <!-- Title -->
@@ -531,7 +531,7 @@
     <!-- Connect with us -->
     {% if fieldRelatedOffice.entity.fieldExternalLink.title %}
       {% assign socialLinksObject = fieldRelatedOffice.entity.fieldSocialMediaLinks.platformValues | jsonToObj %}
-      <div class="vads-l-grid-container vads-u-padding-y--3 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
+      <div class="vads-l-grid-container vads-u-padding-y--3 vads-u-padding-x--4 desktop-lg:vads-u-padding-x--0">
         <div class="vads-l-row">
           <!-- CONTENT -->
           <div class="vads-l-col--12 medium-screen:vads-l-col--9">
@@ -620,7 +620,7 @@
 
     <!-- VA Benefits -->
     {% if fieldBenefitCategories != empty %}
-      <div class="vads-l-grid-container vads-u-padding-y--3 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
+      <div class="vads-l-grid-container vads-u-padding-y--3 vads-u-padding-x--4 desktop-lg:vads-u-padding-x--0">
         <div class="vads-l-row">
           <div class="vads-l-col--12 medium-screen:vads-l-col--9">
             <!-- Title -->

--- a/src/site/layouts/checklist.drupal.liquid
+++ b/src/site/layouts/checklist.drupal.liquid
@@ -15,7 +15,7 @@
             {% include "src/site/includes/support_resources_search_bar.drupal.liquid" %}
           </div>
 
-          <article class="vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
+          <article class="vads-u-padding-x--1 desktop-lg:vads-u-padding-x--0">
             <!-- Title -->
             <h1>{{ title }}</h1>
 

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -12,7 +12,7 @@
         {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
       {% endunless %}
 
-      <div class="vads-u-display--flex vads-u-flex-direction--column vads-u-padding-x--1p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--2">
+      <div class="vads-u-display--flex vads-u-flex-direction--column vads-u-padding-x--1p5 desktop-lg:vads-u-padding-x--0 vads-u-padding-bottom--2">
         {% include "src/site/includes/lovell-switch-link.drupal.liquid" with
          entityUrl = entityUrl %}
 

--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -30,7 +30,7 @@
 	</main>
 </div>
 <div class="usa-grid usa-grid-full">
-	<div class="last-updated vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
+	<div class="last-updated vads-u-padding-x--1 desktop-lg:vads-u-padding-x--0">
 	  <div class="vads-u-display--flex above-footer-elements-container">
 		<div class="vads-u-flex--1 vads-u-text-align--right">
 		  <span class="vads-u-text-align--right">

--- a/src/site/layouts/faq_multiple_q_a.drupal.liquid
+++ b/src/site/layouts/faq_multiple_q_a.drupal.liquid
@@ -33,7 +33,7 @@
             {% include "src/site/includes/support_resources_search_bar.drupal.liquid" %}
           </div>
 
-          <article class="vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
+          <article class="vads-u-padding-x--1 desktop-lg:vads-u-padding-x--0">
             <!-- Title -->
             <h1>{{ title }}</h1>
 

--- a/src/site/layouts/home-sandbox.drupal.liquid
+++ b/src/site/layouts/home-sandbox.drupal.liquid
@@ -7,7 +7,7 @@
   {% include "src/site/includes/homepage-benefits.drupal.liquid" with hubs %}
   <!-- Medallia feedback button-->
   <div class="usa-grid usa-grid-full">
-    <div class="last-updated vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
+    <div class="last-updated vads-u-padding-x--1 desktop-lg:vads-u-padding-x--0">
       <div class="vads-u-display--flex above-footer-elements-container">
         <div class="vads-u-flex--1 vads-u-text-align--right">
           <span class="vads-u-text-align--right">

--- a/src/site/layouts/home.drupal.liquid
+++ b/src/site/layouts/home.drupal.liquid
@@ -7,7 +7,7 @@
   {% include "src/site/includes/homepage-benefits.drupal.liquid" with hubs %}
   <!-- Medallia feedback button-->
   <div class="usa-grid usa-grid-full">
-    <div class="last-updated vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
+    <div class="last-updated vads-u-padding-x--1 desktop-lg:vads-u-padding-x--0">
       <div class="vads-u-display--flex above-footer-elements-container">
         <div class="vads-u-flex--1 vads-u-text-align--right">
           <span class="vads-u-text-align--right">

--- a/src/site/layouts/media_list_images.drupal.liquid
+++ b/src/site/layouts/media_list_images.drupal.liquid
@@ -12,7 +12,7 @@
             {% include "src/site/includes/support_resources_search_bar.drupal.liquid" %}
           </div>
 
-          <article class="vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
+          <article class="vads-u-padding-x--1 desktop-lg:vads-u-padding-x--0">
             <!-- Title -->
             <h1>{{ title }}</h1>
 

--- a/src/site/layouts/media_list_videos.drupal.liquid
+++ b/src/site/layouts/media_list_videos.drupal.liquid
@@ -12,7 +12,7 @@
             {% include "src/site/includes/support_resources_search_bar.drupal.liquid" %}
           </div>
 
-          <article class="vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
+          <article class="vads-u-padding-x--1 desktop-lg:vads-u-padding-x--0">
             <!-- Title -->
             <h1>{{ title }}</h1>
 

--- a/src/site/layouts/page-breadcrumbs.html
+++ b/src/site/layouts/page-breadcrumbs.html
@@ -4,7 +4,7 @@
   {% include "src/site/includes/gibs-down.html" %}
 {% endif %}
 
-<div class="vads-l-grid-container large-screen:vads-u-padding-x--0">
+<div class="vads-l-grid-container desktop-lg:vads-u-padding-x--0">
   {% include "src/site/includes/breadcrumbs.html" newGrid=true %}
 </div>
 

--- a/src/site/layouts/page-react.html
+++ b/src/site/layouts/page-react.html
@@ -9,7 +9,7 @@
     {% include "src/site/components/react-loader.html" %}
   {% if includeFeedbackButton != false %}
     <div class="usa-grid usa-grid-full">
-      <div class="last-updated vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
+      <div class="last-updated vads-u-padding-x--1 desktop-lg:vads-u-padding-x--0">
         <div class="vads-u-display--flex above-footer-elements-container">
           <div class="vads-u-flex--auto">
             <span class="vads-u-text-align--justify">

--- a/src/site/layouts/publication_listing.drupal.liquid
+++ b/src/site/layouts/publication_listing.drupal.liquid
@@ -175,7 +175,7 @@
                   vads-u-flex-direction--column
                   vads-u-padding-top--1p5
                   medium-screen:vads-u-padding-left--3
-                  large-screen:vads-u-padding-left--0
+                  desktop-lg:vads-u-padding-left--0
                   medium-screen:vads-l-col--8
                   medium-body-utility
                   large-screen:vads-l-col--12">

--- a/src/site/layouts/support_resources_article_listing.drupal.liquid
+++ b/src/site/layouts/support_resources_article_listing.drupal.liquid
@@ -13,16 +13,16 @@
     <div class="usa-grid usa-grid-full">
       <div class="usa-width-three-fourths">
         <div class="usa-content">
-          <div class="vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
+          <div class="vads-u-padding-x--1 desktop-lg:vads-u-padding-x--0">
             <h1>{{ title }}</h1>
           </div>
 
           <!-- Search bar -->
           {% include "src/site/includes/support_resources_search_bar.drupal.liquid" %}
 
-          <p class="vads-u-padding-x--1 large-screen:vads-u-padding-x--0">{{ paginationTitle }}</p>
+          <p class="vads-u-padding-x--1 desktop-lg:vads-u-padding-x--0">{{ paginationTitle }}</p>
 
-          <ul class="usa-unstyled-list vads-u-padding-x--1 large-screen:vads-u-padding-x--0" role="list">
+          <ul class="usa-unstyled-list vads-u-padding-x--1 desktop-lg:vads-u-padding-x--0" role="list">
           {% for article in articles %}
             <li>
               <div class="vads-u-padding-y--3 vads-u-border-top--1px vads-u-border-color--gray-lighter">

--- a/src/site/layouts/support_resources_detail_page.drupal.liquid
+++ b/src/site/layouts/support_resources_detail_page.drupal.liquid
@@ -16,7 +16,7 @@
             {% include "src/site/includes/support_resources_search_bar.drupal.liquid" %}
           </div>
 
-          <article class="usa-content vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
+          <article class="usa-content vads-u-padding-x--1 desktop-lg:vads-u-padding-x--0">
             <!-- Title -->
             <h1>{{ title }}</h1>
 


### PR DESCRIPTION
## Summary

Updating breakpoint names in classes to the USWDS v3 name. No visual changes should occur.

## Related issue(s)
Partial [CSS Library - Utilities - Swap padding import #3215](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3215)

