### PR TITLE
remove conditional style.css

### DIFF
--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -72,13 +72,7 @@
   <link rel="preload" href="/generated/fa-solid-900.woff2" as="font" type="font/woff2" crossorigin>
 
   <!-- CSS -->
-  {% comment %}
-    Apps that opt out of the site-wide stylesheet must include a smaller subset of styles
-    in their application bundle
-  {% endcomment %}
-  {% unless useLocalStylesAndComponents %}
-    <link rel="stylesheet" data-entry-name="style.css">
-  {% endunless %}
+  <link rel="stylesheet" data-entry-name="style.css">
   <link rel="stylesheet" data-entry-content="content-build.css">
   <link rel="stylesheet" data-entry-name="{{ entryname | default: 'static-pages' }}.css">
 


### PR DESCRIPTION
## Description
This pull request removes the conditional style.css import in the header when `useLocalStyleAndComponents` is present. We're removing it because no apps are opting out of the global stylesheet. 