### PR TITLE
Source Cypress from Va-internal S3.

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -393,20 +393,20 @@ jobs:
 
   cypress-tests:
     name: Cypress E2E Tests
-    runs-on: [self-hosted, asg]
+    runs-on: ubuntu-16-cores-latest
     needs:
       - login-to-amazon-ecr
       - build
     timeout-minutes: 30
     container:
-      image: 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/cypress-io:node16.13.2-chrome100-ff98
+      image: 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/cypress-io/cypress/browsers:node16.16.0-chrome107-ff107-edge
       credentials:
         username: ${{ needs.login-to-amazon-ecr.outputs.docker_username }}
         password: ${{ needs.login-to-amazon-ecr.outputs.docker_password }}
-      options: --user 1001:1001
-      volumes:
-        - /usr/local/share:/share
-        - /etc/ssl/certs:/etc/ssl/certs
+      # options: --user 1001:1001
+      # volumes:
+      #   - /usr/local/share:/share
+      #   - /etc/ssl/certs:/etc/ssl/certs
 
     env:
       NODE_EXTRA_CA_CERTS: /etc/ssl/certs/ca-certificates.crt
@@ -428,13 +428,12 @@ jobs:
         uses: ./.github/workflows/install
         timeout-minutes: 30
         with:
-          key: on-demand-runner-cypress-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: on-demand-runner-cypress-
+          key: ${{ hashFiles('yarn.lock') }}
           yarn_cache_folder: .cache/yarn
           path: |
             .cache/yarn
             /github/home/.cache/Cypress
-            **/node_modules
+            node_modules
 
       - name: Start server
         run: node src/platform/testing/e2e/test-server.js --buildtype vagovprod --port=3002 &

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -257,11 +257,7 @@ jobs:
         with:
           key: ${{ hashFiles('yarn.lock') }}
           yarn_cache_folder: .cache/yarn
-          path: |
-            .cache/yarn
-            node_modules
-            /github/home/.cache/Cypress
-
+          path: .cache
       - name: Run registry validation
         run: yarn validate:registry
 
@@ -278,10 +274,7 @@ jobs:
         with:
           key: ${{ hashFiles('yarn.lock') }}
           yarn_cache_folder: .cache/yarn
-          path: |
-            .cache/yarn
-            node_modules
-            /github/home/.cache/Cypress
+          path: .cache
 
       - name: Create test results folder
         run: mkdir -p test-results
@@ -323,10 +316,7 @@ jobs:
         with:
           key: ${{ hashFiles('yarn.lock') }}
           yarn_cache_folder: .cache/yarn
-          path: |
-            .cache/yarn
-            node_modules
-            /github/home/.cache/Cypress
+          path: .cache
 
       - name: Update browserslist
         run: yarn exec -- browserslist --update-db
@@ -347,10 +337,7 @@ jobs:
         with:
           key: ${{ hashFiles('yarn.lock') }}
           yarn_cache_folder: .cache/yarn
-          path: |
-            .cache/yarn
-            node_modules
-            /github/home/.cache/Cypress
+          path: .cache
 
       - name: Audit dependencies
         run: yarn security-check
@@ -368,10 +355,7 @@ jobs:
         with:
           key: ${{ hashFiles('yarn.lock') }}
           yarn_cache_folder: .cache/yarn
-          path: |
-            .cache/yarn
-            node_modules
-            /github/home/.cache/Cypress
+          path: .cache
 
       - name: Fetch Drupal cache
         run: yarn fetch-drupal-cache
@@ -433,13 +417,9 @@ jobs:
         uses: ./.github/workflows/install
         timeout-minutes: 30
         with:
-          key: on-demand-runner-cypress-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: on-demand-runner-cypress-
+          key: ${{ hashFiles('yarn.lock') }}
           yarn_cache_folder: .cache/yarn
-          path: |
-            .cache/yarn
-            /github/home/.cache/Cypress
-            **/node_modules
+          path: .cache
 
       - name: Start server
         run: node src/platform/testing/e2e/test-server.js --buildtype vagovprod --port=3002 &
@@ -639,10 +619,7 @@ jobs:
         with:
           key: ${{ hashFiles('yarn.lock') }}
           yarn_cache_folder: .cache/yarn
