### PR TITLE
DO NOT MERGE: VACMS - Build with va-manila-health-care added to sidenav

### DIFF
--- a/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
+++ b/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
@@ -141,6 +141,7 @@ const FACILITY_MENU_NAMES = [
   // VISN 21
   'manila-va-clinic',
   'va-central-california-health-car',
+  'va-manila-health-care',
   'va-northern-california-health-ca',
   'va-pacific-islands-health-care',
   'va-palo-alto-health-care',


### PR DESCRIPTION
## Summary

- Adds va-manila-health-care to sidenav list
- Sitewide team, manage VA Facilities

### Generated summary
This pull request includes a small change to the `src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js` file. The change adds a new facility name to the `FACILITY_MENU_NAMES` array.

* [`src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js`](diffhunk://#diff-cfc370f9a7c4ddbd47af85b2ecb2d579ca26e9d4eaa2192cddb2f6011e3fcd62R144): Added 'va-manila-health-care' to the `FACILITY_MENU_NAMES` array.

Tested that it does not break breadcrumbs on manila-va-clinic and sub-pages
Tested that build completes

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20606

## Are you removing or changing a registry.json `entryName` in this PR?
- [x] No, I'm not changing any `entryName`s (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing or changing an `entryName`

## Testing done

- Tested locally that build completes with no graphql errors
- Tested that breadcrumbs continue to work on Manila VA Clinic pages and subpages

## Screenshots

N/A

## What areas of the site does it impact?

Manila Sidenav when system is supported

## Acceptance criteria

Sidenav works as expected

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Check that Sidenav continues to work. Check if sidenav works on published VA Manila system (not required as more things may need to be introduced - e.g. removing the manila pages processor).