### PR TITLE
VACMS-19255 Remove CMS feature toggle from Find Forms

### DIFF
--- a/src/site/components/va_related_form.drupal.liquid
+++ b/src/site/components/va_related_form.drupal.liquid
@@ -11,36 +11,17 @@
 
 {{ vaForm.fieldVaFormUsage.processed }}
 
-{% assign showPDFModal = ''| featureFindFormsPDFModal %}
-
-{% if showPDFModal %}
-  <div id="{{ vaForm.fieldVaFormNumber }}-download-button-{{ vaForm.fieldVaFormLanguage }}-parent">
-    <button
-      class="va-button-link vads-u-display--flex vads-u-align-items--center"
-      data-widget-type="find-va-forms-pdf-download-helper"
-      data-href="{{ vaForm.fieldVaFormUrl.uri }}"
-      data-form-number="{{ vaForm.fieldVaFormNumber }}"
-      id="{{ vaForm.fieldVaFormNumber }}-download-button-{{ vaForm.fieldVaFormLanguage }}"
-      lang="{{ vaForm.fieldVaFormLanguage }}"
-    >
-      {% assign translatedDownloadText = vaForm.fieldVaFormLanguage | deriveLanguageTranslation: 'downloadVaForm', vaForm.fieldVaFormNumber %}
-      <va-icon class="vads-u-margin-right--0p5" icon="file_download" size="3"></va-icon>
-      {{ translatedDownloadText }} (PDF)
-    </button>
-  </div>
-{% else %}
-  <a
-    href="{{ vaForm.fieldVaFormUrl.uri }}"
-    download
+<div id="{{ vaForm.fieldVaFormNumber }}-download-button-{{ vaForm.fieldVaFormLanguage }}-parent">
+  <button
+    class="va-button-link vads-u-display--flex vads-u-align-items--center"
+    data-widget-type="find-va-forms-pdf-download-helper"
+    data-href="{{ vaForm.fieldVaFormUrl.uri }}"
     data-form-number="{{ vaForm.fieldVaFormNumber }}"
+    id="{{ vaForm.fieldVaFormNumber }}-download-button-{{ vaForm.fieldVaFormLanguage }}"
     lang="{{ vaForm.fieldVaFormLanguage }}"
-    >
-      <va-icon
-        class="vads-u-margin-right--0p5"
-        icon="file_download"
-        size="3"
-      ></va-icon>
-      {% assign translatedDownloadText = vaForm.fieldVaFormLanguage | deriveLanguageTranslation: 'downloadVaForm', vaForm.fieldVaFormNumber %}
-      {{ translatedDownloadText }} (PDF)
-  </a>
-{% endif %}
+  >
+    {% assign translatedDownloadText = vaForm.fieldVaFormLanguage | deriveLanguageTranslation: 'downloadVaForm', vaForm.fieldVaFormNumber %}
+    <va-icon class="vads-u-margin-right--0p5" icon="file_download" size="3"></va-icon>
+    {{ translatedDownloadText }} (PDF)
+  </button>
+</div>

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -2241,8 +2241,4 @@ module.exports = function registerFilters() {
     }
     return null;
   };
-
-  liquid.filters.featureFindFormsPDFModal = () => {
-    return cmsFeatureFlags.FEATURE_FIND_FORMS_MODAL;
-  };
 };

--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -90,39 +90,20 @@
           <h2 class="vads-u-margin-bottom--2">Downloadable PDF</h2>
         {% endif %}
 
-        {% assign showPDFModal = ''| featureFindFormsPDFModal %}
-
-        {% if showPDFModal %}
-          <div id="main-download-container">
-            <button
-              class="va-button-link vads-u-display--flex vads-u-align-items--center"
-              data-widget-type="find-va-forms-pdf-download-helper"
-              data-href="{{ fieldVaFormUrl.uri }}"
-              data-form-number="{{ fieldVaFormNumber }}"
-              id="main-download-button"
-              lang="{{ fieldVaFormLanguage }}"
-            >
-              {% assign translatedDownloadText = fieldVaFormLanguage | deriveLanguageTranslation: 'downloadVaForm', fieldVaFormNumber %}
-              <va-icon class="vads-u-margin-right--0p5" icon="file_download" size="3"></va-icon>
-              {{ translatedDownloadText }} (PDF)
-            </button>
-          </div>
-        {% else %}
-          <a
-            href="{{ fieldVaFormUrl.uri }}"
-            download
+        <div id="main-download-container">
+          <button
+            class="va-button-link vads-u-display--flex vads-u-align-items--center"
+            data-widget-type="find-va-forms-pdf-download-helper"
+            data-href="{{ fieldVaFormUrl.uri }}"
             data-form-number="{{ fieldVaFormNumber }}"
