### PR TITLE
VACMS-12082 Fix service accordions headers

### DIFF
--- a/src/site/facilities/health_service.drupal.liquid
+++ b/src/site/facilities/health_service.drupal.liquid
@@ -1,52 +1,55 @@
-        {% assign serviceTaxonomy = healthService.fieldServiceNameAndDescripti.entity %}
-        <va-accordion-item
-            {% if serviceTaxonomy.fieldAlsoKnownAs %}
-                subheader="{{ serviceTaxonomy.fieldAlsoKnownAs }}"
-                data-childlabel="{{ serviceTaxonomy.fieldAlsoKnownAs }}"
-            {% endif %}
-            class="va-accordion-item"
-            data-label="{{ serviceTaxonomy.name }}"
-            data-template="facilities/health_service"
-            id="item-{{ serviceTaxonomy.name | hashReference: 60 }}"
-            uswds="true"
-        >
-            <h3 slot="headline">
-                {{ serviceTaxonomy.name }}
-            </h3>
-            <div id="{{ serviceTaxonomy.entityBundle }}-{{ serviceTaxonomy.entityId }}">
-                {% if serviceTaxonomy.fieldCommonlyTreatedCondition %}
-                    <p class="vads-u-margin-bottom--2">
-                        Common conditions: {{ serviceTaxonomy.fieldCommonlyTreatedCondition }}
-                    </p>
-                {% endif %}
-                {% if section.name == "Lovell - TRICARE" and serviceTaxonomy.fieldTricareDescription %}
-                    <description>{{ serviceTaxonomy.fieldTricareDescription | phoneLinks }}</description>
-                {% elsif serviceTaxonomy.description.processed  %}
-                    <description>{{ serviceTaxonomy.description.processed | phoneLinks }}</description>
-                {% endif %}
+{% assign serviceTaxonomy = healthService.fieldServiceNameAndDescripti.entity %}
+<va-accordion-item
+  {% if serviceTaxonomy.fieldAlsoKnownAs %}
+    subheader="{{ serviceTaxonomy.fieldAlsoKnownAs }}"
+    data-childlabel="{{ serviceTaxonomy.fieldAlsoKnownAs }}"
+  {% endif %}
+  class="va-accordion-item"
+  data-label="{{ serviceTaxonomy.name }}"
+  data-template="facilities/health_service"
+  id="item-{{ serviceTaxonomy.name | hashReference: 60 }}"
+  uswds="true"
+>
+  <h3 slot="headline">
+    {{ serviceTaxonomy.name }}
+  </h3>
+  <div id="{{ serviceTaxonomy.entityBundle }}-{{ serviceTaxonomy.entityId }}">
+    {% if serviceTaxonomy.fieldCommonlyTreatedCondition %}
+      <p class="vads-u-margin-bottom--2">
+        Common conditions: {{ serviceTaxonomy.fieldCommonlyTreatedCondition }}
+      </p>
+    {% endif %}
 
-                {% if healthService.fieldLocalHealthCareService.length > 0 %}
-                    <h3>Available at these {{ regionOrOffice }} locations</h3>
-                    <ul class="usa-unstyled-list" role="list">
-                        {% assign orderedHealthServices = healthService.fieldLocalHealthCareService | orderFieldLocalHealthCareServices %}
-                        {% for location in orderedHealthServices %}
-                            {% assign facility = location.entity.fieldFacilityLocation.entity %}
-                            {% if location.entity.status and facility != empty %}
-                                <li class="vads-u-margin-bottom--2">
-                                    <va-link
-                                        href="{{ facility.entityUrl.path }}/#{{serviceTaxonomy.name | hashReference: 60}}"
-                                        text="{{ facility.title }}"
-                                    >
-                                    </va-link>
-                                </li>
-                            {% endif %}
-                        {% endfor %}
-                    </ul>
-                {% endif %}
+    {% if section.name == "Lovell - TRICARE" and serviceTaxonomy.fieldTricareDescription %}
+      <description>{{ serviceTaxonomy.fieldTricareDescription | phoneLinks }}</description>
+    {% elsif serviceTaxonomy.description.processed  %}
+      <description>{{ serviceTaxonomy.description.processed | phoneLinks }}</description>
+    {% endif %}
 
