### PR TITLE
VATEAM-94709: Normalize Your Personal Information chapter

### DIFF
--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/digitalForm.graphql.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/digitalForm.graphql.js
@@ -1,7 +1,6 @@
 const address = require('./address.graphql');
-const identificationInformation = require('./identificationInformation.graphql');
-const nameAndDateOfBirth = require('./nameAndDateOfBirth.graphql');
 const phoneAndEmail = require('./phoneAndEmail.graphql');
+const yourPersonalInformation = require('./yourPersonalInformation.graphql');
 
 /*
  *
@@ -10,9 +9,8 @@ const phoneAndEmail = require('./phoneAndEmail.graphql');
  */
 module.exports = `
   ${address}
-  ${identificationInformation}
-  ${nameAndDateOfBirth}
   ${phoneAndEmail}
+  ${yourPersonalInformation}
 
   fragment digitalForm on NodeDigitalForm {
     nid
@@ -33,9 +31,8 @@ module.exports = `
           }
         }
         ...address
-        ...identificationInformation
-        ...nameAndDateOfBirth
         ...phoneAndEmail
+        ...yourPersonalInformation
       }
     }
   }

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/yourPersonalInformation.graphql.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/yourPersonalInformation.graphql.js
@@ -1,0 +1,28 @@
+const identificationInformation = require('./identificationInformation.graphql');
+const nameAndDateOfBirth = require('./nameAndDateOfBirth.graphql');
+
+/*
+ *
+ * The "Your personal information" Digital Form pattern.
+ *
+ * Pattern documentation:
+ * https://github.com/department-of-veterans-affairs/vets-website/blob/0ae48c0b017a37d84f6ae425c67c332f4c67fb8b/src/applications/simple-forms/mock-simple-forms-patterns-v3/config/form.js#L40
+ *
+ */
+module.exports = `
+  ${identificationInformation}
+  ${nameAndDateOfBirth}
+
+  fragment yourPersonalInformation on ParagraphDigitalFormYourPersonalInfo {
+    fieldNameAndDateOfBirth {
+      entity {
+        ...nameAndDateOfBirth
+      }
+    }
+    fieldIdentificationInformation {
+      entity {
+        ...identificationInformation
+      }
+    }
+  }
+`;

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
@@ -32,14 +32,25 @@ const formatDate = dateString => {
   return `${removeLeadingZero(month)}/${removeLeadingZero(day)}/${year}`;
 };
 
