### PR TITLE
VATEAM-101164/101174/101167/101171: Normalize Custom Step components

### DIFF
--- a/src/site/stages/build/drupal/static-data-files/digitalForm/chapters.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/chapters.js
@@ -37,26 +37,27 @@ const normalizeComponent = entity => {
     type,
   };
 
-  if (type === 'digital_form_date_component') {
-    return {
-      ...defaultComponent,
-      dateFormat: entity.fieldDigitalFormDateFormat,
-    };
+  switch (type) {
+    case 'digital_form_date_component':
+      return {
+        ...defaultComponent,
+        dateFormat: entity.fieldDigitalFormDateFormat,
+      };
+    case 'digital_form_radio_button':
+    case 'digital_form_checkbox':
+      return {
+        ...defaultComponent,
+        responseOptions: entity.fieldDfResponseOptions.map(
+          ({ entity: optionEntity }) => ({
+            id: optionEntity.entityId,
+            label: optionEntity.fieldDigitalFormLabel,
+            description: optionEntity.fieldDigitalFormDescription,
+          }),
+        ),
+      };
+    default:
+      return defaultComponent;
   }
-  if (type === 'digital_form_radio_button') {
-    return {
-      ...defaultComponent,
-      responseOptions: entity.fieldDfResponseOptions.map(
-        ({ entity: optionEntity }) => ({
-          id: optionEntity.entityId,
-          label: optionEntity.fieldDigitalFormLabel,
-          description: optionEntity.fieldDigitalFormDescription,
-        }),
-      ),
-    };
-  }
-
-  return defaultComponent;
 };
 
 const customStepChapter = entity => ({

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/chapters.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/chapters.js
@@ -26,19 +26,21 @@ const initialChapter = entity => ({
   type: entity.type.entity.entityId,
 });
 
+const normalizeComponent = entity => ({
+  hint: entity.fieldDigitalFormHintText,
+  id: entity.entityId,
+  label: entity.fieldDigitalFormLabel,
+  required: entity.fieldDigitalFormRequired,
+  type: entity.type.entity.entityId,
+});
+
 const customStepChapter = entity => ({
   ...initialChapter(entity),
   chapterTitle: entity.fieldTitle,
   pages: entity.fieldDigitalFormPages.map(({ entity: pageEntity }) => ({
     bodyText: pageEntity.fieldDigitalFormBodyText,
     components: pageEntity.fieldDigitalFormComponents.map(
-      ({ entity: componentEntity }) => ({
-        hint: componentEntity.fieldDigitalFormHintText,
-        id: componentEntity.entityId,
-        label: componentEntity.fieldDigitalFormLabel,
-        required: componentEntity.fieldDigitalFormRequired,
-        type: componentEntity.type.entity.entityId,
-      }),
+      ({ entity: componentEntity }) => normalizeComponent(componentEntity),
     ),
     id: pageEntity.entityId,
     pageTitle: pageEntity.fieldTitle,
@@ -86,4 +88,4 @@ const normalizeChapter = ({ entity }) => {
   }
 };
 
-module.exports = { normalizeChapter };
+module.exports = { normalizeChapter, normalizeComponent };

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/chapters.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/chapters.js
@@ -43,6 +43,18 @@ const normalizeComponent = entity => {
       dateFormat: entity.fieldDigitalFormDateFormat,
     };
   }
+  if (type === 'digital_form_radio_button') {
+    return {
+      ...defaultComponent,
+      responseOptions: entity.fieldDfResponseOptions.map(
+        ({ entity: optionEntity }) => ({
+          id: optionEntity.entityId,
+          label: optionEntity.fieldDigitalFormLabel,
+          description: optionEntity.fieldDigitalFormDescription,
+        }),
+      ),
+    };
+  }
 
   return defaultComponent;
 };

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/chapters.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/chapters.js
@@ -64,6 +64,7 @@ const normalizeChapter = ({ entity }) => {
               type: componentEntity.type.entity.entityId,
             }),
           ),
+          id: pageEntity.entityId,
           pageTitle: pageEntity.fieldTitle,
         })),
       };

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/chapters.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/chapters.js
@@ -59,6 +59,7 @@ const normalizeChapter = ({ entity }) => {
           components: pageEntity.fieldDigitalFormComponents.map(
             ({ entity: componentEntity }) => ({
               hint: componentEntity.fieldDigitalFormHintText,
+              id: componentEntity.entityId,
               label: componentEntity.fieldDigitalFormLabel,
               required: componentEntity.fieldDigitalFormRequired,
               type: componentEntity.type.entity.entityId,

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/chapters.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/chapters.js
@@ -26,13 +26,26 @@ const initialChapter = entity => ({
   type: entity.type.entity.entityId,
 });
 
-const normalizeComponent = entity => ({
-  hint: entity.fieldDigitalFormHintText,
-  id: entity.entityId,
-  label: entity.fieldDigitalFormLabel,
-  required: entity.fieldDigitalFormRequired,
-  type: entity.type.entity.entityId,
-});
+const normalizeComponent = entity => {
+  const type = entity.type.entity.entityId;
+
+  const defaultComponent = {
+    hint: entity.fieldDigitalFormHintText,
+    id: entity.entityId,
+    label: entity.fieldDigitalFormLabel,
+    required: entity.fieldDigitalFormRequired,
+    type,
+  };
+
+  if (type === 'digital_form_date_component') {
+    return {
+      ...defaultComponent,
+      dateFormat: entity.fieldDigitalFormDateFormat,
+    };
+  }
+
+  return defaultComponent;
+};
 
 const customStepChapter = entity => ({
   ...initialChapter(entity),

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/checkbox.graphql
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/checkbox.graphql
@@ -1,5 +1,3 @@
-const responseOption = require('./responseOption.graphql');
-
 /*
  *
  * The "Checkbox" Digital Form component.
@@ -9,8 +7,6 @@ const responseOption = require('./responseOption.graphql');
  *
  */
 module.exports = `
-${responseOption}
-
 fragment checkbox on ParagraphDigitalFormCheckbox {
   fieldDigitalFormLabel
   fieldDigitalFormHintText

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/checkbox.graphql
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/checkbox.graphql
@@ -11,7 +11,7 @@ const responseOption = require('./responseOption.graphql');
 module.exports = `
 ${responseOption}
 
-fragment radioButton on ParagraphDigitalFormCheckbox {
+fragment checkbox on ParagraphDigitalFormCheckbox {
   fieldDigitalFormLabel
   fieldDigitalFormHintText
   fieldDigitalFormRequired

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/checkbox.graphql
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/checkbox.graphql
@@ -1,0 +1,31 @@
+const responseOption = require('./responseOption.graphql');
+
+/*
+ *
+ * The "Checkbox" Digital Form component.
+ *
+ * Pattern documentation:
+ * https://design.va.gov/components/form/checkbox
+ *
+ */
+module.exports = `
+${responseOption}
+
+fragment radioButton on ParagraphDigitalFormCheckbox {
+  fieldDigitalFormLabel
+  fieldDigitalFormHintText
+  fieldDigitalFormRequired
+  fieldDfResponseOptions {
+    entity {
+      entityId
+      type {
+        entity {
+          entityLabel
+          entityId
+        }
+      }
+      ...responseOption
+    }
+  }
+}
+  `;

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/date.graphql
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/date.graphql
@@ -1,0 +1,16 @@
+/*
+ *
+ * The "Date" Digital Form component.
+ *
+ * Pattern documentation:
+ * https://design.va.gov/components/form/date-input
+ *
+ */
+module.exports = `
+fragment date on ParagraphDigitalFormTextInput {
+  fieldDigitalFormLabel
+  fieldDigitalFormHintText
+  fieldDigitalFormRequired
+  fieldDigitalFormDateFormat
+}
+  `;

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/date.graphql
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/date.graphql
@@ -7,7 +7,7 @@
  *
  */
 module.exports = `
-fragment date on ParagraphDigitalFormTextInput {
+fragment date on ParagraphDigitalFormDateComponent {
   fieldDigitalFormLabel
   fieldDigitalFormHintText
   fieldDigitalFormRequired

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/page.graphql.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/page.graphql.js
@@ -1,3 +1,4 @@
+const textArea = require('./textArea.graphql');
 const textInput = require('./textInput.graphql');
 
 /*
@@ -6,6 +7,7 @@ const textInput = require('./textInput.graphql');
  *
  */
 module.exports = `
+${textArea}
 ${textInput}
 
 fragment page on ParagraphDigitalFormPage {
@@ -20,6 +22,7 @@ fragment page on ParagraphDigitalFormPage {
           entityLabel
         }
       }
+      ...textArea
       ...textInput
     }
   }

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/page.graphql.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/page.graphql.js
@@ -1,3 +1,4 @@
+const checkbox = require('./checkbox.graphql');
 const date = require('./date.graphql');
 const radioButton = require('./radioButton.graphql');
 const textArea = require('./textArea.graphql');
@@ -9,6 +10,7 @@ const textInput = require('./textInput.graphql');
  *
  */
 module.exports = `
+${checkbox}
 ${date}
 ${radioButton}
 ${textArea}
@@ -26,6 +28,7 @@ fragment page on ParagraphDigitalFormPage {
           entityLabel
         }
       }
+      ...checkbox
       ...date
       ...radioButton
       ...textArea

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/page.graphql.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/page.graphql.js
@@ -1,6 +1,7 @@
 const checkbox = require('./checkbox.graphql');
 const date = require('./date.graphql');
 const radioButton = require('./radioButton.graphql');
+const responseOption = require('./responseOption.graphql');
 const textArea = require('./textArea.graphql');
 const textInput = require('./textInput.graphql');
 
@@ -13,6 +14,7 @@ module.exports = `
 ${checkbox}
 ${date}
 ${radioButton}
+${responseOption}
 ${textArea}
 ${textInput}
 

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/page.graphql.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/page.graphql.js
@@ -1,4 +1,5 @@
 const date = require('./date.graphql');
+const radioButton = require('./radioButton.graphql');
 const textArea = require('./textArea.graphql');
 const textInput = require('./textInput.graphql');
 
@@ -9,6 +10,7 @@ const textInput = require('./textInput.graphql');
  */
 module.exports = `
 ${date}
+${radioButton}
 ${textArea}
 ${textInput}
 
@@ -25,6 +27,7 @@ fragment page on ParagraphDigitalFormPage {
         }
       }
       ...date
+      ...radioButton
       ...textArea
       ...textInput
     }

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/page.graphql.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/page.graphql.js
@@ -1,3 +1,4 @@
+const date = require('./date.graphql');
 const textArea = require('./textArea.graphql');
 const textInput = require('./textInput.graphql');
 
@@ -7,6 +8,7 @@ const textInput = require('./textInput.graphql');
  *
  */
 module.exports = `
+${date}
 ${textArea}
 ${textInput}
 
@@ -22,6 +24,7 @@ fragment page on ParagraphDigitalFormPage {
           entityLabel
         }
       }
+      ...date
       ...textArea
       ...textInput
     }

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/radioButton.graphql
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/radioButton.graphql
@@ -1,0 +1,31 @@
+const responseOption = require('./responseOption.graphql');
+
+/*
+ *
+ * The "Radio Button" Digital Form component.
+ *
+ * Pattern documentation:
+ * https://design.va.gov/components/form/radio-button
+ *
+ */
+module.exports = `
+${responseOption}
+
+fragment radioButton on ParagraphDigitalFormRadioButton {
+  fieldDigitalFormLabel
+  fieldDigitalFormHintText
+  fieldDigitalFormRequired
+  fieldDfResponseOptions {
+    entity {
+      entityId
+      type {
+        entity {
+          entityLabel
+          entityId
+        }
+      }
+      ...responseOption
+    }
+  }
+}
+  `;

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/radioButton.graphql
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/radioButton.graphql
@@ -1,5 +1,3 @@
-const responseOption = require('./responseOption.graphql');
-
 /*
  *
  * The "Radio Button" Digital Form component.
@@ -9,8 +7,6 @@ const responseOption = require('./responseOption.graphql');
  *
  */
 module.exports = `
-${responseOption}
-
 fragment radioButton on ParagraphDigitalFormRadioButton {
   fieldDigitalFormLabel
   fieldDigitalFormHintText

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/responseOption.graphql
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/responseOption.graphql
@@ -8,7 +8,7 @@
  *
  */
 module.exports = `
-fragment textInput on ParagraphDigitalFormTextInput {
+fragment responseOption on ParagraphDigitalFormResponseOption {
   fieldDigitalFormLabel
   fieldDigitalFormDescription
 }

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/responseOption.graphql
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/responseOption.graphql
@@ -1,0 +1,15 @@
+/*
+ *
+ * A choice from a group.
+ * Used by radio buttons and checkboxes.
+ *
+ * Pattern documentation:
+ * https://design.va.gov/components/form/radio-button
+ *
+ */
+module.exports = `
+fragment textInput on ParagraphDigitalFormTextInput {
+  fieldDigitalFormLabel
+  fieldDigitalFormDescription
+}
+  `;

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/textArea.graphql
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/textArea.graphql
@@ -1,0 +1,15 @@
+/*
+ *
+ * The "Textarea" Digital Form component.
+ *
+ * Pattern documentation:
+ * https://design.va.gov/components/form/textarea
+ *
+ */
+module.exports = `
+fragment textArea on ParagraphDigitalFormTextArea {
+  fieldDigitalFormLabel
+  fieldDigitalFormHintText
+  fieldDigitalFormRequired
+}
+  `;

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/chapters.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/chapters.unit.spec.js
@@ -116,6 +116,12 @@ describe('digitalForm chapters', () => {
           queryPage.fieldDigitalFormComponents.length,
         );
       });
+
+      it('includes an ID for components', () => {
+        expect(normalizedPage.components[0].id).to.eq(
+          queryPage.fieldDigitalFormComponents[0].entity.entityId,
+        );
+      });
     });
 
     describe('Text Input component', () => {

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/chapters.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/chapters.unit.spec.js
@@ -175,6 +175,44 @@ describe('digitalForm chapters', () => {
           );
         });
       });
+
+      context('with a Date component', () => {
+        const queryComponent = {
+          entityId: '172741',
+          type: {
+            entity: {
+              entityId: 'digital_form_date_component',
+              entityLabel: 'Digital Form: Date Component',
+            },
+          },
+          fieldDigitalFormLabel: 'My custom date component',
+          fieldDigitalFormHintText: null,
+          fieldDigitalFormRequired: false,
+          fieldDigitalFormDateFormat: 'month_year',
+        };
+        const normalizedComponent = normalizeComponent(queryComponent);
+
+        it('has the correct fields', () => {
+          expect(normalizedComponent.type).to.eq(
+            queryComponent.type.entity.entityId,
+          );
+          expect(normalizedComponent.label).to.eq(
+            queryComponent.fieldDigitalFormLabel,
+          );
+          expect(normalizedComponent.hint).to.eq(
+            queryComponent.fieldDigitalFormHintText,
+          );
+          expect(normalizedComponent.required).to.eq(
+            queryComponent.fieldDigitalFormRequired,
+          );
+        });
+
+        it('includes the date format', () => {
+          expect(normalizedComponent.dateFormat).to.eq(
+            queryComponent.fieldDigitalFormDateFormat,
+          );
+        });
+      });
     });
   });
 });

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/chapters.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/chapters.unit.spec.js
@@ -290,6 +290,69 @@ describe('digitalForm chapters', () => {
           );
         });
       });
