### PR TITLE
Revert gov banner updates that migrated the .usa-media-block classes

### DIFF
--- a/src/site/includes/usa-website-header.html
+++ b/src/site/includes/usa-website-header.html
@@ -9,33 +9,23 @@
       </button>
       </div>
     </div>
-    <div class="usa-banner-content vads-grid-container usa-accordion-content vads-u-background-color--gray-lightest" id="gov-banner" aria-hidden="true">
-      <div class="vads-grid-row">
-        <div class="usa-media-block desktop-lg:vads-grid-col-6">
-          <img
-            alt="Dot gov"
-            class="usa-banner-icon usa-media-block__img"
-            src="https://www.va.gov/img/icon-dot-gov.svg"
-          />
-          <p class="usa-media-block__body vads-u-margin-top--0">
+    <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner" aria-hidden="true">
+      <div class="usa-banner-guidance-gov usa-width-one-half">
+        <img class="usa-banner-icon usa-media_block-img" src="/img/icon-dot-gov.svg" alt="Dot gov">
+        <div class="usa-media_block-body">
+          <p>
             <strong>The .gov means it’s official.</strong>
-            <br />
-            Federal government websites often end in .gov or .mil. Before
-            sharing sensitive information, make sure you’re on a federal
-            government site.
+            <br>
+            Federal government websites often end in .gov or .mil. Before sharing sensitive information, make sure you're on a federal government site.
           </p>
         </div>
-        <div class="usa-media-block desktop-lg:vads-grid-col-6">
-          <img
-            alt="SSL"
-            class="usa-banner-icon usa-media-block__img"
-            src="https://www.va.gov/img/icon-https.svg"
-          />
-          <p class="usa-media-block__body vads-u-margin-top--0">
+      </div>
+      <div class="usa-banner-guidance-ssl usa-width-one-half">
+        <img class="usa-banner-icon usa-media_block-img" src="/img/icon-https.svg" alt="SSL">
+        <div class="usa-media_block-body">
+          <p>
             <strong>The site is secure.</strong>
-            <br /> The <strong>https://</strong> ensures that you’re
-            connecting to the official website and that any information you
-            provide is encrypted and sent securely.
+            <br> The <strong>https://</strong> ensures that you're connecting to the official website and that any information you provide is encrypted and sent securely.
           </p>
         </div>
       </div>


### PR DESCRIPTION
This reverts commit 7ef09fd31d5abd0b0451e8ffc33763e9e42e172c.

**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

<!--
Note: GitHub Copilot will be added as a PR reviewer automatically. Please pay attention to its suggestions, but use your judgement when deciding whether to incorporate them.
-->

## Summary

I realized after migrating the media-block classes to USWDS v3 that the gov banner is the _only_ place it was being used and that it will/should be replaced by the `va-official-gov-banner` web component in [this ticket](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4576) in the near future. So it seems unnecessary to introduce these changes.

What should probably happen in order to get off of the old v1 .usa-media-block classes is to just migrate to that web component. Fussing with updating these old templates seems like the long way around so this reverts the previous updates.

### Generated summary
(Select this text, hit the Copilot button, and select "Generate".)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3748
- https://github.com/department-of-veterans-affairs/vets-website/pull/38171
- https://github.com/department-of-veterans-affairs/vets-website/pull/38059

## Are you removing or changing a registry.json `entryName` in this PR?
- [ ] No, I'm not changing any `entryName`s (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing or changing an `entryName`

If you are:
1. **Deleting an entryName**: First search [vets-website](https://github.com/department-of-veterans-affairs/vets-website/) for references to this `entryName` that are _not_ in the app folder (particularly in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`) and merge a PR that removes those references, if any.
   - _Add the link to your merged vets-website PR here_

2. **Changing an entryName**: First search [vets-website](https://github.com/department-of-veterans-affairs/vets-website/) for references to this `entryName` that are _not_ in the app folder (particularly in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`) and merge a PR that updates those references, if any.
   - _Add the link to your merged vets-website PR here_
  
_**If you do not do this, other applications will break!**_

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

<img width="1250" height="405" alt="Screenshot 2025-08-07 at 3 38 05 PM" src="https://github.com/user-attachments/assets/caf25992-6ad1-453e-8eea-0a5a19de01a8" />

<img width="1010" height="604" alt="Screenshot 2025-08-07 at 3 38 15 PM" src="https://github.com/user-attachments/assets/24874dee-0d9e-4a3d-b796-324171b0f319" />

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
