### PR TITLE
Remove SM Pilot app from registry.json

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -992,17 +992,6 @@
     }
   },
   {
-    "appName": "MHV Secure Messaging - OH Pilot",
-    "entryName": "mhv-secure-messaging-pilot",
-    "rootUrl": "/my-health/secure-messages-pilot",
-    "productId": "802ebe63-66e9-4ab1-82cd-bbf45d2db91f",
-    "template": {
-      "vagovprod": false,
-      "layout": "page-react.html",
-      "private": true
-    }
-  },
-  {
     "appName": "MHV Medical Records",
     "entryName": "medical-records",
     "rootUrl": "/my-health/medical-records",


### PR DESCRIPTION
## Summary

- Remove SM Pilot app from registry.json. Note the app has already been deleted and a redirect is in place.
- Team: MHV on VA.gov

### Generated summary

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/114617

## Are you removing or changing a registry.json `entryName` in this PR?
- [ ] No, I'm not changing any `entryName`s (skip to Summary and delete the rest of this section)
- [X] Yes, I'm removing or changing an `mhv-secure-messaging-pilot`

## Testing done
N/A

## Screenshots
N/A

## What areas of the site does it impact?
MHV SM App

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
