### PR TITLE
VACMS-18456 Update legacy action links to DS action links

### DIFF
--- a/src/site/facilities/main_buttons.drupal.liquid
+++ b/src/site/facilities/main_buttons.drupal.liquid
@@ -3,56 +3,50 @@
   Also used for VBA with parameter
 {% endcomment %}
 <div data-template="facilities/main_buttons">
-  <div>
-    {% if buttonType == 'vba' %}
-      <va-link-action
-        class="vads-u-display--block"
-        href="https://va.my.site.com/VAVERA/s/"
-        text="Make an appointment"
-        type="secondary"
-      ></va-link-action>
-    {% else %}
-      {% assign topTask = "make-an-appointment" | topTaskLovellComp: path, buildtype, fieldAdministration, fieldVamcEhrSystem, fieldRegionPage, fieldOffice %}
-      <va-link-action
-        class="vads-u-display--block"
-        href="{{topTask.url}}"
-        text="{{topTask.text}}"
-        type="secondary"
-      ></va-link-action>
-    {% endif %}
-  </div>
-  <div class="vads-u-margin-y--2">
-    {% if buttonType == 'vba' %}
-      <va-link-action
-        class="vads-u-display--block"
-        href="https://ask.va.gov"
-        text="Ask a benefit question"
-        type="secondary"
-      ></va-link-action>
-    {% else %}
-      <va-link-action
-        class="vads-u-display--block"
-        href="/{{ path }}/health-services"
-        text="View all health services"
-        type="secondary"
-      ></va-link-action> 
-    {% endif %}
-  </div>
-  <div>
-    {% if buttonType == 'vba' %}
-      <va-link-action
-        class="vads-u-display--block"
-        href="/claim-or-appeal-status"
-        text="Check a claim status"
-        type="secondary"
-      ></va-link-action>
-    {% else %}
-      <va-link-action
-        class="vads-u-display--block"
-        href="/{{ path }}/register-for-care"
-        text="Register for care"
-        type="secondary"
-      ></va-link-action>
-    {% endif %}
-  </div>
+  {% if buttonType == 'vba' %}
+    <va-link-action
+      class="vads-u-display--block"
+      href="https://va.my.site.com/VAVERA/s/"
+      text="Make an appointment"
+      type="secondary"
+    ></va-link-action>
+  {% else %}
+    {% assign topTask = "make-an-appointment" | topTaskLovellComp: path, buildtype, fieldAdministration, fieldVamcEhrSystem, fieldRegionPage, fieldOffice %}
+    <va-link-action
+      class="vads-u-display--block"
+      href="{{topTask.url}}"
+      text="{{topTask.text}}"
+      type="secondary"
+    ></va-link-action>
+  {% endif %}
+  {% if buttonType == 'vba' %}
+    <va-link-action
+      class="vads-u-display--block"
+      href="https://ask.va.gov"
+      text="Ask a benefit question"
+      type="secondary"
+    ></va-link-action>
+  {% else %}
+    <va-link-action
+      class="vads-u-display--block"
+      href="/{{ path }}/health-services"
+      text="View all health services"
+      type="secondary"
+    ></va-link-action> 
+  {% endif %}
+  {% if buttonType == 'vba' %}
+    <va-link-action
+      class="vads-u-display--block"
+      href="/claim-or-appeal-status"
+      text="Check a claim status"
+      type="secondary"
+    ></va-link-action>
+  {% else %}
+    <va-link-action
+      class="vads-u-display--block"
+      href="/{{ path }}/register-for-care"
+      text="Register for care"
+      type="secondary"
+    ></va-link-action>
+  {% endif %}
 </div>

--- a/src/site/facilities/main_buttons.drupal.liquid
+++ b/src/site/facilities/main_buttons.drupal.liquid
@@ -1,28 +1,58 @@
 {% comment %}
-    This is used for Region Landing page and Contact us page
-    Also used for VBA with parameter
+  This is used for Region Landing page and Contact us page
+  Also used for VBA with parameter
 {% endcomment %}
 <div data-template="facilities/main_buttons">
