### PR TITLE
VACMS 19842 - conditional rendering of data-widget-type div or full-width-banners based on CMS toggle

### DIFF
--- a/src/site/components/banners.drupal.liquid
+++ b/src/site/components/banners.drupal.liquid
@@ -17,9 +17,6 @@
   >{{ banner.body.processed }}</va-banner>
 {% endfor %}
 
-<!-- Situation Updates banner -->
-<div data-widget-type="situation-updates-banner"></div>
-
 <!-- Maintenance banner -->
 <div data-widget-type="maintenance-banner"></div>
 

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -180,9 +180,14 @@
     {% include "src/site/components/banners.drupal.liquid" %}
   </header>
 
-  <!-- Fullwidth banner alerts -->
-  {% include "src/site/components/fullwidth_banner_alerts.drupal.liquid" %}
-
+  {% if enabledFeatureFlags.FEATURE_BANNER_USE_ALTERNATIVE_BANNERS %}
+    <!-- Situation Updates banner -->
+    <div data-widget-type="situation-updates-banner"></div>
+  {% else %}
+    <!-- Fullwidth banner alerts -->
+    {% include "src/site/components/fullwidth_banner_alerts.drupal.liquid" %}
+  {% endif %}
+  
   <script nonce="**CSP_NONCE**" type="text/javascript">
     {% include "src/site/assets/js/skip-link-focus.js" %}
   </script>


### PR DESCRIPTION
## Summary

- Puts div for React widget injection next to full width banners in header.html and makes it conditional based on CMS toggle
- Sitewide team
- CMS toggle `FEATURE_BANNER_USE_ALTERNATIVE_BANNERS`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19842

## Testing done

- Conditionally renders the div with the widget type for using vets-website banner when toggled feature is on and uses standard existing div with va-banner from graphql if off.
- Manually tested two builds on a tugboat

## Screenshots

<details>
<summary>Build with FEATURE_BANNER_USE_ALTERNATIVE_BANNERS: true but tugboat doesn't build the new v-w so div is blank (but still no full-width-banner from liquid template)</summary>
<img width="1610" alt="Screenshot 2024-12-06 at 10 32 32 AM" src="https://github.com/user-attachments/assets/671a4efd-5945-4fe9-a45b-4e09a7b02561">
</details>

<details>
<summary>Build with FEATURE_BANNER_USE_ALTERNATIVE_BANNERS: false</summary>
<img width="1616" alt="Screenshot 2024-12-06 at 11 30 55 AM" src="https://github.com/user-attachments/assets/da118988-3e90-4aa7-9240-15c63fabeeb1">
</details>

## What areas of the site does it impact?

Affects the pages in VAMC systems (including va-manila-clinic which is a system to itself) for the full-width banners under the header

## Acceptance criteria

- [x] When CMS feature toggle FEATURE_BANNER_USE_ALTERNATIVE_BANNERS is enabled, in content-build, the existing prod build of VAMC BwSU should disappear across ALL templates


### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Check a tugboat build with `/admin/config/system/feature_toggle` on and off for FEATURE_BANNER_USE_ALTERNATIVE_BANNERS
this was done on https://main-pjrkdo5kzgprzxpfz31rnvzleiegcmh4.demo.cms.va.gov/admin/config/system/feature_toggle