### PR TITLE
Fix padding issue on R&S pages contact information

### DIFF
--- a/src/site/paragraphs/contact_information.drupal.liquid
+++ b/src/site/paragraphs/contact_information.drupal.liquid
@@ -2,7 +2,7 @@
   <div class="vads-u-background-color--gray-light-alt">
     <div class="usa-grid usa-grid-full">
       <div class="usa-width-three-fourths">
-        <div class="usa-content vads-u-padding-x--1 desktop-lg::vads-u-padding-x--0">
+        <div class="usa-content vads-u-padding-x--1 desktop-lg:vads-u-padding-x--0">
           <section class="vads-u-display--flex vads-u-flex-direction--column vads-u-padding-y--2" data-template="paragraphs/contact_information">
             <h2 class="vads-u-font-size--h3 vads-u-border-bottom--4px vads-u-border-color--primary vads-u-margin--0 vads-u-margin-y--1 vads-u-padding-bottom--1">Need more help?</h2>
             {% if 


### PR DESCRIPTION
## Summary
Remove extra colon (`:`) from CSS class to fix padding on R&S pages (contact information at the bottom).

Test page: `/resources/signing-in-to-vagov/`

Current:
<img width="783" alt="Screenshot 2024-10-16 at 8 57 16 AM" src="https://github.com/user-attachments/assets/c8047429-ec43-450a-8df8-fd22429ef6bc">

Fixed:
<img width="774" alt="Screenshot 2024-10-16 at 8 58 12 AM" src="https://github.com/user-attachments/assets/63242db8-9c42-47c9-a097-44526356891b">