### PR TITLE
VACMS-13935: Remove html code for regionOrOffice for Available at these locations

### DIFF
--- a/src/site/facilities/health_service.drupal.liquid
+++ b/src/site/facilities/health_service.drupal.liquid
@@ -27,7 +27,7 @@
     {% endif %}
 
     {% if healthService.fieldLocalHealthCareService.length > 0 %}
-      <h4 class="vads-u-font-size--h3">Available at these {{ regionOrOffice }} locations</h3>
+      <h4 class="vads-u-font-size--h3">Available at these locations</h3>
       <ul class="usa-unstyled-list" role="list">
         {% assign orderedHealthServices = healthService.fieldLocalHealthCareService | orderFieldLocalHealthCareServices %}
 


### PR DESCRIPTION
## Are you removing or changing a registry.json `entryName` in this PR?
- [x] No, I'm not changing any `entryName`s (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing or changing an `entryName`

## Summary
Removes the regionOrOffice in the `health_service.drupal.liquid` template

## Related issue(s)
[#13935](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13935)

## Testing done


## Screenshots



## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
