### PR TITLE
[Medallia Digital Surveys] Revert AVS Feedback Button Survey

### DIFF
--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -3225,7 +3225,7 @@ describe('getSurvey', () => {
         'vagovprod',
         '/my-health/medical-records/summaries-and-notes/visit-summary/8N73HF67C5CC77FC1D17091606996587',
       ),
-    ).to.equal(56);
+    ).to.equal(17);
   });
 
   it('returns correct survey ID for subpath URL match in staging', () => {

--- a/src/site/filters/medalliaSurveysConfig.js
+++ b/src/site/filters/medalliaSurveysConfig.js
@@ -34,7 +34,7 @@ const medalliaSurveys = {
       staging: SURVEY_NUMBERS.HEALTH_CARE_STAGING,
     },
     '/my-health/medical-records/summaries-and-notes/visit-summary': {
-      production: SURVEY_NUMBERS.AFTER_VISIT_SUMMARY_PROD,
+      production: SURVEY_NUMBERS.DEFAULT_PROD_SURVEY,
       staging: SURVEY_NUMBERS.AFTER_VISIT_SUMMARY_STAGING,
     },
     '/resources': {


### PR DESCRIPTION
## Summary

This PR changes the target Medallia feedback button survey on `/my-health/medical-records/summaries-and-notes/visit-summary/**`

After UAT with the survey team, an issue was identified with the survey. Reverting changes made [in this PR](https://github.com/department-of-veterans-affairs/content-build/pull/2295/).

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#94851

## Testing done
Note: Will need to merge in order to test in staging.

## Screenshots
N/A

## What areas of the site does it impact?

The Feedback button on `/my-health/medical-records/summaries-and-notes/visit-summary/` and subpaths

## Acceptance criteria
-[x] Afterv-visit summary feedback button changed back to sitewide default survey
-[x] Update unit test

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