+
+      context('with a checkbox component', () => {
+        const queryComponent = {
+          entityId: '172746',
+          type: {
+            entity: {
+              entityId: 'digital_form_checkbox',
+              entityLabel: 'Digital Form: Checkbox Component',
+            },
+          },
+          fieldDigitalFormLabel: 'My custom checkbox',
+          fieldDigitalFormHintText: null,
+          fieldDigitalFormRequired: false,
+          fieldDfResponseOptions: [
+            {
+              entity: {
+                entityId: '172745',
+                type: {
+                  entity: {
+                    entityLabel: 'Digital Form: Response Option',
+                    entityId: 'digital_form_response_option',
+                  },
+                },
+                fieldDigitalFormLabel: 'I agree to all these things',
+                fieldDigitalFormDescription: null,
+              },
+            },
+          ],
+        };
+        const normalizedComponent = normalizeComponent(queryComponent);
+
+        it('has the correct fields', () => {
+          expect(normalizedComponent.type).to.eq(
+            queryComponent.type.entity.entityId,
+          );
+          expect(normalizedComponent.label).to.eq(
+            queryComponent.fieldDigitalFormLabel,
+          );
+          expect(normalizedComponent.hint).to.eq(
+            queryComponent.fieldDigitalFormHintText,
+          );
+          expect(normalizedComponent.required).to.eq(
+            queryComponent.fieldDigitalFormRequired,
+          );
+        });
+
+        it('includes response options', () => {
+          expect(normalizedComponent.responseOptions.length).to.eq(
+            queryComponent.fieldDfResponseOptions.length,
+          );
+
+          const normalizedOption = normalizedComponent.responseOptions[0];
+          const queryOption = queryComponent.fieldDfResponseOptions[0].entity;
+
+          expect(normalizedOption.id).to.eq(queryOption.entityId);
+          expect(normalizedOption.label).to.eq(
+            queryOption.fieldDigitalFormLabel,
+          );
+          expect(normalizedOption.description).to.eq(
+            queryOption.fieldDigitalFormDescription,
+          );
+        });
+      });
     });
   });
 });

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/chapters.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/chapters.unit.spec.js
@@ -2,7 +2,7 @@
 
 import { expect } from 'chai';
 import queryResult from './fixtures/queryResult.json';
