### PR TITLE
Disallow crawling of outdated sitemap.xml file.

### DIFF
--- a/src/site/assets/robots.txt
+++ b/src/site/assets/robots.txt
@@ -11,6 +11,7 @@ Disallow: /analytics-opt-out.html
 Disallow: /cgi-bin/
 Disallow: /drupal
 Disallow: /covid19screen
+Disallow: /sitemap.xml
 
 # disallow WIP VAMCs
 # make sure to add a trailing slash at the end of the path


### PR DESCRIPTION
## Summary

This prevents an old sitemap.xml file from being crawled. 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/22085

