### PR TITLE
add .va-nav-breadcrumbs--playbook to styles

### DIFF
--- a/src/site/assets/sass/style.scss
+++ b/src/site/assets/sass/style.scss
@@ -97,6 +97,75 @@
   }
 }
 
+//===== Playbook and Facility Locator
+.va-nav-breadcrumbs--playbook {
+  background: none;
+  margin: 0 0 1em 0;
+  padding: 0;
+
+  h2 {
+    font-size: 1em;
+  }
+
+  li {
+    text-transform: none;
+    margin: 0.25em 0;
+    padding: 0.1em;
+    display: inline-block;
+    line-height: 1.15em;
+    vertical-align: middle;
+    font-size: 1.35em;
+
+    &:hover {
+      border-bottom: none;
+      text-decoration: none;
+    }
+  }
+
+  a {
+    border-bottom: 3px solid var(--vads-color-white);
+    text-decoration: none !important;
+    color: var(--vads-color-white);
+    &:hover {
+      text-decoration: none;
+      background: var(--color-link-default-hover);
+      border-bottom: 3px solid var(--vads-color-warning);
+    }
+  }
+}
+
+.va-nav-breadcrumbs--playbook {
+  .parent {
+    padding-top: 0.5em;
+    margin: 0 0 0.75em 0;
+  
+    &:after {
+      content: " › ";
+      display: inline-block;
+      color: var(--vads-color-white);
+      padding: 0 0.5em;
+    }
+  }
+  
+  .active {
+    background: var(--vads-color-warning);
+    color: var(--vads-color-black);
+    font: 400 1.35em / 1.15em var(--font-family-serif);
+    margin: 0.5em 0;
+    padding: 0.2em;
+  
+    @media (min-width: 768px) {
+      font-size: 1.8em;
+    }
+  
+    &:before {
+      content: "";
+      padding: 0;
+      margin: 0;
+    }
+  }
+}
+
 // START: Styles for mobile app promo banner
 .smartbanner {
   position: absolute;


### PR DESCRIPTION
## Summary
`.va-nav-breadcrumbs--playbook` was imported from formation. With the formation deprecation effort, and since this class only applies to a single template in content-build, we decided to copy it over to content-build.

- It appears that the template, `page-playbook.html` which uses this class, is not in use anymore. We are still copying this over just in case there is an instance that we missed.


## Related issue(s)
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2341


## Testing done
- Ran build locally without errors
- Visual testing could not be done because it appears that the template that uses this css class is no longer in use


## What areas of the site does it impact?

unknown

## Acceptance criteria

### Quality Assurance & Testing

- [ x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ x] Linting warnings have been addressed
- [ x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ x] Screenshot of the developed feature is added
- [ x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ x] Browser console contains no warnings or errors.
- [ x] Events are being sent to the appropriate logging solution
- [ x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