-                {% if healthService.fieldBody.processed %}
-                    <h3>Care we provide at {{ fieldOffice.entity.entityLabel }}</h3>
-                    <description>{{ healthService.fieldBody.processed | phoneLinks }}</description>
-                {% endif %}
-            </div>
-        </va-accordion-item>
+    {% if healthService.fieldLocalHealthCareService.length > 0 %}
+      <h4 class="vads-u-font-size--h3">Available at these {{ regionOrOffice }} locations</h3>
+      <ul class="usa-unstyled-list" role="list">
+        {% assign orderedHealthServices = healthService.fieldLocalHealthCareService | orderFieldLocalHealthCareServices %}
+
+        {% for location in orderedHealthServices %}
+          {% assign facility = location.entity.fieldFacilityLocation.entity %}
+
+          {% if location.entity.status and facility != empty %}
+            <li class="vads-u-margin-bottom--2">
+              <va-link
+                  href="{{ facility.entityUrl.path }}/#{{serviceTaxonomy.name | hashReference: 60}}"
+                  text="{{ facility.title }}"
+              >
+              </va-link>
+            </li>
+          {% endif %}
+        {% endfor %}
+      </ul>
+    {% endif %}
+
+    {% if healthService.fieldBody.processed %}
+      <h4 class="vads-u-font-size--h3">Care we provide at {{ fieldOffice.entity.entityLabel }}</h3>
+      <description>{{ healthService.fieldBody.processed | phoneLinks }}</description>
+    {% endif %}
+  </div>
+</va-accordion-item>


### PR DESCRIPTION
## Summary
Adjust hard-coded service accordion interior headings to be `<h4>` instead of `<h3>`.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12082

## Testing done
Tested at http://localhost:3002/boston-health-care/health-services/, http://localhost:3002/lovell-federal-health-care-va/health-services/ and http://localhost:3002/lovell-federal-health-care-tricare/health-services/.

## Screenshots

### /boston-health-care/health-services/

<img width="600" alt="Screenshot 2024-12-27 at 2 39 29 PM" src="https://github.com/user-attachments/assets/5c0c3011-50f0-4194-936b-a06da15da2e6" />

<img width="436" alt="Screenshot 2024-12-27 at 2 39 37 PM" src="https://github.com/user-attachments/assets/ee6a5aa8-23ea-4e4b-85ec-8a435fc796b0" />

<br />
<br />
<br />
<img width="600" alt="Screenshot 2024-12-27 at 2 40 02 PM" src="https://github.com/user-attachments/assets/a3d180c6-96d2-4aa5-9ac0-861e62e6e531" />
<img width="427" alt="Screenshot 2024-12-27 at 2 40 10 PM" src="https://github.com/user-attachments/assets/ed5cfec9-4e1c-43bf-b989-d980dbb40a2b" />

### /lovell-federal-health-care-va/health-services/
<img width="600" alt="Screenshot 2024-12-27 at 2 44 46 PM" src="https://github.com/user-attachments/assets/7f331171-dd5a-4aa0-aacd-6f0eb61d5adf" />
<img width="422" alt="Screenshot 2024-12-27 at 2 44 56 PM" src="https://github.com/user-attachments/assets/d577cf4c-3b20-4d87-83ad-377346feb19d" />

### /lovell-federal-health-care-tricare/health-services/
<img width="600" alt="Screenshot 2024-12-27 at 2 45 57 PM" src="https://github.com/user-attachments/assets/1c9c8242-cc42-4993-a026-5422d2b1baca" />
<img width="436" alt="Screenshot 2024-12-27 at 2 46 08 PM" src="https://github.com/user-attachments/assets/b14afbf8-ad9d-4848-bfd4-3c143f19c151" />

## What areas of the site does it impact?

VAMC Health Services pages