### PR TITLE
Update actions/cache to most recent and non-deprecated version.

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -139,7 +139,7 @@ jobs:
 
       - name: Cache dependencies
         id: cache-dependencies
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: |
             .cache/yarn
@@ -367,9 +367,9 @@ jobs:
 
       - name: Upload build
         run: aws s3 cp ${{ env.BUILDTYPE }}.tar.bz2 s3://vetsgov-website-builds-s3-upload/content-build/${{needs.validate-build-status.outputs.REF}}/${{ env.BUILDTYPE }}.tar.bz2 --acl public-read --region us-gov-west-1 --no-progress
-      
+
       - name: Delete build
-        run: rm ${{ env.BUILDTYPE }}.tar.bz2 
+        run: rm ${{ env.BUILDTYPE }}.tar.bz2
 
       - name: Debug filesystem size
         run: |
@@ -401,7 +401,7 @@ jobs:
           du -a . | sort -n -r | head -n 10
           du -a /home/runner/ | sort -n -r | head -n 10
           find /home/runner/ -type f -printf '%s %p\n' | sort -nr | head
-          
+
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Cache dependencies
         id: cache-dependencies
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: |
             .cache/yarn

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -38,7 +38,7 @@ runs:
 
     - name: Cache dependencies
       id: cache-dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         path: ${{ inputs.path }}
         key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ inputs.key }}

--- a/.github/workflows/manual-review.yml
+++ b/.github/workflows/manual-review.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Cache dependencies
         id: cache-dependencies
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: |
             ~/.cache/yarn
@@ -100,7 +100,7 @@ jobs:
 
       - name: Cache dependencies
         id: cache-dependencies
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: |
             ~/.cache/yarn
@@ -164,7 +164,7 @@ jobs:
 
       - name: Cache dependencies
         id: cache-dependencies
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: |
             ~/.cache/yarn


### PR DESCRIPTION
## Summary

Updating actions/cache in Github Actions workflows to most recent version due to previous version deprecation.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20394

## Testing done

Github actions are untestable.

