### PR TITLE
VACMS-21015: Excludes press release listings

### DIFF
--- a/src/site/constants/brokenLinkIgnorePatterns.js
+++ b/src/site/constants/brokenLinkIgnorePatterns.js
@@ -19,7 +19,7 @@
   */
 const IGNORE_PATTERNS = [
   /\/events($|\/)?/, // This ignores all links to Event and Event Listing pages.
-  /\/news-releases($|\/)?/, // This ignores all links to Press Release pages.
+  /\/news-releases($|\/)?/, // This ignores all links to News Release and News Release Listing pages.
   /\/staff-profiles($|\/)?/, // This ignores all links to Staff Profile pages.
   /\/stories($|\/)?/, // This ignores all links to Stories and Story Listing pages.
 ];

--- a/src/site/layouts/press_releases_listing.drupal.liquid
+++ b/src/site/layouts/press_releases_listing.drupal.liquid
@@ -1,4 +1,8 @@
 {% comment %}
+This template is no longer used to build production content.
+Please make any changes you need in Next Build.
+{% endcomment %}
+{% comment %}
 Example data:
 
   "entityUrl": {
@@ -90,7 +94,7 @@ larger space in the Fayette Plaza at 627 Pittsburgh Road, Suite 2, Uniontown,
             {% if allPressReleaseTeasers.entities.length < 1 %}
               <div class="clearfix-text">No news releases at this time.</div>
             {% endif %}
-            {% include "src/site/includes/pagination.drupal.liquid" with 
+            {% include "src/site/includes/pagination.drupal.liquid" with
               entityUrl = entityUrl.path
               pagePrefix = true
               totalPages = allPressReleaseTeasers.entities.length

--- a/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
@@ -113,7 +113,6 @@ const buildQuery = () => {
         ... nodeOffice
         ... benefitListingPage
         ... leadershipListingPage
-        ... pressReleasesListingPage
         ... healthServicesListingPage
         ... locationListingPage
         ... vaFormPage

--- a/src/site/stages/build/drupal/individual-queries.js
+++ b/src/site/stages/build/drupal/individual-queries.js
@@ -18,10 +18,6 @@ const {
 } = require('./graphql/healthServicesListingPage.graphql');
 
 const {
-  GetNodePressReleaseListingPages,
-} = require('./graphql/pressReleasesListingPage.graphql');
-
-const {
   GetNodeLocationsListingPages,
 } = require('./graphql/locationsListingPage.graphql');
 const {
@@ -96,7 +92,6 @@ function getNodeQueries(entityCounts) {
     ...getNodeOfficeQueries(entityCounts),
     ...getNodeHealthCareLocalFacilityPageQueries(entityCounts),
     ...getNodeHealthServicesListingPageQueries(entityCounts),
-    GetNodePressReleaseListingPages,
     ...getVaPoliceQueries(entityCounts),
     GetNodeLocationsListingPages,
     GetNodeLeadershipListingPages,


### PR DESCRIPTION
## Summary

- Removes the News Release/Press Release listings from the queries

### Generated summary
This pull request focuses on deprecating the `pressReleasesListingPage` functionality and updating related files to remove references to it. Additionally, it refines the description of ignored patterns for broken links in the site constants file.

### Deprecation of `pressReleasesListingPage` functionality:

* [`src/site/layouts/press_releases_listing.drupal.liquid`](diffhunk://#diff-a30fa8216e16006beebecb92aa9a21a2f712ce76754278845174997111f47025R2-R5): Added comments indicating that this template is no longer used for production content and advising to make changes in the Next Build environment.
* [`src/site/stages/build/drupal/graphql/GetAllPages.graphql.js`](diffhunk://#diff-28a6b9f0b78255b19344de34218b668f023e6e1cb87de132aae0a4ffa250d00dL116): Removed the `...pressReleasesListingPage` fragment from the GraphQL query.
* [`src/site/stages/build/drupal/individual-queries.js`](diffhunk://#diff-0c17c1fa1f8088539fc5d410fa77c95bcdec5b2c06d0abf4a63d39dcdf77e6d6L20-L23): Deleted imports and references to `GetNodePressReleaseListingPages` in both the `const {` declaration and the `getNodeQueries` function. [[1]](diffhunk://#diff-0c17c1fa1f8088539fc5d410fa77c95bcdec5b2c06d0abf4a63d39dcdf77e6d6L20-L23) [[2]](diffhunk://#diff-0c17c1fa1f8088539fc5d410fa77c95bcdec5b2c06d0abf4a63d39dcdf77e6d6L99)

### Refinement of ignored patterns for broken links:

* [`src/site/constants/brokenLinkIgnorePatterns.js`](diffhunk://#diff-a9287b28390a2add1e77a15606315571a4f1124bc426fbf202e63afd8bc4dfb5L22-R22): Updated the description for the `/news-releases($|\/)?/` pattern to clarify that it ignores links to both News Release and News Release Listing pages.
## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21015

## Are you removing or changing a registry.json `entryName` in this PR?
- [x] No, I'm not changing any `entryName`s (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing or changing an `entryName`

If you are:
1. **Deleting an entryName**: First search [vets-website](https://github.com/department-of-veterans-affairs/vets-website/) for references to this `entryName` that are _not_ in the app folder (particularly in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`) and merge a PR that removes those references, if any.
   - _Add the link to your merged vets-website PR here_

2. **Changing an entryName**: First search [vets-website](https://github.com/department-of-veterans-affairs/vets-website/) for references to this `entryName` that are _not_ in the app folder (particularly in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`) and merge a PR that updates those references, if any.
   - _Add the link to your merged vets-website PR here_
  
_**If you do not do this, other applications will break!**_

## Testing done

- [ ] Release content using the branch from this PR
- [ ] Go to [Boston health care](https://web-epucwqfswxx98l4vwecud95qdux59csn.demo.cms.va.gov/boston-health-care/)
- [ ] Confirm that the system is shown
- [ ] Click on "News Releases"
- [ ] Confirm that a 404 is returned


## What areas of the site does it impact?

This work should only result is a smaller build by content-build.

## Acceptance criteria
- [ ] The sitemap-cb shows fewer items (as it does, per [my comment below](https://github.com/department-of-veterans-affairs/content-build/pull/2582#issuecomment-3024796493))