### PR TITLE
VACMS-15636 family caregiver rum

### DIFF
--- a/src/site/includes/datadog_rum/family-caregiver-benefit-hub.html
+++ b/src/site/includes/datadog_rum/family-caregiver-benefit-hub.html
@@ -1,0 +1,20 @@
+<script
+    src="https://www.datadoghq-browser-agent.com/datadog-rum-v6.js"
+    type="text/javascript">
+</script>
+<script>
+    window.DD_RUM && window.DD_RUM.init({
+      clientToken: 'pubd7a6c99934887d257e49455e667b1bcd',
+      applicationId: '8eb3ffe5-db3c-49a4-88d8-506ca2f9babd',
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
+      site: 'ddog-gov.com',
+      service: 'family-and-caregiver-benefit-hub',
+      env: '<ENV_NAME>',
+      // Specify a version number to identify the deployed version of your application in Datadog
+      // version: '1.0.0',
+      sessionSampleRate: 100,
+      sessionReplaySampleRate: 20,
+      defaultPrivacyLevel: 'mask-user-input',
+    });
+</script>

--- a/src/site/includes/datadog_rum/family-caregiver-benefit-hub.html
+++ b/src/site/includes/datadog_rum/family-caregiver-benefit-hub.html
@@ -11,10 +11,9 @@
       site: 'ddog-gov.com',
       service: 'family-and-caregiver-benefit-hub',
       env: '<ENV_NAME>',
-      // Specify a version number to identify the deployed version of your application in Datadog
-      // version: '1.0.0',
+      version: '1.0.0',
       sessionSampleRate: 100,
-      sessionReplaySampleRate: 20,
+      sessionReplaySampleRate: 10,
       defaultPrivacyLevel: 'mask-user-input',
     });
 </script>

--- a/src/site/includes/datadog_rum/family-caregiver-benefit-hub.html
+++ b/src/site/includes/datadog_rum/family-caregiver-benefit-hub.html
@@ -6,14 +6,16 @@
     window.DD_RUM && window.DD_RUM.init({
       clientToken: 'pubd7a6c99934887d257e49455e667b1bcd',
       applicationId: '8eb3ffe5-db3c-49a4-88d8-506ca2f9babd',
-      // `site` refers to the Datadog site parameter of your organization
-      // see https://docs.datadoghq.com/getting_started/site/
       site: 'ddog-gov.com',
       service: 'family-and-caregiver-benefit-hub',
-      env: '<ENV_NAME>',
-      version: '1.0.0',
+      env: 'vagovprod',
+      version: '1.0.1',
       sessionSampleRate: 100,
       sessionReplaySampleRate: 10,
+      trackUserInteractions: true,
+      trackViewsManually: true,
+      trackResources: true,
+      trackLongTasks: true,
       defaultPrivacyLevel: 'mask-user-input',
     });
 </script>

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -134,6 +134,10 @@
     </style>
   {% endif %}
 
+  {% if entityUrl.path contains 'family-caregiver-benefits' and enabledFeatureFlags.FEATURE_RUM_FAMILY_CAREGIVER_HUB %}
+    {% include "src/site/includes/datadog_rum/family-caregiver-benefit-hub.html" %}
+  {% endif %}
+
 </head>
 
 <body class="{{ body_class }} merger">

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -134,7 +134,8 @@
     </style>
   {% endif %}
 
-  {% if entityUrl.path contains 'family-and-caregiver-benefits' %}
+  {% if entityUrl.path contains 'family-and-caregiver-benefits' and buildtype == "vagovprod" %}
+   <!-- DD_RUM family-caregiver-benefit -->
     {% include "src/site/includes/datadog_rum/family-caregiver-benefit-hub.html" %}
   {% endif %}
 </head>

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -134,10 +134,9 @@
     </style>
   {% endif %}
 
-  {% if entityUrl.path contains 'family-and-caregiver-benefits' and enabledFeatureFlags.FEATURE_RUM_FAMILY_CAREGIVER_HUB %}
+  {% if entityUrl.path contains 'family-and-caregiver-benefits' %}
     {% include "src/site/includes/datadog_rum/family-caregiver-benefit-hub.html" %}
   {% endif %}
-
 </head>
 
 <body class="{{ body_class }} merger">
@@ -194,6 +193,7 @@
   <script nonce="**CSP_NONCE**" type="text/javascript">
     {% include "src/site/assets/js/skip-link-focus.js" %}
   </script>
+  
 
 <script  type="text/javascript" defer>
   window.onload = function() {

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -134,7 +134,7 @@
     </style>
   {% endif %}
 
-  {% if entityUrl.path contains 'family-caregiver-benefits' and enabledFeatureFlags.FEATURE_RUM_FAMILY_CAREGIVER_HUB %}
+  {% if entityUrl.path contains 'family-and-caregiver-benefits' and enabledFeatureFlags.FEATURE_RUM_FAMILY_CAREGIVER_HUB %}
     {% include "src/site/includes/datadog_rum/family-caregiver-benefit-hub.html" %}
   {% endif %}
 

--- a/src/site/layouts/page.drupal.liquid
+++ b/src/site/layouts/page.drupal.liquid
@@ -2,7 +2,6 @@
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" %}
 
-
 <div itemscope itemprop="mainEntity" itemtype="https://schema.org/FAQPage">
 
   <div id="content" class="interior">

--- a/src/site/layouts/page.drupal.liquid
+++ b/src/site/layouts/page.drupal.liquid
@@ -2,6 +2,7 @@
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" %}
 
+
 <div itemscope itemprop="mainEntity" itemtype="https://schema.org/FAQPage">
 
   <div id="content" class="interior">


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary
Allows Datadog RUM for family caregiver rum on prod.


### Generated summary

This pull request includes updates to the `src/site/includes` directory, focusing on the Datadog configuration and feature flag usage. The most important changes include specifying a version number for Datadog, adjusting the session replay sample rate, and modifying the feature flag condition for including the Datadog script.

Updates to Datadog configuration:

* [`src/site/includes/datadog_rum/family-caregiver-benefit-hub.html`](diffhunk://#diff-e07ef0e796a90f9290a5909d9cc5162bc106eba09f1fa6e6fac896d934cff093L14-R16): Specified a version number for the deployed application and adjusted the session replay sample rate from 20 to 10.

Changes to feature flag usage:

* [`src/site/includes/header.html`](diffhunk://#diff-295d898dfe0fe9f0fdafd1e9bb9044859e7743eacd9f66ddbb90eba4d26eb9ceL137-L140): Modified the condition for including the Datadog script to check for the path containing 'family-and-caregiver-benefits' instead of relying on a feature flag.

Minor formatting changes:

* [`src/site/includes/header.html`](diffhunk://#diff-295d898dfe0fe9f0fdafd1e9bb9044859e7743eacd9f66ddbb90eba4d26eb9ceR197): Added a blank line for better readability in the script section.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15636

## Are you removing or changing a registry.json `entryName` in this PR?
- [x] No, I'm not changing any `entryName`s (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing or changing an `entryName`


## Testing done
Tested this locally and reviewed recorded RUM sessions to ensure no PII is being leaked.