-import { normalizeChapter } from '../chapters';
+import { normalizeChapter, normalizeComponent } from '../chapters';
 
 describe('digitalForm chapters', () => {
   const queryForm = queryResult.data.nodeQuery.entities[1];
@@ -124,32 +124,56 @@ describe('digitalForm chapters', () => {
       });
     });
 
-    describe('Text Input component', () => {
-      const normalizedComponent = normalizedPage.components[0];
-      const queryComponent = queryPage.fieldDigitalFormComponents[0].entity;
+    describe('normalizeComponent', () => {
+      context('with a Text Input component', () => {
+        const queryComponent = queryPage.fieldDigitalFormComponents[0].entity;
+        const normalizedComponent = normalizeComponent(queryComponent);
 
-      it('has the correct type', () => {
-        expect(normalizedComponent.type).to.eq(
-          queryComponent.type.entity.entityId,
-        );
+        it('has the correct fields', () => {
+          expect(normalizedComponent.type).to.eq(
+            queryComponent.type.entity.entityId,
+          );
+          expect(normalizedComponent.label).to.eq(
+            queryComponent.fieldDigitalFormLabel,
+          );
+          expect(normalizedComponent.hint).to.eq(
+            queryComponent.fieldDigitalFormHintText,
+          );
+          expect(normalizedComponent.required).to.eq(
+            queryComponent.fieldDigitalFormRequired,
+          );
+        });
       });
 
-      it('includes the label', () => {
-        expect(normalizedComponent.label).to.eq(
-          queryComponent.fieldDigitalFormLabel,
-        );
-      });
+      context('with a Text Area component', () => {
+        const queryComponent = {
+          entityId: '172747',
+          type: {
+            entity: {
+              entityId: 'digital_form_text_area',
+              entityLabel: 'Digital Form: Text Area Component',
+            },
+          },
+          fieldDigitalFormLabel: 'Custom text area',
+          fieldDigitalFormHintText: null,
+          fieldDigitalFormRequired: false,
+        };
+        const normalizedComponent = normalizeComponent(queryComponent);
 
-      it('includes the hint text', () => {
-        expect(normalizedComponent.hint).to.eq(
-          queryComponent.fieldDigitalFormHintText,
-        );
-      });
-
-      it('indicates whether the component is required', () => {
-        expect(normalizedComponent.required).to.eq(
-          queryComponent.fieldDigitalFormRequired,
-        );
+        it('has the correct fields', () => {
+          expect(normalizedComponent.type).to.eq(
+            queryComponent.type.entity.entityId,
+          );
+          expect(normalizedComponent.label).to.eq(
+            queryComponent.fieldDigitalFormLabel,
+          );
+          expect(normalizedComponent.hint).to.eq(
+            queryComponent.fieldDigitalFormHintText,
+          );
+          expect(normalizedComponent.required).to.eq(
+            queryComponent.fieldDigitalFormRequired,
+          );
+        });
       });
     });
   });

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/chapters.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/chapters.unit.spec.js
@@ -213,6 +213,83 @@ describe('digitalForm chapters', () => {
           );
         });
       });
+
+      context('with a Radio Button component', () => {
+        const queryComponent = {
+          entityId: '172742',
+          type: {
+            entity: {
+              entityId: 'digital_form_radio_button',
+              entityLabel: 'Digital Form: Radio Button Component',
+            },
+          },
+          fieldDigitalFormLabel: 'Test radio component',
+          fieldDigitalFormHintText: null,
+          fieldDigitalFormRequired: false,
+          fieldDfResponseOptions: [
+            {
+              entity: {
+                entityId: '172743',
+                type: {
+                  entity: {
+                    entityLabel: 'Digital Form: Response Option',
+                    entityId: 'digital_form_response_option',
+                  },
+                },
+                fieldDigitalFormLabel: 'My custom option',
+                fieldDigitalFormDescription:
+                  'This option as optional description text.',
+              },
+            },
+            {
+              entity: {
+                entityId: '172744',
+                type: {
+                  entity: {
+                    entityLabel: 'Digital Form: Response Option',
+                    entityId: 'digital_form_response_option',
+                  },
+                },
+                fieldDigitalFormLabel: 'My second option',
+                fieldDigitalFormDescription: null,
+              },
+            },
+          ],
+        };
+        const normalizedComponent = normalizeComponent(queryComponent);
+
+        it('has the correct fields', () => {
+          expect(normalizedComponent.type).to.eq(
+            queryComponent.type.entity.entityId,
+          );
+          expect(normalizedComponent.label).to.eq(
+            queryComponent.fieldDigitalFormLabel,
+          );
+          expect(normalizedComponent.hint).to.eq(
+            queryComponent.fieldDigitalFormHintText,
+          );
+          expect(normalizedComponent.required).to.eq(
+            queryComponent.fieldDigitalFormRequired,
+          );
+        });
+
+        it('includes response options', () => {
+          expect(normalizedComponent.responseOptions.length).to.eq(
+            queryComponent.fieldDfResponseOptions.length,
+          );
+
+          const normalizedOption = normalizedComponent.responseOptions[0];
+          const queryOption = queryComponent.fieldDfResponseOptions[0].entity;
+
+          expect(normalizedOption.id).to.eq(queryOption.entityId);
+          expect(normalizedOption.label).to.eq(
+            queryOption.fieldDigitalFormLabel,
+          );
+          expect(normalizedOption.description).to.eq(
+            queryOption.fieldDigitalFormDescription,
+          );
+        });
+      });
     });
   });
 });

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/chapters.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/chapters.unit.spec.js
@@ -97,6 +97,10 @@ describe('digitalForm chapters', () => {
     });
 
     describe('Custom Step page', () => {
+      it('includes the entity ID', () => {
+        expect(normalizedPage.id).to.eq(queryPage.entityId);
+      });
+
       it('includes the correct page title', () => {
         expect(normalizedPage.pageTitle).to.eq(queryPage.fieldTitle);
       });

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/checkbox.graphql.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/checkbox.graphql.unit.spec.js
@@ -1,0 +1,18 @@
+/* eslint-disable @department-of-veterans-affairs/axe-check-required */
+
+import { expect } from 'chai';
+import checkbox from '../../fragments/checkbox.graphql';
+
+describe('checkbox fragment', () => {
+  it('includes the correct fields', () => {
+    expect(checkbox).to.have.string('fieldDigitalFormLabel');
+    expect(checkbox).to.have.string('fieldDigitalFormHintText');
+    expect(checkbox).to.have.string('fieldDigitalFormRequired');
+    expect(checkbox).to.have.string('fieldDfResponseOptions');
+  });
+
+  it('imports the textInput fragment', () => {
+    expect(checkbox).to.have.string('fragment responseOption');
+    expect(checkbox).to.have.string('...responseOption');
+  });
+});

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/checkbox.graphql.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/checkbox.graphql.unit.spec.js
@@ -11,8 +11,7 @@ describe('checkbox fragment', () => {
     expect(checkbox).to.have.string('fieldDfResponseOptions');
   });
 
-  it('imports the textInput fragment', () => {
-    expect(checkbox).to.have.string('fragment responseOption');
+  it('calls the responseOption fragment', () => {
     expect(checkbox).to.have.string('...responseOption');
   });
 });

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/date.graphql.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/date.graphql.unit.spec.js
@@ -1,0 +1,22 @@
+/* eslint-disable @department-of-veterans-affairs/axe-check-required */
+
+import { expect } from 'chai';
+import date from '../../fragments/date.graphql';
+
+describe('date fragment', () => {
+  it('includes fieldDigitalFormLabel', () => {
+    expect(date).to.have.string('fieldDigitalFormLabel');
+  });
+
+  it('includes fieldDigitalFormHintText', () => {
+    expect(date).to.have.string('fieldDigitalFormHintText');
+  });
+
+  it('includes fieldDigitalFormRequired', () => {
+    expect(date).to.have.string('fieldDigitalFormRequired');
+  });
+
+  it('includes fieldDigitalFormDateFormat', () => {
+    expect(date).to.have.string('fieldDigitalFormDateFormat');
+  });
+});

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/page.graphql.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/page.graphql.unit.spec.js
@@ -14,4 +14,9 @@ describe('page fragment', () => {
     expect(page).to.have.string('fragment textInput');
     expect(page).to.have.string('...textInput');
   });
+
+  it('imports the textArea fragment', () => {
+    expect(page).to.have.string('fragment textArea');
+    expect(page).to.have.string('...textArea');
+  });
 });

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/page.graphql.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/page.graphql.unit.spec.js
@@ -29,4 +29,9 @@ describe('page fragment', () => {
     expect(page).to.have.string('fragment radioButton');
     expect(page).to.have.string('...radioButton');
   });
