### PR TITLE
Update form upload rootUrl

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1179,7 +1179,7 @@
   {
     "appName": "Form Upload Flow",
     "entryName": "form-upload-flow",
-    "rootUrl": "/form-upload",
+    "rootUrl": "/find-forms/upload",
     "productId": "88558f52-5c6c-447f-ab78-e006b01a32db",
     "template": {
       "vagovprod": false,


### PR DESCRIPTION
## Summary
This PR changes the `rootUrl` for the Form Upload tool, in accordance with the changes in [this `vets-website` PR](https://github.com/department-of-veterans-affairs/vets-website/pull/34208).

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1443/views/3?sliceBy%5Bvalue%5D=Thrillberg&pane=issue&itemId=94053329&issue=department-of-veterans-affairs%7Cva.gov-team%7C101254
