### PR TITLE
VACMS-10851 Find Forms code cleanup

### DIFF
--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -102,7 +102,7 @@
           >
             {% assign translatedDownloadText = fieldVaFormLanguage | deriveLanguageTranslation: 'downloadVaForm', fieldVaFormNumber %}
             <va-icon class="vads-u-margin-right--0p5" icon="file_download" size="3"></va-icon>
-            {{ translatedDownloadText }} (PDF)
+            {{ translatedDownloadText }}
           </button>
         </div>
 


### PR DESCRIPTION
## Are you removing or changing a registry.json `entryName` in this PR?
- [x] No, I'm not changing any `entryName`s (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing or changing an `entryName`

## Summary
On Form Detail pages, we have a section titled `Downloadable PDF`, but we also have `(PDF)` in the link text which is redundant. We have the same download buttons on Form Search Result pages, but they do not have `(PDF)` in the link text. This PR removes that text to make things consistent.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/10851

## Testing done
Tested on `/find-forms/about-form-10-1086/`:

| Before | After |
| ------ | ----- |
|  <img width="518" alt="Screenshot 2025-02-12 at 11 54 08 AM" src="https://github.com/user-attachments/assets/17b1a7a4-a13b-4da9-86a2-53eb1e759857" /> | <img width="528" alt="Screenshot 2025-02-12 at 11 54 01 AM" src="https://github.com/user-attachments/assets/f3427a32-8622-4934-aae8-ef3aa2a633b8" /> |

Current production version of Form Search Result pages, for reference:

<img width="431" alt="Screenshot 2025-02-12 at 11 58 59 AM" src="https://github.com/user-attachments/assets/60b125f4-b564-4711-afdb-855185d61386" />