### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,4 +12,4 @@ To contribute to this repository please follow the instructions on our platform 
 - [Frontend workflow](https://depo-platform-documentation.scrollhelp.site/developer-docs/Frontend-workflow.1846083611.html)
 - [Resolving critical issues](https://depo-platform-documentation.scrollhelp.site/developer-docs/Resolving-critical-issues.1846182121.html)
 
-Alternatively, you can contribute by [submitting an issue](https://github.com/department-of-veterans-affairs/content-build/issues/new/choose) to this repository outlining your request.
+Alternatively, you can contribute by [submitting an issue](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/new/choose) to the CMS Team issue queue outlining your request.


### PR DESCRIPTION
Change destination repo for making Content Build request.



## Summary

### Generated summary
This pull request includes a small update to the `CONTRIBUTING.md` file. The change updates the link for submitting an issue to direct contributors to the CMS Team issue queue instead of the previous repository.

* [`CONTRIBUTING.md`](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L15-R15): Updated the issue submission link to point to the CMS Team issue queue.