+
+  it('imports the checkbox fragment', () => {
+    expect(page).to.have.string('fragment checkbox');
+    expect(page).to.have.string('...checkbox');
+  });
 });

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/page.graphql.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/page.graphql.unit.spec.js
@@ -34,4 +34,8 @@ describe('page fragment', () => {
     expect(page).to.have.string('fragment checkbox');
     expect(page).to.have.string('...checkbox');
   });
+
+  it('imports the responseOption fragment', () => {
+    expect(page).to.have.string('fragment responseOption');
+  });
 });

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/page.graphql.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/page.graphql.unit.spec.js
@@ -19,4 +19,9 @@ describe('page fragment', () => {
     expect(page).to.have.string('fragment textArea');
     expect(page).to.have.string('...textArea');
   });
+
+  it('imports the date fragment', () => {
+    expect(page).to.have.string('fragment date');
+    expect(page).to.have.string('...date');
+  });
 });

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/page.graphql.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/page.graphql.unit.spec.js
@@ -24,4 +24,9 @@ describe('page fragment', () => {
     expect(page).to.have.string('fragment date');
     expect(page).to.have.string('...date');
   });
+
+  it('imports the radioButton fragment', () => {
+    expect(page).to.have.string('fragment radioButton');
+    expect(page).to.have.string('...radioButton');
+  });
 });

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/radioButton.graphql.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/radioButton.graphql.unit.spec.js
@@ -1,0 +1,18 @@
+/* eslint-disable @department-of-veterans-affairs/axe-check-required */
+
+import { expect } from 'chai';
+import radioButton from '../../fragments/radioButton.graphql';
+
+describe('radioButton fragment', () => {
+  it('includes the correct fields', () => {
+    expect(radioButton).to.have.string('fieldDigitalFormLabel');
+    expect(radioButton).to.have.string('fieldDigitalFormHintText');
+    expect(radioButton).to.have.string('fieldDigitalFormRequired');
+    expect(radioButton).to.have.string('fieldDfResponseOptions');
+  });
+
+  it('imports the textInput fragment', () => {
+    expect(radioButton).to.have.string('fragment responseOption');
+    expect(radioButton).to.have.string('...responseOption');
+  });
+});

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/radioButton.graphql.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/radioButton.graphql.unit.spec.js
@@ -11,8 +11,7 @@ describe('radioButton fragment', () => {
     expect(radioButton).to.have.string('fieldDfResponseOptions');
   });
 
