### PR TITLE
Remove fa-solid-900.woff references.

### DIFF
--- a/src/site/includes/accredited-representative-portal/head.html
+++ b/src/site/includes/accredited-representative-portal/head.html
@@ -31,7 +31,6 @@
   <link rel="preload" href="/generated/sourcesanspro-bold-webfont.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="/generated/sourcesanspro-regular-webfont.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="/generated/bitter-bold.woff2" as="font" type="font/woff2" crossorigin>
-  <link rel="preload" href="/generated/fa-solid-900.woff2" as="font" type="font/woff2" crossorigin>
 
   <!-- CSS -->
   <link rel="stylesheet" data-entry-name="style.css">

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -69,7 +69,6 @@
   <link rel="preload" href="/generated/sourcesanspro-bold-webfont.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="/generated/sourcesanspro-regular-webfont.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="/generated/bitter-bold.woff2" as="font" type="font/woff2" crossorigin>
-  <link rel="preload" href="/generated/fa-solid-900.woff2" as="font" type="font/woff2" crossorigin>
 
   <!-- CSS -->
   <link rel="stylesheet" data-entry-name="style.css">
@@ -187,7 +186,7 @@
     <!-- Fullwidth banner alerts -->
     {% include "src/site/components/fullwidth_banner_alerts.drupal.liquid" %}
   {% endunless %}
-  
+
   <script nonce="**CSP_NONCE**" type="text/javascript">
     {% include "src/site/assets/js/skip-link-focus.js" %}
   </script>


### PR DESCRIPTION
## Summary

- removed references to fa-solid-900.woff, as the file is no longer being generated

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20219

## Testing done

Generated files no longer attempt to load fa-solid-900.woff
