### PR TITLE
Remove Event page queries from Content Build

### DIFF
--- a/src/site/constants/brokenLinkIgnorePatterns.js
+++ b/src/site/constants/brokenLinkIgnorePatterns.js
@@ -18,7 +18,7 @@
 
   */
 const IGNORE_PATTERNS = [
-  /\/events\//, // This ignores all links to Event and Event Listing pages.
+  /\/events($|\/)?/, // This ignores all links to Event and Event Listing pages.
 ];
 
 module.exports = {

--- a/src/site/constants/brokenLinkIgnorePatterns.js
+++ b/src/site/constants/brokenLinkIgnorePatterns.js
@@ -1,0 +1,26 @@
+/*
+  This is a set of patterns which the broken link checker should ignore when making a check.
+
+  Given a page dog.html that contains the following three links:
+    - /animals/cat.html
+    - /animals/horse.html
+    - /animals/capybara.html
+
+  If an item in IGNORE_PATTERNS contains 'capybara', it will ignore the third link.
+  If an item in IGNORE_PATTERNS contains 'animals', it will ignore ALL the links.
+
+  Note that it's the target URL that checks the ignore pattern. If you included
+  'dog' in the IGNORE_PATTERNS in the example above, it would still test dog.html
+  for broken links it contains, but block testing dog.html as a destination.
+
+  Be very careful of unintended consequences when adding these patterns. Be
+  sure you are targeting what you want to ignore precisely.
+
+  */
+const IGNORE_PATTERNS = [
+  /\/events\//, // This ignores all links to Event and Event Listing pages.
+];
+
+module.exports = {
+  IGNORE_PATTERNS,
+};

--- a/src/site/stages/build/drupal/graphql/CountEntityTypes.graphql.js
+++ b/src/site/stages/build/drupal/graphql/CountEntityTypes.graphql.js
@@ -91,26 +91,6 @@ const CountEntityTypes = `
     count
   }
 
-  eventListing: nodeQuery(
-    filter: {
-      conditions: [
-        {field: "status", value: ["1"]},
-        {field: "type", value: ["event_listing"]}
-      ]}
-  	) {
-    count
-  }
-
-  event: nodeQuery(
-    filter: {
-      conditions: [
-        {field: "status", value: ["1"]},
-        {field: "type", value: ["event"]}
-      ]}
-  	) {
-    count
-  }
-
   healthCareRegionDetailPage: nodeQuery(
     filter: {
       conditions: [

--- a/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
@@ -115,8 +115,7 @@ const buildQuery = () => {
         ... nodeOffice
         ... bioPage
         ... benefitListingPage
-        ... nodeEventListing
-        ... nodeEvent
+
         ... storyListingPage
         ... leadershipListingPage
         ... pressReleasesListingPage

--- a/src/site/stages/build/drupal/individual-queries.js
+++ b/src/site/stages/build/drupal/individual-queries.js
@@ -30,12 +30,6 @@ const {
 } = require('./graphql/pressReleasesListingPage.graphql');
 
 const {
-  getNodeEventListingQueries,
-} = require('./graphql/nodeEventListing.graphql');
-
-const { getNodeEventQueries } = require('./graphql/nodeEvent.graphql');
-
-const {
   GetNodeStoryListingPages,
 } = require('./graphql/storyListingPage.graphql');
 
@@ -118,8 +112,6 @@ function getNodeQueries(entityCounts) {
     ...getNewsStoryQueries(entityCounts),
     ...getPressReleaseQueries(entityCounts),
     GetNodePressReleaseListingPages,
-    ...getNodeEventListingQueries(entityCounts),
-    ...getNodeEventQueries(entityCounts),
     ...getVaPoliceQueries(entityCounts),
     GetNodeStoryListingPages,
     GetNodeLocationsListingPages,

--- a/src/site/stages/build/plugins/modify-dom/check-broken-links/helpers/isBrokenLink.js
+++ b/src/site/stages/build/plugins/modify-dom/check-broken-links/helpers/isBrokenLink.js
@@ -33,7 +33,8 @@ function isBrokenLink(link, pagePath, allPaths) {
   if (!path.extname(filePath)) {
     filePath = path.join(filePath, 'index.html');
   }
-
+  // eslint-disable-next-line no-console
+  console.log(filePath);
   return !allPaths.has(filePath);
 }
 

--- a/src/site/stages/build/plugins/modify-dom/check-broken-links/helpers/isBrokenLink.js
+++ b/src/site/stages/build/plugins/modify-dom/check-broken-links/helpers/isBrokenLink.js
@@ -1,5 +1,8 @@
 const path = require('path');
 const url = require('url');
+const {
+  IGNORE_PATTERNS,
+} = require('../../../../../../constants/brokenLinkIgnorePatterns');
 
 /**
  * Validates an HREF/SRC value
@@ -24,6 +27,15 @@ function isBrokenLink(link, pagePath, allPaths) {
 
   let filePath = decodeURIComponent(parsed.pathname);
 
+  // Check for link destinations we are not testing.
+  for (let i = 0; i < IGNORE_PATTERNS; i += 1) {
+    if (filePath.match(IGNORE_PATTERNS[i])) {
+      // eslint-disable-next-line no-console
+      console.log(filePath);
+      return false;
+    }
+  }
+
   if (path.isAbsolute(filePath)) {
     filePath = path.join('.', filePath);
   } else {
@@ -33,8 +45,6 @@ function isBrokenLink(link, pagePath, allPaths) {
   if (!path.extname(filePath)) {
     filePath = path.join(filePath, 'index.html');
   }
-  // eslint-disable-next-line no-console
-  console.log(filePath);
   return !allPaths.has(filePath);
 }
 

--- a/src/site/stages/build/plugins/modify-dom/check-broken-links/helpers/isBrokenLink.js
+++ b/src/site/stages/build/plugins/modify-dom/check-broken-links/helpers/isBrokenLink.js
@@ -28,7 +28,7 @@ function isBrokenLink(link, pagePath, allPaths) {
   let filePath = decodeURIComponent(parsed.pathname);
 
   // Check for link destinations we are not testing.
-  for (let i = 0; i < IGNORE_PATTERNS; i += 1) {
+  for (let i = 0; i < IGNORE_PATTERNS.length; i += 1) {
     if (filePath.match(IGNORE_PATTERNS[i])) {
       // eslint-disable-next-line no-console
       console.log(filePath);

--- a/src/site/stages/build/plugins/modify-dom/check-broken-links/helpers/isBrokenLink.js
+++ b/src/site/stages/build/plugins/modify-dom/check-broken-links/helpers/isBrokenLink.js
@@ -30,8 +30,6 @@ function isBrokenLink(link, pagePath, allPaths) {
   // Check for link destinations we are not testing.
   for (let i = 0; i < IGNORE_PATTERNS.length; i += 1) {
     if (filePath.match(IGNORE_PATTERNS[i])) {
-      // eslint-disable-next-line no-console
-      console.log(filePath);
       return false;
     }
   }


### PR DESCRIPTION
Currently a test: put into PR form to test CI and on Tugboat against CMS. 

## Summary

This removes Event and Event Listing pages from being output by Content Build. Broadly, this has 2 parts:
- remove the queries, including removing Events from the node count queries
- update the broken link checker to ignore Event pages, since they are no longer available to be checked

Events are being removed because they are now deployed to production by Next Build. 

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19811

## Testing done

- Multiple content-releases on Tugboat using this branch
  - Tested that output completed successfully
  - Tested that Event & Event Listings were not included
  - Tested that pages that incorporate Events within them do still render correctly
  - Checked that the broken link check is not affected by the removal

## QA steps
This was built on this Tugboat instance: https://main-jhfxzor0fzbac0tpmbor1dbj6qgizfwj.demo.cms.va.gov/admin/content/deploy
- [ ] Check that output completed successfully

Front-end is here: https://web-jhfxzor0fzbac0tpmbor1dbj6qgizfwj.demo.cms.va.gov/
Investigate that output looks normal. It largely should. The main thing to be careful of is Events not being there. 

Here is an example VAMC: https://web-jhfxzor0fzbac0tpmbor1dbj6qgizfwj.demo.cms.va.gov/manchester-health-care/
- [ ] You should have Events down the page: https://web-jhfxzor0fzbac0tpmbor1dbj6qgizfwj.demo.cms.va.gov/manchester-health-care/
- [ ] The individual events should show a 404 if you try to click through.
- [ ] 'See all Events' on this page should show a 404.
- [ ] Clicking 'Events' in the sidebar should result in a 404. 
- [ ] Clicking in other sidebar menu items like 'News releases' should click through.
- [ ] Examine the build output for this preview: https://main-jhfxzor0fzbac0tpmbor1dbj6qgizfwj.demo.cms.va.gov/sites/default/files/build.txt
- [ ] It should not show broken links related to Events.
- [ ] The build should have completed without errors.

