### PR TITLE
10-7959f-2 | Populate title & breadcrumbs from registry

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1525,7 +1525,19 @@
     "productId": "66edb145-7655-4137-a74d-dfb20f4e752a",
     "template": {
       "vagovprod": true,
-      "layout": "page-react.html"
+      "layout": "page-react.html",
+      "title": "File a Foreign Medical Program (FMP) claim",
+      "includeBreadcrumbs": true,
+      "breadcrumbs_override": [
+        {
+          "path": "health-care",
+          "name": "Health care"
+        },
+        {
+          "path": "health-care/file-foreign-medical-program-claim",
+          "name": "File a Foreign Medical Program (FMP) claim"
+        }
+      ]
     }
   },
   {


### PR DESCRIPTION
## Summary

This PR sets the title and breadcrumbs in the registry for the 10-7959f-2 app. The goal is to move this declaration into the registry and not having it set in the React app in `vets-website`.

### Generated summary

This pull request updates the configuration for the Foreign Medical Program (FMP) claim application in `src/applications/registry.json`. The main focus is on improving the page's metadata and navigation experience for users.

Improvements to page metadata and navigation:

* Added a `title` property to set the page title to "File a Foreign Medical Program (FMP) claim".
* Enabled breadcrumbs navigation by adding `includeBreadcrumbs` and a `breadcrumbs_override` array, which provides a clear navigation path for users from "Health care" to the FMP claim page.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#117301

## Are you removing or changing a registry.json `entryName` in this PR?
- [x] No, I'm not changing any `entryName`s (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing or changing an `entryName`

## Acceptance criteria

 - Title and breadcrumbs are set via the registry and not client-side from `vets-website`

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
