### PR TITLE
Revert "Remove build timeout until we know why content release is slow."

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -91,7 +91,7 @@ jobs:
     runs-on: [self-hosted, asg]
     needs:
       - validate-build-status
-    # timeout-minutes: 75
+    timeout-minutes: 75
     defaults:
       run:
         working-directory: content-build


### PR DESCRIPTION
The conditions that required this change have passed, and we do want the timeout to alert us if content-release is taking too long.

Reverts department-of-veterans-affairs/content-build#2321