-  it('imports the textInput fragment', () => {
-    expect(radioButton).to.have.string('fragment responseOption');
+  it('calls the responseOption fragment', () => {
     expect(radioButton).to.have.string('...responseOption');
   });
 });

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/responseOption.graphql.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/responseOption.graphql.unit.spec.js
@@ -1,0 +1,14 @@
+/* eslint-disable @department-of-veterans-affairs/axe-check-required */
+
+import { expect } from 'chai';
+import responseOption from '../../fragments/responseOption.graphql';
+
+describe('responseOption fragment', () => {
+  it('includes fieldDigitalFormLabel', () => {
+    expect(responseOption).to.have.string('fieldDigitalFormLabel');
+  });
+
+  it('includes fieldDigitalFormDescription', () => {
+    expect(responseOption).to.have.string('fieldDigitalFormDescription');
+  });
+});

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/textArea.graphql.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/textArea.graphql.unit.spec.js
@@ -1,0 +1,18 @@
+/* eslint-disable @department-of-veterans-affairs/axe-check-required */
+
+import { expect } from 'chai';
+import textArea from '../../fragments/textArea.graphql';
+
+describe('textArea fragment', () => {
+  it('includes fieldDigitalFormLabel', () => {
+    expect(textArea).to.have.string('fieldDigitalFormLabel');
+  });
+
+  it('includes fieldDigitalFormHintText', () => {
+    expect(textArea).to.have.string('fieldDigitalFormHintText');
+  });
+
+  it('includes fieldDigitalFormRequired', () => {
+    expect(textArea).to.have.string('fieldDigitalFormRequired');
+  });
+});


