### PR TITLE
Remove the `socks-proxy-agent` and its `ip` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,7 +194,6 @@
     "sass-loader": "^12.1.0",
     "semver": "^7.5.2",
     "sentry-testkit": "^6.4.1",
-    "socks-proxy-agent": "^5.0.0",
     "style-loader": "^3.2.1",
     "table": "^6.7.6",
     "tar": "^7.5.10",

--- a/src/site/stages/build/drupal/api.js
+++ b/src/site/stages/build/drupal/api.js
@@ -2,9 +2,6 @@ const moment = require('moment');
 const fetch = require('node-fetch');
 const pRetry = require('p-retry');
 const chalk = require('chalk');
-const SocksProxyAgent = require('socks-proxy-agent');
-
-const syswidecas = require('syswide-cas');
 const { queries, getQuery } = require('./queries');
 const {
   getIndividualizedQueries,
@@ -51,38 +48,14 @@ function getDrupalClient(buildOptions, clientOptionsArg) {
     Authorization: `Basic ${encodedCredentials}`,
     'Content-Type': 'application/json',
   };
-  const agent = new SocksProxyAgent('socks://127.0.0.1:2001');
 
   return {
-    // We have to point to aws urls on Jenkins, so the only
-    // time we'll be using cms.va.gov addresses is locally,
-    // when we need a proxy
-    usingProxy:
-      /cms\.va\.gov$/.test(new URL(address).hostname) &&
-      !buildOptions['no-drupal-proxy'],
-
     getSiteUri() {
       return address;
     },
 
     async proxyFetch(url, options = {}) {
-      if (this.usingProxy) {
-        // addCAs() is here because VA uses self-signed certificates with a
-        // non-globally trusted Root Certificate Authority and we need to
-        // tell our code to trust it, otherwise we get self-signed certificate errors.
-        syswidecas.addCAs([
-          'certs/VA-Internal-S2-RCA1-v1.pem',
-          'certs/VA-Internal-S2-RCA2.pem',
-        ]);
-      }
-
-      return fetch(
-        url,
-        // eslint-disable-next-line prefer-object-spread
-        Object.assign({}, options, {
-          agent: this.usingProxy ? agent : undefined,
-        }),
-      );
+      return fetch(url, options);
     },
 
     async query(args) {

--- a/src/site/stages/build/drupal/static-data-files/fetchApi.js
+++ b/src/site/stages/build/drupal/static-data-files/fetchApi.js
@@ -1,8 +1,6 @@
 const { readFile } = require('fs').promises;
 const { fileURLToPath } = require('url');
 const fetch = require('node-fetch');
-const SocksProxyAgent = require('socks-proxy-agent');
-const syswidecas = require('syswide-cas');
 
 const { Response } = fetch;
 
@@ -39,33 +37,9 @@ function getCurlClient(buildOptions, _clientOptionsArg = { verbose: true }) {
     Authorization: `Basic ${encodedCredentials}`,
     'Content-Type': 'application/json',
   };
-  const agent = new SocksProxyAgent('socks://127.0.0.1:2001');
   return {
-    // We have to point to aws urls on Jenkins, so the only
-    // time we'll be using cms.va.gov addresses is locally,
-    // when we need a proxy
-
     async proxyFetch(url, options = { headers }) {
-      const usingProxy =
-        /^https?:\/\/.*\.cms\.va\.gov\//.test(url) &&
-        !buildOptions['no-drupal-proxy'];
-
-      if (usingProxy) {
-        // addCAs() is here because VA uses self-signed certificates with a
-        // non-globally trusted Root Certificate Authority and we need to
-        // tell our code to trust it, otherwise we get self-signed certificate errors.
-        syswidecas.addCAs([
-          'certs/VA-Internal-S2-RCA1-v1.pem',
-          'certs/VA-Internal-S2-RCA2.pem',
-        ]);
-      }
-      return fetchWrapper(
-        url,
-        // eslint-disable-next-line prefer-object-spread
-        Object.assign({}, options, {
-          agent: usingProxy ? agent : undefined,
-        }),
-      );
+      return fetchWrapper(url, options);
     },
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2437,13 +2437,6 @@ address@^1.0.1:
   resolved "https://registry.yarnpkg.com/address/-/address-1.1.2.tgz#bf1116c9c758c51b7a933d296b72c221ed9428b6"
   integrity sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA==
 
-agent-base@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
-  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
-  dependencies:
-    debug "4"
-
 agent-base@^7.1.0, agent-base@^7.1.2:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
@@ -3677,7 +3670,7 @@ colord@^2.0.1, colord@^2.6:
   resolved "https://registry.yarnpkg.com/colord/-/colord-2.7.0.tgz#706ea36fe0cd651b585eb142fe64b6480185270e"
   integrity sha512-pZJBqsHz+pYyw3zpX6ZRXWoCHM1/cvFikY9TV8G3zcejCaKE0lhankoj8iScyrrePA8C7yJ5FStfA9zbcOnw7Q==
 
-colorette@^1.2.1, colorette@^1.2.2, colorette@^1.3.0, colorette@^1.4.0:
+colorette@^1.2.1, colorette@^1.3.0, colorette@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.4.0.tgz#5190fbb87276259a86ad700bff2c6d6faa3fca40"
   integrity sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==
@@ -6649,11 +6642,6 @@ intersection-observer@0.12.0:
   resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.12.0.tgz#6c84628f67ce8698e5f9ccf857d97718745837aa"
   integrity sha512-2Vkz8z46Dv401zTWudDGwO7KiGHNDkMv417T5ItcNYfmvHR/1qCTVBO9vwH8zZmQ0WkA/1ARwpysR9bsnop4NQ==
 
-ip@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
-  integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
-
 ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
@@ -7105,15 +7093,7 @@ jpeg-js@^0.4.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@4.1.0:
-  version "3.14.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
-  integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^4.0.0"
-
-js-yaml@^3.13.1, js-yaml@^3.14.2, js-yaml@^3.4.6, js-yaml@^3.5.1, js-yaml@^3.5.4, js-yaml@^3.8.1:
+js-yaml@4.1.0, js-yaml@^3.13.1, js-yaml@^3.14.2, js-yaml@^3.4.6, js-yaml@^3.5.1, js-yaml@^3.5.4, js-yaml@^3.8.1:
   version "3.14.2"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.2.tgz#77485ce1dd7f33c061fd1b16ecea23b55fcb04b0"
   integrity sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==
@@ -8417,7 +8397,7 @@ nanoid@3.3.3:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
   integrity sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==
 
-nanoid@^3.1.23, nanoid@^3.3.11:
+nanoid@^3.3.11:
   version "3.3.11"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
   integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
@@ -10814,11 +10794,6 @@ slug-component@~1.1.0:
   resolved "https://registry.yarnpkg.com/slug-component/-/slug-component-1.1.0.tgz#224290a04591bf9ac08b9c622d3a14f43e3a0df7"
   integrity sha1-IkKQoEWRv5rAi5xiLToU9D46Dfc=
 
-smart-buffer@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.1.0.tgz#91605c25d91652f4661ea69ccf45f1b331ca21ba"
-  integrity sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==
-
 sockjs@^0.3.24:
   version "0.3.24"
   resolved "https://registry.yarnpkg.com/sockjs/-/sockjs-0.3.24.tgz#c9bc8995f33a111bea0395ec30aa3206bdb5ccce"
@@ -10828,32 +10803,10 @@ sockjs@^0.3.24:
     uuid "^8.3.2"
     websocket-driver "^0.7.4"
 
-socks-proxy-agent@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-5.0.1.tgz#032fb583048a29ebffec2e6a73fca0761f48177e"
-  integrity sha512-vZdmnjb9a2Tz6WEQVIurybSwElwPxMZaIc7PzqbJTrezcKNznv6giT7J7tZDZ1BojVaa1jvO/UiUdhDVB0ACoQ==
-  dependencies:
-    agent-base "^6.0.2"
-    debug "4"
-    socks "^2.3.3"
-
-socks@^2.3.3:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/socks/-/socks-2.6.1.tgz#989e6534a07cf337deb1b1c94aaa44296520d30e"
-  integrity sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==
-  dependencies:
-    ip "^1.1.5"
-    smart-buffer "^4.1.0"
-
 "source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
-
-source-map-js@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-0.6.2.tgz#0bb5de631b41cfbda6cfba8bd05a80efdfd2385e"
-  integrity sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==
 
 source-map-support@^0.5.16, source-map-support@~0.5.20:
   version "0.5.20"


### PR DESCRIPTION
## Summary

We were getting a security alert for `ip` ([97](https://github.com/department-of-veterans-affairs/content-build/security/dependabot/97), and it's only used by `socks-proxy-agent`. We do not use SOCKS anymore, so we can remove it.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/24049

## Testing done