-          path: |
-            .cache/yarn
-            node_modules
-            /github/home/.cache/Cypress
+          path: .cache
 
       - name: Set output of latest_run_number
         id: latest-run-number
@@ -750,11 +727,8 @@ jobs:
         timeout-minutes: 30
         with:
           key: ${{ hashFiles('yarn.lock') }}
-          yarn_cache_folder: ~/.cache/yarn
-          path: |
-            ~/.cache/yarn
-            node_modules
-            /github/home/.cache/Cypress
+          yarn_cache_folder: .cache/yarn
+          path: .cache
 
       - name: Trigger Jenkins pipeline
         run: node script/github-actions/trigger-jenkins.js

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -257,7 +257,10 @@ jobs:
         with:
           key: ${{ hashFiles('yarn.lock') }}
           yarn_cache_folder: .cache/yarn
-          path: .cache
+          path: |
+            .cache/yarn
+            node_modules
+
       - name: Run registry validation
         run: yarn validate:registry
 
@@ -274,7 +277,9 @@ jobs:
         with:
           key: ${{ hashFiles('yarn.lock') }}
           yarn_cache_folder: .cache/yarn
-          path: .cache
+          path: |
+            .cache/yarn
+            node_modules
 
       - name: Create test results folder
         run: mkdir -p test-results
@@ -316,7 +321,9 @@ jobs:
         with:
           key: ${{ hashFiles('yarn.lock') }}
           yarn_cache_folder: .cache/yarn
-          path: .cache
+          path: |
+            .cache/yarn
+            node_modules
 
       - name: Update browserslist
         run: yarn exec -- browserslist --update-db
@@ -337,7 +344,9 @@ jobs:
         with:
           key: ${{ hashFiles('yarn.lock') }}
           yarn_cache_folder: .cache/yarn
-          path: .cache
+          path: |
+            .cache/yarn
+            node_modules
 
       - name: Audit dependencies
         run: yarn security-check
@@ -355,7 +364,9 @@ jobs:
         with:
           key: ${{ hashFiles('yarn.lock') }}
           yarn_cache_folder: .cache/yarn
-          path: .cache
+          path: |
+            .cache/yarn
+            node_modules
 
       - name: Fetch Drupal cache
         run: yarn fetch-drupal-cache
@@ -417,9 +428,13 @@ jobs:
         uses: ./.github/workflows/install
         timeout-minutes: 30
         with:
-          key: ${{ hashFiles('yarn.lock') }}
+          key: on-demand-runner-cypress-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: on-demand-runner-cypress-
           yarn_cache_folder: .cache/yarn
-          path: .cache
+          path: |
+            .cache/yarn
+            /github/home/.cache/Cypress
+            **/node_modules
 
       - name: Start server
         run: node src/platform/testing/e2e/test-server.js --buildtype vagovprod --port=3002 &
@@ -619,7 +634,9 @@ jobs:
         with:
           key: ${{ hashFiles('yarn.lock') }}
           yarn_cache_folder: .cache/yarn
-          path: .cache
+          path: |
+            .cache/yarn
+            node_modules
 
       - name: Set output of latest_run_number
         id: latest-run-number
@@ -727,8 +744,10 @@ jobs:
         timeout-minutes: 30
         with:
           key: ${{ hashFiles('yarn.lock') }}
-          yarn_cache_folder: .cache/yarn
-          path: .cache
+          yarn_cache_folder: ~/.cache/yarn
+          path: |
+            ~/.cache/yarn
+            node_modules
 
       - name: Trigger Jenkins pipeline
         run: node script/github-actions/trigger-jenkins.js

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -416,10 +416,10 @@ jobs:
       - name: Install dependencies
         uses: ./.github/workflows/install
         timeout-minutes: 30
-        with:
-          key: ${{ hashFiles('yarn.lock') }}
-          yarn_cache_folder: .cache/yarn
-          path: .cache
+        # with:
+        #   key: ${{ hashFiles('yarn.lock') }}
+        #   yarn_cache_folder: .cache/yarn
+        #   path: .cache
 
       - name: Start server
         run: node src/platform/testing/e2e/test-server.js --buildtype vagovprod --port=3002 &

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -416,10 +416,10 @@ jobs:
       - name: Install dependencies
         uses: ./.github/workflows/install
         timeout-minutes: 30
