### PR TITLE
[VACMS-19406]Don't build health care region pages for Manila

### DIFF
--- a/src/site/stages/build/drupal/process-manila-pages.js
+++ b/src/site/stages/build/drupal/process-manila-pages.js
@@ -11,25 +11,25 @@ function getManilaClinicUrl(path) {
 
 function isManilaVAClinicPage(page) {
   return (
-    page.fieldAdministration?.entity?.entityId === MANILA_VA_CLINIC_ENTITY_ID
+    page?.fieldAdministration?.entity?.entityId === MANILA_VA_CLINIC_ENTITY_ID
   );
 }
 
 function isManillaVaRegionHomepage(page) {
   return (
     isManilaVAClinicPage(page) &&
-    page.entityBundle === ENTITY_BUNDLES.HEALTH_CARE_REGION_PAGE
+    page?.entityBundle === ENTITY_BUNDLES.HEALTH_CARE_REGION_PAGE
   );
 }
 
 function updateManilaSystemLinks(page) {
   // Update main URL path
-  if (page.entityUrl?.path) {
+  if (page?.entityUrl?.path) {
     page.entityUrl.path = getManilaClinicUrl(page.entityUrl.path);
   }
 
   // Update breadcrumb links
-  if (page.entityUrl?.breadcrumb) {
+  if (page?.entityUrl?.breadcrumb) {
     page.entityUrl.breadcrumb = page.entityUrl.breadcrumb.map(crumb => ({
       ...crumb,
       url: crumb.url ? getManilaClinicUrl(crumb.url) : crumb.url,
@@ -37,14 +37,14 @@ function updateManilaSystemLinks(page) {
   }
 
   // Update field office links
-  if (page.fieldOffice?.entity?.entityUrl) {
+  if (page?.fieldOffice?.entity?.entityUrl) {
     page.fieldOffice.entity.entityUrl.path = getManilaClinicUrl(
       page.fieldOffice.entity.entityUrl.path,
     );
   }
 
   // Update any listing page links
-  if (page.fieldListing?.entity?.entityUrl) {
+  if (page?.fieldListing?.entity?.entityUrl) {
     page.fieldListing.entity.entityUrl.path = getManilaClinicUrl(
       page.fieldListing.entity.entityUrl.path,
     );

--- a/src/site/stages/build/drupal/process-manila-pages.js
+++ b/src/site/stages/build/drupal/process-manila-pages.js
@@ -11,14 +11,14 @@ function getManilaClinicUrl(path) {
 
 function isManilaVAClinicPage(page) {
   return (
-    page?.fieldAdministration?.entity?.entityId === MANILA_VA_CLINIC_ENTITY_ID
+    page.fieldAdministration?.entity?.entityId === MANILA_VA_CLINIC_ENTITY_ID
   );
 }
 
 function isManillaVaRegionHomepage(page) {
   return (
     isManilaVAClinicPage(page) &&
-    page?.entityBundle === ENTITY_BUNDLES.HEALTH_CARE_REGION_PAGE
+    page.entityBundle === ENTITY_BUNDLES.HEALTH_CARE_REGION_PAGE
   );
 }
 
@@ -37,14 +37,14 @@ function updateManilaSystemLinks(page) {
   }
 
   // Update field office links
-  if (page?.fieldOffice?.entity?.entityUrl) {
+  if (page.fieldOffice?.entity?.entityUrl) {
     page.fieldOffice.entity.entityUrl.path = getManilaClinicUrl(
       page.fieldOffice.entity.entityUrl.path,
     );
   }
 
   // Update any listing page links
-  if (page?.fieldListing?.entity?.entityUrl) {
+  if (page.fieldListing?.entity?.entityUrl) {
     page.fieldListing.entity.entityUrl.path = getManilaClinicUrl(
       page.fieldListing.entity.entityUrl.path,
     );

--- a/src/site/stages/build/drupal/process-manila-pages.js
+++ b/src/site/stages/build/drupal/process-manila-pages.js
@@ -1,4 +1,6 @@
 /* eslint-disable no-param-reassign */
+const { ENTITY_BUNDLES } = require('../../../constants/content-modeling');
+
 const MANILA_VA_CLINIC_ENTITY_ID = '1187';
 
 function getManilaClinicUrl(path) {
@@ -10,6 +12,13 @@ function getManilaClinicUrl(path) {
 function isManilaVAClinicPage(page) {
   return (
     page?.fieldAdministration?.entity?.entityId === MANILA_VA_CLINIC_ENTITY_ID
+  );
+}
+
+function isManillaVaRegionHomepage(page) {
+  return (
+    isManilaVAClinicPage(page) &&
+    page?.entityBundle === ENTITY_BUNDLES.HEALTH_CARE_REGION_PAGE
   );
 }
 
@@ -53,6 +62,10 @@ function processManilaPages(drupalData) {
       if (isManilaVAClinicPage(page)) {
         acc.manilaVAClinicPages.push(page);
       } else {
+        // Federal Region Homepage should not be created for Manila VA Clinic
+        if (isManillaVaRegionHomepage(page)) {
+          return acc;
+        }
         acc.otherPages.push(page);
       }
 


### PR DESCRIPTION
## Summary

- Makes it so that even when published, system nodes for Manila's VA Clinic will not be built
- It was desired to put this in as a safety net in case future editors accidentally publish this system node
- Sitewide Team
- No Flipper

## Related issue(s)

-  Issue: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19406

## Testing done

- Archived Manila System Node to have a clean Manila VA clinic node
- Created Tugboat [here](https://tugboat.vfs.va.gov/678ac1a85134c90ada6b552b) for testing
- On tugboat's CMS did a content-build with this branch
- Then published Manila VA System
- No changes appear https://web-iqtwo8u4khq2nt7e1xd8m7yjtc7ohro9.demo.cms.va.gov/manila-va-clinic/ it remains identical to https://www.va.gov/manila-va-clinic/

## What areas of the site does it impact?
Manila System Node

## Acceptance criteria
- [x] Manila VAMC System node is published in Drupal, but no FE page generated

- [x] Manila VAMC System page can't make it through content-build to the FE

- [x] Regression test FE in a tugboat and ensure that all URLs match the [IA document in SharePoint.](https://dvagov.sharepoint.com/:x:/s/SitewideContract/EblgAS21OUtHloKK3a8ZvNIBHzV1S6uO2l4hj4dqYG0avQ?e=J8UVZh)AMC

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
