### PR TITLE
Deprecate events and event listings

### DIFF
--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -1,3 +1,8 @@
+{% comment %}
+This template is no longer used to build production content.
+Please make any changes you need in Next Build.
+{% endcomment %}
+
 {% include "src/site/includes/header.html" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" with deriveBreadcrumbsFromUrl = true replaceLastItem = true %}

--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -1,3 +1,8 @@
+{% comment %}
+This template is no longer used to build production content.
+Please make any changes you need in Next Build.
+{% endcomment %}
+
 {% include "src/site/includes/header.html" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" %}


### PR DESCRIPTION
## Summary

This just adds a comment at the top of the files for Event and Event Listing layouts. Both of these content types are built using Next Build now, so changes to these templates won't affect production.

### Generated summary
(Select this text, hit the Copilot button, and select "Generate".)

## Related issue(s)

Relates to https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20566
Relates to https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20565