### PR TITLE
DMT | Add temp apps using new root URL for multiple apps

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -129,7 +129,7 @@
       "includeBreadcrumbs": true,
       "breadcrumbs_override": [
         {
-          "path": "manage-dependents",
+          "path": "manage-dependents/",
           "name": "View or change dependents on your VA disability benefits"
         },
         {

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -339,7 +339,6 @@
     "appName": "21-0538 Dependents verification form new-url",
     "entryName": "0538-dependents-verification-new-url",
     "rootUrl": "/manage-dependents/verify-dependents-form-21-0538",
-    "productId": "34b9f018-c72d-4788-9cce-b73c8f234116",
     "template": {
       "vagovprod": true,
       "layout": "page-react.html"

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -118,6 +118,27 @@
       ]
     }
   },
+    {
+    "appName": "View Dependents new-url",
+    "entryName": "dependents-view-dependents-new-url",
+    "rootUrl": "/manage-dependents/view",
+    "template": {
+      "title": "View Dependents",
+      "layout": "page-react.html",
+      "vagovprod": true,
+      "includeBreadcrumbs": true,
+      "breadcrumbs_override": [
+        {
+          "path": "manage-dependents",
+          "name": "View or change dependents on your VA disability benefits"
+        },
+        {
+          "path": "manage-dependents/view",
+          "name": "Your VA dependents"
+        }
+      ]
+    }
+  },
   {
     "appName": "Facility Locator",
     "entryName": "facilities",
@@ -267,9 +288,38 @@
     }
   },
   {
+    "appName": "686C-674-new-url",
+    "entryName": "686C-674-new-url",
+    "rootUrl": "/manage-dependents/add-remove-form-21-686c",
+    "template": {
+      "layout": "page-react.html",
+      "vagovprod": true,
+      "includeBreadcrumbs": true,
+      "breadcrumbs_override": [
+        {
+          "path": "manage-dependents/",
+          "name": "View or change dependents on your VA disability benefits"
+        },
+        {
+          "path": "manage-dependents/add-remove-form-21-686c/",
+          "name": "Add or remove dependents with VA Form 21-686C"
+        }
+      ]
+    }
+  },
+  {
     "appName": "686C-674-v2",
     "entryName": "686C-674-v2",
     "rootUrl": "/view-change-dependents/add-remove-form-21-686c-674",
+    "template": {
+      "layout": "page-react.html",
+      "vagovprod": true
+    }
+  },
+    {
+    "appName": "686C-674-v2-new-url",
+    "entryName": "686C-674-v2-new-url",
+    "rootUrl": "/manage-dependents/add-remove-form-21-686c-674",
     "template": {
       "layout": "page-react.html",
       "vagovprod": true
@@ -279,6 +329,16 @@
     "appName": "21-0538 Dependents verification form",
     "entryName": "0538-dependents-verification",
     "rootUrl": "/view-change-dependents/verify-dependents-form-21-0538",
+    "productId": "34b9f018-c72d-4788-9cce-b73c8f234116",
+    "template": {
+      "vagovprod": true,
+      "layout": "page-react.html"
+    }
+  },
+    {
+    "appName": "21-0538 Dependents verification form new-url",
+    "entryName": "0538-dependents-verification-new-url",
+    "rootUrl": "/manage-dependents/verify-dependents-form-21-0538",
     "productId": "34b9f018-c72d-4788-9cce-b73c8f234116",
     "template": {
       "vagovprod": true,

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -118,7 +118,7 @@
       ]
     }
   },
-    {
+  {
     "appName": "View Dependents new-url",
     "entryName": "dependents-view-dependents-new-url",
     "rootUrl": "/manage-dependents/view",
@@ -316,7 +316,7 @@
       "vagovprod": true
     }
   },
