### PR TITLE
VACMS 19968 - remove 2 extra uses of old phone numbers

### DIFF
--- a/src/site/stages/build/drupal/graphql/bioPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/bioPage.graphql.js
@@ -15,7 +15,6 @@ const personProfileFragment = `
     fieldSuffix
     fieldDescription
     fieldEmailAddress
-    fieldPhoneNumber
     ${personTelephone}
     fieldCompleteBiographyCreate
     fieldCompleteBiography { entity { url } }

--- a/src/site/stages/build/drupal/graphql/vamcBillingAndInsurancePage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vamcBillingAndInsurancePage.graphql.js
@@ -12,7 +12,6 @@ const billingAndInsuranceFragment = `
     entityUrl {
       path
     }
-    fieldPhoneNumber
     fieldTelephone {
       ... on FieldNodeVamcSystemBillingInsuranceFieldTelephone {
         entity {


### PR DESCRIPTION
## Summary

- Removes 2 more uses from GQL that were missed in the first PR
- Sitewide team
- This was noticed because of a removal of a CMS toggle and field

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19968

## Testing done

- Manually tested

## Screenshots

Just GQL data that was excluded from liquid templates in the past, so no visible changes

## What areas of the site does it impact?

Graphql data

## Acceptance criteria

GQL download completes

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Check that GQL download completes from: https://pr20101-3l0mof51ngr1hdlfew7vcusi6oi5unbr.ci.cms.va.gov/

e.g. `yarn build --use-cached-assets --pull-drupal --drupal-address=https://pr20101-3l0mof51ngr1hdlfew7vcusi6oi5unbr.ci.cms.va.gov/`