### PR TITLE
VATEAM-93614: Normalize List and Loop pattern output

### DIFF
--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/digitalForm.graphql.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/digitalForm.graphql.js
@@ -1,6 +1,7 @@
 const address = require('./address.graphql');
 const phoneAndEmail = require('./phoneAndEmail.graphql');
 const yourPersonalInformation = require('./yourPersonalInformation.graphql');
+const listLoop = require('./listLoop.graphql');
 
 /*
  *
@@ -9,6 +10,7 @@ const yourPersonalInformation = require('./yourPersonalInformation.graphql');
  */
 module.exports = `
   ${address}
+  ${listLoop}
   ${phoneAndEmail}
   ${yourPersonalInformation}
 
@@ -31,6 +33,7 @@ module.exports = `
           }
         }
         ...address
+        ...listLoop
         ...phoneAndEmail
         ...yourPersonalInformation
       }

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/listLoop.graphql.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/listLoop.graphql.js
@@ -1,0 +1,14 @@
+/*
+ *
+ * The "List & Loop" Digital Form pattern.
+ *
+ * Pattern documentation:
+ * https://design.va.gov/patterns/ask-users-for/multiple-responses
+ *
+ */
+module.exports = `
+fragment listLoop on ParagraphDigitalFormListLoop {
+  fieldTitle
+  fieldOptional
+}
+`;

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
@@ -8,6 +8,10 @@ const extractAdditionalFields = entity => {
       return {
         militaryAddressCheckbox: entity.fieldMilitaryAddressCheckbox,
       };
+    case 'digital_form_list_loop':
+      return {
+        optional: entity.fieldOptional,
+      };
     case 'digital_form_phone_and_email':
       return {
         includeEmail: entity.fieldIncludeEmail,

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fixtures/queryResult.json
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fixtures/queryResult.json
@@ -95,6 +95,19 @@
                 "fieldTitle": "Generated Phone",
                 "fieldIncludeEmail": false
               }
+            },
+            {
+              "entity": {
+                "entityId": "162026",
+                "type": {
+                  "entity": {
+                    "entityId": "digital_form_list_loop",
+                    "entityLabel": "Digital Form: List & Loop"
+                  }
+                },
+                "fieldTitle": "Generated List & Loop",
+                "fieldOptional": false
+              }
             }
           ]
         }

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/digitalForm.graphql.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/digitalForm.graphql.unit.spec.js
@@ -18,7 +18,7 @@ describe('digitalForm fragment', () => {
   });
 
   describe('chapter fragments', () => {
-    ['address', 'phoneAndEmail', 'yourPersonalInformation'].forEach(
+    ['address', 'listLoop', 'phoneAndEmail', 'yourPersonalInformation'].forEach(
       fragment => {
         it(`imports the ${fragment} fragment`, () => {
           expect(digitalForm).to.have.string(`fragment ${fragment}`);

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/listLoop.graphql.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/listLoop.graphql.unit.spec.js
@@ -1,0 +1,14 @@
+/* eslint-disable @department-of-veterans-affairs/axe-check-required */
+
+import { expect } from 'chai';
+import listLoop from '../../fragments/listLoop.graphql';
+
+describe('listLoop fragment', () => {
+  it('includes fieldTitle', () => {
+    expect(listLoop).to.have.string('fieldTitle');
+  });
+
+  it('includes fieldOptional', () => {
+    expect(listLoop).to.have.string('fieldOptional');
+  });
+});

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/postProcessDigitalForm.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/postProcessDigitalForm.unit.spec.js
@@ -51,6 +51,7 @@ describe('postProcessDigitalForm', () => {
     describe('additionalFields', () => {
       [
         ['digital_form_address', 'militaryAddressCheckbox', false],
+        ['digital_form_list_loop', 'optional', false],
         ['digital_form_phone_and_email', 'includeEmail', false],
       ].forEach(([type, additionalField, value]) => {
         context(`with a ${type} step`, () => {


### PR DESCRIPTION
## Summary

- Normalizes the List & Loop Paragraph type created by department-of-veterans-affairs/va.gov-cms#19816

### Example output
```json
      {
        "id": 162032,
        "type": "digital_form_list_loop",
        "additionalFields": {
          "optional": true
        },
        "chapterTitle": "Veteran's employment history",
        "pageTitle": "List & Loop"
      }
```

## Related issue(s)

- Closes department-of-veterans-affairs/va.gov-team#93614

## Testing done

- Added unit tests to the Digital Form post processor, the Digital Form GraphQL fragment, and the `listLoop` GraphQL fragment
- Pulled local Drupal data and confirmed the resulting output from `content-build`

## What areas of the site does it impact?

Only affects the output of `digital-forms.json`.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

I'm not even sure if we'll need a `pageTitle` attribute for list and loops, but it's not doing any harm at the moment.