### PR TITLE
VACMS 17866 billing and insurance phone number paragraphs

### DIFF
--- a/src/site/components/phone-number.drupal.liquid
+++ b/src/site/components/phone-number.drupal.liquid
@@ -10,7 +10,15 @@
     {% assign tty = true %}
   {% endif %}
   <h{{ phoneHeaderLevel }}>{{ phoneLabel | default: 'Phone' }}</h{{ phoneHeaderLevel }}>
-  <div>
+  {% if useParagraph %}
+    <p>
+  {% else %}
+    <div>
+  {% endif %}
     {% include "src/site/components/phone-number-base.drupal.liquid" %}
-  </div>
+  {% if useParagraph %}
+    </p>
+  {% else %}
+    </div>
+  {% endif %}
 {% endif %}

--- a/src/site/includes/facilityListing.drupal.liquid
+++ b/src/site/includes/facilityListing.drupal.liquid
@@ -42,9 +42,6 @@
            <strong>VA health connect:</strong> {{ fieldVaHealthConnectPhone | processPhoneToVaTelephoneOrFallback : '',  'VA health connect' }}
          </div>
       {% endif %}
-      <script>
-        console.log("SSSSS", {{ enabledFeatureFlags.FEATURE_TELEPHONE_MIGRATION_V1|json}})
-      </script>
       {% if entity.fieldTelephone and enabledFeatureFlags.FEATURE_TELEPHONE_MIGRATION_V1 %}
         <div>
           {% include "src/site/components/phone-number-no-header.drupal.liquid" with

--- a/src/site/layouts/vamc_system_billing_insurance.drupal.liquid
+++ b/src/site/layouts/vamc_system_billing_insurance.drupal.liquid
@@ -39,7 +39,16 @@
                 immunizations.
               </p>
             {% endif %}
-            {% if fieldPhoneNumber %}
+            {% if fieldTelephone and enabledFeatureFlags.FEATURE_TELEPHONE_MIGRATION_V1 %}
+                {% include "src/site/components/phone-number.drupal.liquid" with 
+                  phoneHeaderLevel = 3
+                  useParagraph = true 
+                  phoneNumber = fieldTelephone.entity.fieldPhoneNumber
+                  phoneExtension = fieldTelephone.entity.fieldPhoneExtension
+                  phoneNumberType = fieldTelephone.entity.fieldPhoneNumberType
+                  phoneLabel = fieldTelephone.entity.fieldPhoneLabel
+                %}
+            {% elsif fieldPhoneNumber and !enabledFeatureFlags.FEATURE_TELEPHONE_MIGRATION_V1 %}
               <h3>
                 Phone
               </h3>

--- a/src/site/stages/build/drupal/graphql/vamcBillingAndInsurancePage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vamcBillingAndInsurancePage.graphql.js
@@ -1,5 +1,6 @@
 const healthCareRegionNonClinicialServices = require('./facilities-fragments/healthCareRegionNonClinicialServices.node.graphql');
 const entityElementsFromPages = require('./entityElementsForPages.graphql');
+const phoneNumberParagraphGraphql = require('./paragraph-fragments/phoneNumber.paragraph.graphql');
 
 const billingAndInsuranceFragment = `
   fragment billingAndInsuranceFragment on NodeVamcSystemBillingInsurance {
@@ -12,6 +13,13 @@ const billingAndInsuranceFragment = `
       path
     }
     fieldPhoneNumber
+    fieldTelephone {
+      ... on FieldNodeVamcSystemBillingInsuranceFieldTelephone {
+        entity {
+          ... phoneNumber
+        }
+      }
+    }
     fieldOfficeHours {
       day
       starthours
@@ -48,8 +56,9 @@ const billingAndInsuranceFragment = `
 `;
 
 const GetBillingAndInsurancePages = `
+  ${phoneNumberParagraphGraphql}
   ${billingAndInsuranceFragment}
-
+  
   query GetBillingAndInsurancePages($onlyPublishedContent: Boolean!) {
     nodeQuery(limit: 500, filter: {
       conditions: [


### PR DESCRIPTION
## Summary

- Adds Billing and Insurance Paragraph usage

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17866

## Testing done

- Used to use fieldPhone and now uses fieldTelephone paragraph type and modified heading-inclusive template.
- Manually tested

## Screenshots

<details>
<summary>PR</summary>
<img width="1728" alt="Screenshot 2024-10-25 at 5 23 01 PM" src="https://github.com/user-attachments/assets/918b4a7c-49c2-4774-9290-9741091965f8">
</details>


<details>
<summary>Prior/current va.gov</summary>
<img width="1728" alt="Screenshot 2024-10-25 at 5 23 11 PM" src="https://github.com/user-attachments/assets/7dbf5926-c55c-43a6-95f1-048a635988f0">
</details>



## What areas of the site does it impact?

Billing and Insurance pages of the VAMC Systems

## Acceptance criteria

- [x] If type Fax is selected, number is not clickable
- [x] If type SMS is selected, number uses the `sms` prop
- [x] If type TTY is selected, number shows "TTY"
- [x] Exts are displayed and parsed correctly
- [x] The existing hardcoded label displays
- [ ] Requires accessibility review


### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Test Billing and Insurance pages e.g. `/white-river-junction-health-care/billing-and-insurance`