### PR TITLE
Enable Prod flag for 5490 fry/dea application

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1741,7 +1741,7 @@
     "rootUrl": "/education/survivor-dependent-education-benefit-22-5490",
     "productId": "5544d590-0b67-48b1-a312-824c98d367ae",
     "template": {
-      "vagovprod": false,
+      "vagovprod": true,
       "layout": "page-react.html"
     }
   },


### PR DESCRIPTION
## Summary
Turns Production Flag ON for application survivor-dependent-education-benefit-22-5490

## Related issue(s)

## Testing done


## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?
Enables application survivor-dependent-education-benefit-22-5490 in Production

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

