### PR TITLE
VACMS-21017: Removes news release from queries

### DIFF
--- a/src/site/constants/brokenLinkIgnorePatterns.js
+++ b/src/site/constants/brokenLinkIgnorePatterns.js
@@ -19,6 +19,7 @@
   */
 const IGNORE_PATTERNS = [
   /\/events($|\/)?/, // This ignores all links to Event and Event Listing pages.
+  /\/news-releases($|\/)?/, // This ignores all links to Press Release pages.
   /\/staff-profiles($|\/)?/, // This ignores all links to Staff Profile pages.
   /\/stories($|\/)?/, // This ignores all links to Stories and Story Listing pages.
 ];

--- a/src/site/layouts/press_release.drupal.liquid
+++ b/src/site/layouts/press_release.drupal.liquid
@@ -1,3 +1,7 @@
+{% comment %}
+This template is no longer used to build production content.
+Please make any changes you need in Next Build.
+{% endcomment %}
 {% include "src/site/includes/header.html" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
@@ -50,7 +54,7 @@
                                         <p class="vads-u-margin-top--1 vads-u-margin-bottom--0">{{ c.title }}{% if c.fieldDescription != empty %}, {{ c.fieldDescription }} {% endif %}</p>
                                         {% if c.fieldTelephone %}
                                             <p class="vads-u-margin-top--1 vads-u-margin-bottom--0">
-                                                {% include "src/site/components/phone-number-no-header.drupal.liquid" with 
+                                                {% include "src/site/components/phone-number-no-header.drupal.liquid" with
                                                     phoneNumber = c.fieldTelephone.entity.fieldPhoneNumber
                                                     phoneExtension = c.fieldTelephone.entity.fieldPhoneExtension
                                                     phoneNumberType = c.fieldTelephone.entity.fieldPhoneNumberType
@@ -98,7 +102,7 @@
                     <va-link
                         active
                         href="{{ fieldListing.entity.entityUrl.path }}"
-                        text="See all news releases" 
+                        text="See all news releases"
                     />
                 </article>
                 <!-- Last updated & feedback button-->

--- a/src/site/stages/build/drupal/graphql/CountEntityTypes.graphql.js
+++ b/src/site/stages/build/drupal/graphql/CountEntityTypes.graphql.js
@@ -41,16 +41,6 @@ const CountEntityTypes = `
     count
   }
 
-  pressReleases: nodeQuery(
-    filter: {
-      conditions: [
-        {field: "status", value: ["1"]},
-        {field: "type", value: ["press_release"]}
-      ]}
-  	) {
-    count
-  }
-
   healthCareLocalFacility: nodeQuery(
     filter: {
       conditions: [

--- a/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
@@ -109,7 +109,6 @@ const buildQuery = () => {
         ... healthCareRegionPage
         ... healthCareLocalFacilityPage
         ... healthCareRegionDetailPage
-        ... pressReleasePage
         ... vamcOperatingStatusAndAlerts
         ... nodeOffice
         ... benefitListingPage

--- a/src/site/stages/build/drupal/individual-queries.js
+++ b/src/site/stages/build/drupal/individual-queries.js
@@ -18,10 +18,6 @@ const {
 } = require('./graphql/healthServicesListingPage.graphql');
 
 const {
-  getPressReleaseQueries,
-} = require('./graphql/pressReleasePage.graphql');
-
-const {
   GetNodePressReleaseListingPages,
 } = require('./graphql/pressReleasesListingPage.graphql');
 
@@ -100,7 +96,6 @@ function getNodeQueries(entityCounts) {
     ...getNodeOfficeQueries(entityCounts),
     ...getNodeHealthCareLocalFacilityPageQueries(entityCounts),
     ...getNodeHealthServicesListingPageQueries(entityCounts),
-    ...getPressReleaseQueries(entityCounts),
     GetNodePressReleaseListingPages,
     ...getVaPoliceQueries(entityCounts),
     GetNodeLocationsListingPages,


### PR DESCRIPTION
## Summary

- Removing the queries to build New Release pages
- Adding a comment on the template to instruct developers

### Generated summary
This pull request removes support for press release pages from the codebase and updates related configurations. The most important changes include eliminating queries and templates associated with press releases, and adding a new pattern to ignore broken links for press release pages.

### Removal of Press Release Page Support:

* [`src/site/stages/build/drupal/graphql/CountEntityTypes.graphql.js`](diffhunk://#diff-3365de6921597a2845b5e8683c845b2511685389aa35545bbbbe8024a6e26ad2L44-L53): Removed the `pressReleases` query from the `CountEntityTypes` GraphQL file.
* [`src/site/stages/build/drupal/graphql/GetAllPages.graphql.js`](diffhunk://#diff-28a6b9f0b78255b19344de34218b668f023e6e1cb87de132aae0a4ffa250d00dL112): Removed the `pressReleasePage` fragment from the `GetAllPages` GraphQL query.
* [`src/site/stages/build/drupal/individual-queries.js`](diffhunk://#diff-0c17c1fa1f8088539fc5d410fa77c95bcdec5b2c06d0abf4a63d39dcdf77e6d6L20-L23): Removed `getPressReleaseQueries` from imports and excluded it from the `getNodeQueries` function. [[1]](diffhunk://#diff-0c17c1fa1f8088539fc5d410fa77c95bcdec5b2c06d0abf4a63d39dcdf77e6d6L20-L23) [[2]](diffhunk://#diff-0c17c1fa1f8088539fc5d410fa77c95bcdec5b2c06d0abf4a63d39dcdf77e6d6L103)

### Configuration Updates:

* [`src/site/constants/brokenLinkIgnorePatterns.js`](diffhunk://#diff-a9287b28390a2add1e77a15606315571a4f1124bc426fbf202e63afd8bc4dfb5R22): Added a new pattern to ignore broken links for press release pages.
* [`src/site/layouts/press_release.drupal.liquid`](diffhunk://#diff-7770e7e388aba08c0939ce27fa2efd095b01f0cb6947708cbf15fb0c8f5a2f06R1-R4): Added a comment indicating that this template is no longer used for production content.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21017

## Are you removing or changing a registry.json `entryName` in this PR?
- [x] No, I'm not changing any `entryName`s (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing or changing an `entryName`


## Testing done

- [ ] Run a content release from Drupal in Tugboat
- [x] Go to [Boston health care new releases list](https://web-epucwqfswxx98l4vwecud95qdux59csn.demo.cms.va.gov/boston-health-care/news-releases/)
- [x] Click on a news release
- [x] Confirm that it is not found
- [x] Confirm that individual News Releases are not added to the content-build sitemap


## What areas of the site does it impact?

News release pages

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
