### PR TITLE
Fix added to Dockerfile for the same problem occurring in vets-website CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,12 @@ RUN groupadd -g $userid vets-website \
 ENV YARN_VERSION 1.19.1
 ENV NODE_ENV production
 
+# Fix for Debian Buster EOL - use archive repositories
+RUN echo "deb http://archive.debian.org/debian buster main" > /etc/apt/sources.list && \
+    echo "deb http://archive.debian.org/debian-security buster/updates main" >> /etc/apt/sources.list && \
+    echo "Acquire::Check-Valid-Until \"false\";" > /etc/apt/apt.conf.d/100disablechecks
+
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
   gconf-service libasound2 libatk1.0-0 libc6 libcairo2 \
   libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 \


### PR DESCRIPTION
## Summary

- _The Debian repo used by our Dockerfile has been archived.  Any branch of content-build without this fix will now show a failure with the Jenkins job._
- _This fix uses the same logic that resolved the problem in `vets-website`.  It simply points Jenkins to Debian's archives where the needed code now lives._

### Generated summary
(Select this text, hit the Copilot button, and select "Generate".)

## Related issue(s)

- _Link to support ticket where this issue was reported_
[Platform Support Ticket](https://dsva.slack.com/archives/CBU0KDSB1/p1752768055755399)

## Are you removing or changing a registry.json `entryName` in this PR?
- [x] No, I'm not changing any `entryName`s (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing or changing an `entryName`

## Testing done

- _This same logic fixed the problem for `vets-website` 24 hours ago.  No issues have been reported._
- _This fix corrected the job failure in a VFS team PR's branch._

## What areas of the site does it impact?
This is all CI, no site impact to be had.

## Requested Feedback

If there is a better solution out there, I'd be happy to manage it.
