### PR TITLE
Remove unused efolders app

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -716,16 +716,6 @@
     }
   },
   {
-    "appName": "eFolders",
-    "entryName": "my-documents",
-    "rootUrl": "/my-documents",
-    "template": {
-      "title": "My Documents",
-      "layout": "page-react.html",
-      "vagovprod": false
-    }
-  },
-  {
     "appName": "Financial Status Report",
     "entryName": "request-debt-help-form-5655",
     "rootUrl": "/manage-va-debt/request-debt-help-form-5655",


### PR DESCRIPTION
## Are you removing or changing a registry.json `entryName` in this PR?
- [x] Yes, I'm removing or changing an `entryName`

If you are:
1. **Deleting an entryName**: First search [vets-website](https://github.com/department-of-veterans-affairs/vets-website/) for references to this `entryName` that are _not_ in the app folder (particularly in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`) and merge a PR that removes those references, if any.
   - searched, no references
  
## Summary
Removes non-functional app that was created 5 years ago

Related vets-website PR: https://github.com/department-of-veterans-affairs/vets-website/pull/35340

