### PR TITLE
Remove error handling for uncaught exceptions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -405,16 +405,17 @@ jobs:
             /github/home/.cache/Cypress
             node_modules
 
-      - name: Start server
-        run: node src/platform/testing/e2e/test-server.js --buildtype vagovprod --port=3002 &
-
-      - name: Wait for server
-        run: |
-          timeout 30 bash -c 'until curl -sf http://127.0.0.1:3002 > /dev/null 2>&1; do sleep 1; done'
-          echo "Server is ready"
-
+      # Run the static server in the same shell session as Cypress. Starting the
+      # server in a prior step and backgrounding with `&` can leave the process
+      # vulnerable to teardown between steps on some runners, which surfaces as
+      # ECONNREFUSED to 127.0.0.1:3002 during cy.visit (unrelated to IPv6/localhost DNS).
       - name: Run Cypress tests
-        run: yarn cy:run --reporter cypress-multi-reporters --reporter-options "configFile=config/cypress-reporters.json" --env buildtype=vagovprod
+        run: |
+          set -euo pipefail
+          node src/platform/testing/e2e/test-server.js --buildtype vagovprod --port=3002 &
+          timeout 60 bash -c 'until curl -sf http://127.0.0.1:3002 > /dev/null 2>&1; do sleep 1; done'
+          echo "Server is ready"
+          yarn cy:run --reporter cypress-multi-reporters --reporter-options "configFile=config/cypress-reporters.json" --env buildtype=vagovprod
 
       - name: Publish test results
         if: ${{ always() }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -410,8 +410,9 @@ jobs:
       # vulnerable to teardown between steps on some runners, which surfaces as
       # ECONNREFUSED to 127.0.0.1:3002 during cy.visit (unrelated to IPv6/localhost DNS).
       - name: Run Cypress tests
+        # Container image defaults to `sh` (dash), which does not support `set -o pipefail`.
+        shell: bash
         run: |
-          set -euo pipefail
           node src/platform/testing/e2e/test-server.js --buildtype vagovprod --port=3002 &
           timeout 60 bash -c 'until curl -sf http://127.0.0.1:3002 > /dev/null 2>&1; do sleep 1; done'
           echo "Server is ready"

--- a/src/platform/testing/e2e/test-server.js
+++ b/src/platform/testing/e2e/test-server.js
@@ -22,16 +22,6 @@ const options = commandLineArgs(optionDefinitions);
 const root = path.resolve(__dirname, `../../../../build/${options.buildtype}`);
 const routes = manifestHelpers.getAppRoutes();
 
-// Prevent Node 22 from crashing on unhandled rejections/exceptions
-process.on('uncaughtException', err => {
-  // eslint-disable-next-line no-console
-  console.error('Test server uncaughtException:', err);
-});
-process.on('unhandledRejection', reason => {
-  // eslint-disable-next-line no-console
-  console.error('Test server unhandledRejection:', reason);
-});
-
 const app = express();
 
 app.use(

--- a/src/site/tests/home/00-required.cypress.spec.js
+++ b/src/site/tests/home/00-required.cypress.spec.js
@@ -1,13 +1,17 @@
 const path = require('path');
 
 Cypress.Commands.add('verifyGoogleAnalytics', () => {
+  const envBuildtype = Cypress.env('buildtype') || 'vagovdev';
+  // Keep in sync with src/site/includes/google-analytics.liquid (localhost uses vagovdev assets).
+  const analyticsFileBuildtype =
+    envBuildtype === 'localhost' ? 'vagovdev' : envBuildtype;
   const filePath = path.join(
     'content-build',
     __dirname,
     '..',
     '..',
     'assets/js/google-analytics/',
-    `${Cypress.env('buildtype') || 'vagovdev'}.js`,
+    `${analyticsFileBuildtype}.js`,
   );
   cy.readFile(filePath).then(str => {
     cy.get('[data-e2e="analytics-script"]')


### PR DESCRIPTION
What tipped me off to this change was seeing [this Copilot review comment](https://github.com/department-of-veterans-affairs/content-build/pull/2821/changes#r2911989892) saying that the change made in https://github.com/department-of-veterans-affairs/content-build/pull/2821 could mask failures.

I undid that change and then troubleshooted the cypress failures in CI.

Looks like I can remove that code and still get passing tests if I make some other changes to the workflow scripts. The `ECONNREFUSED` failures we were getting seemed to be the test server shutting itself down.