### PR TITLE
Fix GraphQL error on preview server

### DIFF
--- a/src/site/stages/build/drupal/graphql/fragments.graphql.js
+++ b/src/site/stages/build/drupal/graphql/fragments.graphql.js
@@ -58,7 +58,6 @@ const ALL_FRAGMENTS = `
   ${reactWidget}
   ${richTextCharLimit1000}
   ${spanishSummary}
-  ${staffProfile}
   ${supportService}
   ${table}
   ${termLcCategory}


### PR DESCRIPTION
## Summary

I'm not sure if this happens during build too, but we're trying to troubleshoot preview errors in production right now, and we know this is logging errors and keeps me from seeing the previewed pages locally. This was the error:

```
Error: Drupal errors: [
  {
    "message": "Fragment \"staffProfile\" is never used.",
    "extensions": {
      "category": "graphql"
    },
    "locations": [
      {
        "line": 527,
        "column": 3
      }
    ]
  }
]
```

This is when it started: https://github.com/department-of-veterans-affairs/content-build/pull/2924. I guess since that was the only page left that was using it, it became unused, and GraphQL doesn't like that.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/next-build/pull/1885

## Testing

1. Run `yarn watch` in one terminal and `yarn preview` in another.
2. Go to http://localhost:3002/preview?nodeId=68
3. Should succeed on this branch and fail on `main`