### PR TITLE
[VACMS-19506]Remove aria-labelledby from fullwidth banner alerts

### DIFF
--- a/src/site/components/fullwidth_banner_alerts.drupal.liquid
+++ b/src/site/components/fullwidth_banner_alerts.drupal.liquid
@@ -25,7 +25,6 @@
     <div
       data-template="components/fullwidth_banner_alerts"
       data-entity-id="{{ entity.entityId }}"
-      aria-labelledby="{{ entity.title }}"
     >
       <va-banner
         type="{{ alertType }}"


### PR DESCRIPTION
## Summary

- Removes the aria-labelledby from fullwidth banner alerts
- This was generating errors in AMP due to it creating labels without corresponding ids
- Sitewide team
- These fullwidth banner alerts are behind a flipper as a backup to real-time banners from the vets-api

## Related issue(s)

- Issue: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19506#issuecomment-2552199034

## Testing done

- Confirmed when the flipper to use alternative banners is disabled, content build creates fullwidth-banner-alerts without the corresponding aria-labelledby attributes.

## What areas of the site does it impact?
The no longer utilized VAMC fullwidthBannerAlerts


## Acceptance criteria
- [x] aria-labelledby attribute is removed from the div that holds the content-build VAMC banners

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user