### PR TITLE
VACMS-28709 in this section a11y iOS fix

### DIFF
--- a/src/site/navigation/sidebar_nav.drupal.liquid
+++ b/src/site/navigation/sidebar_nav.drupal.liquid
@@ -1,14 +1,26 @@
 <nav data-template="navigation/sidebar_nav" aria-label="Secondary" id="va-detailpage-sidebar" data-drupal-sidebar="true" class="va-drupal-sidebarnav usa-width-one-fourth va-sidebarnav">
-<div aria-modal="true" role="dialog">
+<div aria-modal="true" role="dialog" aria-labelledby="sidebar_header">
         <button class="va-sidenav-btn-close va-sidebarnav-close" type="button" aria-label="Close this menu">
             <va-icon icon="close" size="3" class="vads-u-color--gray-dark"></va-icon>
         </button>
+        <script>
+            document.addEventListener('keydown', function(event) {
+                if (event.key === 'Escape') {
+                    const sidebar = document.getElementById('va-detailpage-sidebar');
+                    const closeButton = sidebar.querySelector('.va-sidenav-btn-close');
+
+                if (sidebar && closeButton) {
+                    closeButton.click();
+                }
+                }
+            });
+        </script>
 
         {% for link in sidebar.links %}
             {% if forloop.first == true %}
                 <div class="vads-u-display--flex vads-u-align-items--center left-side-nav-title">
                     {{ fieldTitleIcon | getHubIcon: '3', 'vads-u-margin-right--1' }}
-                    <h4>{{ link.label }}</h4>
+                    <h4 id="sidebar_header">{{ link.label }}</h4>
                 </div>
 
                 {% assign deepLinksString = link.links | findCurrentPathDepth: entityUrl.path %}
@@ -17,6 +29,7 @@
                 {% assign deepLinks = deepLinksObj.links %}
 
                 {% if depth <= 2 %}
+                    <nav aria-label="Secondary">
                     <ul class="usa-accordion">
                     {% for link in link.links %}
                         <li>
@@ -72,6 +85,7 @@
                         </li>
                     {% endfor %}
                 </ul>
+                </nav>
             {% else %}
                 <div class="sidenav-previous-page">
                     <a href="{{ deepLinks.url.path }}">{{ deepLinks.label }}</a>

--- a/src/site/navigation/sidebar_nav.drupal.liquid
+++ b/src/site/navigation/sidebar_nav.drupal.liquid
@@ -1,5 +1,5 @@
 <nav data-template="navigation/sidebar_nav" aria-label="Secondary" id="va-detailpage-sidebar" data-drupal-sidebar="true" class="va-drupal-sidebarnav usa-width-one-fourth va-sidebarnav">
-<div aria-modal="true" aria-labelledby="Family and caaregiver benefits" role="dialog">
+<div aria-modal="true" role="dialog">
         <button class="va-sidenav-btn-close va-sidebarnav-close" type="button" aria-label="Close this menu">
             <va-icon icon="close" size="3" class="vads-u-color--gray-dark"></va-icon>
         </button>

--- a/src/site/navigation/sidebar_nav.drupal.liquid
+++ b/src/site/navigation/sidebar_nav.drupal.liquid
@@ -1,6 +1,5 @@
 <nav data-template="navigation/sidebar_nav" aria-label="Secondary" id="va-detailpage-sidebar" data-drupal-sidebar="true" class="va-drupal-sidebarnav usa-width-one-fourth va-sidebarnav">
-    <div>
-
+<div aria-modal="true" aria-labelledby="Family and caaregiver benefits" role="dialog">
         <button class="va-sidenav-btn-close va-sidebarnav-close" type="button" aria-label="Close this menu">
             <va-icon icon="close" size="3" class="vads-u-color--gray-dark"></va-icon>
         </button>


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary
In this PR we add markup to the div containing the accordion dropdown to allow the cursor in iOS to stay once the drawer is open.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/28709

## Testing done
Hard to test this in iOS. But checked that the new markup is showing locally.

## Screenshots
![Health_And_Disability_Benefits_For_Family_And_Caregivers___Veterans_Affairs](https://github.com/user-attachments/assets/ab01598d-8a89-4c1d-b6ac-1c23dd003854)


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