+const stripPrefix = label => label.replace('Digital Form: ', '');
+
 const normalizeChapter = ({ entity }) => {
-  return {
+  const type = entity.type.entity.entityId;
+  const initialChapter = {
     id: parseInt(entity.entityId, 10),
-    chapterTitle: entity.fieldTitle,
-    type: entity.type.entity.entityId,
-    pageTitle: entity.type.entity.entityLabel.replace('Digital Form: ', ''),
+    pageTitle: stripPrefix(entity.type.entity.entityLabel),
     additionalFields: extractAdditionalFields(entity),
+    type,
   };
+
+  if (type === 'digital_form_your_personal_info') {
+    return {
+      ...initialChapter,
+      chapterTitle: stripPrefix(entity.type.entity.entityLabel),
+    };
+  }
+
+  return { ...initialChapter, chapterTitle: entity.fieldTitle };
 };
 
 const normalizeForm = (form, logger = logDrupal) => {

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
@@ -8,14 +8,6 @@ const extractAdditionalFields = entity => {
       return {
         militaryAddressCheckbox: entity.fieldMilitaryAddressCheckbox,
       };
-    case 'digital_form_identification_info':
-      return {
-        includeServiceNumber: entity.fieldIncludeVeteranSService,
-      };
-    case 'digital_form_name_and_date_of_bi':
-      return {
-        includeDateOfBirth: entity.fieldIncludeDateOfBirth,
-      };
     case 'digital_form_phone_and_email':
       return {
         includeEmail: entity.fieldIncludeEmail,
@@ -38,19 +30,37 @@ const normalizeChapter = ({ entity }) => {
   const type = entity.type.entity.entityId;
   const initialChapter = {
     id: parseInt(entity.entityId, 10),
-    pageTitle: stripPrefix(entity.type.entity.entityLabel),
-    additionalFields: extractAdditionalFields(entity),
     type,
   };
 
   if (type === 'digital_form_your_personal_info') {
+    const identificationInformation =
+      entity.fieldIdentificationInformation.entity;
+    const nameAndDateOfBirth = entity.fieldNameAndDateOfBirth.entity;
+
     return {
       ...initialChapter,
       chapterTitle: stripPrefix(entity.type.entity.entityLabel),
+      pages: [
+        {
+          pageTitle: nameAndDateOfBirth.fieldTitle,
+          includeDateOfBirth: nameAndDateOfBirth.fieldIncludeDateOfBirth,
+        },
+        {
+          pageTitle: identificationInformation.fieldTitle,
+          includeServiceNumber:
+            identificationInformation.fieldIncludeVeteranSService,
+        },
+      ],
     };
   }
 
-  return { ...initialChapter, chapterTitle: entity.fieldTitle };
+  return {
+    ...initialChapter,
+    additionalFields: extractAdditionalFields(entity),
+    chapterTitle: entity.fieldTitle,
+    pageTitle: stripPrefix(entity.type.entity.entityLabel),
+  };
 };
 
 const normalizeForm = (form, logger = logDrupal) => {

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fixtures/queryResult.json
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fixtures/queryResult.json
@@ -14,15 +14,25 @@
           "fieldChapters": [
             {
               "entity": {
-                "entityId": "157904",
+                "entityId": "162008",
                 "type": {
                   "entity": {
-                    "entityId": "digital_form_name_and_date_of_bi",
-                    "entityLabel": "Digital Form: Name and Date of Birth"
+                    "entityId": "digital_form_your_personal_info",
+                    "entityLabel": "Digital Form: Your personal information"
                   }
                 },
-                "fieldTitle": "The Only Step",
-                "fieldIncludeDateOfBirth": true
+                "fieldNameAndDateOfBirth": {
+                  "entity": {
+                    "fieldTitle": "Name",
+                    "fieldIncludeDateOfBirth": true
+                  }
+                },
+                "fieldIdentificationInformation": {
+                  "entity": {
+                    "fieldTitle": "Identification information",
+                    "fieldIncludeVeteranSService": false
+                  }
+                }
               }
             }
           ]
@@ -39,28 +49,25 @@
           "fieldChapters": [
             {
               "entity": {
-                "entityId": "157906",
+                "entityId": "162008",
                 "type": {
                   "entity": {
-                    "entityId": "digital_form_name_and_date_of_bi",
-                    "entityLabel": "Digital Form: Name and Date of Birth"
+                    "entityId": "digital_form_your_personal_info",
+                    "entityLabel": "Digital Form: Your personal information"
                   }
                 },
-                "fieldTitle": "First Step",
-                "fieldIncludeDateOfBirth": true
-              }
-            },
-            {
-              "entity": {
-                "entityId": "157907",
-                "type": {
+                "fieldNameAndDateOfBirth": {
                   "entity": {
-                    "entityId": "digital_form_name_and_date_of_bi",
-                    "entityLabel": "Digital Form: Name and Date of Birth"
+                    "fieldTitle": "Name and Date of Birth",
+                    "fieldIncludeDateOfBirth": true
                   }
                 },
-                "fieldTitle": "Second Step",
-                "fieldIncludeDateOfBirth": false
+                "fieldIdentificationInformation": {
+                  "entity": {
+                    "fieldTitle": "Identification information",
+                    "fieldIncludeVeteranSService": false
+                  }
+                }
               }
             },
             {
@@ -74,19 +81,6 @@
                 },
                 "fieldTitle": "Generated Address",
                 "fieldMilitaryAddressCheckbox": false
-              }
-            },
-            {
-              "entity": {
-                "entityId": "160594",
-                "type": {
-                  "entity": {
-                    "entityId": "digital_form_identification_info",
-                    "entityLabel": "Digital Form: Identification Information"
-                  }
-                },
-                "fieldTitle": "Identification information",
-                "fieldIncludeVeteranSService": true
               }
             },
             {

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/digitalForm.graphql.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/digitalForm.graphql.unit.spec.js
@@ -18,16 +18,13 @@ describe('digitalForm fragment', () => {
   });
 
   describe('chapter fragments', () => {
-    [
-      'address',
-      'identificationInformation',
-      'nameAndDateOfBirth',
-      'phoneAndEmail',
-    ].forEach(fragment => {
-      it(`imports the ${fragment} fragment`, () => {
-        expect(digitalForm).to.have.string(`fragment ${fragment}`);
-        expect(digitalForm).to.have.string(`...${fragment}`);
-      });
-    });
+    ['address', 'phoneAndEmail', 'yourPersonalInformation'].forEach(
+      fragment => {
+        it(`imports the ${fragment} fragment`, () => {
+          expect(digitalForm).to.have.string(`fragment ${fragment}`);
+          expect(digitalForm).to.have.string(`...${fragment}`);
+        });
+      },
+    );
   });
 });

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/yourPersonalInformation.graphql.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/yourPersonalInformation.graphql.unit.spec.js
@@ -1,0 +1,13 @@
+/* eslint-disable @department-of-veterans-affairs/axe-check-required */
+
+import { expect } from 'chai';
+import yourPersonalInformation from '../../fragments/yourPersonalInformation.graphql';
+
+describe('yourPersonalInformation fragment', () => {
+  ['identificationInformation', 'nameAndDateOfBirth'].forEach(fragment => {
+    it(`imports the ${fragment} fragment`, () => {
+      expect(yourPersonalInformation).to.have.string(`fragment ${fragment}`);
+      expect(yourPersonalInformation).to.have.string(`...${fragment}`);
+    });
+  });
+});

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/postProcessDigitalForm.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/postProcessDigitalForm.unit.spec.js
@@ -51,8 +51,6 @@ describe('postProcessDigitalForm', () => {
     describe('additionalFields', () => {
       [
         ['digital_form_address', 'militaryAddressCheckbox', false],
-        // ['digital_form_identification_info', 'includeServiceNumber', true],
-        // ['digital_form_name_and_date_of_bi', 'includeDateOfBirth', true],
         ['digital_form_phone_and_email', 'includeEmail', false],
       ].forEach(([type, additionalField, value]) => {
         context(`with a ${type} step`, () => {

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/postProcessDigitalForm.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/postProcessDigitalForm.unit.spec.js
@@ -17,6 +17,7 @@ describe('postProcessDigitalForm', () => {
     });
 
     it('returns a normalized JSON object', () => {
+      const queryChapter = manyStepEntity.fieldChapters[1].entity;
       const testChapter = testForm.chapters[1];
 
       expect(testForm.cmsId).to.eq(71004);
@@ -25,9 +26,9 @@ describe('postProcessDigitalForm', () => {
       expect(testForm.chapters.length).to.eq(
         manyStepEntity.fieldChapters.length,
       );
-      expect(testChapter.id).to.eq(157907);
-      expect(testChapter.chapterTitle).to.eq('Second Step');
-      expect(testChapter.type).to.eq('digital_form_name_and_date_of_bi');
+      expect(testChapter.id).to.eq(Number(queryChapter.entityId));
+      expect(testChapter.chapterTitle).to.eq(queryChapter.fieldTitle);
+      expect(testChapter.type).to.eq(queryChapter.type.entity.entityId);
       expect(Object.keys(testChapter.additionalFields).length).to.eq(1);
     });
 
@@ -44,14 +45,14 @@ describe('postProcessDigitalForm', () => {
     it('removes the "Digital Form" prefix', () => {
       const [, testChapter] = testForm.chapters;
 
-      expect(testChapter.pageTitle).to.eq('Name and Date of Birth');
+      expect(testChapter.pageTitle).to.eq('Address');
     });
 
     describe('additionalFields', () => {
       [
         ['digital_form_address', 'militaryAddressCheckbox', false],
-        ['digital_form_identification_info', 'includeServiceNumber', true],
-        ['digital_form_name_and_date_of_bi', 'includeDateOfBirth', true],
+        // ['digital_form_identification_info', 'includeServiceNumber', true],
+        // ['digital_form_name_and_date_of_bi', 'includeDateOfBirth', true],
         ['digital_form_phone_and_email', 'includeEmail', false],
       ].forEach(([type, additionalField, value]) => {
         context(`with a ${type} step`, () => {
@@ -64,6 +65,25 @@ describe('postProcessDigitalForm', () => {
           });
         });
       });
+    });
+
+    describe('Your personal information', () => {
+      let ypiChapter;
+
+      beforeEach(() => {
+        ypiChapter = testForm.chapters.find(
+          chapter => chapter.type === 'digital_form_your_personal_info',
+        );
+      });
+
+      it('includes the correct chapter title', () => {
+        expect(ypiChapter.chapterTitle).to.eq('Your personal information');
+      });
+
+      it('includes a Name and Date of Birth page');
+      it('includes an Identification information page');
+      it('includes the includeDateOfBirth key');
+      it('includes the includeServiceNumber key');
     });
   });
 

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/postProcessDigitalForm.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/postProcessDigitalForm.unit.spec.js
@@ -69,6 +69,7 @@ describe('postProcessDigitalForm', () => {
 
     describe('Your personal information', () => {
       let ypiChapter;
+      const queryYpi = manyStepEntity.fieldChapters[0].entity;
 
       beforeEach(() => {
         ypiChapter = testForm.chapters.find(
@@ -80,10 +81,25 @@ describe('postProcessDigitalForm', () => {
         expect(ypiChapter.chapterTitle).to.eq('Your personal information');
       });
 
-      it('includes a Name and Date of Birth page');
-      it('includes an Identification information page');
-      it('includes the includeDateOfBirth key');
-      it('includes the includeServiceNumber key');
+      it('includes a Name and Date of Birth page', () => {
+        const nameAndDateOfBirth = ypiChapter.pages[0];
+        const queryNdob = queryYpi.fieldNameAndDateOfBirth.entity;
+
+        expect(nameAndDateOfBirth.pageTitle).to.eq(queryNdob.fieldTitle);
+        expect(nameAndDateOfBirth.includeDateOfBirth).to.eq(
+          queryNdob.fieldIncludeDateOfBirth,
+        );
+      });
+
+      it('includes an Identification information page', () => {
+        const identificationInformation = ypiChapter.pages[1];
+        const queryIi = queryYpi.fieldIdentificationInformation.entity;
+
+        expect(identificationInformation.pageTitle).to.eq(queryIi.fieldTitle);
+        expect(identificationInformation.includeServiceNumber).to.eq(
+          queryIi.fieldIncludeVeteranSService,
+        );
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

- Normalizes the "Your personal information" Paragraph type created by department-of-veterans-affairs/va.gov-cms#19534

### Example output
```json
     {
        "id": 162013,
        "type": "digital_form_your_personal_info",
        "chapterTitle": "Your personal information",
        "pages": [
          {
            "pageTitle": "Name and date of birth",
            "includeDateOfBirth": true
          },
          {
            "pageTitle": "Identification information",
            "includeServiceNumber": true
          }
        ]
      }
```

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#94709

## Testing done

- Added unit tests to the Digital Form post processor, the Digital Form GraphQL fragment, and the `yourPersonalInformation` GraphQL fragment
- Pulled local Drupal data and confirmed the resulting output from `content-build`

## What areas of the site does it impact?

Only affects the output of `digital-forms.json`.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

This PR introduces a `pages` array to the normalized output. I notably did _not_ update the other chapter types to use the `pages` array and left the `pageTitle` key on the root level of the chapter for those chapter types. This makes sense to me in the context of how we're currently determining page and chapter titles for chapters with only one page, but let me know if you have a different opinion.