### PR TITLE
Adds holiday checker in front of daily production tag, including override.

### DIFF
--- a/.github/workflows/daily-production-release.yml
+++ b/.github/workflows/daily-production-release.yml
@@ -2,6 +2,11 @@ name: Daily Production Release
 
 on:
   workflow_dispatch:
+    inputs:
+      override_code_freeze:
+        type: boolean
+        description: "Override code freeze and create production tag"
+        default: false
   schedule:
     - cron: 0 16 * * 1-5
 
@@ -15,9 +20,21 @@ env:
   DSVA_SCHEDULE_ENABLED: true
 
 jobs:
+  holiday-checker:
+    runs-on: ubuntu-latest
+    outputs:
+      is_holiday: ${{ steps.holiday-check.outputs.is_holiday }}
+    steps:
+      - name: Check if today is a holiday
+        id: holiday-check
+        uses: department-of-veterans-affairs/vsp-github-actions/holiday-checker@main
   create-release:
     name: Create Release
+    needs: holiday-checker
     runs-on: ubuntu-latest
+    # Do not run the workflow during VA holidays unless we explicitly override it.
+    if: >
+      (needs.holiday-checker.outputs.is_holiday == 'false' || (inputs && inputs.override_code_freeze))
     outputs:
       RELEASE_NAME: ${{ steps.export-release-name.outputs.RELEASE_NAME }}
 


### PR DESCRIPTION
## Summary
- This adds a VA holiday checker action in front of Daily Production Release to halt production tagging if in a code freeze
- It can be manually overridden in the Github interface

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19910

## Testing done
This was tested by attempting to run the workflow from this branch, both without and then with the override. The overridden version was halted before completing in order to not violate code freeze.

- Without Override (halted itself without completing due to being in code freeze): https://github.com/department-of-veterans-affairs/content-build/actions/runs/12486388271
- With override (continued successfully to later parts of the workflow): https://github.com/department-of-veterans-affairs/content-build/actions/runs/12486397868

