### PR TITLE
VACMS-19913 Pharmacy text update for health services and VAMC pages

### DIFF
--- a/src/site/facilities/facilities_health_services_buttons.drupal.liquid
+++ b/src/site/facilities/facilities_health_services_buttons.drupal.liquid
@@ -2,14 +2,23 @@
     This is used for Facility details pages and (A-Z) Health Services page
 {% endcomment %}
 <div data-template="facilities/facilities_health_services_buttons">
-    <div>
-        {% assign topTask = "make-an-appointment" | topTaskLovellComp: path, buildtype, fieldAdministration, fieldVamcEhrSystem, fieldRegionPage, fieldOffice %}
-        <a class="vads-c-action-link--blue" href="{{topTask.url}}">{{topTask.text}}</a>
-    </div>
-    <div class="vads-u-margin-y--2">
-        <a class="vads-c-action-link--blue" href="/{{ path }}/register-for-care">Register for care</a>
-    </div>
-    <div>
-        <a class="vads-c-action-link--blue" href="/{{ path }}/pharmacy">Pharmacy</a>
-    </div>
+  {% assign topTask = "make-an-appointment" | topTaskLovellComp: path, buildtype, fieldAdministration, fieldVamcEhrSystem, fieldRegionPage, fieldOffice %}
+  <va-link-action
+    class="vads-u-display--block"
+    href="{{topTask.url}}"
+    text="{{topTask.text}}"
+    type="secondary"
+  ></va-link-action>  
+  <va-link-action
+    class="vads-u-display--block"
+    href="/{{ path }}/register-for-care"
+    text="Register for care"
+    type="secondary"
+  ></va-link-action>   
+  <va-link-action
+    class="vads-u-display--block"
+    href="/{{ path }}/pharmacy"
+    text="Learn about pharmacy services"
+    type="secondary"
+  ></va-link-action>   
 </div>

--- a/src/site/tests/cypress/vamc-lovell.cypress.spec.js
+++ b/src/site/tests/cypress/vamc-lovell.cypress.spec.js
@@ -1,3 +1,5 @@
+import { expect } from 'chai';
+
 const verifyActionLink = (expectedText, expectedHref) =>
   cy
     .get('va-link-action')
@@ -14,18 +16,10 @@ describe('VAMC Lovell - All TRICARE pages with expected MHS Genesis Patient Port
     cy.visit('/lovell-federal-health-care-tricare/');
     cy.injectAxeThenAxeCheck();
 
-    verifyActionLink(
-      'MHS Genesis Patient Portal',
-      'https://my.mhsgenesis.health.mil/',
-    );
-    verifyActionLink(
-      'View all health services',
-      '/lovell-federal-health-care-tricare/health-services',
-    );
-    verifyActionLink(
-      'Register for care',
-      '/lovell-federal-health-care-tricare/register-for-care',
-    );
+    cy.findByText('MHS Genesis Patient Portal').then(el => {
+      const attr = el.attr('href');
+      expect(attr).to.equal('https://my.mhsgenesis.health.mil/');
+    });
   });
 
   it('TRICARE Health services has MHS Genesis Patient Portal link', () => {
@@ -36,32 +30,16 @@ describe('VAMC Lovell - All TRICARE pages with expected MHS Genesis Patient Port
       'MHS Genesis Patient Portal',
       'https://my.mhsgenesis.health.mil/',
     );
-    verifyActionLink(
-      'Register for care',
-      '/lovell-federal-health-care-tricare/register-for-care',
-    );
-    verifyActionLink(
-      'Learn about pharmacy services',
-      '/lovell-federal-health-care-tricare/pharmacy',
-    );
   });
 
   it('TRICARE Locations has MHS Genesis Patient Portal link', () => {
     cy.visit('/lovell-federal-health-care-tricare/locations');
     cy.injectAxeThenAxeCheck();
 
-    verifyActionLink(
-      'MHS Genesis Patient Portal',
-      'https://my.mhsgenesis.health.mil/',
-    );
-    verifyActionLink(
-      'View all health services',
-      '/lovell-federal-health-care-tricare/health-services',
-    );
-    verifyActionLink(
-      'Register for care',
-      '/lovell-federal-health-care-tricare/register-for-care',
-    );
+    cy.findByText('MHS Genesis Patient Portal').then(el => {
+      const attr = el.attr('href');
+      expect(attr).to.equal('https://my.mhsgenesis.health.mil/');
+    });
   });
 
   it('TRICARE Captain James A. Lovell Location has MHS Genesis Patient Portal link', () => {
@@ -74,14 +52,6 @@ describe('VAMC Lovell - All TRICARE pages with expected MHS Genesis Patient Port
       'MHS Genesis Patient Portal',
       'https://my.mhsgenesis.health.mil/',
     );
-    verifyActionLink(
-      'Register for care',
-      '/lovell-federal-health-care-tricare/register-for-care',
-    );
-    verifyActionLink(
-      'Learn about pharmacy services',
-      '/lovell-federal-health-care-tricare/pharmacy',
-    );
   });
 });
 