+            id="main-download-button"
             lang="{{ fieldVaFormLanguage }}"
           >
-              <va-icon
-                class="vads-u-margin-right--0p5"
-                icon="file_download"
-                size="3"
-              ></va-icon>
             {% assign translatedDownloadText = fieldVaFormLanguage | deriveLanguageTranslation: 'downloadVaForm', fieldVaFormNumber %}
+            <va-icon class="vads-u-margin-right--0p5" icon="file_download" size="3"></va-icon>
             {{ translatedDownloadText }} (PDF)
-          </a>
-        {% endif %}
+          </button>
+        </div>
 
         {% if fieldVaFormUpload %}
           <div


### PR DESCRIPTION
## Summary
In https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18855, we re-added the download modal to form detail pages. This required implementing a feature toggle for the content-build changes and a feature toggle for the vets-api changes. This work is for removing the feature toggle used for the form detail page.

The markup for the form detail page should be a `<button>` and never an `<a>`.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19255

## Testing done
- Regression testing for the form search results (nothing changed; this only changes the form detail pages)
- Tested the modal opening for a form detail page with one modal trigger
- Tested the modal opening for a form detail page with multiple modal triggers (e.g. has related forms)
- Tested the errors for when part of the data calls fail on the form detail page

## Screenshots

<details><summary>Regression check: form search results</summary>

<img width="600" alt="Screenshot 2024-10-25 at 7 54 35 AM" src="https://github.com/user-attachments/assets/bdd5d6e5-c1e2-4b5a-921e-f93ddc7cb0a7">

</details>

<details><summary>Form detail page: modal opens for a single trigger (form 10-10m)</summary>

<img width="600" alt="Screenshot 2024-10-25 at 8 03 53 AM" src="https://github.com/user-attachments/assets/47a0adf2-f080-42d2-acec-d4e7dbf63234">

</details>

<details><summary>Form detail page: modal opens for multiple triggers (form 10-0003k & 10-0003k-2)</summary>

#### 10-0003k

<img width="600" alt="Screenshot 2024-10-25 at 8 04 18 AM" src="https://github.com/user-attachments/assets/5007eb8d-50f9-42b6-b2db-71e1341b549f">

<img width="525" alt="Screenshot 2024-10-25 at 8 04 52 AM" src="https://github.com/user-attachments/assets/6c1d3571-26ad-487a-b797-ad874602c296">
<img width="471" alt="Screenshot 2024-10-25 at 8 05 03 AM" src="https://github.com/user-attachments/assets/c4d49b87-592f-4020-9956-c11cb7d82ed5">

#### 10-0003k-2

<img width="600" alt="Screenshot 2024-10-25 at 8 04 25 AM" src="https://github.com/user-attachments/assets/7048565a-0d88-4aaf-80eb-be86f2f7f053">

<img width="509" alt="Screenshot 2024-10-25 at 8 05 11 AM" src="https://github.com/user-attachments/assets/8eaa3543-9d66-46e6-992c-9904d53ded0a">
<img width="470" alt="Screenshot 2024-10-25 at 8 05 20 AM" src="https://github.com/user-attachments/assets/d2052ab7-a48b-45db-a4f3-d7f5675f1330">

</details>

<details><summary>Error banners when parts of the data calls don't work</summary>

#### Single trigger
<img width="600" alt="Screenshot 2024-10-25 at 8 08 34 AM" src="https://github.com/user-attachments/assets/8184a26c-7001-4493-907c-bef04975965c">

#### Multiple triggers

<img width="600" alt="Screenshot 2024-10-25 at 8 08 23 AM" src="https://github.com/user-attachments/assets/6d9d01b6-c961-4a38-a258-0b15559891ff">

</details>

## What areas of the site does it impact?

Find Forms **detail pages only**

## Acceptance criteria

- [x] Forms detail pages for forms with related forms (e.g. https://www.va.gov/find-forms/about-form-10-10ez) should still work as expected:
  - [x] Correct form download buttons appear for the primary form and the related forms
  - [x] When clicking on download buttons, the modal should appear with the correct download link
- [x] Forms detail pages for forms without related forms (e.g. https://www.va.gov/find-forms/about-form-10-10065/) should still work as expected:
  - [x] Correct form download buttons appear for the primary form and the related forms
  - [x] When clicking on download buttons, the modal should appear with the correct download link