### PR TITLE
Forcing concurrency on main branch

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,8 +20,8 @@ env:
   DRUPAL_PASSWORD: drupal8
 
 concurrency:
-  group: ${{ github.ref != 'refs/heads/main' && github.ref || github.sha }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  group: only-one-ci-on-main
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -755,7 +755,7 @@ jobs:
   notify-failure:
     name: Notify Failure
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/main' && (failure() || cancelled()) }}
+    if: ${{ github.ref == 'refs/heads/main' && (failure()) }}
     needs: deploy
 
     steps:


### PR DESCRIPTION
## Summary

- Change has been made to ensure that only one build of the main branch can be done at a time, in order to reduce the amount of times the CI Workflow runs. 
- Solution will be to set the spec.concurrency tag on the CI Workflow to 'cancel-in-progress: true' so that only one instance is being run and if others are run, the most recent will be run with the older ones cancelled.
- This fix would be maintained by DevOps

### Generated summary
(Select this text, hit the Copilot button, and select "Generate".)

## Related issue(s)

- [Ticket here](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21477)

## Are you removing or changing a registry.json `entryName` in this PR?
- [x] No, I'm not changing any `entryName`s (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing or changing an `entryName`

If you are:
1. **Deleting an entryName**: First search [vets-website](https://github.com/department-of-veterans-affairs/vets-website/) for references to this `entryName` that are _not_ in the app folder (particularly in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`) and merge a PR that removes those references, if any.
   - _Add the link to your merged vets-website PR here_

2. **Changing an entryName**: First search [vets-website](https://github.com/department-of-veterans-affairs/vets-website/) for references to this `entryName` that are _not_ in the app folder (particularly in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`) and merge a PR that updates those references, if any.
   - _Add the link to your merged vets-website PR here_
  
_**If you do not do this, other applications will break!**_

## Testing done

- Previously when a push to main is done, the CI Workflow would allow for every individual push to run the CI Build workflow, which consumed resources unnecessarily 
- For this PR to be working as expected, only ONE instance of CI Workflow should be seen as running when multiple PRs are merged to main. The others should just be cancelled, with no notification being sent out on this.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
