### PR TITLE
Add plain language header field to digital form graphql fragment

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1729,6 +1729,7 @@
     "productId": "2e00cd49-14e2-4eb0-a3c6-5bc92c9e4618",
     "template": {
       "vagovprod": false,
+      "title": "Provide your employment history and related loss of income",
       "layout": "page-react.html"
     }
   },

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/digitalForm.graphql.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/digitalForm.graphql.js
@@ -19,6 +19,7 @@ module.exports = `
   fragment digitalForm on NodeDigitalForm {
     nid
     entityLabel
+    fieldPlainLanguageTitle
     fieldVaFormNumber
     fieldOmbNumber
     fieldRespondentBurden

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
@@ -11,6 +11,7 @@ const normalizeForm = (form, logger = logDrupal) => {
       formId: form.fieldVaFormNumber,
       moderationState: form.moderationState,
       title: form.entityLabel,
+      plainLanguageHeader: form.fieldPlainLanguageTitle,
       ombInfo: {
         expDate: formatDate(form.fieldExpirationDate.value),
         ombNumber: form.fieldOmbNumber,

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fixtures/queryResult.json
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fixtures/queryResult.json
@@ -7,6 +7,7 @@
           "entityLabel": "Form with One Step",
           "fieldVaFormNumber": "11111",
           "fieldOmbNumber": "1111-1111",
+          "fieldPlainLanguageTitle": "Single step form",
           "fieldRespondentBurden": 48,
           "moderationState": "published",
           "fieldExpirationDate": {
@@ -41,6 +42,7 @@
         {
           "nid": 71004,
           "entityLabel": "Form with Many Steps",
+          "fieldPlainLanguageTitle": "Multi step form",
           "fieldVaFormNumber": "222222",
           "fieldOmbNumber": "1212-1212",
           "fieldRespondentBurden": 30,
@@ -202,6 +204,7 @@
         {
           "nid": 76371,
           "entityLabel": "Draft form",
+          "fieldPlainLanguageTitle": "A draft form",
           "fieldVaFormNumber": "abcdefg",
           "fieldOmbNumber": "1234-7890",
           "fieldRespondentBurden": 7,

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/digitalForm.graphql.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/digitalForm.graphql.unit.spec.js
@@ -7,6 +7,7 @@ describe('digitalForm fragment', () => {
   it('includes form fields', () => {
     expect(digitalForm).to.have.string('nid');
     expect(digitalForm).to.have.string('entityLabel');
+    expect(digitalForm).to.have.string('fieldPlainLanguageTitle');
     expect(digitalForm).to.have.string('fieldVaFormNumber');
     expect(digitalForm).to.have.string('fieldChapters');
     expect(digitalForm).to.have.string('moderationState');

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/postProcessDigitalForm.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/postProcessDigitalForm.unit.spec.js
@@ -23,6 +23,9 @@ describe('postProcessDigitalForm', () => {
       expect(testForm.cmsId).to.eq(71004);
       expect(testForm.formId).to.eq('222222');
       expect(testForm.title).to.eq(manyStepEntity.entityLabel);
+      expect(testForm.plainLanguageHeader).to.eq(
+        manyStepEntity.fieldPlainLanguageTitle,
+      );
       expect(testForm.moderationState).to.eq(manyStepEntity.moderationState);
       expect(testForm.chapters.length).to.eq(
         manyStepEntity.fieldChapters.length,


### PR DESCRIPTION
## Summary
Added the plain language header to the digital form graphql fragment and relevant test files.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/104665
https://github.com/department-of-veterans-affairs/va.gov-team/issues/105059

## Are you removing or changing a registry.json `entryName` in this PR?
- [x] No, I'm not changing any `entryName`s (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing or changing an `entryName`

## Testing done
```
yarn test:unit src/site/stages/build/drupal/static-data-files/digitalForm/**/*.spec.js
yarn run v1.19.1
$ node ./script/run-unit-test.js src/site/stages/build/drupal/static-data-files/digitalForm/tests/chapters.unit.spec.js src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/address.graphql.unit.spec.js src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/checkbox.graphql.unit.spec.js src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/customStep.graphql.unit.spec.js src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/date.graphql.unit.spec.js src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/digitalForm.graphql.unit.spec.js src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/identificationInformation.graphql.unit.spec.js src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/listLoop.graphql.unit.spec.js src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/nameAndDateOfBirth.graphql.unit.spec.js src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/page.graphql.unit.spec.js src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/phoneAndEmail.graphql.unit.spec.js src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/radioButton.graphql.unit.spec.js src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/responseOption.graphql.unit.spec.js src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/textArea.graphql.unit.spec.js src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/textInput.graphql.unit.spec.js src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/yourPersonalInformation.graphql.unit.spec.js src/site/stages/build/drupal/static-data-files/digitalForm/tests/index.unit.spec.js src/site/stages/build/drupal/static-data-files/digitalForm/tests/postProcessDigitalForm.unit.spec.js src/site/stages/build/drupal/static-data-files/digitalForm/tests/utils.unit.spec.js
choma: to re-use this ordering, run tests with CHOMA_SEED=S6rVAIlUeu
Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme

  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]

  81 passing (202ms)

✨  Done in 4.63s.
```

# Screenshots

Adjusts the title in the `<head>` element

![Screenshot 2025-03-25 at 12 18 26 PM](https://github.com/user-attachments/assets/22d9fe47-ff5b-4e7c-8073-143a7d09fbd9)



## What areas of the site does it impact?

digital form pages

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
