### PR TITLE
init(21-2680): Add 21-2680 House Bound Status

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1909,5 +1909,15 @@
       "vagovprod": false,
       "layout": "page-react.html"
     }
+  },
+  {
+    "appName": "21-2680 House Bound Status",
+    "entryName": "21-2680-house-bound-status",
+    "rootUrl": "/21-2680-house-bound-status",
+    "productId": "803cc23f-a627-4ea7-a3ea-0f5595d0dfd3",
+    "template": {
+      "vagovprod": false,
+      "layout": "page-react.html"
+    }
   }
 ]


### PR DESCRIPTION
## Summary

- Added new registry entry for the 21-2680 House Bound Status application to support the development and deployment of a new form application
- This establishes the application's routing configuration, product ID, and template settings in the content-build registry

### Generated summary
(Select this text, hit the Copilot button, and select "Generate".)

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
  department-of-veterans-affairs/va.gov-team#
- _Link to epic if not included in ticket_
  department-of-veterans-affairs/va.gov-team#

### Related PR
- [init(21-2680): Add Application for Examination for Housebound Status or Permanent Need for Regular Aid](https://github.com/department-of-veterans-affairs/vets-website/pull/38889)

## Are you removing or changing a registry.json `entryName` in this PR?
- [x] No, I'm not changing any `entryName`s (skip to Summary and delete the rest of this section)

## Testing done

- The old behavior was that the 21-2680 House Bound Status application was not registered in the system
- To verify the changes, confirmed the new registry entry is properly formatted with valid JSON syntax and contains all required fields (appName, entryName, rootUrl, productId, and template configuration)
- Verified that the registry.json file maintains valid JSON structure after adding the new entry
- Confirmed the productId follows the standard UUID format
- Ensured the template configuration matches the pattern used by other form applications

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

N/A - Registry configuration change only, no UI components

## What areas of the site does it impact?

This change only impacts the application registry configuration and enables the future deployment of the 21-2680 House Bound Status form at the `/21-2680-house-bound-status` URL path. No existing functionality is affected.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
