### PR TITLE
VACMS 18229 - fixes ordering of outstations

### DIFF
--- a/src/site/layouts/vet_center_locations_list.drupal.liquid
+++ b/src/site/layouts/vet_center_locations_list.drupal.liquid
@@ -56,8 +56,15 @@
               %}
             {% endfor %}
 
-            {% assign mobileVetCenters = fieldNearbyMobileVetCenters | getValuesForPath: 'entity' | concat: fieldOffice.entity.reverseFieldOfficeNode.entities | filterBy: 'entityBundle', 'vet_center_mobile_vet_center' | sortObjectsBy: 'title' %}
-            {% for mobileVetCenter in mobileVetCenters %}
+            {% assign mainMVC = fieldOffice.entity.reverseFieldOfficeNode.entities | filterBy: 'entityBundle', 'vet_center_mobile_vet_center' | sortObjectsBy: 'title' %}
+            {% for mobileVetCenter in mainMVC %}
+            {% include "src/site/includes/vet_centers/address_phone_image.liquid" with
+              vetCenter = mobileVetCenter
+              mainVetCenterPhone = fieldOffice.entity.fieldPhoneNumber %}
+            {% endfor %}
+
+            {% assign nearbyMVC = fieldNearbyMobileVetCenters | getValuesForPath: 'entity' | filterBy: 'entityBundle', 'vet_center_mobile_vet_center' | sortObjectsBy: 'title' %}
+            {% for mobileVetCenter in nearbyMVC %}
               {% include "src/site/includes/vet_centers/address_phone_image.liquid" with
                   vetCenter = mobileVetCenter
                   mainVetCenterPhone = fieldOffice.entity.fieldPhoneNumber %}


### PR DESCRIPTION
## Summary

- Orders connected outstations first before nearby
- Sitewide team - operates facility pages

### Generated summary

This pull request includes changes to the `src/site/layouts/vet_center_locations_list.drupal.liquid` file to improve the organization and display of mobile vet centers. The most important changes include separating the main and nearby mobile vet centers and ensuring that each category is processed and displayed correctly.

Improvements to the organization and display of mobile vet centers:

* Separated the main and nearby mobile vet centers into two distinct groups: `mainMVC` and `nearbyMVC`.
* Updated the `for` loops to iterate over the newly defined groups and include the `address_phone_image.liquid` template for each mobile vet center.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18229

## Are you removing or changing a registry.json `entryName` in this PR?
- [x] No, I'm not changing any `entryName`s (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing or changing an `entryName`


## Testing done

- Tested locally on a few Vet Center locations pages including the identified 

## Screenshots

<details>
<summary>Before</summary>
<img width="1308" alt="Screenshot 2025-03-17 at 11 17 15 AM" src="https://github.com/user-attachments/assets/1e22ff95-69dc-46be-b917-3c509f6411cc" />

</details>


<details>
<summary>After</summary>
<img width="853" alt="Screenshot 2025-03-17 at 11 17 25 AM" src="https://github.com/user-attachments/assets/4f06a0c9-de54-4c76-851e-9e4e5f218bc7" />
</details>

## What areas of the site does it impact?

Vet Center locations pages

## Acceptance criteria

Main MVC appear before nearby ones

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Ignore the map change on the the satellite Vet Center since that's a different PR

Look at the ordering on multiple locations pages of Vet Centers.