### PR TITLE
add preconnect links for API urls

### DIFF
--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -22,6 +22,13 @@
 
   <!-- Preconnecting required origins: https://web.dev/uses-rel-preconnect/ -->
   <link rel="preconnect" href="https://www.googletagmanager.com" />
+  {% if buildtype == 'vagovprod' %}
+    <link rel="preconnect" href="https://api.va.gov" />
+  {% elseif buildtype == 'vagovstaging' %}
+    <link rel="preconnect" href="https://staging-api.va.gov" />
+  {% elseif buildtype == 'vagovdev' %}
+    <link rel="preconnect" href="https://dev-api.va.gov" />
+  {% endif %}
 
   <!-- Index only pages on production. -->
   {% if buildtype != 'vagovprod' %}


### PR DESCRIPTION
## Summary

This PR adds a [preconnect hint](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/preconnect) for the vets-api URL for each environment. This should improve application load times at the margin, as most apps need to fetch at least the user & feature toggles endpoints before rendering. Downsides are unlikely since this is a separate origin and won't block TCP connection slots for the revproxy and S3 origins.

![Screenshot 2025-05-08 at 11 05 33](https://github.com/user-attachments/assets/901a61ad-14bc-40fb-aa1d-65a797bec359)

## Are you removing or changing a registry.json `entryName` in this PR?
- [x] No, I'm not changing any `entryName`s (skip to Summary and delete the rest of this section)