-    <div>
-        {% if buttonType == 'vba' %}
-            <a class="vads-c-action-link--blue" href="https://va.my.site.com/VAVERA/s/">Make an appointment</a>
-        {% else %}
-            {% assign topTask = "make-an-appointment" | topTaskLovellComp: path, buildtype, fieldAdministration, fieldVamcEhrSystem, fieldRegionPage, fieldOffice %}
-            <a class="vads-c-action-link--blue" href="{{topTask.url}}">{{topTask.text}}</a>
-        {% endif %}
-    </div>
-    <div class="vads-u-margin-y--2">
-        {% if buttonType == 'vba'  %}
-            <a class="vads-c-action-link--blue" href="https://ask.va.gov">Ask a benefit question</a>
-        {% else %}
-            <a class="vads-c-action-link--blue" href="/{{ path }}/health-services">View all health services</a>
-        {% endif %}
-    </div>
-    <div>
-        {% if buttonType == 'vba' %}
-            <a class="vads-c-action-link--blue" href="/claim-or-appeal-status">Check a claim status</a>
-        {% else %}
-            <a class="vads-c-action-link--blue" href="/{{ path }}/register-for-care">Register for care</a>
-        {% endif %}
-    </div>
+  <div>
+    {% if buttonType == 'vba' %}
+      <va-link-action
+        class="vads-u-display--block"
+        href="https://va.my.site.com/VAVERA/s/"
+        text="Make an appointment"
+        type="secondary"
+      ></va-link-action>
+    {% else %}
+      {% assign topTask = "make-an-appointment" | topTaskLovellComp: path, buildtype, fieldAdministration, fieldVamcEhrSystem, fieldRegionPage, fieldOffice %}
+      <va-link-action
+        class="vads-u-display--block"
+        href="{{topTask.url}}"
+        text="{{topTask.text}}"
+        type="secondary"
+      ></va-link-action>
+    {% endif %}
+  </div>
+  <div class="vads-u-margin-y--2">
+    {% if buttonType == 'vba' %}
+      <va-link-action
+        class="vads-u-display--block"
+        href="https://ask.va.gov"
+        text="Ask a benefit question"
+        type="secondary"
+      ></va-link-action>
+    {% else %}
+      <va-link-action
+        class="vads-u-display--block"
+        href="/{{ path }}/health-services"
+        text="View all health services"
+        type="secondary"
+      ></va-link-action> 
+    {% endif %}
+  </div>
+  <div>
+    {% if buttonType == 'vba' %}
+      <va-link-action
+        class="vads-u-display--block"
+        href="/claim-or-appeal-status"
+        text="Check a claim status"
+        type="secondary"
+      ></va-link-action>
+    {% else %}
+      <va-link-action
+        class="vads-u-display--block"
+        href="/{{ path }}/register-for-care"
+        text="Register for care"
+        type="secondary"
+      ></va-link-action>
+    {% endif %}
+  </div>
 </div>

--- a/src/site/includes/support_resources_cta_list.drupal.liquid
+++ b/src/site/includes/support_resources_cta_list.drupal.liquid
@@ -1,7 +1,7 @@
 {% if fieldButtons.length > 1 %}
   <ul class="vads-u-margin-y--3 usa-unstyled-list">
     {% for fieldButton in fieldButtons %}
-      <li class="vads-u-margin-bottom--2">
+      <li>
         {% include "src/site/paragraphs/action_link.drupal.liquid" with entity = fieldButton.entity %}
       </li>
     {% endfor %}

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -169,12 +169,12 @@
             <!-- Call to action -->
             {% if fieldClpVideoPanelMoreVideo.entity.fieldButtonLink.url.path and fieldClpVideoPanelMoreVideo.entity.fieldButtonLabel %}
               <p>
-                <va-link
-                  class="vads-c-action-link--blue"
+                <va-link-action
+                  class="vads-u-display--block"
                   href="{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLink.url.path }}"
                   text="{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLabel | strip }}"
-                  >
-                </va-link>
+                  type="secondary"
+                ></va-link-action>
               </p>
             {% endif %}
           </div>

--- a/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
+++ b/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
@@ -25,12 +25,11 @@
             <div class="usa-grid usa-grid-full vads-u-margin-y--1p5">
               <div class="vads-l-row">
                 <div class="vads-u-margin-right--2p5">
