### PR TITLE
VACMS-15636: Add RUM for family caregiver benefit hub

### DIFF
--- a/src/site/includes/datadog_rum/family-caregiver-benefit-hub.html
+++ b/src/site/includes/datadog_rum/family-caregiver-benefit-hub.html
@@ -1,0 +1,20 @@
+<script
+    src="https://www.datadoghq-browser-agent.com/datadog-rum-v6.js"
+    type="text/javascript">
+</script>
+<script>
+    window.DD_RUM && window.DD_RUM.init({
+      clientToken: 'pubd7a6c99934887d257e49455e667b1bcd',
+      applicationId: '8eb3ffe5-db3c-49a4-88d8-506ca2f9babd',
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
+      site: 'ddog-gov.com',
+      service: 'family-and-caregiver-benefit-hub',
+      env: '<ENV_NAME>',
+      // Specify a version number to identify the deployed version of your application in Datadog
+      // version: '1.0.0',
+      sessionSampleRate: 100,
+      sessionReplaySampleRate: 20,
+      defaultPrivacyLevel: 'mask-user-input',
+    });
+</script>

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -134,6 +134,10 @@
     </style>
   {% endif %}
 
+  {% if entityUrl.path contains 'family-caregiver-benefits' and enabledFeatureFlags.FEATURE_RUM_FAMILY_CAREGIVER_HUB %}
+    {% include "src/site/includes/datadog_rum/family-caregiver-benefit-hub.html" %}
+  {% endif %}
+
 </head>
 
 <body class="{{ body_class }} merger">

--- a/src/site/layouts/page.drupal.liquid
+++ b/src/site/layouts/page.drupal.liquid
@@ -2,6 +2,7 @@
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" %}
 
+
 <div itemscope itemprop="mainEntity" itemtype="https://schema.org/FAQPage">
 
   <div id="content" class="interior">


### PR DESCRIPTION
## Summary
This PR adds Datadog RUM for the family caregiver benefit hub. The script tag is added to URL paths with `/family-caregiver-benefits/` to capture all paths that can be followed from the landing page. We also added a feature flag `FEATURE_RUM_FAMILY_CAREGIVER_HUB`  for this to test in staging and lower envs to make sure no PII is being passed to Datadog.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15636

## Are you removing or changing a registry.json `entryName` in this PR?
- [x] No, I'm not changing any `entryName`s (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing or changing an `entryName`

## Testing done
Tested adding the script and then checking the data is flowing properly to the new app created in datadog.
https://vagov.ddog-gov.com/rum/performance-monitoring?query=%40application.id%3A8eb3ffe5-db3c-49a4-88d8-506ca2f9babd%20%40session.type%3Auser&fromUser=false&tab=overview&from_ts=1741065721854&to_ts=1741670521854&live=true

## Screenshots
![Performance_Monitoring___Datadog](https://github.com/user-attachments/assets/b7bcaf0e-83b6-4df7-8759-36eece92811b)


## What areas of the site does it impact?

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
