### PR TITLE
VACMS-24049 add workflow permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build and Push Docker Image to ECR
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/close-stale-pull-requests.yml
+++ b/.github/workflows/close-stale-pull-requests.yml
@@ -1,4 +1,8 @@
 name: 'Close stale PRs'
+permissions:
+  issues: write
+  pull-requests: write
+
 on:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,10 @@
 name: 'CodeQL'
 
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -1,4 +1,7 @@
 name: Content Release
+permissions:
+  actions: read
+  contents: read
 
 on:
   repository_dispatch:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,4 +1,6 @@
 name: Continuous Integration
+permissions:
+  contents: read
 
 on:
   push:
@@ -222,6 +224,9 @@ jobs:
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -352,6 +357,9 @@ jobs:
     needs:
       - login-to-amazon-ecr
       - build
+    permissions:
+      checks: write
+      contents: read
     timeout-minutes: 30
     container:
       image: 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/cypress-io/cypress/browsers:node16.16.0-chrome107-ff107-edge
@@ -443,6 +451,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [cypress-tests]
     if: ${{ needs.cypress-tests.result == 'failure' || needs.cypress-tests.result == 'success' }}
+    permissions:
+      checks: write
+      contents: read
     continue-on-error: true
     timeout-minutes: 30
     steps:
@@ -576,6 +587,9 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ always() && github.ref == 'refs/heads/main' && needs.cypress-tests.result == 'success' }}
     needs: cypress-tests
+    permissions:
+      actions: read
+      contents: read
     outputs:
       latest_run_number: ${{ steps.latest-run-number.outputs.latest_run_number }}
 

--- a/.github/workflows/daily-production-release.yml
+++ b/.github/workflows/daily-production-release.yml
@@ -1,4 +1,6 @@
 name: Daily Production Release
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:
@@ -32,6 +34,9 @@ jobs:
     name: Create Release
     needs: holiday-checker
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
     # Do not run the workflow during VA holidays unless we explicitly override it.
     if: >
       (needs.holiday-checker.outputs.is_holiday == 'false' || (inputs && inputs.override_code_freeze))

--- a/.github/workflows/daily-release-warning.yml
+++ b/.github/workflows/daily-release-warning.yml
@@ -1,5 +1,8 @@
 name: Daily Release Warning
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: 0 15 * * 1-5
@@ -17,6 +20,9 @@ jobs:
   notify:
     name: Notify Start
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
 
     steps:
       - name: Cancel workflow due to DSVA schedule

--- a/.github/workflows/deploy-content-preview-server.yml
+++ b/.github/workflows/deploy-content-preview-server.yml
@@ -1,5 +1,7 @@
 name: Deploy Content Preview Server
 
+permissions: {}
+
 on:
   workflow_run:
     workflows:

--- a/.github/workflows/gha-metrics.yml
+++ b/.github/workflows/gha-metrics.yml
@@ -1,6 +1,5 @@
 name: 'Send GHA metrics to Datadog'
-permissions:
-  contents: read
+permissions: {}
 on:
   workflow_run:
     workflows:

--- a/.github/workflows/gha-metrics.yml
+++ b/.github/workflows/gha-metrics.yml
@@ -1,4 +1,6 @@
 name: 'Send GHA metrics to Datadog'
+permissions:
+  contents: read
 on:
   workflow_run:
     workflows:

--- a/.github/workflows/manual-deploy-dev-staging.yml
+++ b/.github/workflows/manual-deploy-dev-staging.yml
@@ -1,4 +1,6 @@
 name: Manual dev/staging Deploy
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/manual-review.yml
+++ b/.github/workflows/manual-review.yml
@@ -1,5 +1,8 @@
 name: Manual Review
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [ready_for_review, synchronize, reopened, opened]

--- a/.github/workflows/preview-environment-cleanup.yml
+++ b/.github/workflows/preview-environment-cleanup.yml
@@ -3,6 +3,9 @@ on:
 
 name: Preview Environment Cleanup
 
+permissions:
+  contents: read
+
 env:
   DELETED_BRANCH: ${{ github.event.ref }}
   CURRENT_REPOSITORY: ${{ github.event.repository.name }}

--- a/.github/workflows/prune-self-hosted-runners.yml
+++ b/.github/workflows/prune-self-hosted-runners.yml
@@ -1,5 +1,8 @@
 name: Prune Self-Hosted Runners
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION

## Summary

Adds explicit permissions to github workflows to resolve some of these security notices: https://github.com/department-of-veterans-affairs/content-build/security/code-scanning

### Generated summary
(Select this text, hit the Copilot button, and select "Generate".)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/24049

## Are you removing or changing a registry.json `entryName` in this PR?
- [x] No, I'm not changing any `entryName`s (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing or changing an `entryName`

## Testing done

- [ ] CI tests/verifications run and pass
- [ ] Content-release runs successfully

## Requested Feedback

Normal PR CI run tests a portion of these. Content-release needs tested separately. 
