### PR TITLE
Don't treat benefits hub intro text as raw HTML

### DIFF
--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -23,7 +23,7 @@ https://github.com/department-of-veterans-affairs/next-build/tree/main/src/compo
         {% endif %}
 
         <div class="va-introtext">
-          <p>{{ fieldIntroText }}</p>
+          <p>{{ fieldIntroText | escape | newline_to_br }}</p>
         </div>
 
         {% if fieldSpokes != empty and fieldSpokes.length > 1 %}

--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -22,9 +22,7 @@ https://github.com/department-of-veterans-affairs/next-build/tree/main/src/compo
           <h1>{{ title }}</h1>
         {% endif %}
 
-        <div class="va-introtext">
-          <p>{{ fieldIntroText | escape | newline_to_br }}</p>
-        </div>
+        <p class="va-introtext">{{ fieldIntroText | escape | newline_to_br }}</p>
 
         {% if fieldSpokes != empty and fieldSpokes.length > 1 %}
           <va-on-this-page></va-on-this-page>


### PR DESCRIPTION
## Summary

Renders Benefit Hub intro text as escaped plain text with line breaks from CMS, instead of as raw HTML. Also fixes inconsistent application of mobile `.va-introtext` styles as pointed out in the original ticket.

Related PR in next-build: https://github.com/department-of-veterans-affairs/next-build/pull/1857

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/24029

## Testing done

Statically built the site and viewed the web page created for `/family-and-caregiver-benefits/`.

1. Go to https://va-gov-cms.ddev.site/family-and-caregiver-benefits and edit the intro text to include some script injection like <script>window.alert('all your base are belong to us!')</script>. 
2. Publish it
3. Comment out [these lines](https://github.com/department-of-veterans-affairs/content-build/blob/pwolfert/fix-unescaped-html-string/src/site/stages/build/drupal/individual-queries.js#L48-L58) to make the build faster and then `yarn build`
4. Run `yarn serve` and visit http://localhost:3002/family-and-caregiver-benefits/.
5. On the main branch you'll be vulnerable to that script injection. On this branch, the HTML will be escaped.

## Screenshots

Before:

<details>
<summary>Script injection</summary>

<img width="1624" height="1056" alt="Screenshot 2026-04-24 at 1 34 17 PM" src="https://github.com/user-attachments/assets/fbe6d1fb-c142-4278-aa0c-0056007f0b0a" />
</details>

After:

<details>
<summary>No script injection</summary>

<img width="1624" height="1056" alt="Screenshot 2026-04-24 at 3 12 32 PM" src="https://github.com/user-attachments/assets/819dee78-6d18-45a4-bcad-e37b57840b10" />
</details>