### PR TITLE
Update Ask VA widget name

### DIFF
--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -73,7 +73,7 @@
             <section>
               <h3 class="vads-u-font-size--h4">Message us</h3>
               <ul class="va-nav-linkslist-list social">
-                <li data-widget-type="ask-va"></li>
+                <li data-widget-type="ask-va-widget"></li>
               </ul>
             </section>
 


### PR DESCRIPTION
## Summary

The Ask VA widget name was not updated for benefit hub landing pages, resulting in the "Message us" area in the sidebar being blank because the widget was missing.

Related Slack thread: https://dsva.slack.com/archives/C03LFSPGV16/p1741972056662109

![image](https://github.com/user-attachments/assets/3239b34f-c704-4a5f-840b-6db24697938b)

I updated the widget name, and the widget showed up. I also verified this is the only spot in the content-build code where this widget appears.

<img width="340" alt="Screenshot 2025-03-14 at 12 24 30 PM" src="https://github.com/user-attachments/assets/694f6ddb-14da-4539-933b-af5939d05e0a" />