### PR TITLE
Revert "Forcing concurrency on main branch"

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,8 +20,8 @@ env:
   DRUPAL_PASSWORD: drupal8
 
 concurrency:
-  group: only-one-ci-on-main
-  cancel-in-progress: true
+  group: ${{ github.ref != 'refs/heads/main' && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   build:
@@ -755,7 +755,7 @@ jobs:
   notify-failure:
     name: Notify Failure
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/main' && (failure()) }}
+    if: ${{ github.ref == 'refs/heads/main' && (failure() || cancelled()) }}
     needs: deploy
 
     steps:


### PR DESCRIPTION
Reverts department-of-veterans-affairs/content-build#2586

The previous setup allows for CI to run against multiple branches at once, and we do need that. See discussion: https://dsva.slack.com/archives/CT4GZBM8F/p1753201673056799