### PR TITLE
VATEAM-99169: Normalize Introduction Page fields

### DIFF
--- a/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/digitalForm.graphql.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/fragments/digitalForm.graphql.js
@@ -19,6 +19,8 @@ module.exports = `
   fragment digitalForm on NodeDigitalForm {
     nid
     entityLabel
+    fieldDigitalFormWhatToKnow
+    fieldIntroText
     fieldVaFormNumber
     fieldOmbNumber
     fieldRespondentBurden

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/postProcessDigitalForm.js
@@ -9,6 +9,7 @@ const normalizeForm = (form, logger = logDrupal) => {
     return {
       cmsId: form.nid,
       formId: form.fieldVaFormNumber,
+      introParagraph: form.fieldIntroText,
       moderationState: form.moderationState,
       title: form.entityLabel,
       ombInfo: {
@@ -16,6 +17,7 @@ const normalizeForm = (form, logger = logDrupal) => {
         ombNumber: form.fieldOmbNumber,
         resBurden: form.fieldRespondentBurden,
       },
+      whatToKnowBullets: form.fieldDigitalFormWhatToKnow,
       chapters: form.fieldChapters.map(normalizeChapter),
     };
   } catch (error) {

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fixtures/queryResult.json
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fixtures/queryResult.json
@@ -41,9 +41,16 @@
         {
           "nid": 71004,
           "entityLabel": "Form with Many Steps",
+          "fieldIntroText":
+            "This form has many steps and is used primarily to test post-processing of Digital Forms.",
           "fieldVaFormNumber": "222222",
           "fieldOmbNumber": "1212-1212",
           "fieldRespondentBurden": 30,
+          "fieldDigitalFormWhatToKnow": [
+            "A form will have What to Know bullets.",
+            "It can have as many as five bullets.",
+            "But it can also have less."
+          ],
           "moderationState": "published",
           "fieldExpirationDate": {
             "value": "2027-01-29"

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/digitalForm.graphql.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/fragments/digitalForm.graphql.unit.spec.js
@@ -7,8 +7,10 @@ describe('digitalForm fragment', () => {
   it('includes form fields', () => {
     expect(digitalForm).to.have.string('nid');
     expect(digitalForm).to.have.string('entityLabel');
+    expect(digitalForm).to.have.string('fieldDigitalFormWhatToKnow');
     expect(digitalForm).to.have.string('fieldVaFormNumber');
     expect(digitalForm).to.have.string('fieldChapters');
+    expect(digitalForm).to.have.string('fieldIntroText');
     expect(digitalForm).to.have.string('moderationState');
   });
 

--- a/src/site/stages/build/drupal/static-data-files/digitalForm/tests/postProcessDigitalForm.unit.spec.js
+++ b/src/site/stages/build/drupal/static-data-files/digitalForm/tests/postProcessDigitalForm.unit.spec.js
@@ -30,6 +30,14 @@ describe('postProcessDigitalForm', () => {
       expect(testChapter.id).to.eq(Number(queryChapter.entityId));
     });
 
+    it('includes Introduction Page fields', () => {
+      expect(testForm.introParagraph).to.eq(manyStepEntity.fieldIntroText);
+      expect(testForm.whatToKnowBullets.length).to.eq(3);
+      expect(testForm.whatToKnowBullets[1]).to.eq(
+        manyStepEntity.fieldDigitalFormWhatToKnow[1],
+      );
+    });
+
     it('includes an OMB info object', () => {
       const { ombInfo } = testForm;
       // towStepEntity.fieldExpirationDate is 2027-01-29


### PR DESCRIPTION
## Summary

- Updates the GraphQL query to fetch the following fields for the Introduction Page:
   - Intro Paragraph
   - "What to Know" bullet points
- Normalizes those fields for the JSON KISS file.

### Example output
```json
[
  {
    "cmsId": 76353,
    "formId": "21-4140",
    "introParagraph": "This is the paragraph that will appear on the Introduction Page.",
    "moderationState": "draft",
    "title": "Employment Questionnaire",
    "ombInfo": {
      "expDate": "8/31/2027",
      "ombNumber": "2900-0079",
      "resBurden": 5
    },
    "whatToKnowBullets": [
      "Adding test bullets",
      "A second bullet",
      "Maybe even a third bullet"
    ],
    "chapters": [ ... ]
  }
]
```

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#99169

## Are you removing or changing a registry.json `entryName` in this PR?
- [x] No, I'm not changing any `entryName`s (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing or changing an `entryName`

## Testing done

- New/updated unit tests for the new and updated GraphQL fragments and the Digital Form post processor
- Pulled local Drupal data and confirmed the resulting output from `content-build`

## What areas of the site does it impact?

Only affects the output of `digital-forms.json`.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
