### PR TITLE
VACMS-21021: Deprecate news_story

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -514,6 +514,7 @@ jobs:
           repository: department-of-veterans-affairs/testing-tools-team-dashboard-data
           token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
           path: testing-tools-team-dashboard-data
+          ref: 'fd11ee70184e88e50671d725e5fe5aa364d11e01'
 
       # TODO: Set .nvmrc in testing-tools-team-dashboard-data.
       # - name: Get Node version

--- a/src/site/constants/brokenLinkIgnorePatterns.js
+++ b/src/site/constants/brokenLinkIgnorePatterns.js
@@ -20,6 +20,7 @@
 const IGNORE_PATTERNS = [
   /\/events($|\/)?/, // This ignores all links to Event and Event Listing pages.
   /\/staff-profiles($|\/)?/, // This ignores all links to Staff Profile pages.
+  /\/stories($|\/)?/, // This ignores all links to Stories pages.
 ];
 
 module.exports = {

--- a/src/site/layouts/news_story.drupal.liquid
+++ b/src/site/layouts/news_story.drupal.liquid
@@ -1,3 +1,7 @@
+{% comment %}
+    This template is no longer used to build production content.
+    Please make any changes you need in Next Build.
+{% endcomment %}
 {% if header == empty %}
     {% assign header = "h4" %}
 {% endif %}

--- a/src/site/stages/build/drupal/graphql/CountEntityTypes.graphql.js
+++ b/src/site/stages/build/drupal/graphql/CountEntityTypes.graphql.js
@@ -41,16 +41,6 @@ const CountEntityTypes = `
     count
   }
 
-  newsStories: nodeQuery(
-    filter: {
-      conditions: [
-        {field: "status", value: ["1"]},
-        {field: "type", value: ["news_story"]}
-      ]}
-  	) {
-    count
-  }
-
   pressReleases: nodeQuery(
     filter: {
       conditions: [

--- a/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
@@ -111,10 +111,8 @@ const buildQuery = () => {
         ... healthCareRegionDetailPage
         ... pressReleasePage
         ... vamcOperatingStatusAndAlerts
-        ... newsStoryPage
         ... nodeOffice
         ... benefitListingPage
-
         ... storyListingPage
         ... leadershipListingPage
         ... pressReleasesListingPage

--- a/src/site/stages/build/drupal/individual-queries.js
+++ b/src/site/stages/build/drupal/individual-queries.js
@@ -17,8 +17,6 @@ const {
   getNodeHealthServicesListingPageQueries,
 } = require('./graphql/healthServicesListingPage.graphql');
 
-const { getNewsStoryQueries } = require('./graphql/newStoryPage.graphql');
-
 const {
   getPressReleaseQueries,
 } = require('./graphql/pressReleasePage.graphql');
@@ -106,7 +104,6 @@ function getNodeQueries(entityCounts) {
     ...getNodeOfficeQueries(entityCounts),
     ...getNodeHealthCareLocalFacilityPageQueries(entityCounts),
     ...getNodeHealthServicesListingPageQueries(entityCounts),
-    ...getNewsStoryQueries(entityCounts),
     ...getPressReleaseQueries(entityCounts),
     GetNodePressReleaseListingPages,
     ...getVaPoliceQueries(entityCounts),


### PR DESCRIPTION
## Summary

Removes news_story from graphQL queries and adds comment on template.

### Generated summary
This pull request removes support for "news_story" content types and updates related configurations, templates, and queries. Additionally, it introduces a new ignore pattern for stories in the broken link checker.

### Removal of "news_story" content type:

* [`src/site/stages/build/drupal/graphql/CountEntityTypes.graphql.js`](diffhunk://#diff-3365de6921597a2845b5e8683c845b2511685389aa35545bbbbe8024a6e26ad2L44-L53): Removed the query for counting "news_story" nodes.
* [`src/site/stages/build/drupal/graphql/GetAllPages.graphql.js`](diffhunk://#diff-28a6b9f0b78255b19344de34218b668f023e6e1cb87de132aae0a4ffa250d00dL114-L117): Removed the fragment for "newsStoryPage" from the list of GraphQL queries.
* [`src/site/stages/build/drupal/individual-queries.js`](diffhunk://#diff-0c17c1fa1f8088539fc5d410fa77c95bcdec5b2c06d0abf4a63d39dcdf77e6d6L20-L21): Removed the import and usage of `getNewsStoryQueries` in the individual queries setup. [[1]](diffhunk://#diff-0c17c1fa1f8088539fc5d410fa77c95bcdec5b2c06d0abf4a63d39dcdf77e6d6L20-L21) [[2]](diffhunk://#diff-0c17c1fa1f8088539fc5d410fa77c95bcdec5b2c06d0abf4a63d39dcdf77e6d6L109)

### Updates to templates and configurations:

* [`src/site/layouts/news_story.drupal.liquid`](diffhunk://#diff-63a239ce0e035deab586c3f0e25cf42a64bd04d820517f8ca89601cf45facaacR1-R4): Added a comment indicating that this template is no longer used for production content, redirecting changes to the Next Build.

### Enhancements to broken link checker:

* [`src/site/constants/brokenLinkIgnorePatterns.js`](diffhunk://#diff-a9287b28390a2add1e77a15606315571a4f1124bc426fbf202e63afd8bc4dfb5R23): Added a new ignore pattern to exclude links to "stories" pages from the broken link checker.
## Related issue(s)

Relates to [VACMS-21021](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21021)

## Are you removing or changing a registry.json `entryName` in this PR?
- [x] No, I'm not changing any `entryName`s (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing or changing an `entryName`

## Testing done

CI - pipeline build

## What areas of the site does it impact?

content-build of the news_story content type in Drupal

## Acceptance criteria
 - [ ] news_story is removed from 'get individual' and 'get all pages' queries
 - [ ] news_story is removed from 'count' query
 - [ ] broken link checker to ignore any links to the Story Detail pages
 - [ ] a comment exists at the top of the news_story template indicating that it is no longer in use
 

