### PR TITLE
Cut over from old Chapter 31 form to new

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -605,30 +605,6 @@
     }
   },
   {
-    "appName": "28-1900 Veteran Readiness",
-    "entryName": "28-1900-chapter-31",
-    "rootUrl": "/careers-employment/vocational-rehabilitation/apply-vre-form-28-1900",
-    "template": {
-      "vagovprod": true,
-      "layout": "page-react.html",
-      "includeBreadcrumbs": true,
-      "breadcrumbs_override": [
-        {
-          "path": "careers-employment",
-          "name": "Careers and employment"
-        },
-        {
-          "path": "careers-employment/vocational-rehabilitation",
-          "name": "Veteran Readiness and Employment"
-        },
-        {
-          "path": "/careers-employment/vocational-rehabilitation/apply-vre-form-28-1900",
-          "name": "Apply for Veteran Readiness and Employment Form 28‑1900"
-        }
-      ]
-    }
-  },
-  {
     "appName": "Apply for Personalized Career Planning and Guidance with VA Form 27-8832",
     "entryName": "25-8832-planning-and-career-guidance",
     "rootUrl": "/careers-employment/education-and-career-counseling/apply-career-guidance-form-25-8832",
@@ -1756,9 +1732,9 @@
     }
   },
   {
-    "appName": "New 28-1900 Veteran Readiness",
+    "appName": "28-1900 Veteran Readiness",
     "entryName": "new-28-1900-chapter-31",
-    "rootUrl": "/temporary/apply-vre-form-28-1900",
+    "rootUrl": "/careers-employment/vocational-rehabilitation/apply-vre-form-28-1900",
     "productId": "7fec94cf-e9f7-44c9-963a-97593f3c9e3f",
     "template": {
       "vagovprod": false,


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

<!--
Note: GitHub Copilot will be added as a PR reviewer automatically. Please pay attention to its suggestions, but use your judgement when deciding whether to incorporate them.
-->

## Summary

- Changes the registry so that the URL for the Chapter 31 form resolves to the new version of the app
- I work for VA IIR and we own this product

### Generated summary
(Select this text, hit the Copilot button, and select "Generate".)
This pull request makes updates to the `src/applications/registry.json` file to consolidate and streamline configuration for the "28-1900 Veteran Readiness" application. The changes primarily involve removing a duplicate entry and updating the configuration of the remaining entry to align with the correct URL and naming conventions.

### Removal of duplicate entry:
* Removed a redundant entry for "28-1900 Veteran Readiness" with outdated configuration, including its `rootUrl`, breadcrumbs, and template details.

### Update to remaining entry:
* Updated the `appName` of the remaining "28-1900 Veteran Readiness" entry to remove the "New" prefix.
* Updated the `rootUrl` of the entry to point to the correct permanent URL: `/careers-employment/vocational-rehabilitation/apply-vre-form-28-1900`.

## Related issue(s)

- [VA IIR issue 1484](https://github.com/department-of-veterans-affairs/va-iir/issues/1484)

## Are you removing or changing a registry.json `entryName` in this PR?
- [ ] No, I'm not changing any `entryName`s (skip to Summary and delete the rest of this section)
- [x] Yes, I'm removing or changing an `entryName`

If you are:
1. **Deleting an entryName**: First search [vets-website](https://github.com/department-of-veterans-affairs/vets-website/) for references to this `entryName` that are _not_ in the app folder (particularly in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`) and merge a PR that removes those references, if any.
   - _Add the link to your merged vets-website PR here_

2. **Changing an entryName**: First search [vets-website](https://github.com/department-of-veterans-affairs/vets-website/) for references to this `entryName` that are _not_ in the app folder (particularly in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`) and merge a PR that updates those references, if any.
   - _Add the link to your merged vets-website PR here_
  
_**If you do not do this, other applications will break!**_

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
