### PR TITLE
VACMS-19516 Add container and toggle for Email Signup React widget

### DIFF
--- a/src/site/assets/sass/style.scss
+++ b/src/site/assets/sass/style.scss
@@ -80,6 +80,13 @@
   }
 }
 
+.homepage-email-update-wrapper {
+  .veteran-banner-container {
+    max-width: 80rem;
+    margin: 0 auto;
+  }
+}
+
 // START: Styles for mobile app promo banner
 #alert-with-additional-info {
 

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -2241,4 +2241,8 @@ module.exports = function registerFilters() {
     }
     return null;
   };
+
+  liquid.filters.featureEmailUpdateWidget = () => {
+    return cmsFeatureFlags.FEATURE_EMAIL_UPDATE_WIDGET;
+  };
 };

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -2242,7 +2242,7 @@ module.exports = function registerFilters() {
     return null;
   };
 
-  liquid.filters.featureEmailUpdateWidget = () => {
+  liquid.filters.showExistingEmailForm = () => {
     return cmsFeatureFlags.FEATURE_EMAIL_UPDATE_WIDGET;
   };
 };

--- a/src/site/includes/email-update-signup.drupal.liquid
+++ b/src/site/includes/email-update-signup.drupal.liquid
@@ -1,59 +1,61 @@
-<div class="homepage-email-update-wrapper vads-u-background-color--primary-alt-lightest">
-  <div class="vads-u-padding-x--2p5 vads-u-padding-top--2p5">
-    <div class="vads-u-display--flex vads-u-justify-content--center">
-      <div>
-        <div class="vads-u-margin-top--2p5 medium-screen:vads-u-margin-top--0">
-          <form
-            action="https://public.govdelivery.com/accounts/USVACHOOSE/subscribers/qualify"
-            accept-charset="UTF-8"
-            method="post"
-          >
-            <input type="hidden" name="utf8" value="✓">
-            <input type="hidden" name="category_id" id="category_id_top" value="USVACHOOSE_C1">
-            <input type="hidden" name="email" id="homepage-hidden-email" value="">
-            <va-text-input
-              autocomplete="email"
-              class="vads-u-width--full medium-screen:vads-u-width-auto homepage-email-input"
-              form-heading="Sign up to get the latest VA updates"
-              form-heading-level="2"
-              id="homepage-email-signup-input"
-              inputmode="email"
-              label="Email Address"
-              type="email"
-              use-forms-pattern="single"
-            /></va-text-input>
-            <button
-              onclick="recordMultipleEvents([
-                { 
-                  event: 'cta-button-click', 'button-type': 'primary', 'button-click-label': 'Sign up',  
-                },
-                { event: 'homepage-email-sign-up', action: 'Homepage email sign up' }
-                ]);"
-              type="submit"
-              class="vads-u-width--full
-                    medium-screen:vads-u-width--auto
-                    vads-u-display--block vads-u-margin-bottom--2">
-              Sign up
-            </button>
-          </form>
-        </div>
-      </div>
+<div class="homepage-email-update-wrapper vads-u-background-color--primary-alt-lightest vads-u-padding-x--2p5 vads-u-padding-top--2p5">
+  <div class="vads-u-display--flex vads-u-justify-content--center">
+    <div class="vads-u-margin-top--2p5 medium-screen:vads-u-margin-top--0">
+      {% assign shouldShowExistingEmailForm = '' | showExistingEmailForm %}
+
+      {% if true %}
+        <form
+          action="https://public.govdelivery.com/accounts/USVACHOOSE/subscribers/qualify"
+          accept-charset="UTF-8"
+          method="post"
+        >
+          <input type="hidden" name="utf8" value="✓">
+          <input type="hidden" name="category_id" id="category_id_top" value="USVACHOOSE_C1">
+          <input type="hidden" name="email" id="homepage-hidden-email" value="">
+          <va-text-input
+            autocomplete="email"
+            class="vads-u-width--full medium-screen:vads-u-width-auto homepage-email-input"
+            form-heading="Sign up to get the latest VA updates"
+            form-heading-level="2"
+            id="homepage-email-signup-input"
+            inputmode="email"
+            label="Email Address"
+            type="email"
+            use-forms-pattern="single"
+          /></va-text-input>
+          <button
+            onclick="recordMultipleEvents([
+              { 
+                event: 'cta-button-click', 'button-type': 'primary', 'button-click-label': 'Sign up',  
+              },
+              { event: 'homepage-email-sign-up', action: 'Homepage email sign up' }
+              ]);"
+            type="submit"
+            class="vads-u-width--full
+                  medium-screen:vads-u-width--auto
+                  vads-u-display--block vads-u-margin-bottom--2">
+            Sign up
+          </button>
+        </form>
+      {% else %}
+        <div data-widget-type="homepage-email-signup"></div>
+      {% endif %}
     </div>