@@ -90,18 +60,10 @@ describe('VAMC Lovell - All VA pages with expected Make an appointment Top Task 
     cy.visit('/lovell-federal-health-care-va/');
     cy.injectAxeThenAxeCheck();
 
-    verifyActionLink(
-      'Make an appointment',
-      '/lovell-federal-health-care-va/make-an-appointment',
-    );
-    verifyActionLink(
-      'View all health services',
-      '/lovell-federal-health-care-tricare/health-services',
-    );
-    verifyActionLink(
-      'Register for care',
-      '/lovell-federal-health-care-tricare/register-for-care',
-    );
+    cy.findByText('Make an appointment').then(el => {
+      const attr = el.attr('href');
+      expect(attr.endsWith('make-an-appointment')).to.be.true;
+    });
   });
 
   it('VA Health services has Make an appointment link', () => {
@@ -112,32 +74,16 @@ describe('VAMC Lovell - All VA pages with expected Make an appointment Top Task 
       'Make an appointment',
       '/lovell-federal-health-care-va/make-an-appointment',
     );
-    verifyActionLink(
-      'Register for care',
-      '/lovell-federal-health-care-tricare/register-for-care',
-    );
-    verifyActionLink(
-      'Learn about pharmacy services',
-      '/lovell-federal-health-care-tricare/pharmacy',
-    );
   });
 
   it('VA Locations has Make an appointment link', () => {
     cy.visit('/lovell-federal-health-care-va/locations/');
     cy.injectAxeThenAxeCheck();
 
-    verifyActionLink(
-      'Make an appointment',
-      '/lovell-federal-health-care-va/make-an-appointment',
-    );
-    verifyActionLink(
-      'View all health services',
-      '/lovell-federal-health-care-tricare/health-services',
-    );
-    verifyActionLink(
-      'Register for care',
-      '/lovell-federal-health-care-tricare/register-for-care',
-    );
+    cy.findByText('Make an appointment').then(el => {
+      const attr = el.attr('href');
+      expect(attr.endsWith('make-an-appointment')).to.be.true;
+    });
   });
 
   it('VA Captain James A. Lovell Location has Make an appointment link', () => {
@@ -149,14 +95,6 @@ describe('VAMC Lovell - All VA pages with expected Make an appointment Top Task 
     verifyActionLink(
       'Make an appointment',
       '/lovell-federal-health-care-va/make-an-appointment',
-    );
-    verifyActionLink(
-      'Register for care',
-      '/lovell-federal-health-care-tricare/register-for-care',
-    );
-    verifyActionLink(
-      'Learn about pharmacy services',
-      '/lovell-federal-health-care-tricare/pharmacy',
     );
   });
 });

