### PR TITLE
remove find-form/upload from site map

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1090,7 +1090,8 @@
     "productId": "88558f52-5c6c-447f-ab78-e006b01a32db",
     "template": {
       "vagovprod": true,
-      "layout": "page-react.html"
+      "layout": "page-react.html",
+      "private": true
     }
   },
   {


### PR DESCRIPTION

Removing find-form/upload from xml sitemap. The static page is archived and we want users to stop getting to it through google. 

Related issue(s)
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4686

Testing done
Not sure how to test the site map locally

Screenshots
No UI changes

What areas of the site does it impact?
/find-form/upload

Acceptance criteria
Quality Assurance & Testing
Tests in CI

Error Handling
N/A

Authentication
N/A

Requested Feedback
N/A