### PR TITLE
Disable connected devices app

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1038,7 +1038,7 @@
     "entryName": "dhp-consent-flow",
     "rootUrl": "/health-care/connected-devices",
     "template": {
-      "vagovprod": true,
+      "vagovprod": false,
       "layout": "page-react.html",
       "title": "Connected Devices"
     }


### PR DESCRIPTION
## Summary

- This app is slated to be decommissioned by the health portfolio. It already gives a 404, but doing this to make things extra clear.