### PR TITLE
Bump ncipollo/release-action from 1.12.0 to 1.16.0

### DIFF
--- a/.github/workflows/daily-production-release.yml
+++ b/.github/workflows/daily-production-release.yml
@@ -100,7 +100,7 @@ jobs:
             git tag v0.0.$next_patch ${{ steps.get-current-ref.outputs.REF }} && git push --no-verify origin v0.0.$next_patch
 
       - name: Create release
-        uses: ncipollo/release-action@a2e71bdd4e7dab70ca26a852f29600c98b33153e # v1.12.0
+        uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
         with:
           tag: v0.0.${{ env.new_patch }}
           name: content-build/v0.0.${{ env.new_patch }}


### PR DESCRIPTION
This is a recreation of https://github.com/department-of-veterans-affairs/content-build/pull/2529 via my user, which is a member of the department-of-veteran-affairs org and therefore has permission to retrieve from our SSM store. Dependabot-created PRs cannot access SSM.

Bumps [ncipollo/release-action](https://github.com/ncipollo/release-action) from 1.12.0 to 1.16.0.
- [Release notes](https://github.com/ncipollo/release-action/releases)
- [Commits](https://github.com/ncipollo/release-action/compare/a2e71bdd4e7dab70ca26a852f29600c98b33153e...440c8c1cb0ed28b9f43e4d1d670870f059653174)

---
updated-dependencies:
- dependency-name: ncipollo/release-action dependency-version: 1.16.0 dependency-type: direct:production update-type: version-update:semver-minor ...

