### PR TITLE
update registry entry for debt help wizard

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1653,7 +1653,10 @@
       "minimalHeader": {
         "title": "Explore pattern demonstrations in our sample form",
         "subtitle": "Mock Form Minimal Header",
-        "excludePaths": ["/introduction", "/confirmation"]
+        "excludePaths": [
+          "/introduction",
+          "/confirmation"
+        ]
       },
       "minimalFooter": true
     }
@@ -1787,5 +1790,18 @@
       "localhost": true,
       "layout": "page-react.html"
     }
-  }
+  },
+  {
+    "appName": "Debt Help Options",
+    "entryName": "debt-help-options",
+    "rootUrl": "/manage-va-debt/debt-help-options",
+    "productId": "2a188e78-8922-48af-9520-f062effbbeca",
+    "template": {
+      "vagovprod": false,
+      "vagovstaging": true,
+      "vagovdev": true,
+      "localhost": true,
+      "layout": "page-react.html"
+    }
+  } 
 ]


### PR DESCRIPTION
## Adding a new application path  registry.json `entryName` in this PR

```
  {
    "appName": "Debt Help Options",
    "entryName": "debt-help-options",
    "rootUrl": "/manage-va-debt/debt-help-options",
    "productId": "2a188e78-8922-48af-9520-f062effbbeca",
    "template": {
      "vagovprod": false,
      "vagovstaging": true,
      "vagovdev": true,
      "localhost": true,
      "layout": "page-react.html"
    }
  }
 ```

_**If you do not do this, other applications will break!**_


## Summary

- We are creating a new debt-help-options wizard on vets-website
PR https://github.com/department-of-veterans-affairs/vets-website/pull/34550


## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#102368


## What areas of the site does it impact?

- Creates routing to a new app, debt-help-options under manage-va-debt

## Acceptance criteria

- The initial wizard setup is implemented, and the new route is accessible in the browser.
- Collaborate with the design team to finalize URLs and behaviors.

