### PR TITLE
FDF: set vagovprod to true

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -2187,7 +2187,7 @@
   "entryName": "form-renderer",
   "rootUrl": "/my-va/submissions",
   "template": {
-    "vagovprod": false,
+    "vagovprod": true,
     "title": "Copy of 686c submission",
     "layout": "page-react.html",
     "includeBreadcrumbs": false,


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

<!--
Note: GitHub Copilot will be added as a PR reviewer automatically. Please pay attention to its suggestions, but use your judgement when deciding whether to incorporate them.
-->

## Summary

- _(Summarize the changes that have been made to the platform)_
This PR sets vagovprod to true on the form-renderer application so it is visible in prod.

## Are you removing or changing a registry.json `entryName` in this PR?
- [X] No, I'm not changing any `entryName`s (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing or changing an `entryName`

If you are:
1. **Deleting an entryName**: First search [vets-website](https://github.com/department-of-veterans-affairs/vets-website/) for references to this `entryName` that are _not_ in the app folder (particularly in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`) and merge a PR that removes those references, if any.
   - _Add the link to your merged vets-website PR here_

2. **Changing an entryName**: First search [vets-website](https://github.com/department-of-veterans-affairs/vets-website/) for references to this `entryName` that are _not_ in the app folder (particularly in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`) and merge a PR that updates those references, if any.
   - _Add the link to your merged vets-website PR here_

_**If you do not do this, other applications will break!**_

## What areas of the site does it impact?

form-renderer application