### PR TITLE
Update name for the Appointments tool

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -46,7 +46,7 @@
     }
   },
   {
-    "appName": "VA Online Scheduling",
+    "appName": "Appointments",
     "entryName": "vaos",
     "rootUrl": "/my-health/appointments",
     "template": {
@@ -1751,7 +1751,7 @@
     "productId": "908a02e6-c63d-42e0-87f9-ed208e47034e",
     "template": {
       "vagovprod": true,
-      "title": "Dispute your VA debt",         
+      "title": "Dispute your VA debt",
       "layout": "page-react.html",
       "includeBreadcrumbs": true,
       "breadcrumbs_override": [
@@ -1760,7 +1760,7 @@
           "name": "Manage your VA debt"
         },
         {
-          "path": "manage-va-debt/dispute-debt", 
+          "path": "manage-va-debt/dispute-debt",
           "name": "Dispute your VA debt"
         }
       ]


### PR DESCRIPTION
## Summary

- We've confirmed with UX that we want to update the app name for Appointments tool pages under `/my-health/appointments`, see linked issue with discussion details.
- We need to coordinate the changes with those in vets-website [here](https://github.com/department-of-veterans-affairs/vets-website/pull/37629)
- Appointments FE Team
- This is not behind a flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/113645

## Are you removing or changing a registry.json `entryName` in this PR?
- [x] No, I'm not changing any `entryName`s (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing or changing an `entryName`

## Testing done

- I'm not sure how I would test this change so I'm open to suggestions

## Screenshots

N/A

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user