-    {
+  {
     "appName": "686C-674-v2-new-url",
     "entryName": "686C-674-v2-new-url",
     "rootUrl": "/manage-dependents/add-remove-form-21-686c-674",


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > Update root URL based on C/IA recommendations
  > Changes include all these URLs:
  > - `/manage-dependents/add-remove-form-21-686c` (v1)
  > - `/manage-dependents/add-remove-form-21-686c-674` (v2)
  > - `/view-change-dependents/view`
  > - `/view-change-dependents/verify-dependents-form-21-0538`
  >
  > [Related Slack thread](https://dsva.slack.com/archives/C05NEL4DKMX/p1748884678144449) and [this slack thread about the additional URLs](https://dsva.slack.com/archives/C0547Q0K0LF/p1749566317444999)

  > NOTE: This PR is tied to https://github.com/department-of-veterans-affairs/vets-website/pull/38407 - maybe adding 4 temp manifest.json files will allow having apps render at both the new and old URL, so there won't be any downtime? Will get feedback from sitewide before merging this (and corresponding vets-website PR)
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Lifestages / Dependents Management Team
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

### Generated summary

This pull request updates the URLs and breadcrumbs for several applications related to managing VA dependents. The changes ensure consistency by replacing references to "view-change-dependents" with "manage-dependents" across the codebase.

### URL Updates in Application Registry:

* Added 4 new entries with updated `rootUrl` and breadcrumb paths in `src/applications/registry.json` for the following applications:
  - "View Dependents new-url" (`rootUrl` set to `/manage-dependents/view`).
  - "686C-674-new-url" (`rootUrl` set to `/manage-dependents/add-remove-form-21-686c`).
  - "686C-674-v2-new-url" (`rootUrl` set to `/manage-dependents/add-remove-form-21-686c-674`).
  - "21-0538 Dependents verification form new-url" (`rootUrl` set to `/manage-dependents/verify-dependents-form-21-0538`).

### Breadcrumb Updates in Unit Tests:

* Adjusted breadcrumb paths in `src/site/filters/liquid.unit.spec.js` to reflect the URL changes:
  - Modified paths in `formatForBreadcrumbsHTML` test cases to use "manage-dependents" instead of "view-change-dependents." [[1]](diffhunk://#diff-54dba0fc3dca56c5a63462fc29d1dde036b22b34b1aa6af69abe97372f362f04L935-R939) [[2]](diffhunk://#diff-54dba0fc3dca56c5a63462fc29d1dde036b22b34b1aa6af69abe97372f362f04L948-R964) [[3]](diffhunk://#diff-54dba0fc3dca56c5a63462fc29d1dde036b22b34b1aa6af69abe97372f362f04L973-R973)

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/111052

Related PRs:
- https://github.com/department-of-veterans-affairs/vets-website/pull/38407
>
- ~https://github.com/department-of-veterans-affairs/vets-website/pull/37049~
- https://github.com/department-of-veterans-affairs/vets-website/pull/38369
- https://github.com/department-of-veterans-affairs/vets-website/pull/37051
- https://github.com/department-of-veterans-affairs/content-build/pull/2561
- https://github.com/department-of-veterans-affairs/vets-api/pull/22639
- https://github.com/department-of-veterans-affairs/vsp-platform-revproxy/pull/945 (Route)
- https://github.com/department-of-veterans-affairs/vsp-platform-revproxy/pull/947 (Redirect)

## Are you removing or changing a registry.json `entryName` in this PR?
- [x] No, I'm not changing any `entryName`s (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing or changing an `entryName`

If you are:
1. **Deleting an entryName**: First search [vets-website](https://github.com/department-of-veterans-affairs/vets-website/) for references to this `entryName` that are _not_ in the app folder (particularly in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`) and merge a PR that removes those references, if any.
   - _Add the link to your merged vets-website PR here_

2. **Changing an entryName**: First search [vets-website](https://github.com/department-of-veterans-affairs/vets-website/) for references to this `entryName` that are _not_ in the app folder (particularly in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`) and merge a PR that updates those references, if any.
   - _Add the link to your merged vets-website PR here_
  
_**If you do not do this, other applications will break!**_

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A

## What areas of the site does it impact?

  - "View Dependents" app
  - "686C-674" - Dependents Management form 686c-674 (current)
  - "686C-674-v2" - Dependents Management form 686c-674 (updated)
  - "21-0538 Dependents verification form" - Dependents verification form (WIP)

## Acceptance criteria

- [ ] Coordinate merging in changes from `content-build`, `vsp-platform-revproxy` and `vets-website`
- [ ] Maximize efficiency to minimize any downtime 

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
