### PR TITLE
VATEAM-101161: Normalize Custom Step with pages and components

### DIFF
--- a/src/site/stages/build/drupal/static-data-files/digitalForm/chapters.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/chapters.js
@@ -28,34 +28,42 @@ const normalizeChapter = ({ entity }) => {
     type,
   };
 
-  if (type === 'digital_form_your_personal_info') {
-    const identificationInformation =
-      entity.fieldIdentificationInformation.entity;
-    const nameAndDateOfBirth = entity.fieldNameAndDateOfBirth.entity;
+  switch (type) {
+    case 'digital_form_your_personal_info': {
+      const identificationInformation =
+        entity.fieldIdentificationInformation.entity;
+      const nameAndDateOfBirth = entity.fieldNameAndDateOfBirth.entity;
 
-    return {
-      ...initialChapter,
-      chapterTitle: stripPrefix(entity.type.entity.entityLabel),
-      pages: [
-        {
-          pageTitle: nameAndDateOfBirth.fieldTitle,
-          includeDateOfBirth: nameAndDateOfBirth.fieldIncludeDateOfBirth,
-        },
-        {
-          pageTitle: identificationInformation.fieldTitle,
-          includeServiceNumber:
-            identificationInformation.fieldIncludeVeteranSService,
-        },
-      ],
-    };
+      return {
+        ...initialChapter,
+        chapterTitle: stripPrefix(entity.type.entity.entityLabel),
+        pages: [
+          {
+            pageTitle: nameAndDateOfBirth.fieldTitle,
+            includeDateOfBirth: nameAndDateOfBirth.fieldIncludeDateOfBirth,
+          },
+          {
+            pageTitle: identificationInformation.fieldTitle,
+            includeServiceNumber:
+              identificationInformation.fieldIncludeVeteranSService,
+          },
+        ],
+      };
+    }
+    case 'digital_form_custom_step':
+      return {
+        ...initialChapter,
+        chapterTitle: entity.fieldTitle,
+        pages: entity.fieldDigitalFormPages,
+      };
+    default:
+      return {
+        ...initialChapter,
+        additionalFields: extractAdditionalFields(entity),
+        chapterTitle: entity.fieldTitle,
+        pageTitle: stripPrefix(entity.type.entity.entityLabel),
+      };
   }
-
-  return {
-    ...initialChapter,
-    additionalFields: extractAdditionalFields(entity),
-    chapterTitle: entity.fieldTitle,
-    pageTitle: stripPrefix(entity.type.entity.entityLabel),
-  };
 };
 
 module.exports = { normalizeChapter };

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/chapters.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/chapters.js
@@ -56,7 +56,14 @@ const normalizeChapter = ({ entity }) => {
         chapterTitle: entity.fieldTitle,
         pages: entity.fieldDigitalFormPages.map(({ entity: pageEntity }) => ({
           bodyText: pageEntity.fieldDigitalFormBodyText,
-          components: pageEntity.fieldDigitalFormComponents,
+          components: pageEntity.fieldDigitalFormComponents.map(
+            ({ entity: componentEntity }) => ({
+              hint: componentEntity.fieldDigitalFormHintText,
+              label: componentEntity.fieldDigitalFormLabel,
+              required: componentEntity.fieldDigitalFormRequired,
+              type: componentEntity.type.entity.entityId,
+            }),
+          ),
           pageTitle: pageEntity.fieldTitle,
         })),
       };

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/chapters.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/chapters.js
@@ -54,7 +54,11 @@ const normalizeChapter = ({ entity }) => {
       return {
         ...initialChapter,
         chapterTitle: entity.fieldTitle,
-        pages: entity.fieldDigitalFormPages,
+        pages: entity.fieldDigitalFormPages.map(({ entity: pageEntity }) => ({
+          bodyText: pageEntity.fieldDigitalFormBodyText,
+          components: pageEntity.fieldDigitalFormComponents,
+          pageTitle: pageEntity.fieldTitle,
+        })),
       };
     default:
       return {

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/chapters.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/chapters.js
@@ -1,0 +1,61 @@
+const { stripPrefix } = require('./utils');
+
+const extractAdditionalFields = entity => {
+  const { entityId } = entity.type.entity;
+
+  switch (entityId) {
+    case 'digital_form_address':
+      return {
+        militaryAddressCheckbox: entity.fieldMilitaryAddressCheckbox,
+      };
+    case 'digital_form_list_loop':
+      return {
+        optional: entity.fieldOptional,
+      };
+    case 'digital_form_phone_and_email':
+      return {
+        includeEmail: entity.fieldIncludeEmail,
+      };
+    default:
+      return {};
+  }
+};
+
+const normalizeChapter = ({ entity }) => {
+  const type = entity.type.entity.entityId;
+  const initialChapter = {
+    id: parseInt(entity.entityId, 10),
+    type,
+  };
+
+  if (type === 'digital_form_your_personal_info') {
+    const identificationInformation =
+      entity.fieldIdentificationInformation.entity;
+    const nameAndDateOfBirth = entity.fieldNameAndDateOfBirth.entity;
+
+    return {
+      ...initialChapter,
+      chapterTitle: stripPrefix(entity.type.entity.entityLabel),
+      pages: [
+        {
+          pageTitle: nameAndDateOfBirth.fieldTitle,
+          includeDateOfBirth: nameAndDateOfBirth.fieldIncludeDateOfBirth,
+        },
+        {
+          pageTitle: identificationInformation.fieldTitle,
+          includeServiceNumber:
+            identificationInformation.fieldIncludeVeteranSService,
+        },
+      ],
+    };
+  }
+
+  return {
+    ...initialChapter,
+    additionalFields: extractAdditionalFields(entity),
+    chapterTitle: entity.fieldTitle,
+    pageTitle: stripPrefix(entity.type.entity.entityLabel),
+  };
+};
+
+module.exports = { normalizeChapter };

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/customStep.graphql.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/customStep.graphql.js
@@ -1,0 +1,29 @@
+const page = require('./page.graphql');
+
+/*
+ *
+ * The "Single Response" Digital Form pattern.
+ *
+ * Pattern documentation:
+ * https://design.va.gov/patterns/ask-users-for/a-single-response
+ *
+ */
+module.exports = `
+${page}
+
+fragment customStep on ParagraphDigitalFormCustomStep {
+  fieldTitle
+  fieldDigitalFormPages {
+    entity {
+      entityId
+      type {
+        entity {
+          entityId
+          entityLabel
+        }
+      }
+      ...page
+    }
+  }
+}
+`;

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/digitalForm.graphql.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/digitalForm.graphql.js
@@ -1,4 +1,5 @@
 const address = require('./address.graphql');
+const customStep = require('./customStep.graphql');
 const phoneAndEmail = require('./phoneAndEmail.graphql');
 const yourPersonalInformation = require('./yourPersonalInformation.graphql');
 const listLoop = require('./listLoop.graphql');
@@ -10,6 +11,7 @@ const listLoop = require('./listLoop.graphql');
  */
 module.exports = `
   ${address}
+  ${customStep}
   ${listLoop}
   ${phoneAndEmail}
   ${yourPersonalInformation}
@@ -34,6 +36,7 @@ module.exports = `
           }
         }
         ...address
