### PR TITLE
Log when Facilities cannot find a URL from its breadcrumb rather than erroring.

### DIFF
--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -3,6 +3,7 @@
 const _ = require('lodash');
 const moment = require('moment');
 const liquid = require('tinyliquid');
+const { logDrupal: log } = require('./utilities-drupal');
 const {
   createEntityUrlObj,
   createFileObj,
@@ -198,11 +199,11 @@ function addGetUpdatesFields(page, pages) {
     !regionPageUrlPath &&
     page.entityUrl.breadcrumb[1]?.text !== 'Manila VA Clinic'
   ) {
-    throw new Error(
-      `CMS error while building breadcrumbs: "${page.entityUrl.path}" is missing reference to a parent or grandparent.`,
+    log(
+      `WARNING: CMS error while building breadcrumbs: "${page.entityUrl.path}" is missing reference to a parent or grandparent.`,
     );
   }
-
+  // If regionPageUrlPath is empty, this will simply not find a region page, and this function will complete.
   const regionPage = pages.find(p => p.entityUrl.path === regionPageUrlPath);
 
   if (regionPage) {


### PR DESCRIPTION
## Description
All this does is log when a Facilities page does not have a URL in its second breadcrumb component, rather than throwing an error. Please see discussion https://dsva.slack.com/archives/CT4GZBM8F/p1737124609714199

## Testing
1. _Facilities or helpdesk: Please fill in instructions for how to recreate the data situation that led to the error._
2. Run a content-build on this Tugboat instance with the data from step 1. 

Expected: You should see `WARNING: CMS error while building breadcrumbs` in the log output.
Expected: The build should still complete.