--- a/src/site/tests/cypress/vamc-lovell.cypress.spec.js
+++ b/src/site/tests/cypress/vamc-lovell.cypress.spec.js
@@ -1,34 +1,67 @@
-import { expect } from 'chai';
+const verifyActionLink = (expectedText, expectedHref) =>
+  cy
+    .get('va-link-action')
+    .eq(0)
+    .shadow()
+    .find('a')
+    .should('be.visible')
+    .should('have.text', expectedText)
+    .should('have.attr', 'href')
+    .and('include', expectedHref);
 
 describe('VAMC Lovell - All TRICARE pages with expected MHS Genesis Patient Portal Top Task have it', () => {
   it('TRICARE system has MHS Genesis Patient Portal link', () => {
     cy.visit('/lovell-federal-health-care-tricare/');
     cy.injectAxeThenAxeCheck();
-    cy.findByText('MHS Genesis Patient Portal').then(el => {
-      const attr = el.attr('href');
-      expect(attr).to.equal('https://my.mhsgenesis.health.mil/');
-    });
-    // https://www.va.gov/lovell-federal-health-care-tricare/
+
+    verifyActionLink(
+      'MHS Genesis Patient Portal',
+      'https://my.mhsgenesis.health.mil/',
+    );
+    verifyActionLink(
+      'View all health services',
+      '/lovell-federal-health-care-tricare/health-services',
+    );
+    verifyActionLink(
+      'Register for care',
+      '/lovell-federal-health-care-tricare/register-for-care',
+    );
   });
 
   it('TRICARE Health services has MHS Genesis Patient Portal link', () => {
     cy.visit('/lovell-federal-health-care-tricare/health-services');
     cy.injectAxeThenAxeCheck();
-    cy.findByText('MHS Genesis Patient Portal').then(el => {
-      const attr = el.attr('href');
-      expect(attr).to.equal('https://my.mhsgenesis.health.mil/');
-    });
-    // https://www.va.gov/lovell-federal-health-care-tricare/health-services/
+
+    verifyActionLink(
+      'MHS Genesis Patient Portal',
+      'https://my.mhsgenesis.health.mil/',
+    );
+    verifyActionLink(
+      'Register for care',
+      '/lovell-federal-health-care-tricare/register-for-care',
+    );
+    verifyActionLink(
+      'Learn about pharmacy services',
+      '/lovell-federal-health-care-tricare/pharmacy',
+    );
   });
 
   it('TRICARE Locations has MHS Genesis Patient Portal link', () => {
     cy.visit('/lovell-federal-health-care-tricare/locations');
     cy.injectAxeThenAxeCheck();
-    cy.findByText('MHS Genesis Patient Portal').then(el => {
-      const attr = el.attr('href');
-      expect(attr).to.equal('https://my.mhsgenesis.health.mil/');
-    });
-    // https://www.va.gov/lovell-federal-health-care-tricare/locations/
+
+    verifyActionLink(
+      'MHS Genesis Patient Portal',
+      'https://my.mhsgenesis.health.mil/',
+    );
+    verifyActionLink(
+      'View all health services',
+      '/lovell-federal-health-care-tricare/health-services',
+    );
+    verifyActionLink(
+      'Register for care',
+      '/lovell-federal-health-care-tricare/register-for-care',
+    );
   });
 
   it('TRICARE Captain James A. Lovell Location has MHS Genesis Patient Portal link', () => {
@@ -36,11 +69,19 @@ describe('VAMC Lovell - All TRICARE pages with expected MHS Genesis Patient Port
       '/lovell-federal-health-care-tricare/locations/captain-james-a-lovell-federal-health-care-center/',
     );
     cy.injectAxeThenAxeCheck();
-    cy.findByText('MHS Genesis Patient Portal').then(el => {
-      const attr = el.attr('href');
-      expect(attr).to.equal('https://my.mhsgenesis.health.mil/');
-    });
-    // https://www.va.gov/lovell-federal-health-care-tricare/locations/captain-james-a-lovell-federal-health-care-center/
+
+    verifyActionLink(
+      'MHS Genesis Patient Portal',
+      'https://my.mhsgenesis.health.mil/',
+    );
+    verifyActionLink(
+      'Register for care',
+      '/lovell-federal-health-care-tricare/register-for-care',
+    );
+    verifyActionLink(
+      'Learn about pharmacy services',
+      '/lovell-federal-health-care-tricare/pharmacy',
+    );
   });
 });
 
