### PR TITLE
Shift from shallow to treeless git clones of support repos.

### DIFF
--- a/script/install-repos.sh
+++ b/script/install-repos.sh
@@ -1,27 +1,18 @@
 #!/usr/bin/env bash
 if [ ! -d ../vagov-content ]; then
-  git clone --single-branch --depth 1 https://github.com/department-of-veterans-affairs/vagov-content.git ../vagov-content
+  git clone --filter=tree:0 https://github.com/department-of-veterans-affairs/vagov-content.git ../vagov-content
 else
   echo "Repo vagov-content already cloned."
 fi
 
 if [ ! -d ../vets-website ]; then
-  git clone --single-branch --depth 1 https://github.com/department-of-veterans-affairs/vets-website.git ../vets-website
+  git clone --filter=tree:0 https://github.com/department-of-veterans-affairs/vets-website.git ../vets-website
 else
   echo "Repo vets-website already cloned."
 fi
 
 if [ ! -d ../vets-api ]; then
-  git clone --single-branch --depth 1 https://github.com/department-of-veterans-affairs/vets-api.git ../vets-api
+  git clone --filter=tree:0 https://github.com/department-of-veterans-affairs/vets-api.git ../vets-api
 else
   echo "Repo vets-api already cloned."
-fi
-
-if [ "${RUN_NEXT_BUILD}" = "1" ]; then
-  if [ ! -d ../next-build ]; then
-    git clone --single-branch --depth 1 "https://va-cms-bot:${GITHUB_TOKEN}@github.com/department-of-veterans-affairs/next-build.git" ../next-build
-    cd ../next-build && yarn install
-  else
-    echo "Repo next-build already cloned."
-  fi
 fi


### PR DESCRIPTION
## Summary

Modified the install_repos.sh script to make 'treeless' rather than shallow clones of support repos. 'treeless' clones retain commit information without downloading the file contents, and will download file contents as needed (i.e. when checking a branch out). Shallow clones lose all history and therefore all branch information.

These support repos are used by CMS's review environments to build content-build within those environments. Moving to treeless checkouts will give us proper access to git branch history. No other process or repo calls this script.

This also removes cloning of next-build from this command. This dates from a development path that was abandoned. 

The following shows size difference for the treeless clone relative to a full clone or a shallow clone. Treeless clones do require some additional data transfer, but it is acceptably small.

```
16:16:32 with tcosgrove in ~/code
➜ du -shA vets-website-*
497M	vets-website-full
142M	vets-website-shallow
170M	vets-website-tree

16:16:44 with tcosgrove in ~/code
➜ du -shA vets-api-*
1.0G	vets-api-full
638M	vets-api-shallow
660M	vets-api-tree

16:16:50 with tcosgrove in ~/code
➜ du -shA vagov-content-*
214M	vagov-content-full
 69M	vagov-content-shallow
 73M	vagov-content-tree
```

### Generated summary
This pull request updates the `script/install-repos.sh` file to improve repository cloning efficiency and remove unnecessary code related to the `next-build` repository.

### Repository cloning improvements:
* Updated the `git clone` command for `vagov-content`, `vets-website`, and `vets-api` repositories to use the `--filter=tree:0` option instead of `--single-branch --depth 1`. This change optimizes the cloning process by reducing the amount of data transferred. _Human note: AI got this wrong. There is additional data transferred._

### Code cleanup:
* Removed the conditional block for cloning the `next-build` repository, including its associated `yarn install` step, as it is no longer required.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17209

