### PR TITLE
[VACMS-19449]Add situation updates banner for vets-website to manipulate

### DIFF
--- a/src/site/components/banners.drupal.liquid
+++ b/src/site/components/banners.drupal.liquid
@@ -17,6 +17,13 @@
   >{{ banner.body.processed }}</va-banner>
 {% endfor %}
 
+<!-- Situation Updates banner -->
+<div
+  aria-label="Situation updates banner"
+  data-widget-type="situation-updates-banner"
+  role="region"
+></div>
+
 <!-- Maintenance banner -->
 <div
   aria-label="Maintenance banner"

--- a/src/site/components/banners.drupal.liquid
+++ b/src/site/components/banners.drupal.liquid
@@ -18,16 +18,10 @@
 {% endfor %}
 
 <!-- Situation Updates banner -->
-<div
-  data-widget-type="situation-updates-banner"
-  role="region"
-></div>
+<div data-widget-type="situation-updates-banner"></div>
 
 <!-- Maintenance banner -->
-<div
-  data-widget-type="maintenance-banner"
-  role="region"
-></div>
+<div data-widget-type="maintenance-banner"></div>
 
 <!-- Derive visible promo banners. -->
 {% assign visiblePromoBanners = promoBanners.entities | deriveVisibleBanners: entityUrl.path %}

--- a/src/site/components/banners.drupal.liquid
+++ b/src/site/components/banners.drupal.liquid
@@ -19,14 +19,12 @@
 
 <!-- Situation Updates banner -->
 <div
-  aria-label="Situation updates banner"
   data-widget-type="situation-updates-banner"
   role="region"
 ></div>
 
 <!-- Maintenance banner -->
 <div
-  aria-label="Maintenance banner"
   data-widget-type="maintenance-banner"
   role="region"
 ></div>


### PR DESCRIPTION
## Summary

- Add a situation updates banner to be utilized by vets-website to provide up quickly updatable banners
- Sitewide team
- No flipper involved as this element will not be visible to any users. The vets-website javascript that will interact with this will be kept behind a feature flag `banner_use_alternative_banners`.
- Removes aria labels to keep empty elements hidden from assistive tech

## Related issue(s)

- Issue: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19449
- Epic: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19302

## Testing done

- Verified new element does not appear to users viewing page

## Screenshots

No changes to UI.

## What areas of the site does it impact?

This affects most pages as it is included in the header element throughout the site

## Acceptance criteria
Element is available for vets-website to manipulate but is not visible to users

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

