### PR TITLE
Create Parallel Simple Forms Upload add 686c

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1786,5 +1786,14 @@
       "localhost": true,
       "layout": "page-react.html"
     }
+  },
+  {
+    "appName": "Representative Form Upload",
+    "entryName": "representative-form-upload",
+    "rootUrl": "representative-form-upload",
+    "template": {
+      "vagovprod": false,
+      "layout": "page-react.html"
+    }
   }
 ]


### PR DESCRIPTION
## Summary

- *here* Create a new page that points to Simple Forms Infrastructure and add the 21-686c form as a test
- Create a parallel Simple Forms upload that has the same functionality but does not point to anywhere in Simple Forms. It's its own system
- Make the upload tool ARP compliant
- Add new table arp_in_progress_forms so any reps that are also veterans don't affect their own uploads

## Related issue(s)

- vets-api pr - https://github.com/department-of-veterans-affairs/vets-api/pull/21273
-vets-website pr - https://github.com/department-of-veterans-affairs/vets-website/pull/35272

## Are you removing or changing a registry.json `entryName` in this PR?
- [ ] No, I'm not changing any `entryName`s (skip to Summary and delete the rest of this section)

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

Everything points to simple forms so it looks the same
<img width="1106" alt="Screenshot 2025-03-17 at 10 52 50 AM" src="https://github.com/user-attachments/assets/99be06dd-7366-4473-af42-9842925368b5" />

<img width="1143" alt="Screenshot 2025-03-17 at 10 53 50 AM" src="https://github.com/user-attachments/assets/b8d5128d-b20e-43f0-afb0-858c9b7234da" />

## What areas of the site does it impact?

A new page at /representative-form-upload

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I added unit tests and integration tests for each feature
### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