-                  <a
-                    class="vads-u-margin-top--1 vads-u-margin--0 vads-c-action-link--green"
+                  <va-link-action
+                    class="vads-u-display--block"
                     href="{{ fieldOffice.entity.fieldLinkFacilityEmergList.url.path }}"
-                  >
-                    Subscribe to emergency notifications
-                  </a>
+                    text="Subscribe to emergency notifications"
+                  ></va-link-action>
                 </div>
               </div>
             </div>

--- a/src/site/paragraphs/action_link.drupal.liquid
+++ b/src/site/paragraphs/action_link.drupal.liquid
@@ -3,4 +3,5 @@
   class="vads-u-display--block"
   href="{{ entity.fieldButtonLink.url.path }}"
   text="{{ entity.fieldButtonLabel }}"
+  type="secondary"
 ></va-link-action> 

--- a/src/site/paragraphs/action_link.drupal.liquid
+++ b/src/site/paragraphs/action_link.drupal.liquid
@@ -1,3 +1,6 @@
-<a class="vads-c-action-link--blue" data-template="paragraphs/action_link" href="{{ entity.fieldButtonLink.url.path }}">
-  {{ entity.fieldButtonLabel }}
-</a>
+<va-link-action
+  data-template="paragraphs/action_link"
+  class="vads-u-display--block"
+  href="{{ entity.fieldButtonLink.url.path }}"
+  text="{{ entity.fieldButtonLabel }}"
+></va-link-action> 

--- a/src/site/paragraphs/react_widget.drupal.liquid
+++ b/src/site/paragraphs/react_widget.drupal.liquid
@@ -59,11 +59,17 @@
       <span class="static-widget-content vads-u-display--none" aria-hidden="true">
         {% if entity.fieldDefaultLink != empty %}
           {% if entity.fieldButtonFormat %}
-            {% assign classes = 'class="vads-c-action-link--green"' %}
+            <va-link-action
+              class="vads-u-display--block"
+              href="{{ entity.fieldDefaultLink.url.path }}"
+              text="{{ entity.fieldDefaultLink.title }}"
+            ></va-link-action>
           {% else %}
-            {% assign classes = '' %}
+            <va-link
+              href="{{ entity.fieldDefaultLink.url.path }}"
+              text="{{ entity.fieldDefaultLink.title }}"
+            ></va-link>
           {% endif %}
-          <a href="{{ entity.fieldDefaultLink.url.path }}" {{ classes }}>{{ entity.fieldDefaultLink.title }}</a>
         {% endif %}
       </span>
       {% if entity.fieldErrorMessage != empty %}

--- a/src/site/paragraphs/service_location.drupal.liquid
+++ b/src/site/paragraphs/service_location.drupal.liquid
@@ -222,9 +222,12 @@
         {% assign scheduleAppointmentLink = "/health-care/schedule-view-va-appointments" %}
       {% endif %}
 
-      <a class="vads-c-action-link--blue" href="{{ scheduleAppointmentLink }}">
-        Schedule an appointment online
-      </a>
+      <va-link-action
+        class="vads-u-display--block"
+        href="{{ scheduleAppointmentLink }}"
+        text="Schedule an appointment online"
+        type="secondary"
+      ></va-link-action>
     </div>
   {% endif %}
 

--- a/src/site/tests/cypress/vamc-lovell.cypress.spec.js
+++ b/src/site/tests/cypress/vamc-lovell.cypress.spec.js
@@ -1,5 +1,3 @@
-import { expect } from 'chai';
-
 const verifyActionLink = (expectedText, expectedHref) =>
   cy
     .get('va-link-action')
