### PR TITLE
Add codeowner for /src/site/layouts/accredited-representative-portal.…

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,6 +24,9 @@ src/site/layouts @department-of-veterans-affairs/vfs-public-websites-frontend @d
 src/site/teasers @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/vfs-facilities-frontend
 src/site/filters @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/vfs-facilities-frontend
 
+# Accredited representative
+src/site/layouts/accredited-representative-portal.html @department-of-veterans-affairs/benefits-accredited-rep-facing-engineers
+
 # Facility Locator and VAMC pages
 ## Multiple Facility types
 src/site/facilities @department-of-veterans-affairs/vfs-facilities-frontend


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/layouts/accredited-representative-portal.html doesn't have a declared codeowner. 

https://dsva.slack.com/archives/C05SUUM4GAW/p1730481486176719?thread_ts=1730479925.755819&cid=C05SUUM4GAW
Per @nihil2501 : 
>  This is the team that owns it: https://github.com/orgs/department-of-veterans-affairs/teams/benefits-accredited-rep-facing-engineers