+        ...customStep
         ...listLoop
         ...phoneAndEmail
         ...yourPersonalInformation

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/page.graphql.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/page.graphql.js
@@ -1,0 +1,27 @@
+const textInput = require('./textInput.graphql');
+
+/*
+ *
+ * A Custom Step page containing form components.
+ *
+ */
+module.exports = `
+${textInput}
+
+fragment page on ParagraphDigitalFormPage {
+  fieldTitle
+  fieldDigitalFormBodyText
+  fieldDigitalFormComponents {
+    entity {
+      entityId
+      type {
+        entity {
+          entityId
+          entityLabel
+        }
+      }
+      ...textInput
+    }
+  }
+}
+`;

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/textInput.graphql.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/textInput.graphql.js
@@ -1,0 +1,15 @@
+/*
+ *
+ * The "Text Input" Digital Form component.
+ *
+ * Pattern documentation:
+ * https://design.va.gov/components/form/text-input
+ *
+ */
+module.exports = `
+fragment textInput on ParagraphDigitalFormTextInput {
+  fieldDigitalFormLabel
+  fieldDigitalFormHintText
+  fieldDigitalFormRequired
+}
+  `;

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
@@ -1,64 +1,8 @@
 const { logDrupal } = require('../../utilities-drupal');
-const { stripPrefix, formatDate } = require('./utils');
+const { normalizeChapter } = require('./chapters');
+const { formatDate } = require('./utils');
 
