### PR TITLE
VACMS-20502 Add hardcoded metadata to Policies pages

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -2241,4 +2241,23 @@ module.exports = function registerFilters() {
     }
     return null;
   };
+
+  liquid.filters.assignHardcodedMetaDescription = url => {
+    if (!url) {
+      return null;
+    }
+
+    const META_DESCRIPTIONS = {
+      '/policies':
+        'Find VA policies on privacy and patient rights, family rights, visitation, and more.',
+    };
+
+    for (const [endOfPath, content] of Object.entries(META_DESCRIPTIONS)) {
+      if (url?.endsWith(endOfPath)) {
+        return content;
+      }
+    }
+
+    return null;
+  };
 };

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -3425,3 +3425,46 @@ describe('runAndFnConditions', () => {
     expect(liquid.filters.andFn(3, ...testingParams)).to.be.false;
   });
 });
+
+describe('assignHardcodedMetaDescription', () => {
+  it('should return the correct description when a matching path is given', () => {
+    expect(
+      liquid.filters.assignHardcodedMetaDescription(
+        '/minneapolis-health-care/policies',
+      ),
+    ).to.equal(
+      'Find VA policies on privacy and patient rights, family rights, visitation, and more.',
+    );
+  });
+
+  it('should return null if a matching path is not given', () => {
+    expect(liquid.filters.assignHardcodedMetaDescription('')).to.be.null;
+  });
+
+  it('should return null if a matching path is not given', () => {
+    expect(
+      liquid.filters.assignHardcodedMetaDescription('/minneapolis-health-care'),
+    ).to.be.null;
+  });
+
+  it('should return null if a matching path is not given', () => {
+    expect(liquid.filters.assignHardcodedMetaDescription(null)).to.be.null;
+  });
+
+  it('should return null if a matching path is not given', () => {
+    expect(liquid.filters.assignHardcodedMetaDescription(undefined)).to.be.null;
+  });
+
+  it('should return null if a matching path is not given', () => {
+    expect(liquid.filters.assignHardcodedMetaDescription('/resources')).to.be
+      .null;
+  });
+
+  it('should return null if a matching path is not given', () => {
+    expect(
+      liquid.filters.assignHardcodedMetaDescription(
+        '/minneapolis-health-care/policies-for-something-else',
+      ),
+    ).to.be.null;
+  });
+});

--- a/src/site/includes/metatags.drupal.liquid
+++ b/src/site/includes/metatags.drupal.liquid
@@ -120,6 +120,8 @@
   <meta name="twitter:site" content="@DeptVetAffairs">
 
   <!-- Derive the meta description. -->
+  {% assign description = entityUrl.path | assignHardcodedMetaDescription %}
+
   {% if fieldClinicalHealthServi %}
     {% assign description = fieldClinicalHealthServi.processed | strip_html %}
   {% elsif fieldPressReleaseBlurb %}
@@ -131,6 +133,8 @@
   {% elsif entityUrl.path == '/' %}
     {% assign description = 'Welcome to the official website of the U.S. Department of Veterans Affairs. Discover, apply for, and manage your VA benefits and care.' %}
   {% endif %}
+
+  
 
   <!-- Add meta description tags. -->
   {% if description %}


### PR DESCRIPTION
## Are you removing or changing a registry.json `entryName` in this PR?
- [x] No, I'm not changing any `entryName`s (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing or changing an `entryName`

## Summary
Add hardcoded metadata description to Policies page. This involved writing a liquid filter to catch URLs ending with `/policies` and return a hardcoded description for those URLs. This is flexible enough to be used for other page paths as well.

No pages other than Policies pages should be affected.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20502

## Testing done & screenshots

`/minneapolis-health-care/policies`

<img width="1910" alt="Screenshot 2025-03-03 at 12 13 19 PM" src="https://github.com/user-attachments/assets/d0fdeddd-7054-4717-b74b-ceabbfb1c059" />

Regression check - homepage

<img width="1910" alt="Screenshot 2025-03-03 at 12 13 42 PM" src="https://github.com/user-attachments/assets/debf09a9-db95-4166-a200-7de98d5d92a8" />

Regression check - `/charleston-health-care/stories/vas-dr-ilana-stol-tapped-to-lead-the-charge-in-shaping-national-aging-policies/`

<img width="1910" alt="Screenshot 2025-03-03 at 12 20 58 PM" src="https://github.com/user-attachments/assets/64d3328e-b84c-460f-8206-ca6111f04755" />

## Acceptance criteria

- [x] When on VA Health Care Policies pages, the meta name="description" is `Find VA policies on privacy and patient rights, family rights, visitation, and more.`