### PR TITLE
VACMS-18020: Add metadata description for homepage

### DIFF
--- a/src/site/includes/metatags.drupal.liquid
+++ b/src/site/includes/metatags.drupal.liquid
@@ -129,6 +129,10 @@
   {% elsif fieldIntroText %}
     {% assign description = fieldIntroText.processed | strip_html %}
   {% endif %}
+  {% elsif entityUrl.path = '/' %}
+    {% assign description = 'Welcome to the official website of the U.S. Department of Veterans Affairs. Discover, apply for, and manage your VA benefits and care.' %}
+  {% endif %}
+  entityUrl.path
 
   <!-- Add meta description tags. -->
   {% if description %}

--- a/src/site/includes/metatags.drupal.liquid
+++ b/src/site/includes/metatags.drupal.liquid
@@ -128,7 +128,6 @@
     {% assign description = fieldDescription | newline_to_br %}
   {% elsif fieldIntroText %}
     {% assign description = fieldIntroText.processed | strip_html %}
-  {% endif %}
   {% elsif entityUrl.path == '/' %}
     {% assign description = 'Welcome to the official website of the U.S. Department of Veterans Affairs. Discover, apply for, and manage your VA benefits and care.' %}
   {% endif %}

--- a/src/site/includes/metatags.drupal.liquid
+++ b/src/site/includes/metatags.drupal.liquid
@@ -132,7 +132,6 @@
   {% elsif entityUrl.path == '/' %}
     {% assign description = 'Welcome to the official website of the U.S. Department of Veterans Affairs. Discover, apply for, and manage your VA benefits and care.' %}
   {% endif %}
-  entityUrl.path
 
   <!-- Add meta description tags. -->
   {% if description %}

--- a/src/site/includes/metatags.drupal.liquid
+++ b/src/site/includes/metatags.drupal.liquid
@@ -129,7 +129,7 @@
   {% elsif fieldIntroText %}
     {% assign description = fieldIntroText.processed | strip_html %}
   {% endif %}
-  {% elsif entityUrl.path = '/' %}
+  {% elsif entityUrl.path == '/' %}
     {% assign description = 'Welcome to the official website of the U.S. Department of Veterans Affairs. Discover, apply for, and manage your VA benefits and care.' %}
   {% endif %}
   entityUrl.path


### PR DESCRIPTION
## Summary
Hardcode a metadata description for the homepage to adjust to federal website standards for HTML

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18020

## Testing done
Tested in RI for homepage metadata

## Screenshots
<img width="1379" alt="VA_gov_Home___Veterans_Affairs" src="https://github.com/user-attachments/assets/e8ee5e4c-408a-4c11-ab2c-f7082d778ce4">


## What areas of the site does it impact?


## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