-        # with:
-        #   key: ${{ hashFiles('yarn.lock') }}
-        #   yarn_cache_folder: .cache/yarn
-        #   path: .cache
+        with:
+          key: ${{ hashFiles('yarn.lock') }}
+          yarn_cache_folder: .cache/yarn
+          path: .cache
 
       - name: Start server
         run: node src/platform/testing/e2e/test-server.js --buildtype vagovprod --port=3002 &

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -260,6 +260,7 @@ jobs:
           path: |
             .cache/yarn
             node_modules
+            /github/home/.cache/Cypress
 
       - name: Run registry validation
         run: yarn validate:registry
@@ -280,6 +281,7 @@ jobs:
           path: |
             .cache/yarn
             node_modules
+            /github/home/.cache/Cypress
 
       - name: Create test results folder
         run: mkdir -p test-results
@@ -324,6 +326,7 @@ jobs:
           path: |
             .cache/yarn
             node_modules
+            /github/home/.cache/Cypress
 
       - name: Update browserslist
         run: yarn exec -- browserslist --update-db
@@ -347,6 +350,7 @@ jobs:
           path: |
             .cache/yarn
             node_modules
+            /github/home/.cache/Cypress
 
       - name: Audit dependencies
         run: yarn security-check
@@ -367,6 +371,7 @@ jobs:
           path: |
             .cache/yarn
             node_modules
+            /github/home/.cache/Cypress
 
       - name: Fetch Drupal cache
         run: yarn fetch-drupal-cache
@@ -637,6 +642,7 @@ jobs:
           path: |
             .cache/yarn
             node_modules
+            /github/home/.cache/Cypress
 
       - name: Set output of latest_run_number
         id: latest-run-number
@@ -748,6 +754,7 @@ jobs:
           path: |
             ~/.cache/yarn
             node_modules
+            /github/home/.cache/Cypress
 
       - name: Trigger Jenkins pipeline
         run: node script/github-actions/trigger-jenkins.js

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -39,6 +39,7 @@ runs:
     - name: Cache dependencies
       id: cache-dependencies
       uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+      if: ${{ inputs.path !== null }}
       with:
         path: ${{ inputs.path }}
         key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ inputs.key }}

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -37,22 +37,18 @@ runs:
       run: npm i -g yarn@1.19.1
 
     - name: Cache dependencies
-      # if: ${{ inputs.path && inputs.path != null }}
       id: cache-dependencies
       uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
       with:
         path: ${{ inputs.path }}
         key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ inputs.key }}
+        restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ inputs.restore-keys }}
 
     - name: Install dependencies
       uses: nick-invision/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # v2.8.3
       with:
-        command: |
-          yarn install --frozen-lockfile --prefer-offline --production=false
-          npx cypress install
-          npx cypress --version
+        command: yarn install --frozen-lockfile --prefer-offline --production=false
         max_attempts: 3
         timeout_minutes: 7
       env:
         YARN_CACHE_FOLDER: ${{ inputs.yarn_cache_folder }}
-        CYPRESS_INSTALL_BINARY: https://vetsgov-website-builds-s3-upload.s3.us-gov-west-1.amazonaws.com/artifacts/cypress/13.3.0.zip

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -37,9 +37,9 @@ runs:
       run: npm i -g yarn@1.19.1
 
     - name: Cache dependencies
+      if: ${{ inputs.path && inputs.path != null }}
       id: cache-dependencies
       uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-      if: ${{ inputs.path !== null }}
       with:
         path: ${{ inputs.path }}
         key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ inputs.key }}

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -47,7 +47,10 @@ runs:
     - name: Install dependencies
       uses: nick-invision/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # v2.8.3
       with:
-        command: yarn install --frozen-lockfile --prefer-offline --production=false
+        command: |
+          yarn install --frozen-lockfile --prefer-offline --production=false
+          npx cypress install
+          npx cypress --version
         max_attempts: 3
         timeout_minutes: 7
       env:

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -37,7 +37,7 @@ runs:
       run: npm i -g yarn@1.19.1
 
     - name: Cache dependencies