### PR DESCRIPTION
## Summary

- Updates the GraphQL query to fetch proper fields for all Custom Step components.
- Normalizes fields for all Custom Step components.

### Example output
```json
          {
            "id": "172735",
            "pageTitle": "A Custom Step page",
            "bodyText": "With additional body text",
            "components": [
              {
                "hint": "Optional hint text",
                "id": "172738",
                "label": "A text input",
                "required": true,
                "type": "digital_form_text_input"
              },
              {
                "hint": null,
                "id": "172747",
                "label": "Custom text area",
                "required": false,
                "type": "digital_form_text_area"
              },
              {
                "hint": null,
                "id": "172741",
                "label": "My custom date component",
                "required": false,
                "type": "digital_form_date_component",
                "dateFormat": "month_year"
              },
              {
                "hint": "This date component includes the day as well as the month and the year.",
                "id": "172748",
                "label": "Date with Day",
                "required": true,
                "type": "digital_form_date_component",
                "dateFormat": "month_day_year"
              },
              {
                "hint": null,
                "id": "172742",
                "label": "Test radio component",
                "required": false,
                "type": "digital_form_radio_button",
                "responseOptions": [
                  {
                    "id": "172743",
                    "label": "My custom option",
                    "description": "This option has optional description text."
                  },
                  {
                    "id": "172744",
                    "label": "My second option",
                    "description": null
                  }
                ]
              },
              {
                "hint": null,
                "id": "172746",
                "label": "My custom checkbox",
                "required": true,
                "type": "digital_form_checkbox",
                "responseOptions": [
                  {
                    "id": "172745",
                    "label": "A single checkbox option can be used to confirm agreement",
                    "description": null
                  }
                ]
              }
            ]
          }
```

## Related issue(s)

- Closes department-of-veterans-affairs/va.gov-team#101164
- Closes department-of-veterans-affairs/va.gov-team#101174
- Closes department-of-veterans-affairs/va.gov-team#101167
- Closes department-of-veterans-affairs/va.gov-team#101171
- Closes department-of-veterans-affairs/va.gov-team#104026

## Are you removing or changing a registry.json `entryName` in this PR?
- [x] No, I'm not changing any `entryName`s (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing or changing an `entryName`

## Testing done

- New/updated unit tests for the new and updated GraphQL fragments and the Digital Form post processor
- Pulled local Drupal data and confirmed the resulting output from content-build

## What areas of the site does it impact?

Only affects the output of `digital-forms.json`.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