-const extractAdditionalFields = entity => {
-  const { entityId } = entity.type.entity;
-
-  switch (entityId) {
-    case 'digital_form_address':
-      return {
-        militaryAddressCheckbox: entity.fieldMilitaryAddressCheckbox,
-      };
-    case 'digital_form_list_loop':
-      return {
-        optional: entity.fieldOptional,
-      };
-    case 'digital_form_phone_and_email':
-      return {
-        includeEmail: entity.fieldIncludeEmail,
-      };
-    default:
-      return {};
-  }
-};
 const extractForms = resultObject => resultObject?.data?.nodeQuery?.entities;
-
-const normalizeChapter = ({ entity }) => {
-  const type = entity.type.entity.entityId;
-  const initialChapter = {
-    id: parseInt(entity.entityId, 10),
-    type,
-  };
-
-  if (type === 'digital_form_your_personal_info') {
-    const identificationInformation =
-      entity.fieldIdentificationInformation.entity;
-    const nameAndDateOfBirth = entity.fieldNameAndDateOfBirth.entity;
-
-    return {
-      ...initialChapter,
-      chapterTitle: stripPrefix(entity.type.entity.entityLabel),
-      pages: [
-        {
-          pageTitle: nameAndDateOfBirth.fieldTitle,
-          includeDateOfBirth: nameAndDateOfBirth.fieldIncludeDateOfBirth,
-        },
-        {
-          pageTitle: identificationInformation.fieldTitle,
-          includeServiceNumber:
-            identificationInformation.fieldIncludeVeteranSService,
-        },
-      ],
-    };
-  }
-
-  return {
-    ...initialChapter,
-    additionalFields: extractAdditionalFields(entity),
-    chapterTitle: entity.fieldTitle,
-    pageTitle: stripPrefix(entity.type.entity.entityLabel),
-  };
-};
 
 const normalizeForm = (form, logger = logDrupal) => {
   try {

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
@@ -1,4 +1,5 @@
 const { logDrupal } = require('../../utilities-drupal');
+const { stripPrefix } = require('./utils');
 
 const extractAdditionalFields = entity => {
   const { entityId } = entity.type.entity;
@@ -27,8 +28,6 @@ const formatDate = dateString => {
   const [year, month, day] = dateString.split('-');
   return `${removeLeadingZero(month)}/${removeLeadingZero(day)}/${year}`;
 };
-
-const stripPrefix = label => label.replace('Digital Form: ', '');
 
 const normalizeChapter = ({ entity }) => {
   const type = entity.type.entity.entityId;

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
@@ -1,5 +1,5 @@
 const { logDrupal } = require('../../utilities-drupal');
-const { stripPrefix } = require('./utils');
+const { stripPrefix, formatDate } = require('./utils');
 
 const extractAdditionalFields = entity => {
   const { entityId } = entity.type.entity;
@@ -22,12 +22,6 @@ const extractAdditionalFields = entity => {
   }
 };
 const extractForms = resultObject => resultObject?.data?.nodeQuery?.entities;
-
-const formatDate = dateString => {
-  const removeLeadingZero = s => s.replace(/^0+/, '');
-  const [year, month, day] = dateString.split('-');
-  return `${removeLeadingZero(month)}/${removeLeadingZero(day)}/${year}`;
-};
 
 const normalizeChapter = ({ entity }) => {
   const type = entity.type.entity.entityId;

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/chapters.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/chapters.unit.spec.js
@@ -1,0 +1,95 @@
+/* eslint-disable @department-of-veterans-affairs/axe-check-required */
+
+import { expect } from 'chai';
+import queryResult from './fixtures/queryResult.json';
+import { normalizeChapter } from '../chapters';
+
+describe('digitalForm chapters', () => {
+  const queryForm = queryResult.data.nodeQuery.entities[1];
+
+  it('returns a normalized chapter object', () => {
+    const queryChapter = queryForm.fieldChapters[1];
+    const queryEntity = queryChapter.entity;
+
+    const testChapter = normalizeChapter(queryChapter);
+
+    expect(testChapter.id).to.eq(Number(queryEntity.entityId));
+    expect(testChapter.chapterTitle).to.eq(queryEntity.fieldTitle);
+    expect(testChapter.type).to.eq(queryEntity.type.entity.entityId);
+    expect(Object.keys(testChapter.additionalFields).length).to.eq(1);
+  });
+
+  it('removes the "Digital Form" prefix', () => {
+    const queryChapter = queryForm.fieldChapters[1];
+    const testChapter = normalizeChapter(queryChapter);
+
+    expect(testChapter.pageTitle).to.eq('Address');
+  });
+
+  describe('additionalFields', () => {
+    [
+      ['digital_form_address', 'militaryAddressCheckbox', false],
+      ['digital_form_list_loop', 'optional', false],
+      ['digital_form_phone_and_email', 'includeEmail', false],
+    ].forEach(([type, additionalField, value]) => {
+      context(`with a ${type} step`, () => {
+        it('includes the appropriate additional fields', () => {
+          const queryChapter = queryForm.fieldChapters.find(
+            chapter => chapter.entity.type.entity.entityId === type,
+          );
+
+          const { additionalFields } = normalizeChapter(queryChapter);
+
+          expect(additionalFields[additionalField]).to.eq(value);
+        });
+      });
+    });
+  });
+
+  describe('Your personal information', () => {
+    const queryChapter = queryForm.fieldChapters[0];
+    const queryYpi = queryChapter.entity;
+    const ypiChapter = normalizeChapter(queryChapter);
+
+    it('includes the correct chapter title', () => {
+      expect(ypiChapter.chapterTitle).to.eq('Your personal information');
+    });
+
+    it('includes a Name and Date of Birth page', () => {
+      const nameAndDateOfBirth = ypiChapter.pages[0];
+      const queryNdob = queryYpi.fieldNameAndDateOfBirth.entity;
+
+      expect(nameAndDateOfBirth.pageTitle).to.eq(queryNdob.fieldTitle);
+      expect(nameAndDateOfBirth.includeDateOfBirth).to.eq(
+        queryNdob.fieldIncludeDateOfBirth,
+      );
+    });
+
+    it('includes an Identification information page', () => {
+      const identificationInformation = ypiChapter.pages[1];
+      const queryIi = queryYpi.fieldIdentificationInformation.entity;
+
+      expect(identificationInformation.pageTitle).to.eq(queryIi.fieldTitle);
+      expect(identificationInformation.includeServiceNumber).to.eq(
+        queryIi.fieldIncludeVeteranSService,
+      );
+    });
+  });
+
+  describe('Custom Step', () => {
+    it('includes the correct step title');
+    it('includes the correct number of pages');
+
+    describe('Custom Step page', () => {
+      it('includes the correct page title');
+      it('includes the correct body text');
+      it('include the correct number of components');
+    });
+
+    describe('Text Input component', () => {
+      it('includes the label');
+      it('includes the hint text');
+      it('indicates whether the component is required');
+    });
+  });
+});

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/chapters.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/chapters.unit.spec.js
@@ -77,8 +77,22 @@ describe('digitalForm chapters', () => {
   });
 
   describe('Custom Step', () => {
-    it('includes the correct step title');
-    it('includes the correct number of pages');
+    const queryChapter = queryForm.fieldChapters.find(
+      chapter =>
+        chapter.entity.type.entity.entityId === 'digital_form_custom_step',
+    );
+    const queryEntity = queryChapter.entity;
+    const normalizedChapter = normalizeChapter(queryChapter);
+
+    it('includes the correct step title', () => {
+      expect(normalizedChapter.chapterTitle).to.eq(queryEntity.fieldTitle);
+    });
+
+    it('includes the correct number of pages', () => {
+      expect(normalizedChapter.pages.length).to.eq(
+        queryEntity.fieldDigitalFormPages.length,
+      );
+    });
 
     describe('Custom Step page', () => {
       it('includes the correct page title');

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/chapters.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/chapters.unit.spec.js
@@ -81,8 +81,10 @@ describe('digitalForm chapters', () => {
       chapter =>
         chapter.entity.type.entity.entityId === 'digital_form_custom_step',
     );
-    const queryEntity = queryChapter.entity;
     const normalizedChapter = normalizeChapter(queryChapter);
+    const normalizedPage = normalizedChapter.pages[0];
+    const queryEntity = queryChapter.entity;
+    const queryPage = queryEntity.fieldDigitalFormPages[0].entity;
 
     it('includes the correct step title', () => {
       expect(normalizedChapter.chapterTitle).to.eq(queryEntity.fieldTitle);
@@ -95,9 +97,21 @@ describe('digitalForm chapters', () => {
     });
 
     describe('Custom Step page', () => {
-      it('includes the correct page title');
-      it('includes the correct body text');
-      it('include the correct number of components');
+      it('includes the correct page title', () => {
+        expect(normalizedPage.pageTitle).to.eq(queryPage.fieldTitle);
+      });
+
+      it('includes the correct body text', () => {
+        expect(normalizedPage.bodyText).to.eq(
+          queryPage.fieldDigitalFormBodyText,
+        );
+      });
+
+      it('include the correct number of components', () => {
+        expect(normalizedPage.components.length).to.eq(
+          queryPage.fieldDigitalFormComponents.length,
+        );
+      });
     });
 
     describe('Text Input component', () => {

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/chapters.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/chapters.unit.spec.js
@@ -115,9 +115,32 @@ describe('digitalForm chapters', () => {
     });
 
     describe('Text Input component', () => {
-      it('includes the label');
-      it('includes the hint text');
-      it('indicates whether the component is required');
+      const normalizedComponent = normalizedPage.components[0];
+      const queryComponent = queryPage.fieldDigitalFormComponents[0].entity;
+
+      it('has the correct type', () => {
+        expect(normalizedComponent.type).to.eq(
+          queryComponent.type.entity.entityId,
+        );
+      });
+
+      it('includes the label', () => {
+        expect(normalizedComponent.label).to.eq(
+          queryComponent.fieldDigitalFormLabel,
+        );
+      });
+
+      it('includes the hint text', () => {
+        expect(normalizedComponent.hint).to.eq(
+          queryComponent.fieldDigitalFormHintText,
+        );
+      });
+
+      it('indicates whether the component is required', () => {
+        expect(normalizedComponent.required).to.eq(
+          queryComponent.fieldDigitalFormRequired,
+        );
+      });
     });
   });
 });

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fixtures/queryResult.json
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fixtures/queryResult.json
@@ -110,6 +110,92 @@
                 "fieldTitle": "Generated List & Loop",
                 "fieldOptional": false
               }
+            },
+            {
+              "entity": {
+                "entityId": "172736",
+                "type": {
+                  "entity": {
+                    "entityId": "digital_form_custom_step",
+                    "entityLabel": "Digital Form: Custom Step"
+                  }
+                },
+                "fieldTitle": "Generated Custom Step",
+                "fieldDigitalFormPages": [
+                  {
+                    "entity": {
+                      "entityId": "172734",
+                      "type": {
+                        "entity": {
+                          "entityId": "digital_form_page",
+                          "entityLabel": "Digital Form: Page"
+                        }
+                      },
+                      "fieldTitle": "Generated custom page",
+                      "fieldDigitalFormBodyText": "My custom body text",
+                      "fieldDigitalFormComponents": [
+                        {
+                          "entity": {
+                            "entityId": "172737",
+                            "type": {
+                              "entity": {
+                                "entityId": "digital_form_text_input",
+                                "entityLabel": "Digital Form: Text Input Component"
+                              }
+                            },
+                            "fieldDigitalFormLabel": "My custom text input",
+                            "fieldDigitalFormHintText": "This is optional hint text",
+                            "fieldDigitalFormRequired": true
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "entity": {
+                      "entityId": "172735",
+                      "type": {
+                        "entity": {
+                          "entityId": "digital_form_page",
+                          "entityLabel": "Digital Form: Page"
+                        }
+                      },
+                      "fieldTitle": "An additional page",
+                      "fieldDigitalFormBodyText": "With additonal body text",
+                      "fieldDigitalFormComponents": [
+                        {
+                          "entity": {
+                            "entityId": "172738",
+                            "type": {
+                              "entity": {
+                                "entityId": "digital_form_text_input",
+                                "entityLabel": "Digital Form: Text Input Component"
+                              }
+                            },
+                            "fieldDigitalFormLabel": "A text input with no hint text",
+                            "fieldDigitalFormHintText": null,
+                            "fieldDigitalFormRequired": true
+                          }
+                        },
+                        {
+                          "entity": {
+                            "entityId": "172739",
+                            "type": {
+                              "entity": {
+                                "entityId": "digital_form_text_input",
+                                "entityLabel": "Digital Form: Text Input Component"
+                              }
+                            },
+                            "fieldDigitalFormLabel": "An optional text input",
+                            "fieldDigitalFormHintText": "This input is not required",
+                            "fieldDigitalFormRequired": false
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
             }
           ]
         },

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/customStep.graphql.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/customStep.graphql.unit.spec.js
@@ -1,0 +1,16 @@
+/* eslint-disable @department-of-veterans-affairs/axe-check-required */
+
+import { expect } from 'chai';
+import customStep from '../../fragments/customStep.graphql';
+
+describe('customStep fragment', () => {
+  it('includes the correct fields', () => {
+    expect(customStep).to.have.string('fieldTitle');
+    expect(customStep).to.have.string('fieldDigitalFormPages');
+  });
+
+  it('imports the page fragment', () => {
+    expect(customStep).to.have.string('fragment page');
+    expect(customStep).to.have.string('...page');
+  });
+});

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/digitalForm.graphql.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/digitalForm.graphql.unit.spec.js
@@ -19,13 +19,17 @@ describe('digitalForm fragment', () => {
   });
 
   describe('chapter fragments', () => {
-    ['address', 'listLoop', 'phoneAndEmail', 'yourPersonalInformation'].forEach(
-      fragment => {
-        it(`imports the ${fragment} fragment`, () => {
-          expect(digitalForm).to.have.string(`fragment ${fragment}`);
-          expect(digitalForm).to.have.string(`...${fragment}`);
-        });
-      },
-    );
+    [
+      'address',
+      'customStep',
+      'listLoop',
+      'phoneAndEmail',
+      'yourPersonalInformation',
+    ].forEach(fragment => {
+      it(`imports the ${fragment} fragment`, () => {
+        expect(digitalForm).to.have.string(`fragment ${fragment}`);
+        expect(digitalForm).to.have.string(`...${fragment}`);
+      });
+    });
   });
 });

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/page.graphql.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/page.graphql.unit.spec.js
@@ -1,0 +1,17 @@
+/* eslint-disable @department-of-veterans-affairs/axe-check-required */
+
+import { expect } from 'chai';
+import page from '../../fragments/page.graphql';
+
+describe('page fragment', () => {
+  it('includes the correct fields', () => {
+    expect(page).to.have.string('fieldTitle');
+    expect(page).to.have.string('fieldDigitalFormBodyText');
+    expect(page).to.have.string('fieldDigitalFormComponents');
+  });
+
+  it('imports the textInput fragment', () => {
+    expect(page).to.have.string('fragment textInput');
+    expect(page).to.have.string('...textInput');
+  });
+});

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/textInput.graphql.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/textInput.graphql.unit.spec.js
@@ -1,0 +1,18 @@
+/* eslint-disable @department-of-veterans-affairs/axe-check-required */
+
+import { expect } from 'chai';
+import textInput from '../../fragments/textInput.graphql';
+
+describe('textInput fragment', () => {
+  it('includes fieldDigitalFormLabel', () => {
+    expect(textInput).to.have.string('fieldDigitalFormLabel');
+  });
+
+  it('includes fieldDigitalFormHintText', () => {
+    expect(textInput).to.have.string('fieldDigitalFormHintText');
+  });
+
+  it('includes fieldDigitalFormRequired', () => {
+    expect(textInput).to.have.string('fieldDigitalFormRequired');
+  });
+});

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/postProcessDigitalForm.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/postProcessDigitalForm.unit.spec.js
@@ -28,9 +28,6 @@ describe('postProcessDigitalForm', () => {
         manyStepEntity.fieldChapters.length,
       );
       expect(testChapter.id).to.eq(Number(queryChapter.entityId));
-      expect(testChapter.chapterTitle).to.eq(queryChapter.fieldTitle);
-      expect(testChapter.type).to.eq(queryChapter.type.entity.entityId);
-      expect(Object.keys(testChapter.additionalFields).length).to.eq(1);
     });
 
     it('includes an OMB info object', () => {
@@ -41,65 +38,6 @@ describe('postProcessDigitalForm', () => {
       expect(ombInfo.ombNumber).to.eq(manyStepEntity.fieldOmbNumber);
       expect(ombInfo.expDate).to.eq(formattedDate);
       expect(ombInfo.resBurden).to.eq(manyStepEntity.fieldRespondentBurden);
-    });
-
-    it('removes the "Digital Form" prefix', () => {
-      const [, testChapter] = testForm.chapters;
-
-      expect(testChapter.pageTitle).to.eq('Address');
-    });
-
-    describe('additionalFields', () => {
-      [
-        ['digital_form_address', 'militaryAddressCheckbox', false],
-        ['digital_form_list_loop', 'optional', false],
-        ['digital_form_phone_and_email', 'includeEmail', false],
-      ].forEach(([type, additionalField, value]) => {
-        context(`with a ${type} step`, () => {
-          it('includes the appropriate additional fields', () => {
-            const { additionalFields } = testForm.chapters.find(
-              chapter => chapter.type === type,
-            );
-
-            expect(additionalFields[additionalField]).to.eq(value);
-          });
-        });
-      });
-    });
-
-    describe('Your personal information', () => {
-      let ypiChapter;
-      const queryYpi = manyStepEntity.fieldChapters[0].entity;
-
-      beforeEach(() => {
-        ypiChapter = testForm.chapters.find(
-          chapter => chapter.type === 'digital_form_your_personal_info',
-        );
-      });
-
-      it('includes the correct chapter title', () => {
-        expect(ypiChapter.chapterTitle).to.eq('Your personal information');
-      });
-
-      it('includes a Name and Date of Birth page', () => {
-        const nameAndDateOfBirth = ypiChapter.pages[0];
-        const queryNdob = queryYpi.fieldNameAndDateOfBirth.entity;
-
-        expect(nameAndDateOfBirth.pageTitle).to.eq(queryNdob.fieldTitle);
-        expect(nameAndDateOfBirth.includeDateOfBirth).to.eq(
-          queryNdob.fieldIncludeDateOfBirth,
-        );
-      });
-
-      it('includes an Identification information page', () => {
-        const identificationInformation = ypiChapter.pages[1];
-        const queryIi = queryYpi.fieldIdentificationInformation.entity;
-
-        expect(identificationInformation.pageTitle).to.eq(queryIi.fieldTitle);
-        expect(identificationInformation.includeServiceNumber).to.eq(
-          queryIi.fieldIncludeVeteranSService,
-        );
-      });
     });
   });
 

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/utils.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/utils.unit.spec.js
@@ -1,0 +1,20 @@
+/* eslint-disable @department-of-veterans-affairs/axe-check-required */
+
+import { expect } from 'chai';
+import { stripPrefix } from '../utils';
+
+describe('digitalForm utils', () => {
+  describe('stripPrefix', () => {
+    it('removes the "Digital Form" prefix', () => {
+      const prefixedLabel = 'Digital Form: Address';
+
+      expect(stripPrefix(prefixedLabel)).to.eq('Address');
+    });
+
+    it('does not alter string without the prefix', () => {
+      const nonPrefixedLabel = 'Name of the form';
+
+      expect(stripPrefix(nonPrefixedLabel)).to.eq(nonPrefixedLabel);
+    });
+  });
+});

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/utils.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/utils.unit.spec.js
@@ -1,9 +1,25 @@
 /* eslint-disable @department-of-veterans-affairs/axe-check-required */
 
 import { expect } from 'chai';
-import { stripPrefix } from '../utils';
+import { formatDate, stripPrefix } from '../utils';
 
 describe('digitalForm utils', () => {
+  describe('formatDate', () => {
+    it('formats a date string', () => {
+      const originalDate = '2025-12-23';
+      const formattedDate = '12/23/2025';
+
+      expect(formatDate(originalDate)).to.eq(formattedDate);
+    });
+
+    it('removes leading zeros', () => {
+      const originalDate = '2020-02-09';
+      const formattedDate = '2/9/2020';
+
+      expect(formatDate(originalDate)).to.eq(formattedDate);
+    });
+  });
+
   describe('stripPrefix', () => {
     it('removes the "Digital Form" prefix', () => {
       const prefixedLabel = 'Digital Form: Address';

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/utils.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/utils.js
@@ -1,3 +1,9 @@
+const formatDate = dateString => {
+  const removeLeadingZero = s => s.replace(/^0+/, '');
+  const [year, month, day] = dateString.split('-');
+  return `${removeLeadingZero(month)}/${removeLeadingZero(day)}/${year}`;
+};
+
 const stripPrefix = label => label.replace('Digital Form: ', '');
 
-module.exports = { stripPrefix };
+module.exports = { formatDate, stripPrefix };

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/utils.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/utils.js
@@ -1,0 +1,3 @@
+const stripPrefix = label => label.replace('Digital Form: ', '');
+
+module.exports = { stripPrefix };


### PR DESCRIPTION
## Are you removing or changing a registry.json `entryName` in this PR?
- [x] No, I'm not changing any `entryName`s (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing or changing an `entryName`

## Summary

- Updates the GraphQL query to fetch the proper fields for Custom Step Paragraph entities.
- Normalizes fields for Custom Steps as well as their pages and the Text Input component.

### Example output
```json
      {
        "id": 172736,
        "type": "digital_form_custom_step",
        "chapterTitle": "My custom step",
        "pages": [
          {
            "bodyText": "My custom body text",
            "components": [
              {
                "hint": "This is optional hint text",
                "label": "My custom text input",
                "required": true,
                "type": "digital_form_text_input"
              }
            ],
            "pageTitle": "My custom page"
          },
          {
            "bodyText": "With additonal body text",
            "components": [
              {
                "hint": null,
                "label": "A text input with no hint text",
                "required": true,
                "type": "digital_form_text_input"
              },
              {
                "hint": "This text input is not required",
                "label": "An optional text input",
                "required": false,
                "type": "digital_form_text_input"
              }
            ],
            "pageTitle": "An additional page"
          }
        ]
      }
```

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#101161

## Testing done

- New/updated unit tests for the new and updated GraphQL fragments and the Digital Form post processor
- Pulled local Drupal data and confirmed the resulting output from content-build

## What areas of the site does it impact?

Only affects the output of `digital-forms.json`.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
