### PR TITLE
VACMS 18910 - Michelle M/Product is moving commonly treated conditions to CSV value

### DIFF
--- a/src/site/stages/build/drupal/static-data-files/vaHealthcareServices/index.js
+++ b/src/site/stages/build/drupal/static-data-files/vaHealthcareServices/index.js
@@ -80,10 +80,16 @@ const postProcess = queryResult => {
         description,
         fieldTricareDescription,
       } = service;
+
+      const processedCommon =
+        fieldCommonlyTreatedCondition
+          ?.split(',')
+          .map(condition => condition.trim()) || [];
+
       return [
         name,
         fieldAlsoKnownAs,
-        fieldCommonlyTreatedCondition,
+        processedCommon,
         fieldHealthServiceApiId,
         fieldServiceTypeOfCare,
         fieldShowForVetCenters,


### PR DESCRIPTION
## Summary

- Michelle M and Michael S discussed moving the commonly treated conditions to (when present) CSV in place of "and" terminated list
- Sitewide

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18910

## Testing done

- Manually tested from CMS

## Screenshots

N/A

## What areas of the site does it impact?

JSON creation postprocessing of Drupal loaded data

## Acceptance criteria

- See vets-website PR https://github.com/department-of-veterans-affairs/vets-website/pull/32930

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Check that `.cache/localhost/drupal/static-data-files/va-healthcare-services.json` is created with a second value per array that is now an array of strings.