### PR TITLE
139154 update vass root

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -2189,7 +2189,7 @@
   {
     "appName": "VA Solid Start",
     "entryName": "vass",
-    "rootUrl": "/service-member/benefits/solid-start/schedule",
+    "rootUrl": "/service-member-benefits/solid-start/schedule",
     "productId": "b4e39943-c5e7-497a-ad26-8a1b9342cb97",
     "template": {
       "vagovprod": false,


### PR DESCRIPTION
## Summary

- Updated the VASS (VA Solid Start) `rootUrl` in `registry.json` from `/service-member/benefits/solid-start/schedule` to `/service-member-benefits/solid-start/schedule`. The slash between "member" and "benefits" was creating nested directory segments instead of the intended hyphenated path governed by platform IA.
- Flagged by platform governance ahead of the VASS staging review on April 10, 2026 as a launch blocker.
- One-line change in `registry.json` to align with the corresponding vets-website manifest update.
- Team: VAOS / Solid Start scheduling (VASS) — team that owns this application.
- Flipper: N/A.

### Generated summary

Updates `rootUrl` for the `vass` entry in `registry.json` from `/service-member/benefits/solid-start/schedule` to `/service-member-benefits/solid-start/schedule`.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#139154 _(replace with the authoritative ticket link if different)_
- Companion vets-website PR: department-of-veterans-affairs/vets-website#XXXXX _(insert PR number once created)_
- Epic: N/A _(add department-of-veterans-affairs/va.gov-team#… if applicable)_

## Are you removing or changing a registry.json `entryName` in this PR?

- [x] No, I'm not changing any `entryName`s (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing or changing an `entryName`

Only `rootUrl` is changing; `entryName` remains `vass`.

## Testing done

- **Prior behavior**: `registry.json` registered the VASS app at `/service-member/benefits/solid-start/schedule`, which created an unintended nested path (`service-member` → `benefits` → …).
- **Verification steps**: After updating `registry.json` locally alongside the vets-website manifest change, ran `yarn watch --env entry=vass` and confirmed the dev server serves the VASS app (`VA Solid Start | Veterans Affairs` title, `vass.entry.js` bundle) at the new path `/service-member-benefits/solid-start/schedule/` with HTTP 200.
- **Tests**: `validate-registry` CI check validates no duplicate `rootUrl` or `entryName` values; this change only modifies an existing URL value. No unit tests to update in content-build for a `rootUrl`-only change.
- **Known gap**: Old URL (`/service-member/benefits/…`) will stop resolving to VASS in production after merge. UDO team must update invitation/cancellation email links to the new path (tracked separately in the ticket).

## Screenshots

No UI change; this is a routing configuration update in `registry.json`.

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | N/A    | N/A   |
| Desktop | N/A    | N/A   |

## What areas of the site does it impact?

VASS Solid Start self-scheduling app only (`/service-member-benefits/solid-start/schedule` and child routes). No other applications are affected.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
  _N/A — `rootUrl`-only change in `registry.json`; no unit tests to update in content-build._
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated — VASS `README.md` updated in the companion vets-website PR.
- [ ] Screenshot of the developed feature is added
  _N/A — no UI change._
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
  _N/A — no markup or UI change._

### Error Handling

- [x] Browser console contains no warnings or errors.
  _No runtime change._
- [x] Events are being sent to the appropriate logging solution
  _N/A — no logging change._
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
  _N/A._

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
  _VASS uses low-auth / OTC flows, not standard VA.gov login. Verified the app loads at the new path via local dev server._

## Requested Feedback

- This PR must be merged **immediately after** the companion vets-website PR to avoid CI mismatches between the two repos.
- Please confirm whether a redirect from the old path (`/service-member/benefits/solid-start/schedule`) is needed at the platform/CDN level for any existing bookmarks or cached links.
