### PR TITLE
Fix hyphens

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -402,7 +402,7 @@
         },
         {
           "path": "burials-and-memorials/pre-need/form-10007-apply-for-eligibility/",
-          "name": "Pre&#8211;need eligibility determination"
+          "name": "Pre-need eligibility determination"
         }
       ]
     }
@@ -1190,7 +1190,7 @@
           "path": "supporting-forms-for-claims"
         },
         {
-          "name": "Authorize the release of non&#8208;VA medical information to VA",
+          "name": "Authorize the release of non-VA medical information to VA",
           "path": "supporting-forms-for-claims/release-information-to-va-form-21-4142"
         }
       ]
@@ -1644,9 +1644,7 @@
       "minimalHeader": {
         "title": "Submit a statement to support a claim",
         "subtitle": "Statement in support of a claim (VA Form 21-4138)",
-        "excludePaths": [
-          "/introduction"
-        ]
+        "excludePaths": ["/introduction"]
       }
     }
   },
@@ -1745,10 +1743,7 @@
       "minimalHeader": {
         "title": "Explore pattern demonstrations in our sample form",
         "subtitle": "Mock Form Minimal Header",
-        "excludePaths": [
-          "/introduction",
-          "/confirmation"
-        ]
+        "excludePaths": ["/introduction", "/confirmation"]
       }
     }
   },

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -779,8 +779,8 @@ module.exports = function registerFilters() {
       } = /** @type {{path: string, children: array}} */ (crumb);
       let { name } = /** @type {{name: string}} */ (crumb);
 
-      // Replace hyphens in the name with spaces
-      name = name.replace('-', ' ');
+      // // Replace hyphens in the name with spaces
+      // name = name.replace('-', ' '); // commenting this out to ensure proper functionality
 
       // Capitalize the first letter of the name
       name = name.charAt(0).toUpperCase() + name.slice(1);

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -945,7 +945,7 @@ describe('formatForBreadcrumbsHTML', () => {
     // Verify output
     expect(output).to.eq(
       JSON.stringify(
-        '[{"href":"/","isRouterLink":false,"label":"VA.gov home","lang":"en-US"},{"href":"/view-change-dependents/","isRouterLink":false,"label":"View or change dependents on your VA disability benefits","lang":"en-US"},{"href":"/view-change-dependents/add-remove-form-21-686c-v2/","isRouterLink":false,"label":"Add or remove dependents with VA Form 21 686C","lang":"en-US"}]',
+        '[{"href":"/","isRouterLink":false,"label":"VA.gov home","lang":"en-US"},{"href":"/view-change-dependents/","isRouterLink":false,"label":"View or change dependents on your VA disability benefits","lang":"en-US"},{"href":"/view-change-dependents/add-remove-form-21-686c-v2/","isRouterLink":false,"label":"Add or remove dependents with VA Form 21-686C","lang":"en-US"}]',
       ),
     );
   });
@@ -970,7 +970,7 @@ describe('formatForBreadcrumbsHTML', () => {
     // Verify output
     expect(output).to.eq(
       JSON.stringify(
-        '[{"href":"/","isRouterLink":false,"label":"VA.gov home","lang":"en-US"},{"href":"/view-change-dependents/","isRouterLink":false,"label":"View or change dependents on your VA disability benefits","lang":"en-US"},{"href":"/view-change-dependents/add-remove-form-21-686c-v2/","isRouterLink":false,"label":"Add or remove dependents with VA Form 21 686C","lang":"en-US"}]',
+        '[{"href":"/","isRouterLink":false,"label":"VA.gov home","lang":"en-US"},{"href":"/view-change-dependents/","isRouterLink":false,"label":"View or change dependents on your VA disability benefits","lang":"en-US"},{"href":"/view-change-dependents/add-remove-form-21-686c-v2/","isRouterLink":false,"label":"Add or remove dependents with VA Form 21-686C","lang":"en-US"}]',
       ),
     );
   });


### PR DESCRIPTION
## Summary

- Remove hyphen filter to avoid improper output in breadcrumbs.

Original:
<img width="377" alt="image" src="https://github.com/user-attachments/assets/b654e236-d31e-4949-9983-3d67d1860ee7">

Fixed: 
![image](https://github.com/user-attachments/assets/571166cf-b735-489e-b184-8c9112d9ec80)


