### PR TITLE
VACMS-20274 Reorder form details on detail page for consistency

### DIFF
--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -33,6 +33,15 @@
             </dt>
           </div>
 
+          {% if fieldVaFormRevisionDate or fieldVaFormIssueDate %}
+            <div>
+              <dd>
+                <dfn class="vads-u-font-weight--bold vads-u-display--inline">Form revision date:</dfn>
+                {{ fieldVaFormRevisionDate.value | formatDate: 'MMMM YYYY' }}
+              </dd>
+            </div>
+          {% endif %}
+
           <div class="vads-u-margin-y--1">
             <dd>
               <dfn class="vads-u-font-weight--bold vads-u-display--inline">Related to:</dfn>
@@ -53,15 +62,7 @@
               {% endcase %}
             </dd>
           </div>
-
-          {% if fieldVaFormRevisionDate or fieldVaFormIssueDate %}
-            <div>
-              <dd>
-                <dfn class="vads-u-font-weight--bold vads-u-display--inline">Form revision date:</dfn>
-                {{ fieldVaFormRevisionDate.value | formatDate: 'MMMM YYYY' }}
-              </dd>
-            </div>
-          {% endif %}
+          
         </dl>
 
         {% if fieldVaFormUsage %}


### PR DESCRIPTION
## Summary
The **Form revision date** and **Related to** data are in opposite order on the form detail page and the form search results. We want to update the form detail page to make these consistent. ([Slack thread](https://dsva.slack.com/archives/C03LFSPGV16/p1736804106855099)).

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20274

## Testing done
Tested on `/find-forms/about-form-10-0003k/` and `/find-forms`.

## Screenshots

Search results on `/find-forms`, for reference:
<img width="314" alt="Screenshot 2025-01-13 at 3 34 13 PM" src="https://github.com/user-attachments/assets/eded1374-3e03-4d4c-82b1-b36b4d07c5e4" />

Form detail page:

| Before | After |
| ------ | ----- |
| <img width="674" alt="Screenshot 2025-01-14 at 9 45 34 AM" src="https://github.com/user-attachments/assets/096cd132-a695-4fe4-a18d-122c06362418" /> | <img width="611" alt="Screenshot 2025-01-14 at 9 45 15 AM" src="https://github.com/user-attachments/assets/65d1ffa0-c69b-4230-b504-acaf749061c4" /> |