-    <div id="vets-banner-1" class="vads-u-display--none medium-screen:vads-u-display--block">
-      <div class="veteran-banner-container vads-u-margin-y--0 vads-u-margin-x--auto">
-        <picture>
-          <source
-            srcset="https://s3-us-gov-west-1.amazonaws.com/content.www.va.gov/img/homepage/veterans-banner-mobile-1.png 640w, https://s3-us-gov-west-1.amazonaws.com/content.www.va.gov/img/homepage/veterans-banner-mobile-2.png 920w, https://s3-us-gov-west-1.amazonaws.com/content.www.va.gov/img/homepage/veterans-banner-mobile-3.png 1316w"
-            media="(max-width: 767px)">
-          <source
-            srcset="https://s3-us-gov-west-1.amazonaws.com/content.www.va.gov/img/homepage/veterans-banner-tablet-1.png 1008w, https://s3-us-gov-west-1.amazonaws.com/content.www.va.gov/img/homepage/veterans-banner-tablet-2.png 1887w"
-            media="(max-width: 1008px)">
-          <img class="vads-u-width--full"
-            src="https://s3-us-gov-west-1.amazonaws.com/content.www.va.gov/img/homepage/veterans-banner-desktop-1.png"
-            srcset="https://s3-us-gov-west-1.amazonaws.com/content.www.va.gov/img/homepage/veterans-banner-desktop-1.png 1280w, https://s3-us-gov-west-1.amazonaws.com/content.www.va.gov/img/homepage/veterans-banner-desktop-2.png 2494w"
-            loading="lazy" alt="Veteran portraits">
-        </picture>
-      </div>
+  </div>
+  <div id="vets-banner-1" class="vads-u-display--none medium-screen:vads-u-display--block">
+    <div class="veteran-banner-container vads-u-margin-y--0 vads-u-margin-x--auto">
+      <picture>
+        <source
+          srcset="https://s3-us-gov-west-1.amazonaws.com/content.www.va.gov/img/homepage/veterans-banner-mobile-1.png 640w, https://s3-us-gov-west-1.amazonaws.com/content.www.va.gov/img/homepage/veterans-banner-mobile-2.png 920w, https://s3-us-gov-west-1.amazonaws.com/content.www.va.gov/img/homepage/veterans-banner-mobile-3.png 1316w"
+          media="(max-width: 767px)">
+        <source
+          srcset="https://s3-us-gov-west-1.amazonaws.com/content.www.va.gov/img/homepage/veterans-banner-tablet-1.png 1008w, https://s3-us-gov-west-1.amazonaws.com/content.www.va.gov/img/homepage/veterans-banner-tablet-2.png 1887w"
+          media="(max-width: 1008px)">
+        <img class="vads-u-width--full"
+          src="https://s3-us-gov-west-1.amazonaws.com/content.www.va.gov/img/homepage/veterans-banner-desktop-1.png"
+          srcset="https://s3-us-gov-west-1.amazonaws.com/content.www.va.gov/img/homepage/veterans-banner-desktop-1.png 1280w, https://s3-us-gov-west-1.amazonaws.com/content.www.va.gov/img/homepage/veterans-banner-desktop-2.png 2494w"
+          loading="lazy" alt="Veteran portraits">
+      </picture>
     </div>
   </div>
 </div>

--- a/src/site/includes/email-update-signup.drupal.liquid
+++ b/src/site/includes/email-update-signup.drupal.liquid
@@ -3,7 +3,7 @@
     <div class="vads-u-margin-top--2p5 medium-screen:vads-u-margin-top--0">
       {% assign shouldShowExistingEmailForm = '' | showExistingEmailForm %}
 
