### PR TITLE
Update manage dependenets URL in our apps

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -100,7 +100,7 @@
   {
     "appName": "View Dependents",
     "entryName": "dependents-view-dependents",
-    "rootUrl": "/view-change-dependents/view",
+    "rootUrl": "/manage-dependents/view",
     "template": {
       "title": "View Dependents",
       "layout": "page-react.html",
@@ -108,11 +108,11 @@
       "includeBreadcrumbs": true,
       "breadcrumbs_override": [
         {
-          "path": "view-change-dependents",
+          "path": "manage-dependents",
           "name": "View or change dependents on your VA disability benefits"
         },
         {
-          "path": "view-change-dependents/view",
+          "path": "manage-dependents/view",
           "name": "Your VA dependents"
         }
       ]
@@ -249,18 +249,18 @@
   {
     "appName": "686C-674",
     "entryName": "686C-674",
-    "rootUrl": "/view-change-dependents/add-remove-form-21-686c",
+    "rootUrl": "/manage-dependents/add-remove-form-21-686c",
     "template": {
       "layout": "page-react.html",
       "vagovprod": true,
       "includeBreadcrumbs": true,
       "breadcrumbs_override": [
         {
-          "path": "view-change-dependents/",
+          "path": "manage-dependents/",
           "name": "View or change dependents on your VA disability benefits"
         },
         {
-          "path": "view-change-dependents/add-remove-form-21-686c/",
+          "path": "manage-dependents/add-remove-form-21-686c/",
           "name": "Add or remove dependents with VA Form 21-686C"
         }
       ]
@@ -269,7 +269,7 @@
   {
     "appName": "686C-674-v2",
     "entryName": "686C-674-v2",
-    "rootUrl": "/view-change-dependents/add-remove-form-21-686c-674",
+    "rootUrl": "/manage-dependents/add-remove-form-21-686c-674",
     "template": {
       "layout": "page-react.html",
       "vagovprod": true
@@ -278,7 +278,7 @@
   {
     "appName": "21-0538 Dependents verification form",
     "entryName": "0538-dependents-verification",
-    "rootUrl": "/view-change-dependents/verify-dependents-form-21-0538",
+    "rootUrl": "/manage-dependents/verify-dependents-form-21-0538",
     "productId": "34b9f018-c72d-4788-9cce-b73c8f234116",
     "template": {
       "vagovprod": false,

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -932,11 +932,11 @@ describe('formatForBreadcrumbsHTML', () => {
     // Define original breadcrumbs
     const originalCrumbs = [
       {
-        path: 'view-change-dependents/',
+        path: 'manage-dependents/',
         name: 'View or change dependents on your VA disability benefits',
       },
       {
-        path: 'view-change-dependents/add-remove-form-21-686c-v2/',
+        path: 'manage-dependents/add-remove-form-21-686c-674/',
         name: 'Add or remove dependents with VA Form 21-686C',
       },
     ];
@@ -945,7 +945,7 @@ describe('formatForBreadcrumbsHTML', () => {
     // Verify output
     expect(output).to.eq(
       JSON.stringify(
-        '[{"href":"/","isRouterLink":false,"label":"VA.gov home","lang":"en-US"},{"href":"/view-change-dependents/","isRouterLink":false,"label":"View or change dependents on your VA disability benefits","lang":"en-US"},{"href":"/view-change-dependents/add-remove-form-21-686c-v2/","isRouterLink":false,"label":"Add or remove dependents with VA Form 21-686C","lang":"en-US"}]',
+        '[{"href":"/","isRouterLink":false,"label":"VA.gov home","lang":"en-US"},{"href":"/manage-dependents/","isRouterLink":false,"label":"View or change dependents on your VA disability benefits","lang":"en-US"},{"href":"/manage-dependents/add-remove-form-21-686c-674/","isRouterLink":false,"label":"Add or remove dependents with VA Form 21-686C","lang":"en-US"}]',
       ),
     );
   });
@@ -953,7 +953,7 @@ describe('formatForBreadcrumbsHTML', () => {
     // Define original breadcrumbs
     const originalCrumbs = [
       {
-        path: 'view-change-dependents/',
+        path: 'manage-dependents/',
         name: 'View or change dependents on your VA disability benefits',
       },
       {
@@ -961,7 +961,7 @@ describe('formatForBreadcrumbsHTML', () => {
         name: 'This path does not exist',
       },
       {
-        path: 'view-change-dependents/add-remove-form-21-686c-v2/',
+        path: 'manage-dependents/add-remove-form-21-686c-674/',
         name: 'Add or remove dependents with VA Form 21-686C',
       },
     ];
@@ -970,7 +970,7 @@ describe('formatForBreadcrumbsHTML', () => {
     // Verify output
     expect(output).to.eq(
       JSON.stringify(
-        '[{"href":"/","isRouterLink":false,"label":"VA.gov home","lang":"en-US"},{"href":"/view-change-dependents/","isRouterLink":false,"label":"View or change dependents on your VA disability benefits","lang":"en-US"},{"href":"/view-change-dependents/add-remove-form-21-686c-v2/","isRouterLink":false,"label":"Add or remove dependents with VA Form 21-686C","lang":"en-US"}]',
+        '[{"href":"/","isRouterLink":false,"label":"VA.gov home","lang":"en-US"},{"href":"/manage-dependents/","isRouterLink":false,"label":"View or change dependents on your VA disability benefits","lang":"en-US"},{"href":"/manage-dependents/add-remove-form-21-686c-674/","isRouterLink":false,"label":"Add or remove dependents with VA Form 21-686C","lang":"en-US"}]',
       ),
     );
   });


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > Update root URL based on C/IA recommendations
  > Changes include all these URLs:
  > - `/manage-dependents/add-remove-form-21-686c` (v1)
  > - `/manage-dependents/add-remove-form-21-686c-674` (v2)
  > - `/view-change-dependents/view`
  > - `/view-change-dependents/verify-dependents-form-21-0538`
  >
  > [Related Slack thread](https://dsva.slack.com/archives/C05NEL4DKMX/p1748884678144449) and [this slack thread about the additional URLs](https://dsva.slack.com/archives/C0547Q0K0LF/p1749566317444999)
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Lifestages / Dependents Management Team
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

### Generated summary

This pull request updates the URLs and breadcrumbs for several applications related to managing VA dependents. The changes ensure consistency by replacing references to "view-change-dependents" with "manage-dependents" across the codebase.

### URL Updates in Application Registry:

* Updated `rootUrl` and breadcrumb paths in `src/applications/registry.json` for the following applications:
  - "View Dependents" (`rootUrl` changed to `/manage-dependents/view`).
  - "686C-674" (`rootUrl` changed to `/manage-dependents/add-remove-form-21-686c`).
  - "686C-674-v2" (`rootUrl` changed to `/manage-dependents/add-remove-form-21-686c-674`).
  - "21-0538 Dependents verification form" (`rootUrl` changed to `/manage-dependents/verify-dependents-form-21-0538`).

### Breadcrumb Updates in Unit Tests:

* Adjusted breadcrumb paths in `src/site/filters/liquid.unit.spec.js` to reflect the URL changes:
  - Modified paths in `formatForBreadcrumbsHTML` test cases to use "manage-dependents" instead of "view-change-dependents." [[1]](diffhunk://#diff-54dba0fc3dca56c5a63462fc29d1dde036b22b34b1aa6af69abe97372f362f04L935-R939) [[2]](diffhunk://#diff-54dba0fc3dca56c5a63462fc29d1dde036b22b34b1aa6af69abe97372f362f04L948-R964) [[3]](diffhunk://#diff-54dba0fc3dca56c5a63462fc29d1dde036b22b34b1aa6af69abe97372f362f04L973-R973)

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/111052

## Are you removing or changing a registry.json `entryName` in this PR?
- [x] No, I'm not changing any `entryName`s (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing or changing an `entryName`

If you are:
1. **Deleting an entryName**: First search [vets-website](https://github.com/department-of-veterans-affairs/vets-website/) for references to this `entryName` that are _not_ in the app folder (particularly in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`) and merge a PR that removes those references, if any.
   - _Add the link to your merged vets-website PR here_

2. **Changing an entryName**: First search [vets-website](https://github.com/department-of-veterans-affairs/vets-website/) for references to this `entryName` that are _not_ in the app folder (particularly in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`) and merge a PR that updates those references, if any.
   - _Add the link to your merged vets-website PR here_
  
_**If you do not do this, other applications will break!**_

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A

## What areas of the site does it impact?

  - "View Dependents" app
  - "686C-674" - Dependents Management form 686c-674 (current)
  - "686C-674-v2" - Dependents Management form 686c-674 (updated)
  - "21-0538 Dependents verification form" - Dependents verification form (WIP)

## Acceptance criteria

- [ ] Coordinate merging in changes from `content-build`, `vsp-platform-revproxy` and `vets-website`
- [ ] Maximize efficiency to minimize any downtime 

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