@@ -16,10 +14,10 @@ describe('VAMC Lovell - All TRICARE pages with expected MHS Genesis Patient Port
     cy.visit('/lovell-federal-health-care-tricare/');
     cy.injectAxeThenAxeCheck();
 
-    cy.findByText('MHS Genesis Patient Portal').then(el => {
-      const attr = el.attr('href');
-      expect(attr).to.equal('https://my.mhsgenesis.health.mil/');
-    });
+    verifyActionLink(
+      'MHS Genesis Patient Portal',
+      'https://my.mhsgenesis.health.mil/',
+    );
   });
 
   it('TRICARE Health services has MHS Genesis Patient Portal link', () => {
@@ -36,10 +34,10 @@ describe('VAMC Lovell - All TRICARE pages with expected MHS Genesis Patient Port
     cy.visit('/lovell-federal-health-care-tricare/locations');
     cy.injectAxeThenAxeCheck();
 
-    cy.findByText('MHS Genesis Patient Portal').then(el => {
-      const attr = el.attr('href');
-      expect(attr).to.equal('https://my.mhsgenesis.health.mil/');
-    });
+    verifyActionLink(
+      'MHS Genesis Patient Portal',
+      'https://my.mhsgenesis.health.mil/',
+    );
   });
 
   it('TRICARE Captain James A. Lovell Location has MHS Genesis Patient Portal link', () => {
@@ -60,10 +58,10 @@ describe('VAMC Lovell - All VA pages with expected Make an appointment Top Task 
     cy.visit('/lovell-federal-health-care-va/');
     cy.injectAxeThenAxeCheck();
 
-    cy.findByText('Make an appointment').then(el => {
-      const attr = el.attr('href');
-      expect(attr.endsWith('make-an-appointment')).to.be.true;
-    });
+    verifyActionLink(
+      'Make an appointment',
+      '/lovell-federal-health-care-va/make-an-appointment',
+    );
   });
 
   it('VA Health services has Make an appointment link', () => {
@@ -80,10 +78,10 @@ describe('VAMC Lovell - All VA pages with expected Make an appointment Top Task 
     cy.visit('/lovell-federal-health-care-va/locations/');
     cy.injectAxeThenAxeCheck();
 
-    cy.findByText('Make an appointment').then(el => {
-      const attr = el.attr('href');
-      expect(attr.endsWith('make-an-appointment')).to.be.true;
-    });
+    verifyActionLink(
+      'Make an appointment',
+      '/lovell-federal-health-care-va/make-an-appointment',
+    );
   });
 
   it('VA Captain James A. Lovell Location has Make an appointment link', () => {

--- a/src/site/tests/static-pages/static-page-widgets.unit.spec.js
+++ b/src/site/tests/static-pages/static-page-widgets.unit.spec.js
@@ -14,7 +14,7 @@ const widgetContent = `
       </span>
     </div>
     <span class="static-widget-content vads-u-display--none" aria-hidden="true">
-     <a class="vads-c-action-link--green" href="/pension/application/527EZ">Apply for Veterans Pension Benefits</a>
+      <va-link-action class="vads-u-display--block" href="/pension/application/527EZ" text="Apply for Veterans Pension Benefits"></va-link-action>
     </span>
     <div class="usa-alert usa-alert-error sip-application-error vads-u-display--none" aria-hidden="true">
      <div class="usa-alert-body">


### PR DESCRIPTION
## Summary

Updated the remainder of old action links to `<va-link-action>`.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18456

## Testing done / screenshots

1. [main_buttons.drupal.liquid](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/facilities/main_buttons.drupal.liquid) is used for:

<details><summary>Health Care Region Detail Pages</summary>

Tested at `/boston-health-care/contact-us`

| Before | After |
| ------ | ----- |
| <img width="648" alt="Screenshot 2024-12-17 at 11 47 29 AM" src="https://github.com/user-attachments/assets/951e36ef-49ce-4e26-a927-c958b33be45e" /> | <img width="644" alt="Screenshot 2024-12-17 at 11 47 06 AM" src="https://github.com/user-attachments/assets/84da9b9b-6f40-4a5c-83f2-1ce871624238" /> |
| <img width="374" alt="Screenshot 2024-12-17 at 11 47 39 AM" src="https://github.com/user-attachments/assets/0fa4eab4-f203-4d5c-9f58-735e9dc286fa" /> | <img width="376" alt="Screenshot 2024-12-17 at 11 47 16 AM" src="https://github.com/user-attachments/assets/369ef3ce-2a7a-43e1-a8ea-d0dba5b65c2f" /> |

</details>

<details><summary>Health Care Region Pages</summary>

Tested at `/boston-health-care/`

| Before | After |
| ------ | ----- |
| <img width="698" alt="Screenshot 2024-12-17 at 11 31 16 AM" src="https://github.com/user-attachments/assets/ba18482a-136f-4203-97b5-6c8fe50161e8" /> | <img width="698" alt="Screenshot 2024-12-17 at 11 30 33 AM" src="https://github.com/user-attachments/assets/c14fb973-b87c-4d79-868c-42f2396021c5" /> |
| <img width="375" alt="Screenshot 2024-12-17 at 11 31 29 AM" src="https://github.com/user-attachments/assets/96003ea9-fa2a-43fb-971d-e94d47b088cb" /> | <img width="372" alt="Screenshot 2024-12-17 at 11 28 35 AM" src="https://github.com/user-attachments/assets/9d2aaa4b-9af1-4eb2-a673-614de56eab15" /> |

</details>

<details><summary>Locations Listings</summary>

Tested at `/boston-health-care/locations/`

| Before | After |
| ------ | ----- |
| <img width="248" alt="Screenshot 2024-12-17 at 11 23 45 AM" src="https://github.com/user-attachments/assets/4116be95-a0bd-4762-8123-eeddd5934397" /> | <img width="249" alt="Screenshot 2024-12-17 at 11 23 31 AM" src="https://github.com/user-attachments/assets/94aca3b0-a676-4e9f-b292-7dbc1d71a5b3" /> |
| <img width="371" alt="Screenshot 2024-12-17 at 11 23 56 AM" src="https://github.com/user-attachments/assets/54c2fd23-0077-446f-a5bc-1b76a3608f21" /> | <img width="376" alt="Screenshot 2024-12-17 at 11 23 40 AM" src="https://github.com/user-attachments/assets/2b3551f9-6ed6-4d44-be55-966902cf2561" /> |

</details>

<details><summary>VBA Facilities</summary>

Tested at `/los-angeles-va-regional-benefit-office/`

| Before | After |
| ------ | ----- |
| <img width="679" alt="Screenshot 2024-12-17 at 11 20 21 AM" src="https://github.com/user-attachments/assets/de283564-a296-4475-a4a0-ad03a4bcbf79" /> | <img width="682" alt="Screenshot 2024-12-17 at 11 20 40 AM" src="https://github.com/user-attachments/assets/88e3513b-52c8-4c19-a7e5-721f6d6feb7e" /> |
| <img width="376" alt="Screenshot 2024-12-17 at 11 20 32 AM" src="https://github.com/user-attachments/assets/dd10b9ed-200d-45f1-972e-e5121ef6c31d" /> | <img width="373" alt="Screenshot 2024-12-17 at 11 20 56 AM" src="https://github.com/user-attachments/assets/9ac00b1e-e5f2-40f6-bdde-f12a08147673" /> |

</details>

2. [campaign_landing_page.drupal.liquid](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/layouts/campaign_landing_page.drupal.liquid) has only one change to the CTA in the video section of the page. It should be tested in this Tugboat: https://web-utwv0w9m4qeqkgwsxo9kfzxduoqdz4cj.demo.cms.va.gov/initiatives/va-health-connect/

<details><summary>Screenshots</summary>

<img width="567" alt="Screenshot 2024-12-18 at 8 57 03 AM" src="https://github.com/user-attachments/assets/cb86dada-9262-4b7e-a118-3d8933225089" />
<img width="486" alt="Screenshot 2024-12-18 at 8 57 30 AM" src="https://github.com/user-attachments/assets/f3b51036-9504-4eb7-aee6-6a7ae0a51d0a" />

</details>

4. [vamc_operating_status_and_alerts.drupal.liquid](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid) has a change to the "Subscribe to emergency notifications" link but this link doesn't actually work because it's trying to access CMS data that isn't there. See [this Slack thread](https://dsva.slack.com/archives/C0FQSS30V/p1734387258419199) for context; [ticket stub](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20112) to research what happened with that link (out of scope for this ticket).

5. [action_link.drupal.liquid](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/paragraphs/action_link.drupal.liquid) is used in several places, including:

<details><summary>R&S Detail Page (single action link)</summary>

Tested at `/resources/what-your-decision-review-or-appeal-status-means/`

| Before | After |
| ------ | ----- |
| <img width="674" alt="Screenshot 2024-12-17 at 12 31 32 PM" src="https://github.com/user-attachments/assets/9e779ce7-ef05-4c3b-a152-9f3fcf8b6863" /> | <img width="670" alt="Screenshot 2024-12-17 at 12 31 13 PM" src="https://github.com/user-attachments/assets/ad3daafd-6d58-47e5-9315-47eedced975f" /> |
| <img width="371" alt="Screenshot 2024-12-17 at 12 31 40 PM" src="https://github.com/user-attachments/assets/a1d5379f-0982-4437-9105-b7a44c0af3a8" /> | <img width="377" alt="Screenshot 2024-12-17 at 12 31 21 PM" src="https://github.com/user-attachments/assets/0f6a1a47-39fe-4c80-893b-dec98665f2a1" /> |

</details>

<details><summary>R&S Detail Page (CTA list)</summary>

Tested at `/resources/life-insurance-if-you-have-preexisting-conditions/`

| Before | After |
| ------ | ----- |
| <img width="704" alt="Screenshot 2024-12-17 at 12 40 36 PM" src="https://github.com/user-attachments/assets/efe5e19e-7774-4651-9425-192f93ee7074" /> | <img width="703" alt="Screenshot 2024-12-17 at 12 40 16 PM" src="https://github.com/user-attachments/assets/9e04386e-83a1-4254-8fc0-e96c5e2a9c85" /> |
| <img width="375" alt="Screenshot 2024-12-17 at 12 40 45 PM" src="https://github.com/user-attachments/assets/f6d14584-d150-4647-9fd1-b35989c8d3fe" /> | <img width="370" alt="Screenshot 2024-12-17 at 12 40 25 PM" src="https://github.com/user-attachments/assets/b1f3ec26-b7b1-49d1-a660-8e1efba45478" /> |

</details>

6. [service_location.drupal.liquid](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/paragraphs/service_location.drupal.liquid) is used for health care local facilities:

<details><summary>Health Care Local Facilities</summary>

Tested at `/south-texas-health-care/locations/audie-l-murphy-memorial-veterans-hospital/#health-care-offered-here#cancer-care`

| Before | After |
| ------ | ----- |
| <img width="641" alt="Screenshot 2024-12-17 at 1 03 06 PM" src="https://github.com/user-attachments/assets/13270c24-8ed6-433e-9154-ae065c283834" /> | <img width="645" alt="Screenshot 2024-12-17 at 1 02 47 PM" src="https://github.com/user-attachments/assets/d8bcafc4-7875-403d-ac59-a149e269e534" /> |
| <img width="327" alt="Screenshot 2024-12-17 at 1 03 35 PM" src="https://github.com/user-attachments/assets/398a7f36-96e7-49af-ba0c-6d44e3b43222" /> | <img width="326" alt="Screenshot 2024-12-17 at 1 03 28 PM" src="https://github.com/user-attachments/assets/a2df43b7-ccb1-4f56-9888-d0c1e043a56b" /> |

</details>

7. [react_widget.drupal.liquid](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/paragraphs/react_widget.drupal.liquid) is used in many places, but the non-CTA version with default links is difficult to find. I created one on a Tugboat and had to force it to show locally; I'm not sure exactly what the logic to display this should be. Here's the Tugboat example (under the accordions): https://web-utwv0w9m4qeqkgwsxo9kfzxduoqdz4cj.demo.cms.va.gov/resources/reimbursed-va-travel-expenses-and-mileage-rate

<details><summary>Screenshots</summary>

<img width="400" alt="Screenshot 2024-12-18 at 9 04 17 AM" src="https://github.com/user-attachments/assets/4b5a9b6f-4e74-470e-ab4c-cd0bb04e3c88" />
<img width="400" alt="Screenshot 2024-12-18 at 9 04 25 AM" src="https://github.com/user-attachments/assets/d76e3790-562a-464a-a25d-91b84d944968" />
<img width="400" alt="Screenshot 2024-12-18 at 9 08 49 AM" src="https://github.com/user-attachments/assets/6d058af6-8d6e-4317-befb-25cfd09cce09" />
<img width="400" alt="Screenshot 2024-12-18 at 9 08 55 AM" src="https://github.com/user-attachments/assets/21d53446-6140-42c0-8ce0-632787f9c27a" />

</details>