-      {% if true %}
+      {% if shouldShowExistingEmailForm %}
         <form
           action="https://public.govdelivery.com/accounts/USVACHOOSE/subscribers/qualify"
           accept-charset="UTF-8"

--- a/src/site/layouts/home.drupal.liquid
+++ b/src/site/layouts/home.drupal.liquid
@@ -17,8 +17,8 @@
       </div>
     </div>
   </div>
-
   {% include "src/site/includes/email-update-signup.drupal.liquid" %}
+
 </main> <!-- end #content -->
 
 

--- a/src/site/layouts/home.drupal.liquid
+++ b/src/site/layouts/home.drupal.liquid
@@ -18,13 +18,7 @@
     </div>
   </div>
 
-  {% assign showEmailReactWidget = '' | featureEmailUpdateWidget %}
-
-  {% if showEmailReactWidget %}
-    <div data-widget-type="homepage-email-signup"></div>
-  {% else %}
-    {% include "src/site/includes/email-update-signup.drupal.liquid" %}
-  {% endif %}
+  {% include "src/site/includes/email-update-signup.drupal.liquid" %}
 </main> <!-- end #content -->
 
 

--- a/src/site/layouts/home.drupal.liquid
+++ b/src/site/layouts/home.drupal.liquid
@@ -17,8 +17,14 @@
       </div>
     </div>
   </div>
-  {% include "src/site/includes/email-update-signup.drupal.liquid" %}
 
+  {% assign showEmailReactWidget = '' | featureEmailUpdateWidget %}
+
+  {% if showEmailReactWidget %}
+    <div data-widget-type="homepage-email-signup"></div>
+  {% else %}
+    {% include "src/site/includes/email-update-signup.drupal.liquid" %}
+  {% endif %}
 </main> <!-- end #content -->
 
 


### PR DESCRIPTION
## Summary
Add the CMS feature toggle and empty `<div>` for the React widget for the email signup form.

**Note**: Feature toggle is currently **ON** in staging and production which means when this code is deployed to prod, we should continue to see the current/existing email form and not the new design.

<img width="700" alt="Screenshot 2024-11-04 at 10 58 02 AM" src="https://github.com/user-attachments/assets/d2dfebdc-bdd1-4f75-88ae-f535a25ed03b">

<img width="700" alt="Screenshot 2024-11-04 at 12 27 35 PM" src="https://github.com/user-attachments/assets/05d77b54-4c7e-4894-a873-7720312c4d75">



## Related issue(s)
Ticket: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19516

## Testing done (locally and in Tugboat)
1. Run `content-build` on the `19516-email-signup-widget` branch
  1a. comment everything but `...getNodePageQueries(entityCounts)` out in `individual-queries.js` to speed up the build
  1b. Point your CMS in the `.env` to `DRUPAL_ADDRESS=https://staging.cms.va.gov`
2. Run `vets-website` on `main`
3. Go to `localhost:3002` and validate that the original/current `Sign up to get the latest VA updates` form appears at the bottom of the homepage
4. Update your `.env` to `DRUPAL_ADDRESS=https://cms-g1rglcuobmlvgewnhny9uo7f6vigntwi.demo.cms.va.gov/` In this Tugboat, the feature toggle is OFF
5. Validate that you can only see the Veteran banner photos on desktop because the vets-website React widget has not yet been merged, and the (empty) container for it is replacing the original/current form. On mobile, you will see a narrow light blue box because the Veteran photos will not show, but this is not a realistic scenario that we need to account for.

## Screenshots

### Feature toggle is ON
<img width="800" alt="Screenshot 2024-11-01 at 3 26 20 PM" src="https://github.com/user-attachments/assets/09503414-436c-480b-81ca-dfa0d58d017a">

### Feature toggle is OFF
<img width="800" alt="Screenshot 2024-11-04 at 11 43 24 AM" src="https://github.com/user-attachments/assets/bd4601aa-409e-4483-b949-3765a7a88f30">

## What areas of the site does it impact?
Homepage email signup area only.

## Acceptance criteria
- [x] When the feature toggle is **ON**, the existing form will show
- [x] When the feature toggle is **OFF**, the new form will show