@@ -48,42 +89,75 @@ describe('VAMC Lovell - All VA pages with expected Make an appointment Top Task 
   it('VA system has Make an appointment link', () => {
     cy.visit('/lovell-federal-health-care-va/');
     cy.injectAxeThenAxeCheck();
-    cy.findByText('Make an appointment').then(el => {
-      const attr = el.attr('href');
-      expect(attr.endsWith('make-an-appointment')).to.be.true;
-    });
-    // https://www.va.gov/lovell-federal-health-care-va/
+
+    verifyActionLink(
+      'Make an appointment',
+      '/lovell-federal-health-care-va/make-an-appointment',
+    );
+    verifyActionLink(
+      'View all health services',
+      '/lovell-federal-health-care-tricare/health-services',
+    );
+    verifyActionLink(
+      'Register for care',
+      '/lovell-federal-health-care-tricare/register-for-care',
+    );
   });
 
   it('VA Health services has Make an appointment link', () => {
     cy.visit('/lovell-federal-health-care-va/health-services/');
     cy.injectAxeThenAxeCheck();
-    cy.findByText('Make an appointment').then(el => {
-      const attr = el.attr('href');
-      expect(attr.endsWith('make-an-appointment')).to.be.true;
-    });
-    // https://www.va.gov/lovell-federal-health-care-va/health-services/
+
+    verifyActionLink(
+      'Make an appointment',
+      '/lovell-federal-health-care-va/make-an-appointment',
+    );
+    verifyActionLink(
+      'Register for care',
+      '/lovell-federal-health-care-tricare/register-for-care',
+    );
+    verifyActionLink(
+      'Learn about pharmacy services',
+      '/lovell-federal-health-care-tricare/pharmacy',
+    );
   });
 
   it('VA Locations has Make an appointment link', () => {
     cy.visit('/lovell-federal-health-care-va/locations/');
     cy.injectAxeThenAxeCheck();
-    cy.findByText('Make an appointment').then(el => {
-      const attr = el.attr('href');
-      expect(attr.endsWith('make-an-appointment')).to.be.true;
-    });
-    // https://www.va.gov/lovell-federal-health-care-va/locations/
+
+    verifyActionLink(
+      'Make an appointment',
+      '/lovell-federal-health-care-va/make-an-appointment',
+    );
+    verifyActionLink(
+      'View all health services',
+      '/lovell-federal-health-care-tricare/health-services',
+    );
+    verifyActionLink(
+      'Register for care',
+      '/lovell-federal-health-care-tricare/register-for-care',
+    );
   });
+
   it('VA Captain James A. Lovell Location has Make an appointment link', () => {
     cy.visit(
       '/lovell-federal-health-care-va/locations/captain-james-a-lovell-federal-health-care-center/',
     );
     cy.injectAxeThenAxeCheck();
-    cy.findByText('Make an appointment').then(el => {
-      const attr = el.attr('href');
-      expect(attr.endsWith('make-an-appointment')).to.be.true;
-    });
-    // https://www.va.gov/lovell-federal-health-care-va/locations/captain-james-a-lovell-federal-health-care-center/
+
+    verifyActionLink(
+      'Make an appointment',
+      '/lovell-federal-health-care-va/make-an-appointment',
+    );
+    verifyActionLink(
+      'Register for care',
+      '/lovell-federal-health-care-tricare/register-for-care',
+    );
+    verifyActionLink(
+      'Learn about pharmacy services',
+      '/lovell-federal-health-care-tricare/pharmacy',
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
Update the "Pharmacy" text to "Learn about pharmacy services," and also update the links to `va-link-action` instead.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19913

## Testing done
Tested these URLs:
- /northeast-ohio-health-care/locations/sandusky-va-clinic/
- /northeast-ohio-health-care/health-services/
- /lovell-federal-health-care-va/health-services/
- /lovell-federal-health-care-tricare/health-services/

Also regression checked via Cypress (since I converted the links to `<va-link-action>`)
- /lovell-federal-health-care-tricare/
- /lovell-federal-health-care-tricare/locations
- /lovell-federal-health-care-tricare/locations/captain-james-a-lovell-federal-health-care-center/
- /lovell-federal-health-care-va/
- /lovell-federal-health-care-va/locations/

## Screenshots

`/northeast-ohio-health-care/locations/sandusky-va-clinic/`

| Before | After |
| ------- | ------ | 
 |  <img width="738" alt="Screenshot 2024-11-20 at 4 18 11 PM" src="https://github.com/user-attachments/assets/e8b25eaa-9028-4020-9302-bf1ef6416c2e"> | <img width="731" alt="Screenshot 2024-11-20 at 4 18 18 PM" src="https://github.com/user-attachments/assets/49bd01e2-9648-4265-90ac-5c1f960e1237">  |

`/northeast-ohio-health-care/health-services/`

| Before | After |
| ------- | ------ | 
 |  <img width="710" alt="Screenshot 2024-11-20 at 4 18 35 PM" src="https://github.com/user-attachments/assets/57f6ce5e-53d9-4e51-8867-f86e461e47f5"> | <img width="713" alt="Screenshot 2024-11-20 at 4 18 30 PM" src="https://github.com/user-attachments/assets/7c3c2d0f-57c9-4ff7-9f2c-c395eb29be03">  |

`/lovell-federal-health-care-va/health-services/`

| Before | After |
| ------- | ------ | 
 |  <img width="739" alt="Screenshot 2024-11-20 at 4 18 59 PM" src="https://github.com/user-attachments/assets/f6e4b87b-f930-448b-b5da-3922a8de6a3f"> | <img width="735" alt="Screenshot 2024-11-20 at 4 18 54 PM" src="https://github.com/user-attachments/assets/5ceb237b-104b-4a14-b767-9f1c8fc14421">  |

`/lovell-federal-health-care-tricare/health-services/`

| Before | After |
| ------- | ------ | 
 |  <img width="737" alt="Screenshot 2024-11-20 at 4 19 27 PM" src="https://github.com/user-attachments/assets/894533d6-4915-4ef3-9dad-ab57a2a653fc"> | <img width="740" alt="Screenshot 2024-11-20 at 4 19 22 PM" src="https://github.com/user-attachments/assets/e9f2c2e9-0880-4b0c-a1ac-93f7a3e4aa73">  |

## What areas of the site does it impact?

Health services pages and facilities pages

## Acceptance criteria

- [x] Link text reads as "Learn about pharmacy services"
- [x] Change is reflected on health services pages and facilities pages
- [x] Make sure that Lovell works like everything else.