### PR TITLE
Fix: Allow for null values

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -635,7 +635,9 @@ module.exports = function registerFilters() {
   };
 
   liquid.filters.localHealthCareServiceIsMentalHealth = healthServiceName => {
-    return healthServiceName.toLowerCase().includes('mental health');
+    return (
+      healthServiceName?.toLowerCase?.().includes('mental health') || false
+    );
   };
 
   liquid.filters.accessibleNumber = data => {


### PR DESCRIPTION
## Problem

Content release is failing because a taxonomy term's name is null unexpectedly.

It _shouldn't_ be null, but it apparently is.

## Links

- [Slack thread](https://dsva.slack.com/archives/C02VD909V08/p1750888588337609)
- [Build failure](https://github.com/department-of-veterans-affairs/content-build/actions/runs/15887911920/job/44804306982)