-      if: ${{ inputs.path && inputs.path != null }}
+      # if: ${{ inputs.path && inputs.path != null }}
       id: cache-dependencies
       uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
       with:

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -47,7 +47,7 @@ runs:
     - name: Install dependencies
       uses: nick-invision/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # v2.8.3
       with:
-        command: yarn install --frozen-lockfile --prefer-offline --production=false
+        command: CYPRESS_INSTALL_BINARY=https://vetsgov-website-builds-s3-upload.s3.us-gov-west-1.amazonaws.com/artifacts/cypress/13.3.0.zip yarn install --frozen-lockfile --prefer-offline --production=false
         max_attempts: 3
         timeout_minutes: 7
       env:

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -42,13 +42,13 @@ runs:
       with:
         path: ${{ inputs.path }}
         key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ inputs.key }}
-        restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ inputs.restore-keys }}
 
     - name: Install dependencies
       uses: nick-invision/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # v2.8.3
       with:
-        command: CYPRESS_INSTALL_BINARY=https://vetsgov-website-builds-s3-upload.s3.us-gov-west-1.amazonaws.com/artifacts/cypress/13.3.0.zip yarn install --frozen-lockfile --prefer-offline --production=false
+        command: yarn install --frozen-lockfile --prefer-offline --production=false
         max_attempts: 3
         timeout_minutes: 7
       env:
         YARN_CACHE_FOLDER: ${{ inputs.yarn_cache_folder }}
+        CYPRESS_INSTALL_BINARY: https://vetsgov-website-builds-s3-upload.s3.us-gov-west-1.amazonaws.com/artifacts/cypress/13.3.0.zip

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -3,11 +3,11 @@ description: Install dependencies
 
 inputs:
   key:
-    description: keys for actions/cache@v3
+    description: keys for actions/cache@v4
     required: false
     default: ''
   restore-keys:
-    description: restore-keys for actions/cache@v3
+    description: restore-keys for actions/cache@v4
     required: false
     default: ''
   yarn_cache_folder:
@@ -15,7 +15,7 @@ inputs:
     required: false
     default: ''
   path:
-    description: path for actions/cache@v3
+    description: path for actions/cache@v4
     required: false
     default: ''
 
@@ -28,7 +28,7 @@ runs:
       run: echo NODE_VERSION=$(cat .nvmrc) >> $GITHUB_OUTPUT
 
     - name: Setup Node
-      uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 
@@ -38,16 +38,18 @@ runs:
 
     - name: Cache dependencies
       id: cache-dependencies
-      uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+      uses: actions/cache@v4
       with:
         path: ${{ inputs.path }}
         key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ inputs.key }}
-        restore-keys: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ inputs.restore-keys }}
 
     - name: Install dependencies
-      uses: nick-invision/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # v2.8.3
+      uses: nick-fields/retry@v3
       with:
-        command: yarn install --frozen-lockfile --prefer-offline --production=false
+        command: |
+          CYPRESS_INSTALL_BINARY=https://vetsgov-website-builds-s3-upload.s3.us-gov-west-1.amazonaws.com/artifacts/cypress/13.3.0.zip yarn install --frozen-lockfile --prefer-offline --production=false --network-timeout 1000000000
+          npx cypress install
+          npx cypress --version
         max_attempts: 3
         timeout_minutes: 7
       env:


### PR DESCRIPTION
## Summary

- This brings the Cypress testing mechanism in line with what vets-website is doing
  - The main change is that it runs the container and Cypress testing steps on GHA-hosted infrastructure rather than VA-hosted
- This is being done in response to the Cypress executable no longer being downloadable on the VA network. This is a error we first noticed on Dec 2, 2024. An example: https://github.com/department-of-veterans-affairs/content-build/actions/runs/12120500910/job/33814202119#step:6:226

For reference, here is the vets-website implementation of this:
- https://github.com/department-of-veterans-affairs/vets-website/blob/main/.github/workflows/continuous-integration.yml#L663
- https://github.com/department-of-veterans-affairs/vets-website/blob/main/.github/workflows/install/action.yml

## Testing done

-  Continued runs of CI until it completed correctly
- Cypress test runs output successfully: https://github.com/department-of-veterans-affairs/content-build/actions/runs/12147390354/job/33877182392#step:8:312

