### PR TITLE
VACMS-20243 Add YouTube link to local facility pages

### DIFF
--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -227,6 +227,7 @@
                     fieldTwitter = fieldRegionPage.entity.fieldTwitter
                     fieldInstagram = fieldRegionPage.entity.fieldInstagram
                     fieldFlickr = fieldRegionPage.entity.fieldFlickr
+                    fieldYoutube = fieldRegionPage.entity.fieldYoutube
           %}
         
           <va-back-to-top></va-back-to-top>


### PR DESCRIPTION
## Summary
If a YouTube link is added to a VAMC, it appears on the region page, but it hasn't been appearing on the local facility page. This is because it isn't explicitly passed to the social links template for some reason.

This PR adds the YouTube link to the social links template so the links will be consistent across the region pages and local facility pages.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20243

## Testing done
Tested on `/greater-los-angeles-health-care/` (where it is currently appearing in prod) and `/greater-los-angeles-health-care/locations/west-los-angeles-va-medical-center/` (where it was added).

Can also be tested on `/minneapolis-health-care/` and `/minneapolis-health-care/locations/minneapolis-va-medical-center/`.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Local facility page  |  <img width="711" alt="Screenshot 2025-01-09 at 3 58 56 PM" src="https://github.com/user-attachments/assets/05754441-a732-45f4-9f52-97b6c74f618e" />  |   <img width="726" alt="Screenshot 2025-01-09 at 3 58 33 PM" src="https://github.com/user-attachments/assets/d8b4581a-ae19-4e68-8c47-cecd5333bec5" /> |
| Region page | <img width="717" alt="Screenshot 2025-01-09 at 3 59 12 PM" src="https://github.com/user-attachments/assets/3e4d1f5d-58c8-4c8e-8af6-6840bcd52c06" />   |  <img width="738" alt="Screenshot 2025-01-09 at 3 58 29 PM" src="https://github.com/user-attachments/assets/4f627f41-5a58-4af7-867d-ee37b20278ba" />  |