### PR TITLE
Update title text for Caregivers app entry

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -160,7 +160,7 @@
     "entryName": "1010cg-application-caregiver-assistance",
     "rootUrl": "/family-and-caregiver-benefits/health-and-disability/comprehensive-assistance-for-family-caregivers/apply-form-10-10cg",
     "template": {
-      "title": "Caregiver Application for Benefits",
+      "title": "Apply for the Program of Comprehensive Assistance for Family Caregivers",
       "vagovprod": true,
       "vagovstaging": true,
       "vagovdev": true,


### PR DESCRIPTION
## Summary

This PR updates the title text of the Caregivers application to match the H1 tag and current breadcrumb for the app page. This update was based on a finding from Staging review that uncovered the mismatch.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#99039

## Acceptance criteria

- Page title text matches the current breadcrumb and H1 tag on the page

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
