### PR TITLE
information for 10-8678 created

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -2225,5 +2225,25 @@
         "subtitle": "(VA Form 21-4502)"
       }
     }
+  },
+  {
+  "appName": "Apply for Annual Clothing Allowance",
+  "entryName": "10-8678",
+  "rootUrl": "/disability/eligibility/annual-clothing-allowance/apply-form-10-8678",
+  "template": {
+      "vagovprod": false,
+      "layout": "page-react.html",
+      "includeBreadcrumbs": false,
+      "minimalExcludePaths": [
+        "/introduction",
+        "/confirmation"
+      ],
+      "minimalFooter": true,
+      "minimalHeader": {
+        "title": "Apply for Annual Clothing Allowance",
+        "subtitle": "(VA Form 10-8678)"
+      }
+    }
   }
+
 ]


### PR DESCRIPTION
## Summary

Created the new registry.json entry for the new 10-8678 form. This form is slated for a staging review in early may so we want to get into content build so we can test independently in staging.

## Related issue(s)
[Collab Cycle](https://github.com/department-of-veterans-affairs/va.gov-team/issues/137579)
[Epic](https://github.com/department-of-veterans-affairs/va.gov-team/issues/137679)


## Are you removing or changing a registry.json `entryName` in this PR?
- [ ] No, I'm not changing any `entryName`s (skip to Summary and delete the rest of this section)
- [x] Yes, I'm removing or changing an `entryName`

2. **Changing an entryName**: First search [vets-website](https://github.com/department-of-veterans-affairs/vets-website/) for references to this `entryName` that are _not_ in the app folder (particularly in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`) and merge a PR that updates those references, if any.
   - No references to 10-8678

_**If you do not do this, other applications will break!**_

## Testing done
- No testing to be done

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user