### PR TITLE
Update title text for the HCA app entry

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -225,7 +225,7 @@
     "entryName": "hca",
     "rootUrl": "/health-care/apply-for-health-care-form-10-10ez",
     "template": {
-      "title": "Apply for Health Care",
+      "title": "Apply for VA health care",
       "display_title": "Apply Now",
       "description": "Apply for VA health care benefits. Find out which documents you’ll need, and start your online application today.",
       "body_class": "page-healthcare",


### PR DESCRIPTION
## Summary

This PR updates the title text of the HCA application to match the H1 tag and current breadcrumb for the app page. This update was based on a finding from Staging review of other team app that uncovered the mismatch.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#99709

## Acceptance criteria

- Page title text matches the current breadcrumb and H1 tag on the page

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
